### PR TITLE
Support heterogeneous clusters with per-group config and north-south traffic detection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,8 +9,10 @@ Dockerfile
 
 # Build artifacts
 build/
+bin/
 l8k
 launch-kubernetes
+cluster-configuration/
 *.exe
 *.exe~
 *.dll

--- a/README.md
+++ b/README.md
@@ -68,30 +68,33 @@ Available Commands:
   version     Print the version number
 
 Flags:
-      --ai                             Enable AI deployment
-      --deploy                         Deploy the generated files to the Kubernetes cluster
-      --deployment-type string         Select the deployment type (sriov, rdma_shared, host_device)
-      --discover-cluster-config        Deploy a thin Network Operator profile to discover cluster capabilities
-      --enabled-plugins string         Comma-separated list of plugins to enable (default "network-operator")
-      --fabric string                  Select the fabric type to deploy (infiniband, ethernet)
-  -h, --help                           help for l8k
-      --kubeconfig string              Path to kubeconfig file for cluster deployment (required when using --deploy)
-      --llm-api-key string             API key for the LLM API (required when using --prompt)
-      --llm-api-url string             API URL for the LLM API
-      --llm-interactive                Enable interactive chat mode for LLM-assisted profile selection
-      --llm-model string               Model name for the LLM API (e.g., claude-3-5-sonnet-20241022, gpt-4)
-      --llm-vendor string              Vendor of the LLM API: openai, openai-azure, anthropic, gemini (default "openai-azure")
-      --log-file string                Write logs to file instead of stderr
-      --log-level string               Enable logging at specified level (debug, info, warn, error)
-      --multiplane-mode string         Spectrum-X multiplane mode: swplb, hwplb, uniplane (requires --spectrum-x)
-      --multirail                      Enable multirail deployment
-      --number-of-planes int           Number of planes for Spectrum-X (requires --spectrum-x)
-      --prompt string                  Path to file with a prompt to use for LLM-assisted profile generation
-      --save-cluster-config string     Save discovered cluster configuration to the specified path (default "/opt/nvidia/k8s-launch-kit/cluster-config.yaml")
-      --save-deployment-files string   Save generated deployment files to the specified directory (default "/opt/nvidia/k8s-launch-kit/deployment")
-      --spcx-version string            Spectrum-X firmware version (requires --spectrum-x)
-      --spectrum-x                     Enable Spectrum X deployment
-      --user-config string             Use provided cluster configuration file instead of auto-discovery (skips cluster discovery)
+      --ai                                Enable AI deployment
+      --deploy                            Deploy the generated files to the Kubernetes cluster
+      --deployment-type string            Select the deployment type (sriov, rdma_shared, host_device)
+      --discover-cluster-config           Deploy a thin Network Operator profile to discover cluster capabilities
+      --enabled-plugins string            Comma-separated list of plugins to enable (default "network-operator")
+      --fabric string                     Select the fabric type to deploy (infiniband, ethernet)
+      --group string                      Generate templates for a specific group only (e.g., group-0)
+  -h, --help                              help for l8k
+      --kubeconfig string                 Path to kubeconfig file for cluster deployment (required when using --deploy)
+      --label-selector string             Filter nodes for discovery by label (default "feature.node.kubernetes.io/pci-15b3.present=true")
+      --llm-api-key string                API key for the LLM API (required when using --prompt)
+      --llm-api-url string                API URL for the LLM API
+      --llm-interactive                   Enable interactive chat mode for LLM-assisted profile selection
+      --llm-model string                  Model name for the LLM API (e.g., claude-3-5-sonnet-20241022, gpt-4)
+      --llm-vendor string                 Vendor of the LLM API: openai, openai-azure, anthropic, gemini (default "openai-azure")
+      --log-file string                   Write logs to file instead of stderr
+      --log-level string                  Enable logging at specified level (debug, info, warn, error)
+      --multiplane-mode string            Spectrum-X multiplane mode: swplb, hwplb, uniplane (requires --spectrum-x)
+      --multirail                         Enable multirail deployment
+      --network-operator-namespace string Override the network operator namespace from the config file
+      --number-of-planes int              Number of planes for Spectrum-X (requires --spectrum-x)
+      --prompt string                     Path to file with a prompt to use for LLM-assisted profile generation
+      --save-cluster-config string        Save discovered cluster configuration to the specified path (default "/opt/nvidia/k8s-launch-kit/cluster-config.yaml")
+      --save-deployment-files string      Save generated deployment files to the specified directory (default "/opt/nvidia/k8s-launch-kit/deployment")
+      --spcx-version string               Spectrum-X firmware version (requires --spectrum-x)
+      --spectrum-x                        Enable Spectrum X deployment
+      --user-config string                Use provided cluster configuration file instead of auto-discovery (skips cluster discovery)
 
 Use "l8k [command] --help" for more information about a command.
 ```
@@ -114,10 +117,19 @@ l8k --discover-cluster-config --save-cluster-config ./cluster-config.yaml \
 ### Discover Cluster Configuration
 
 ```bash
-l8k --discover-cluster-config --save-cluster-config ./my-cluster-config.yaml
+l8k --discover-cluster-config --save-cluster-config ./my-cluster-config.yaml \
+    --kubeconfig ~/.kube/config
 ```
 
-### Use Existing Configuration  
+Filter discovery to specific nodes using a label selector:
+
+```bash
+l8k --discover-cluster-config --save-cluster-config ./my-cluster-config.yaml \
+    --label-selector "feature.node.kubernetes.io/pci-15b3.present=true" \
+    --kubeconfig ~/.kube/config
+```
+
+### Use Existing Configuration
 
 Generate and deploy with pre-existing config:
 
@@ -132,6 +144,17 @@ l8k --user-config ./existing-config.yaml \
 ```bash
 l8k --user-config ./config.yaml \
     --fabric ethernet --deployment-type sriov --multirail \
+    --save-deployment-files ./deployments
+```
+
+### Generate Deployment Files for a Specific Node Group
+
+In heterogeneous clusters, discovery produces multiple node groups. Use `--group` to generate manifests for a single group:
+
+```bash
+l8k --user-config ./config.yaml \
+    --fabric infiniband --deployment-type sriov --multirail \
+    --group group-0 \
     --save-deployment-files ./deployments
 ```
 
@@ -156,12 +179,10 @@ networkOperator:
   componentVersion: network-operator-v26.1.0
   repository: nvcr.io/nvidia/mellanox
   namespace: nvidia-network-operator
-
 docaDriver:
-  version: doca3.3.0-26.01-0.9.6.0-0
+  version: doca3.2.0-25.10-1.2.8.0-2
   unloadStorageModules: false
   enableNFSRDMA: false
-
 nvIpam:
   poolName: nv-ipam-pool
   subnets:
@@ -183,80 +204,264 @@ nvIpam:
     gateway: 192.168.9.1
   - subnet: 192.168.10.0/24
     gateway: 192.168.10.1
-
+  - subnet: 192.168.11.0/24
+    gateway: 192.168.11.1
+  - subnet: 192.168.12.0/24
+    gateway: 192.168.12.1
+  - subnet: 192.168.13.0/24
+    gateway: 192.168.13.1
+  - subnet: 192.168.14.0/24
+    gateway: 192.168.14.1
+  - subnet: 192.168.15.0/24
+    gateway: 192.168.15.1
+  - subnet: 192.168.16.0/24
+    gateway: 192.168.16.1
+  - subnet: 192.168.17.0/24
+    gateway: 192.168.17.1
+  - subnet: 192.168.18.0/24
+    gateway: 192.168.18.1
+  - subnet: 192.168.19.0/24
 sriov:
   ethernetMtu: 9000
   infinibandMtu: 4000
   numVfs: 8
   priority: 90
   resourceName: sriov_resource
-  networkName: sriov_network
-
+  networkName: sriov-network
 hostdev:
   resourceName: hostdev-resource
   networkName: hostdev-network
-
 rdmaShared:
-  resourceName: rdma_shared_resource # with multiple pools, _a, _b, _c, prefixes are added to the resource name
+  resourceName: rdma_shared_resource
   hcaMax: 63
-
 ipoib:
-  networkName: ipoib-network # with multiple networks, -a, -b, -c, prefixes are added to the network name
-
+  networkName: ipoib-network
 macvlan:
-  networkName: macvlan-network # with multiple networks, -a, -b, -c, prefixes are added to the network name
-
+  networkName: macvlan-network
 spectrumX:
-  nicType: "1023" # "1023" for ConnectX-8, "a2dc" for BlueField-3 SuperNIC
-  overlay: "none"
-  rdmaPrefix: "roce_p%plane%_r%rail%"
-  netdevPrefix: "eth_p%plane%_r%rail%"
-
-profile:
-  fabric: ethernet # infiniband, ethernet TODO consider ETH/IB
-  deployment: sriov # rdma_shared, sriov, host_device
-  multirail: false
-  spectrumX: # Spectrum-X configuration (set to null or omit if not using Spectrum-X)
-    spcxVersion: "RA2.1" # CLI parameter (overrides this value): --spcx-version
-    multiplaneMode: swplb # CLI parameter (overrides this value): --multiplane-mode (swplb, hwplb, uniplane)
-    numberOfPlanes: 4 # CLI parameter (overrides this value): --number-of-planes, also used as pfsPerNic
-  ai: false
-
+  nicType: "1023"
+  overlay: none
+  rdmaPrefix: roce_p%plane%_r%rail%
+  netdevPrefix: eth_p%plane%_r%rail%
 clusterConfig:
+- identifier: group-0
   capabilities:
     nodes:
-      sriov: true # has nodes with feature.node.kubernetes.io/pci-15b3.present=true
-      rdma: true # has nodes with feature.node.kubernetes.io/rdma.capable=true
-      ib: true # has nodes with IB capable NICs (find via nic config op)      
-  workerNodes: ["worker-0", "worker-1", "worker-2"]
+      sriov: true
+      rdma: true
+      ib: true
   pfs:
-    - deviceID: 1023
-      pciAddress: 0000:05:00.0
-      rdmaDevice: "mlx5_0"
-      networkInterface: "net1"
-      traffic: east-west
-    - deviceID: 1023
-      pciAddress: 0000:75:00.0
-      rdmaDevice: "mlx5_1"
-      networkInterface: "net2"
-      traffic: east-west
-    - deviceID: 1023
-      pciAddress: 0000:85:00.0
-      rdmaDevice: "mlx5_2"
-      networkInterface: "net3"
-      traffic: east-west
-    - deviceID: 1023
-      pciAddress: 0000:f5:00.0
-      rdmaDevice: "mlx5_3"
-      networkInterface: "net4"
-      traffic: east-west
-    - deviceID: 1023
-      pciAddress: 0000:6a:00.0
-      rdmaDevice: "mlx5_4"
-      networkInterface: "net5"
-      traffic: north-south
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: "0000:19:00.0"
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:2a:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:3b:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:4c:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: 101f
+    rdmaDevice: ""
+    pciAddress: 0000:5a:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: 101f
+    rdmaDevice: ""
+    pciAddress: 0000:5a:00.1
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:9b:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:ab:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:c1:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:cb:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:d8:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:d8:00.1
+    networkInterface: ""
+    traffic: east-west
+  workerNodes:
+  - pdx-g22r13-2894-lh2-w01
+  - pdx-g24r13-2894-lh2-w02
   nodeSelector:
-    feature.node.kubernetes.io/pci-15b3.present: "true"
+    nvidia.com/gpu.machine: ThinkSystem-SR680a-V3
+- identifier: group-1
+  capabilities:
+    nodes:
+      sriov: true
+      rdma: true
+      ib: true
+  pfs:
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:1a:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:3c:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:4d:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:5e:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:9c:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:9d:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:9d:00.1
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:bc:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:cc:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:dc:00.0
+    networkInterface: ""
+    traffic: east-west
+  workerNodes:
+  - pdx-g22r23-2894-dh2-w03
+  - pdx-g24r23-2894-dh2-w04
+  nodeSelector:
+    nvidia.com/gpu.machine: PowerEdge-XE9680
+- identifier: group-2
+  capabilities:
+    nodes:
+      sriov: true
+      rdma: true
+      ib: true
+  pfs:
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: "0000:09:00.0"
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: "0000:23:00.0"
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: "0000:35:00.0"
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: "0000:35:00.1"
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: "0000:53:00.0"
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:69:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:8f:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:9c:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:cd:00.0
+    networkInterface: ""
+    traffic: east-west
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:f1:00.0
+    networkInterface: ""
+    traffic: east-west
+  workerNodes:
+  - pdx-g22r31-2894-ch2-w05
+  - pdx-g24r31-2894-ch2-w06
+  nodeSelector:
+    nvidia.com/gpu.machine: UCSC-885A-M8-H22
+```
+
+### North-South Traffic Detection
+
+During cluster discovery, the tool automatically identifies BlueField DPU devices (as opposed to SuperNICs or ConnectX NICs) by matching each device's `partNumber` against a known list of DPU product codes in [pkg/networkoperatorplugin/ns-product-ids](pkg/networkoperatorplugin/ns-product-ids). Devices matching a DPU product code are classified as **north-south** traffic (management/external), while all other devices are classified as **east-west** traffic (GPU interconnect).
+
+North-south PFs are included in the saved cluster configuration for visibility, but are **automatically filtered out** during template rendering so that only east-west PFs appear in the generated manifests. This ensures sequential naming (a, b, c, d) for resources like SriovNetworkNodePolicy and IPPool entries.
+
+Example of mixed traffic types in the config:
+```yaml
+clusterConfig:
+- identifier: group-0
+  pfs:
+  - deviceID: a2dc
+    pciAddress: "0000:19:00.0"
+    traffic: east-west       # SuperNIC — included in manifests
+  - deviceID: a2dc
+    pciAddress: "0000:2a:00.0"
+    traffic: east-west
+  - deviceID: a2dc
+    pciAddress: "0000:3b:00.0"
+    traffic: north-south     # BlueField DPU — excluded from manifests
 ```
 
 ## Docker container

--- a/l8k-config.yaml
+++ b/l8k-config.yaml
@@ -1,6 +1,6 @@
 networkOperator:
   version: v26.1.0
-  componentVersion: network-operator-v25.10.0
+  componentVersion: network-operator-v26.1.0
   repository: nvcr.io/nvidia/mellanox
   namespace: nvidia-network-operator
 
@@ -37,7 +37,7 @@ sriov:
   numVfs: 8
   priority: 90
   resourceName: sriov_resource
-  networkName: sriov_network
+  networkName: sriov-network
 
 hostdev:
   resourceName: hostdev-resource
@@ -70,37 +70,38 @@ profile:
   ai: false
 
 clusterConfig:
-  capabilities:
-    nodes:
-      sriov: true # has nodes with feature.node.kubernetes.io/pci-15b3.present=true
-      rdma: true # has nodes with feature.node.kubernetes.io/rdma.capable=true
-      ib: true # has nodes with IB capable NICs (find via nic config op)      
-  workerNodes: ["worker-0", "worker-1", "worker-2"]
-  pfs:
-    - deviceID: 1023
-      pciAddress: 0000:05:00.0
-      rdmaDevice: "mlx5_0"
-      networkInterface: "net1"
-      traffic: east-west
-    - deviceID: 1023
-      pciAddress: 0000:75:00.0
-      rdmaDevice: "mlx5_1"
-      networkInterface: "net2"
-      traffic: east-west
-    - deviceID: 1023
-      pciAddress: 0000:85:00.0
-      rdmaDevice: "mlx5_2"
-      networkInterface: "net3"
-      traffic: east-west
-    - deviceID: 1023
-      pciAddress: 0000:f5:00.0
-      rdmaDevice: "mlx5_3"
-      networkInterface: "net4"
-      traffic: east-west
-    - deviceID: 1023
-      pciAddress: 0000:6a:00.0
-      rdmaDevice: "mlx5_4"
-      networkInterface: "net5"
-      traffic: north-south
-  nodeSelector:
-    feature.node.kubernetes.io/pci-15b3.present: "true"
+  - identifier: ""
+    capabilities:
+      nodes:
+        sriov: true # has nodes with feature.node.kubernetes.io/pci-15b3.present=true
+        rdma: true # has nodes with feature.node.kubernetes.io/rdma.capable=true
+        ib: true # has nodes with IB capable NICs (find via nic config op)
+    workerNodes: ["worker-0", "worker-1", "worker-2"]
+    pfs:
+      - deviceID: 1023
+        pciAddress: 0000:05:00.0
+        rdmaDevice: "mlx5_0"
+        networkInterface: "net1"
+        traffic: east-west
+      - deviceID: 1023
+        pciAddress: 0000:75:00.0
+        rdmaDevice: "mlx5_1"
+        networkInterface: "net2"
+        traffic: east-west
+      - deviceID: 1023
+        pciAddress: 0000:85:00.0
+        rdmaDevice: "mlx5_2"
+        networkInterface: "net3"
+        traffic: east-west
+      - deviceID: 1023
+        pciAddress: 0000:f5:00.0
+        rdmaDevice: "mlx5_3"
+        networkInterface: "net4"
+        traffic: east-west
+      - deviceID: 1023
+        pciAddress: 0000:6a:00.0
+        rdmaDevice: "mlx5_4"
+        networkInterface: "net5"
+        traffic: north-south
+    nodeSelector:
+      feature.node.kubernetes.io/pci-15b3.present: "true"

--- a/pkg/app/launcher.go
+++ b/pkg/app/launcher.go
@@ -72,7 +72,10 @@ func (l *Launcher) Run() error {
 	for _, plugin := range l.options.EnabledPlugins {
 		switch plugin {
 		case networkoperatorplugin.PluginName:
-			l.plugins[plugin] = &networkoperatorplugin.NetworkOperatorPlugin{}
+			l.plugins[plugin] = &networkoperatorplugin.NetworkOperatorPlugin{
+				GroupFilter:   l.options.Group,
+				LabelSelector: parseLabelSelector(l.options.LabelSelector),
+			}
 		default:
 			err := fmt.Errorf("unknown plugin: %s", plugin)
 			l.logger.Error(err, "Skipping plugin")
@@ -182,7 +185,7 @@ func (l *Launcher) executeWorkflow() error {
 
 			l.logger.Info("Selecting a profile using LLM-assisted prompt")
 
-			prompt, err := llm.SelectPromptWithModel(l.options.Prompt, *fullConfig.ClusterConfig, l.options.LLMApiKey, l.options.LLMApiUrl, l.options.LLMVendor, l.options.LLMModel)
+			prompt, err := llm.SelectPromptWithModel(l.options.Prompt, fullConfig.ClusterConfig, l.options.LLMApiKey, l.options.LLMApiUrl, l.options.LLMVendor, l.options.LLMModel)
 			if err != nil {
 				progress.Fail("AI selection failed")
 				l.ui.Error("Failed to get AI recommendation: %v", err)
@@ -235,12 +238,14 @@ func (l *Launcher) executeWorkflow() error {
 		}
 	}
 
+	aggregatedCapabilities := config.AggregateCapabilities(fullConfig.ClusterConfig)
+
 	foundProfiles := []profiles.Profile{}
 	for pluginName, plugin := range l.plugins {
-		profile, err := profiles.FindApplicableProfile(fullConfig.Profile, fullConfig.ClusterConfig.Capabilities, pluginName)
+		profile, err := profiles.FindApplicableProfile(fullConfig.Profile, aggregatedCapabilities, pluginName)
 		if err != nil {
 			l.ui.Error("Failed to find profile: %v", err)
-			l.logger.Error(err, "Failed to find applicable profile for the plugin", "plugin", plugin.GetName(), "cluster capabilities", fullConfig.ClusterConfig.Capabilities, "profile requirements", fullConfig.Profile)
+			l.logger.Error(err, "Failed to find applicable profile for the plugin", "plugin", plugin.GetName(), "cluster capabilities", aggregatedCapabilities, "profile requirements", fullConfig.Profile)
 			return err
 		}
 		foundProfiles = append(foundProfiles, *profile)
@@ -298,14 +303,7 @@ func (l *Launcher) discoverClusterConfig() error {
 		l.logger.Info("Using CLI override for network operator namespace", "namespace", l.options.NetworkOperatorNamespace)
 	}
 
-	defaults.ClusterConfig = &config.ClusterConfig{
-		Capabilities: &config.ClusterCapabilities{
-			Nodes: &config.NodesCapabilities{},
-		},
-		PFs:          []config.PFConfig{},
-		WorkerNodes:  []string{},
-		NodeSelector: map[string]string{"feature.node.kubernetes.io/pci-15b3.present": "true"},
-	}
+	defaults.ClusterConfig = nil
 	defaults.Profile = nil
 
 	ctx := ui.WithOutput(context.Background(), l.ui)
@@ -430,8 +428,8 @@ func (l *Launcher) deployConfigurationProfile(profile *profiles.Profile) error {
 }
 
 // runInteractiveSession runs an interactive chat session with the LLM
-func (l *Launcher) runInteractiveSession(clusterConfig *config.ClusterConfig) (map[string]string, error) {
-	session, err := llm.NewChatSession(*clusterConfig, l.options.LLMApiKey, l.options.LLMApiUrl, l.options.LLMVendor, l.options.LLMModel)
+func (l *Launcher) runInteractiveSession(clusterConfig []config.ClusterConfig) (map[string]string, error) {
+	session, err := llm.NewChatSession(clusterConfig, l.options.LLMApiKey, l.options.LLMApiUrl, l.options.LLMVendor, l.options.LLMModel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create chat session: %w", err)
 	}
@@ -501,4 +499,26 @@ func (l *Launcher) runInteractiveSession(clusterConfig *config.ClusterConfig) (m
 		fmt.Println(llm.InteractivePromptSuffix)
 		fmt.Println()
 	}
+}
+
+// parseLabelSelector parses a comma-separated "key=value" string into a map.
+func parseLabelSelector(s string) map[string]string {
+	if s == "" {
+		return nil
+	}
+	result := map[string]string{}
+	for _, pair := range strings.Split(s, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) == 2 {
+			result[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -57,6 +57,8 @@ var (
 	logger                = log.Log.WithName("l8k")
 	enabledPlugins              string
 	networkOperatorNamespace    string
+	group                       string
+	labelSelector               string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -98,6 +100,8 @@ Apply the generated deployment files to your Kubernetes cluster by using --deplo
 			MultiplaneMode:        multiplaneMode,
 			NumberOfPlanes:        numberOfPlanes,
 			Prompt:                prompt,
+			Group:                group,
+			LabelSelector:        labelSelector,
 			SaveDeploymentFiles:   saveDeploymentFiles,
 			Deploy:                deploy,
 			Kubeconfig:            kubeconfig,
@@ -165,6 +169,8 @@ func init() {
 	rootCmd.Flags().StringVar(&spcxVersion, "spcx-version", "", "Spectrum-X firmware version (requires --spectrum-x)")
 	rootCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Spectrum-X multiplane mode: swplb, hwplb, uniplane (requires --spectrum-x)")
 	rootCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes for Spectrum-X (requires --spectrum-x)")
+	rootCmd.Flags().StringVar(&group, "group", "", "Generate templates for a specific group only (e.g., group-0)")
+	rootCmd.Flags().StringVar(&labelSelector, "label-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Filter nodes for discovery by label (e.g., key=value,key2=value2)")
 	rootCmd.Flags().StringVar(&prompt, "prompt", "", "Path to file with a prompt to use for LLM-assisted profile generation")
 	rootCmd.Flags().StringVar(&llmApiKey, "llm-api-key", "", "API key for the LLM API (required when using --prompt)")
 	rootCmd.Flags().StringVar(&llmApiUrl, "llm-api-url", "", "API URL for the LLM API")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,7 +37,7 @@ type LaunchKubernetesConfig struct {
 	Macvlan         *MacvlanConfig         `yaml:"macvlan,omitempty"`
 	SpectrumX       *SpectrumXConfig       `yaml:"spectrumX,omitempty"`
 	Profile         *Profile               `yaml:"profile,omitempty"`
-	ClusterConfig   *ClusterConfig         `yaml:"clusterConfig,omitempty"`
+	ClusterConfig   []ClusterConfig        `yaml:"clusterConfig,omitempty"`
 }
 
 type NetworkOperatorConfig struct {
@@ -112,10 +112,14 @@ type ProfileSpectrumX struct {
 }
 
 type ClusterConfig struct {
-	Capabilities *ClusterCapabilities `yaml:"capabilities"`
-	PFs          []PFConfig           `yaml:"pfs"`
-	WorkerNodes  []string             `yaml:"workerNodes"`
-	NodeSelector map[string]string    `yaml:"nodeSelector,omitempty"`
+	Identifier    string              `yaml:"identifier"`
+	MachineType   string              `yaml:"machineType,omitempty"`
+	ProductType   string              `yaml:"productType,omitempty"`
+	LabelSelector map[string]string   `yaml:"labelSelector,omitempty"`
+	Capabilities  *ClusterCapabilities `yaml:"capabilities"`
+	PFs           []PFConfig           `yaml:"pfs"`
+	WorkerNodes   []string             `yaml:"workerNodes"`
+	NodeSelector  map[string]string    `yaml:"nodeSelector,omitempty"`
 }
 
 type ClusterCapabilities struct {
@@ -134,6 +138,20 @@ type PFConfig struct {
 	PciAddress       string `yaml:"pciAddress"`
 	NetworkInterface string `yaml:"networkInterface"`
 	Traffic          string `yaml:"traffic"`
+}
+
+// AggregateCapabilities computes the union of capabilities across all cluster config groups.
+// If any group has a capability, the aggregate has it.
+func AggregateCapabilities(groups []ClusterConfig) *ClusterCapabilities {
+	result := &ClusterCapabilities{Nodes: &NodesCapabilities{}}
+	for _, g := range groups {
+		if g.Capabilities != nil && g.Capabilities.Nodes != nil {
+			result.Nodes.Sriov = result.Nodes.Sriov || g.Capabilities.Nodes.Sriov
+			result.Nodes.Rdma = result.Nodes.Rdma || g.Capabilities.Nodes.Rdma
+			result.Nodes.Ib = result.Nodes.Ib || g.Capabilities.Nodes.Ib
+		}
+	}
+	return result
 }
 
 // LoadFullConfig loads and parses the cluster configuration from the specified path

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -92,11 +92,11 @@ func createLLM(llmApiKey string, llmApiUrl string, llmVendor string, llmModel st
 	}
 }
 
-func SelectPrompt(promptPath string, config config.ClusterConfig, llmApiKey string, llmApiUrl string, llmVendor string) (map[string]string, error) {
+func SelectPrompt(promptPath string, config []config.ClusterConfig, llmApiKey string, llmApiUrl string, llmVendor string) (map[string]string, error) {
 	return SelectPromptWithModel(promptPath, config, llmApiKey, llmApiUrl, llmVendor, "")
 }
 
-func SelectPromptWithModel(promptPath string, config config.ClusterConfig, llmApiKey string, llmApiUrl string, llmVendor string, llmModel string) (map[string]string, error) {
+func SelectPromptWithModel(promptPath string, config []config.ClusterConfig, llmApiKey string, llmApiUrl string, llmVendor string, llmModel string) (map[string]string, error) {
 	llm, err := createLLM(llmApiKey, llmApiUrl, llmVendor, llmModel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create LLM client: %w", err)
@@ -182,7 +182,7 @@ type ChatSession struct {
 }
 
 // NewChatSession creates a new interactive chat session
-func NewChatSession(clusterConfig config.ClusterConfig, llmApiKey, llmApiUrl, llmVendor, llmModel string) (*ChatSession, error) {
+func NewChatSession(clusterConfig []config.ClusterConfig, llmApiKey, llmApiUrl, llmVendor, llmModel string) (*ChatSession, error) {
 	llm, err := createLLM(llmApiKey, llmApiUrl, llmVendor, llmModel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create LLM client: %w", err)

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -18,6 +18,7 @@ package networkoperatorplugin
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"slices"
 	"strings"
@@ -32,6 +33,43 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+//go:embed ns-product-ids
+var nsProductIDsData string
+
+// nsProductIDs is the set of product codes / legacy product IDs for
+// BlueField DPU devices (not SuperNICs). Devices whose PartNumber matches
+// an entry in this set are marked as north-south traffic.
+var nsProductIDs = parseNSProductIDs(nsProductIDsData)
+
+func parseNSProductIDs(data string) map[string]bool {
+	ids := map[string]bool{}
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Format: ProductCode | LegacyProductId | ProductName
+		parts := strings.SplitN(line, "|", 3)
+		if len(parts) >= 2 {
+			productCode := strings.TrimSpace(parts[0])
+			legacyID := strings.TrimSpace(parts[1])
+			if productCode != "" {
+				ids[productCode] = true
+			}
+			if legacyID != "" {
+				ids[legacyID] = true
+			}
+		}
+	}
+	return ids
+}
+
+// isNorthSouthDevice returns true if the device's part number matches
+// a known BlueField DPU (non-SuperNIC) product ID from the ns-product-ids file.
+func isNorthSouthDevice(partNumber string) bool {
+	return nsProductIDs[partNumber]
+}
 
 func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c client.Client, defaultConfig *config.LaunchKubernetesConfig) error {
 	uiOutput := ui.FromContext(ctx)
@@ -122,39 +160,52 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 	}()
 
 	// After creation, list pods in the target namespace and ensure all pods
-	// from the nic-configuration-daemon DaemonSet are Ready
-	if err := checkDaemonSetPodsReady(ctx, c, defaultConfig.NetworkOperator.Namespace, "nic-configuration-daemon"); err != nil {
+	// from the nic-configuration-daemon DaemonSet are Ready.
+	// Returns the set of node names running daemon pods.
+	expectedNodes, err := checkDaemonSetPodsReady(ctx, c, defaultConfig.NetworkOperator.Namespace, "nic-configuration-daemon")
+	if err != nil {
 		return err
 	}
 
-	// Get NicDevice resources and build ClusterConfig.NvidiaNICs from their statuses
+	// Fetch node labels early — needed both for filtering and nodeSelector computation
+	nodeLabels, err := fetchNodeLabels(ctx, c)
+	if err != nil {
+		log.Log.Error(err, "failed to fetch node labels; nodeSelectors will be empty")
+		nodeLabels = map[string]map[string]string{}
+	}
+
+	// Filter expected nodes using the label selector.
+	// Nodes not matching will never report NicDevices, so waiting for them
+	// would cause a timeout.
+	if len(p.LabelSelector) > 0 {
+		expectedNodes = filterNodesByLabels(expectedNodes, nodeLabels, p.LabelSelector)
+		if len(expectedNodes) == 0 {
+			return fmt.Errorf("no nodes match the label selector %v", p.LabelSelector)
+		}
+	}
+
+	// Wait for all expected nodes to report their NicDevice resources
+	if err := waitNicDevicesDiscovered(ctx, c, defaultConfig.NetworkOperator.Namespace, expectedNodes); err != nil {
+		return err
+	}
+
+	// Get NicDevice resources and build ClusterConfig from their statuses
 	devices := &nicop.NicDeviceList{}
 	if err := c.List(ctx, devices, client.InNamespace(defaultConfig.NetworkOperator.Namespace)); err != nil {
 		return err
 	}
-	if len(devices.Items) == 0 {
-		log.Log.Info("No NicDevice resources found yet; waiting for discovery", "namespace", defaultConfig.NetworkOperator.Namespace)
-		if err := waitNicDevicesDiscovered(ctx, c, defaultConfig.NetworkOperator.Namespace); err != nil {
-			return err
-		}
-		// re-list after wait
-		if err := c.List(ctx, devices, client.InNamespace(defaultConfig.NetworkOperator.Namespace)); err != nil {
-			return err
-		}
-		log.Log.Info("NicDevice resources discovered", "count", len(devices.Items))
-	}
 
-	buildClusterConfigFromNicDevices(devices.Items, defaultConfig.ClusterConfig)
+	defaultConfig.ClusterConfig = buildClusterConfig(devices.Items, nodeLabels, p.LabelSelector)
 
 	return nil
 }
 
 // checkDaemonSetPodsReady verifies that all pods owned by the given DaemonSet
-// in the provided namespace are Ready.
-func checkDaemonSetPodsReady(ctx context.Context, c client.Client, namespace, daemonSetName string) error {
+// in the provided namespace are Ready. Returns the list of node names running those pods.
+func checkDaemonSetPodsReady(ctx context.Context, c client.Client, namespace, daemonSetName string) ([]string, error) {
 	podList := &corev1.PodList{}
 	if err := c.List(ctx, podList, client.InNamespace(namespace)); err != nil {
-		return err
+		return nil, err
 	}
 
 	var dsPods []corev1.Pod
@@ -168,16 +219,20 @@ func checkDaemonSetPodsReady(ctx context.Context, c client.Client, namespace, da
 	}
 
 	if len(dsPods) == 0 {
-		return fmt.Errorf("no pods found for DaemonSet %q in namespace %q", daemonSetName, namespace)
+		return nil, fmt.Errorf("no pods found for DaemonSet %q in namespace %q", daemonSetName, namespace)
 	}
 
+	nodes := make([]string, 0, len(dsPods))
 	for _, pod := range dsPods {
 		if !isPodReady(&pod) {
-			return fmt.Errorf("pod %q from DaemonSet %q is not Ready", pod.Name, daemonSetName)
+			return nil, fmt.Errorf("pod %q from DaemonSet %q is not Ready", pod.Name, daemonSetName)
+		}
+		if pod.Spec.NodeName != "" {
+			nodes = append(nodes, pod.Spec.NodeName)
 		}
 	}
 
-	return nil
+	return nodes, nil
 }
 
 func isPodReady(pod *corev1.Pod) bool {
@@ -189,10 +244,10 @@ func isPodReady(pod *corev1.Pod) bool {
 	return false
 }
 
-// waitNicDevicesDiscovered polls until one or more NicDevice objects exist in the given namespace.
-func waitNicDevicesDiscovered(parentCtx context.Context, c client.Client, namespace string) error {
+// waitNicDevicesDiscovered polls until NicDevice objects exist for all expected nodes in the given namespace.
+func waitNicDevicesDiscovered(parentCtx context.Context, c client.Client, namespace string, expectedNodes []string) error {
 	uiOutput := ui.FromContext(parentCtx)
-	progress := uiOutput.StartProgress("Discovering network devices (timeout: 5 min)")
+	progress := uiOutput.StartProgress(fmt.Sprintf("Discovering network devices on %d node(s) (timeout: 5 min)", len(expectedNodes)))
 
 	// Use a bounded timeout if none supplied
 	ctx := parentCtx
@@ -202,72 +257,390 @@ func waitNicDevicesDiscovered(parentCtx context.Context, c client.Client, namesp
 		defer cancel()
 	}
 
+	expectedSet := make(map[string]bool, len(expectedNodes))
+	for _, n := range expectedNodes {
+		expectedSet[n] = true
+	}
+
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
 	for {
 		list := &nicop.NicDeviceList{}
 		if err := c.List(ctx, list, client.InNamespace(namespace)); err == nil {
-			if len(list.Items) > 0 {
-				progress.Success(fmt.Sprintf("Found %d device(s)", len(list.Items)))
+			discoveredNodes := make(map[string]bool)
+			for _, d := range list.Items {
+				if d.Status.Node != "" {
+					discoveredNodes[d.Status.Node] = true
+				}
+			}
+
+			allFound := true
+			for node := range expectedSet {
+				if !discoveredNodes[node] {
+					allFound = false
+					break
+				}
+			}
+
+			if allFound && len(discoveredNodes) > 0 {
+				progress.Success(fmt.Sprintf("Found %d device(s) on %d node(s)", len(list.Items), len(discoveredNodes)))
 				return nil
 			}
+
+			progress.Update(fmt.Sprintf("Discovered devices on %d/%d node(s)...", len(discoveredNodes), len(expectedSet)))
 		}
 
 		select {
 		case <-ctx.Done():
 			progress.Fail("Timeout waiting for devices")
-			return fmt.Errorf("timeout waiting for NicDevice resources in namespace %q", namespace)
+			return fmt.Errorf("timeout waiting for NicDevice resources from all nodes in namespace %q", namespace)
 		case <-ticker.C:
-			progress.Update("Still waiting for device discovery...")
 		}
 	}
 }
 
-// buildClusterConfigFromNicDevices constructs ClusterConfig.NvidiaNICs based on NicDevice statuses.
-func buildClusterConfigFromNicDevices(devices []nicop.NicDevice, cluster *config.ClusterConfig) {
-	cluster.Capabilities.Nodes.Rdma = false
-	cluster.Capabilities.Nodes.Sriov = false
-	cluster.Capabilities.Nodes.Ib = true // TODO fix
+// pfFingerprint identifies a PF by its device ID and PCI address (ignoring RDMA/net names).
+type pfFingerprint struct {
+	DeviceID   string
+	PciAddress string
+}
 
-	cluster.PFs = []config.PFConfig{}
-	pfs := map[config.PFConfig]interface{}{}
-	workerNodes := map[string]interface{}{}
+// nodePFEntry holds the full PF info discovered on a specific node.
+type nodePFEntry struct {
+	pfFingerprint
+	RdmaDevice       string
+	NetworkInterface string
+	IsNorthSouth     bool // true when the device's partNumber matches a DPU product ID
+}
+
+// fetchNodeLabels lists all Kubernetes nodes and returns a map of nodeName → labels.
+func fetchNodeLabels(ctx context.Context, c client.Client) (map[string]map[string]string, error) {
+	nodeList := &corev1.NodeList{}
+	if err := c.List(ctx, nodeList); err != nil {
+		return nil, fmt.Errorf("failed to list nodes: %w", err)
+	}
+	result := make(map[string]map[string]string, len(nodeList.Items))
+	for _, node := range nodeList.Items {
+		result[node.Name] = node.Labels
+	}
+	return result, nil
+}
+
+// filterNodesByLabels returns only nodes whose labels match all entries in the selector.
+func filterNodesByLabels(nodes []string, nodeLabels map[string]map[string]string, selector map[string]string) []string {
+	var filtered []string
+	for _, n := range nodes {
+		labels := nodeLabels[n]
+		if labels == nil {
+			continue
+		}
+		match := true
+		for k, v := range selector {
+			if labels[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			filtered = append(filtered, n)
+		}
+	}
+	return filtered
+}
+
+// buildClusterConfig groups NicDevices by identical PF fingerprints across nodes
+// and returns a ClusterConfig slice with one entry per group.
+func buildClusterConfig(devices []nicop.NicDevice, nodeLabels map[string]map[string]string, labelSelector map[string]string) []config.ClusterConfig {
+	// Step 1: Build per-node PF map and track capabilities per node
+	type nodeInfo struct {
+		pfs     []nodePFEntry
+		hasRdma bool
+		hasPCI  bool
+	}
+	nodeMap := map[string]*nodeInfo{}
 
 	for _, d := range devices {
+		nodeName := d.Status.Node
+		if nodeName == "" {
+			continue
+		}
+		if nodeMap[nodeName] == nil {
+			nodeMap[nodeName] = &nodeInfo{}
+		}
+		ni := nodeMap[nodeName]
+		northSouth := isNorthSouthDevice(d.Status.PartNumber)
 		for _, p := range d.Status.Ports {
+			entry := nodePFEntry{
+				pfFingerprint: pfFingerprint{
+					DeviceID:   d.Status.Type,
+					PciAddress: p.PCI,
+				},
+				RdmaDevice:       p.RdmaInterface,
+				NetworkInterface: p.NetworkInterface,
+				IsNorthSouth:     northSouth,
+			}
+			ni.pfs = append(ni.pfs, entry)
 			if p.RdmaInterface != "" {
-				cluster.Capabilities.Nodes.Rdma = true
+				ni.hasRdma = true
 			}
 			if p.PCI != "" {
-				cluster.Capabilities.Nodes.Sriov = true
+				ni.hasPCI = true
 			}
-
-			pfs[config.PFConfig{
-				DeviceID:         d.Status.Type, // NIC model name, e.g. "ConnectX7"
-				RdmaDevice:       p.RdmaInterface,
-				PciAddress:       p.PCI,
-				NetworkInterface: p.NetworkInterface,
-				Traffic:          "east-west", // TODO fix
-			}] = struct{}{}
-		}
-
-		workerNodes[d.Status.Node] = struct{}{}
-	}
-
-	for node := range workerNodes {
-		if node != "" {
-			cluster.WorkerNodes = append(cluster.WorkerNodes, node)
 		}
 	}
 
-	slices.Sort(cluster.WorkerNodes)
-
-	for pf := range pfs {
-		cluster.PFs = append(cluster.PFs, pf)
+	// Step 2: Compute PF fingerprint per node and group nodes
+	type fingerprintKey string
+	computeFingerprint := func(pfs []nodePFEntry) fingerprintKey {
+		fps := make([]pfFingerprint, len(pfs))
+		for i, p := range pfs {
+			fps[i] = p.pfFingerprint
+		}
+		slices.SortFunc(fps, func(a, b pfFingerprint) int {
+			if c := strings.Compare(a.DeviceID, b.DeviceID); c != 0 {
+				return c
+			}
+			return strings.Compare(a.PciAddress, b.PciAddress)
+		})
+		parts := make([]string, len(fps))
+		for i, fp := range fps {
+			parts[i] = fp.DeviceID + ":" + fp.PciAddress
+		}
+		return fingerprintKey(strings.Join(parts, "|"))
 	}
 
-	slices.SortFunc(cluster.PFs, func(a, b config.PFConfig) int {
-		return strings.Compare(a.PciAddress, b.PciAddress)
-	})
+	// Group nodes by fingerprint, preserving order by first-seen node
+	type nodeGroup struct {
+		fingerprint fingerprintKey
+		nodes       []string
+		pfs         []nodePFEntry // representative PFs from first node
+		hasRdma     bool
+		hasPCI      bool
+	}
+	fingerprintOrder := []fingerprintKey{}
+	groupMap := map[fingerprintKey]*nodeGroup{}
+
+	// Sort node names for deterministic grouping
+	sortedNodes := make([]string, 0, len(nodeMap))
+	for n := range nodeMap {
+		sortedNodes = append(sortedNodes, n)
+	}
+	slices.Sort(sortedNodes)
+
+	for _, nodeName := range sortedNodes {
+		ni := nodeMap[nodeName]
+		fp := computeFingerprint(ni.pfs)
+		if g, ok := groupMap[fp]; ok {
+			g.nodes = append(g.nodes, nodeName)
+			g.hasRdma = g.hasRdma || ni.hasRdma
+			g.hasPCI = g.hasPCI || ni.hasPCI
+		} else {
+			fingerprintOrder = append(fingerprintOrder, fp)
+			groupMap[fp] = &nodeGroup{
+				fingerprint: fp,
+				nodes:       []string{nodeName},
+				pfs:         ni.pfs,
+				hasRdma:     ni.hasRdma,
+				hasPCI:      ni.hasPCI,
+			}
+		}
+	}
+
+	// Step 3: Build ClusterConfig per group
+	singleGroup := len(fingerprintOrder) == 1
+	groups := make([]config.ClusterConfig, 0, len(fingerprintOrder))
+
+	for i, fp := range fingerprintOrder {
+		g := groupMap[fp]
+
+		identifier := ""
+		if !singleGroup {
+			identifier = fmt.Sprintf("group-%d", i)
+		}
+
+		// Build PFs from the representative node's entries.
+		// If multiple nodes exist in the group, RDMA/net device names may differ — omit them.
+		pfs := make([]config.PFConfig, len(g.pfs))
+		for j, entry := range g.pfs {
+			traffic := "east-west"
+			if entry.IsNorthSouth {
+				traffic = "north-south"
+			}
+			pfs[j] = config.PFConfig{
+				DeviceID:   entry.DeviceID,
+				PciAddress: entry.PciAddress,
+				Traffic:    traffic,
+			}
+			if singleGroup || len(g.nodes) == 1 {
+				// Safe to include RDMA/net device names when only one node in group
+				pfs[j].RdmaDevice = entry.RdmaDevice
+				pfs[j].NetworkInterface = entry.NetworkInterface
+			}
+		}
+
+		slices.SortFunc(pfs, func(a, b config.PFConfig) int {
+			return strings.Compare(a.PciAddress, b.PciAddress)
+		})
+
+		slices.Sort(g.nodes)
+
+		// Extract machine/product type from common node labels
+		commonLabels := computeCommonLabels(g.nodes, nodeLabels)
+		machineType := commonLabels["nvidia.com/gpu.machine"]
+		productType := commonLabels["nvidia.com/gpu.product"]
+
+		cc := config.ClusterConfig{
+			Identifier:    identifier,
+			MachineType:   machineType,
+			ProductType:   productType,
+			LabelSelector: labelSelector,
+			Capabilities: &config.ClusterCapabilities{
+				Nodes: &config.NodesCapabilities{
+					Rdma:  g.hasRdma,
+					Sriov: g.hasPCI,
+					Ib:    true, // TODO: detect from NicDevice
+				},
+			},
+			PFs:         pfs,
+			WorkerNodes: g.nodes,
+		}
+
+		groups = append(groups, cc)
+	}
+
+	// Step 4: Compute nodeSelectors per group
+	if len(groups) > 1 {
+		computeNodeSelectors(groups, nodeLabels)
+	}
+
+	return groups
 }
+
+// computeNodeSelectors assigns NodeSelectors to each group using ALL label keys
+// where groups have differing common values. This ensures every group uses the
+// same set of label keys (with different values), making the selectors consistent.
+func computeNodeSelectors(groups []config.ClusterConfig, nodeLabels map[string]map[string]string) {
+	n := len(groups)
+	if n <= 1 {
+		return
+	}
+
+	// Compute common labels per group (intersection of labels across all nodes)
+	groupCommonLabels := make([]map[string]string, n)
+	for i, g := range groups {
+		groupCommonLabels[i] = computeCommonLabels(g.WorkerNodes, nodeLabels)
+	}
+
+	// Collect all label keys present in any group's common labels
+	allKeys := map[string]bool{}
+	for _, cl := range groupCommonLabels {
+		for k := range cl {
+			allKeys[k] = true
+		}
+	}
+
+	// Find all label keys where at least two groups have different common values.
+	// A key "differs" if: group A has value X and group B has value Y (Y != X),
+	// or one group has the key in common and another doesn't.
+	differingKeys := []string{}
+	for k := range allKeys {
+		values := map[string]bool{}
+		missing := false
+		for _, cl := range groupCommonLabels {
+			v, ok := cl[k]
+			if !ok {
+				missing = true
+			} else {
+				values[v] = true
+			}
+		}
+		if len(values) > 1 || (len(values) >= 1 && missing) {
+			differingKeys = append(differingKeys, k)
+		}
+	}
+
+	slices.Sort(differingKeys)
+
+	// Assign ALL differing label keys to each group's NodeSelector
+	for i := range groups {
+		selector := map[string]string{}
+		for _, k := range differingKeys {
+			if v, ok := groupCommonLabels[i][k]; ok {
+				selector[k] = v
+			}
+			// If this group doesn't have the key in common, omit it —
+			// the key still discriminates because other groups DO have it.
+		}
+		if len(selector) > 0 {
+			groups[i].NodeSelector = selector
+		} else {
+			log.Log.Info("Warning: could not compute a unique nodeSelector for group",
+				"group", groups[i].Identifier, "nodes", groups[i].WorkerNodes)
+		}
+	}
+}
+
+// computeCommonLabels returns labels with identical values across all specified nodes.
+func computeCommonLabels(nodes []string, nodeLabels map[string]map[string]string) map[string]string {
+	if len(nodes) == 0 {
+		return map[string]string{}
+	}
+
+	// Start with labels from the first node
+	firstLabels := nodeLabels[nodes[0]]
+	if firstLabels == nil {
+		return map[string]string{}
+	}
+
+	common := make(map[string]string, len(firstLabels))
+	for k, v := range firstLabels {
+		if isNoisyLabel(k) {
+			continue
+		}
+		common[k] = v
+	}
+
+	// Intersect with remaining nodes
+	for _, node := range nodes[1:] {
+		labels := nodeLabels[node]
+		for k, v := range common {
+			if labels[k] != v {
+				delete(common, k)
+			}
+		}
+	}
+
+	return common
+}
+
+// isNoisyLabel returns true for labels that are node-specific or not useful for discrimination.
+func isNoisyLabel(key string) bool {
+	noisyPrefixes := []string{
+		"kubernetes.io/metadata",
+		"node.kubernetes.io/instance-type",
+		"kubernetes.io/hostname",
+		"kubernetes.io/arch",
+		"kubernetes.io/os",
+		"pod-security.kubernetes.io",
+		"topology.kubernetes.io",
+	}
+	noisyExact := []string{
+		"beta.kubernetes.io/arch",
+		"beta.kubernetes.io/os",
+		"kubernetes.io/hostname",
+	}
+
+	for _, prefix := range noisyPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	for _, exact := range noisyExact {
+		if key == exact {
+			return true
+		}
+	}
+	return false
+}
+

--- a/pkg/networkoperatorplugin/networkoperator.go
+++ b/pkg/networkoperatorplugin/networkoperator.go
@@ -33,6 +33,8 @@ const (
 )
 
 type NetworkOperatorPlugin struct {
+	GroupFilter   string
+	LabelSelector map[string]string
 }
 
 func (p *NetworkOperatorPlugin) GetName() string {

--- a/pkg/networkoperatorplugin/ns-product-ids
+++ b/pkg/networkoperatorplugin/ns-product-ids
@@ -1,0 +1,30 @@
+# BlueField DPU Product IDs (NOT SuperNIC) — north-south traffic
+#
+# These are NVIDIA product codes for BlueField products classified as DPUs
+# (not SuperNICs). During discovery, devices whose partNumber matches any
+# product code or legacy product ID in this file have their PFs marked
+# as "north-south" traffic.
+#
+# Format: ProductCode | LegacyProductId | ProductName
+#
+# BlueField-4 DPU
+900-9D4B4-00CV-SA0 | 900-9D4B4-00CV-SA0 | NVIDIA BlueField-4 B4240L 800G Liquid Cooled
+900-9D4B4-00CV-AA0 | 900-9D4B4-00CAV-AA0 | NVIDIA BlueField-4 B4240 800G Air Cooled
+#
+# BlueField-3 B3210E DPU (E-Series FHHL, HDR100 IB)
+900-9D3B6-00CC-EA0 | 900-9D3B6-00CC-EA0 | BlueField-3 B3210E, Crypto
+900-9D3B6-005C-EA0 | 900-9D3B6-005C-EA0 | BlueField-3 B3210E, No crypto
+#
+# BlueField-3 B3220 P-Series DPU (FHHL)
+900-9D3B6-00CV-AA0 | 900-9D3B6-00CV-AA0 | NVIDIA BlueField-3 B3220 P-Series FHHL DPU
+#
+# BlueField-3 B3210L DPU
+900-9D3B4-005C-EA0 | 900-9D384-005C-EA0 | BlueField-3 B3210L, No Crypto
+900-9D3B4-00CC-EA0 | 900-9D384-00CC-EA0 | BlueField-3 B3210L, Crypto
+#
+# BlueField-3 B3240 DPU
+900-9D3B6-00CN-A80 | 900-9D3B6-00CN-A80 | BlueField-3 B3240, Crypto
+900-9D3B6-00CV-PA0 | 900-9D3B6-005V-PA0 | NVIDIA BlueField-3 B3240 cold aisle
+#
+# BlueField-3 B3220 DPU (non-SH, non-P-Series)
+900-9D3B6-005V-AA0 | 900-9D3B6-005V-AA0 | BlueField-3 B3220, No Crypto

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -48,43 +48,129 @@ var templateFuncs = template.FuncMap{
 		result = strings.ReplaceAll(result, "%rail%", fmt.Sprintf("%d", rail))
 		return result
 	},
+	// suffix prepends a "-" if the string is non-empty, producing a name suffix.
+	// e.g., suffix("group-0") → "-group-0", suffix("") → ""
+	"suffix": func(s string) string {
+		if s == "" {
+			return ""
+		}
+		return "-" + s
+	},
 }
 
-// ProcessTemplate processes a Go template file with the given config
-func ProcessTemplate(templatePath string, config *config.LaunchKubernetesConfig) (string, error) {
+// templateContext wraps the full config but presents a single ClusterConfig group.
+// The ClusterConfig field shadows the slice field in LaunchKubernetesConfig,
+// so templates can use .ClusterConfig.PFs, .ClusterConfig.NodeSelector, etc.
+type templateContext struct {
+	*config.LaunchKubernetesConfig
+	ClusterConfig *config.ClusterConfig
+}
+
+// ProcessTemplate processes a Go template file with the given config.
+// Returns a map of filename → rendered content. Templates that reference
+// .ClusterConfig are rendered once per group (producing separate files),
+// while other templates are rendered once.
+func ProcessTemplate(templatePath string, cfg *config.LaunchKubernetesConfig, groupFilter string) (map[string]string, error) {
 	// Read the template file
 	templateContent, err := os.ReadFile(templatePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to read template file %s: %w", templatePath, err)
+		return nil, fmt.Errorf("failed to read template file %s: %w", templatePath, err)
 	}
 
 	// Parse the template with helper functions
 	tmpl, err := template.New(filepath.Base(templatePath)).Funcs(templateFuncs).Parse(string(templateContent))
 	if err != nil {
-		return "", fmt.Errorf("failed to parse template %s: %w", templatePath, err)
+		return nil, fmt.Errorf("failed to parse template %s: %w", templatePath, err)
 	}
 
-	// Execute the template
-	var buf bytes.Buffer
-	err = tmpl.Execute(&buf, config)
-	if err != nil {
-		return "", fmt.Errorf("failed to execute template %s: %w", templatePath, err)
+	baseName := filepath.Base(templatePath)
+	usesClusterConfig := strings.Contains(string(templateContent), ".ClusterConfig")
+
+	if !usesClusterConfig || len(cfg.ClusterConfig) == 0 {
+		// Render once — no per-group variation
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, cfg); err != nil {
+			return nil, fmt.Errorf("failed to execute template %s: %w", templatePath, err)
+		}
+		return map[string]string{baseName: buf.String()}, nil
 	}
 
-	return buf.String(), nil
+	// Determine which groups to render
+	groups := cfg.ClusterConfig
+	singleGroupMode := false
+	if groupFilter != "" {
+		filtered := []config.ClusterConfig{}
+		for _, g := range groups {
+			if g.Identifier == groupFilter {
+				filtered = append(filtered, g)
+			}
+		}
+		if len(filtered) == 0 {
+			return nil, fmt.Errorf("group %q not found in ClusterConfig", groupFilter)
+		}
+		groups = filtered
+		singleGroupMode = true
+	}
+
+	// Render once per group → separate file per group
+	results := map[string]string{}
+	ext := filepath.Ext(baseName)
+	nameNoExt := strings.TrimSuffix(baseName, ext)
+
+	for i := range groups {
+		// When --group is used, clear the identifier so CR names and filenames
+		// don't carry the group suffix (only one group is being rendered).
+		renderGroup := groups[i]
+		if singleGroupMode {
+			renderGroup.Identifier = ""
+		}
+		// Filter out north-south PFs so templates only see east-west devices.
+		// This keeps indices sequential for naming (a, b, c, d instead of a, d, e, f).
+		renderGroup.PFs = filterEastWestPFs(renderGroup.PFs)
+		ctx := &templateContext{
+			LaunchKubernetesConfig: cfg,
+			ClusterConfig:          &renderGroup,
+		}
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, ctx); err != nil {
+			return nil, fmt.Errorf("failed to execute template %s for group %s: %w", templatePath, groups[i].Identifier, err)
+		}
+		id := renderGroup.Identifier
+		fileName := baseName
+		if id != "" {
+			fileName = fmt.Sprintf("%s-%s%s", nameNoExt, id, ext)
+		}
+		results[fileName] = buf.String()
+	}
+
+	return results, nil
 }
 
-// ProcessProfileTemplates processes all template files in a profile directory
-func (p *NetworkOperatorPlugin) GenerateProfileDeploymentFiles(profile *profiles.Profile, config *config.LaunchKubernetesConfig) (map[string]string, error) {
+// filterEastWestPFs returns only PFs with traffic == "east-west",
+// so that template indices stay sequential for naming (a, b, c, d).
+func filterEastWestPFs(pfs []config.PFConfig) []config.PFConfig {
+	var filtered []config.PFConfig
+	for _, pf := range pfs {
+		if pf.Traffic == "east-west" {
+			filtered = append(filtered, pf)
+		}
+	}
+	return filtered
+}
+
+// GenerateProfileDeploymentFiles processes all template files in a profile directory
+func (p *NetworkOperatorPlugin) GenerateProfileDeploymentFiles(profile *profiles.Profile, cfg *config.LaunchKubernetesConfig) (map[string]string, error) {
 	results := make(map[string]string)
 
 	for _, templatePath := range profile.Templates {
-		processed, err := ProcessTemplate(templatePath, config)
+		rendered, err := ProcessTemplate(templatePath, cfg, p.GroupFilter)
 		if err != nil {
 			return nil, fmt.Errorf("failed to process template %s: %w", templatePath, err)
 		}
 
-		results[filepath.Base(templatePath)] = processed
+		for filename, content := range rendered {
+			results[filename] = content
+		}
 	}
 
 	return results, nil

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -38,6 +38,8 @@ type Options struct {
 	MultiplaneMode      string // Spectrum-X multiplane mode (default: swplb)
 	NumberOfPlanes      int    // Number of planes for Spectrum-X (default: 4)
 	Prompt              string // Path to file with a prompt to use for LLM-assisted profile generation
+	Group               string // Generate templates for a specific group identifier only
+	LabelSelector       string // Filter nodes for discovery and manifests (e.g., "key1=val1,key2=val2")
 	SaveDeploymentFiles string // Directory to save generated files
 
 	LLMApiKey      string // API key for the LLM API

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -42,8 +42,7 @@ type Plugin interface {
 	BuildProfileFromLLMResponse(llmResponse map[string]string, profile *config.Profile) error
 	// GetSystemPromptAddendum returns the addendum to the system prompt, specific to the plugin. The addendum will be used to add additional context to the system prompt.
 	GetSystemPromptAddendum() (string, error)
-	// DiscoverClusterConfig discovers the plugin-specific part of the cluster configuration and adds it to the given LaunchKubernetesConfig.
-	// Should not reassign defaultConfig.ClusterConfig, only edit it.
+	// DiscoverClusterConfig discovers the plugin-specific part of the cluster configuration and populates defaultConfig.ClusterConfig.
 	DiscoverClusterConfig(ctx context.Context, kubeClient client.Client, defaultConfig *config.LaunchKubernetesConfig) error
 	// GenerateProfileDeploymentFiles generates the deployment files for the profile.
 	GenerateProfileDeploymentFiles(profile *profiles.Profile, config *config.LaunchKubernetesConfig) (map[string]string, error)

--- a/profiles/host-device-rdma/40-pod.yaml
+++ b/profiles/host-device-rdma/40-pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: hostdev-test-pod
+  name: hostdev-test-pod{{suffix .ClusterConfig.Identifier}}
   namespace: default
   annotations:
     k8s.v1.cni.cncf.io/networks: {{.Hostdev.NetworkName}}

--- a/profiles/ipoib-rdma-shared/40-pod.yaml
+++ b/profiles/ipoib-rdma-shared/40-pod.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: ipoib-test-pod-{{printf "%c" (add 97 $i)}}
+  name: ipoib-test-pod-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
   namespace: default
   annotations:
     k8s.v1.cni.cncf.io/networks: {{$.Ipoib.NetworkName}}-{{printf "%c" (add 97 $i)}}
@@ -47,7 +47,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: ipoib-test-pod
+  name: ipoib-test-pod{{suffix $.ClusterConfig.Identifier}}
   annotations:
     k8s.v1.cni.cncf.io/networks: {{.Ipoib.NetworkName}}
 spec:

--- a/profiles/macvlan-rdma-shared/40-pod.yaml
+++ b/profiles/macvlan-rdma-shared/40-pod.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: macvlan-test-pod-{{printf "%c" (add 97 $i)}}
+  name: macvlan-test-pod-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
   namespace: default
   annotations:
     k8s.v1.cni.cncf.io/networks: {{$.Macvlan.NetworkName}}-{{printf "%c" (add 97 $i)}}
@@ -47,7 +47,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: macvlan-test-pod
+  name: macvlan-test-pod{{suffix $.ClusterConfig.Identifier}}
   namespace: default
   annotations:
     k8s.v1.cni.cncf.io/networks: {{.Macvlan.NetworkName}}

--- a/profiles/spectrum-x/30-nicconfigurationtemplate.yaml
+++ b/profiles/spectrum-x/30-nicconfigurationtemplate.yaml
@@ -1,7 +1,7 @@
 apiVersion: configuration.net.nvidia.com/v1alpha1
 kind: NicConfigurationTemplate
 metadata:
-  name: spectrum-x-configuration
+  name: spectrum-x-configuration{{suffix .ClusterConfig.Identifier}}
   namespace: {{.NetworkOperator.Namespace}}
 spec:
   {{- if .ClusterConfig.NodeSelector }}

--- a/profiles/spectrum-x/50-sriovnetworknodepolicy.yaml
+++ b/profiles/spectrum-x/50-sriovnetworknodepolicy.yaml
@@ -4,7 +4,7 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: rail-{{$i}}
+  name: rail-{{$i}}{{suffix $.ClusterConfig.Identifier}}
   namespace: {{$.NetworkOperator.Namespace}}
 spec:
   bridge:

--- a/profiles/spectrum-x/90-pod.yaml
+++ b/profiles/spectrum-x/90-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: spectrum-x-multirail-test-pod
+  name: spectrum-x-multirail-test-pod{{suffix .ClusterConfig.Identifier}}
   namespace: default
   annotations:
     k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}rail-{{$i}}{{- end}}{{- end}}

--- a/profiles/sriov-ethernet-rdma/30-sriovnetworknodepolicy.yaml
+++ b/profiles/sriov-ethernet-rdma/30-sriovnetworknodepolicy.yaml
@@ -5,7 +5,7 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: ethernet-sriov-{{printf "%c" (add 97 $i)}}
+  name: ethernet-sriov-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
   namespace: {{$.NetworkOperator.Namespace}}
 spec:
   deviceType: netdevice
@@ -32,7 +32,7 @@ spec:
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: ethernet-sriov
+  name: ethernet-sriov{{suffix $.ClusterConfig.Identifier}}
   namespace: {{.NetworkOperator.Namespace}}
 spec:
   deviceType: netdevice

--- a/profiles/sriov-ethernet-rdma/40-sriovnetwork.yaml
+++ b/profiles/sriov-ethernet-rdma/40-sriovnetwork.yaml
@@ -5,7 +5,7 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: {{$.Sriov.NetworkName}}-{{printf "%c" (add 97 $i)}}
+  name: {{$.Sriov.NetworkName}}-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
   namespace: {{$.NetworkOperator.Namespace}}
 spec:
   ipam: |
@@ -22,7 +22,7 @@ spec:
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: {{.Sriov.NetworkName}}
+  name: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}
   namespace: {{.NetworkOperator.Namespace}}
 spec:
   ipam: |

--- a/profiles/sriov-ethernet-rdma/50-pod.yaml
+++ b/profiles/sriov-ethernet-rdma/50-pod.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: sriov-test-pod-{{printf "%c" (add 97 $i)}}
+  name: sriov-test-pod-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
   namespace: default
   annotations:
     k8s.v1.cni.cncf.io/networks: {{$.Sriov.NetworkName}}-{{printf "%c" (add 97 $i)}}
@@ -46,7 +46,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: sriov-test-pod
+  name: sriov-test-pod{{suffix $.ClusterConfig.Identifier}}
   namespace: default
   annotations:
     k8s.v1.cni.cncf.io/networks: {{.Sriov.NetworkName}}

--- a/profiles/sriov-ib-rdma/30-sriovnetworknodepolicy.yaml
+++ b/profiles/sriov-ib-rdma/30-sriovnetworknodepolicy.yaml
@@ -5,7 +5,7 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: infiniband-sriov-{{printf "%c" (add 97 $i)}}
+  name: infiniband-sriov-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
   namespace: {{$.NetworkOperator.Namespace}}
 spec:
   deviceType: netdevice
@@ -32,7 +32,7 @@ spec:
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: infiniband-sriov
+  name: infiniband-sriov{{suffix $.ClusterConfig.Identifier}}
   namespace: {{.NetworkOperator.Namespace}}
 spec:
   deviceType: netdevice

--- a/profiles/sriov-ib-rdma/50-pod.yaml
+++ b/profiles/sriov-ib-rdma/50-pod.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: sriov-ib-test-pod-{{printf "%c" (add 97 $i)}}
+  name: sriov-ib-test-pod-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
   annotations:
     k8s.v1.cni.cncf.io/networks: {{$.Sriov.NetworkName}}-{{printf "%c" (add 97 $i)}}
 spec:
@@ -45,7 +45,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: sriov-ib-test-pod
+  name: sriov-ib-test-pod{{suffix $.ClusterConfig.Identifier}}
   annotations:
     k8s.v1.cni.cncf.io/networks: {{.Sriov.NetworkName}}
 spec:


### PR DESCRIPTION
`clusterConfig` is now an array of node groups, each with its own PFs, nodeSelector, and capabilities. During discovery, nodes are grouped by PF fingerprint (deviceID + PCI address), and nodeSelectors are auto-computed from discriminating node labels.

BlueField DPU devices are identified via an embedded product-ID list (ns-product-ids) and marked as north-south traffic. North-south PFs are filtered out during template rendering to keep resource naming sequential.

New CLI flags: --group (render single group), --label-selector (filter discovery nodes). Templates produce separate files per group with unique CR names via the {{suffix}} function.