### PR TITLE
Use rail-based naming for multirail resources instead of letter suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,61 +256,73 @@ clusterConfig:
     pciAddress: "0000:19:00.0"
     networkInterface: ""
     traffic: east-west
+    rail: 0
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:2a:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 1
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:3b:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 2
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:4c:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 3
   - deviceID: 101f
     rdmaDevice: ""
     pciAddress: 0000:5a:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 4
   - deviceID: 101f
     rdmaDevice: ""
     pciAddress: 0000:5a:00.1
     networkInterface: ""
     traffic: east-west
+    rail: 5
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:9b:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 6
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:ab:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 7
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:c1:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 8
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:cb:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 9
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:d8:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 10
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:d8:00.1
     networkInterface: ""
     traffic: east-west
+    rail: 11
   workerNodes:
   - pdx-g22r13-2894-lh2-w01
   - pdx-g24r13-2894-lh2-w02
@@ -328,51 +340,61 @@ clusterConfig:
     pciAddress: 0000:1a:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 0
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:3c:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 1
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:4d:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 2
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:5e:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 3
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:9c:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 4
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:9d:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 5
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:9d:00.1
     networkInterface: ""
     traffic: east-west
+    rail: 6
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:bc:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 7
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:cc:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 8
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:dc:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 9
   workerNodes:
   - pdx-g22r23-2894-dh2-w03
   - pdx-g24r23-2894-dh2-w04
@@ -390,51 +412,61 @@ clusterConfig:
     pciAddress: "0000:09:00.0"
     networkInterface: ""
     traffic: east-west
+    rail: 0
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: "0000:23:00.0"
     networkInterface: ""
     traffic: east-west
+    rail: 1
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: "0000:35:00.0"
     networkInterface: ""
     traffic: east-west
+    rail: 2
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: "0000:35:00.1"
     networkInterface: ""
     traffic: east-west
+    rail: 3
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: "0000:53:00.0"
     networkInterface: ""
     traffic: east-west
+    rail: 4
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:69:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 5
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:8f:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 6
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:9c:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 7
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:cd:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 8
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:f1:00.0
     networkInterface: ""
     traffic: east-west
+    rail: 9
   workerNodes:
   - pdx-g22r31-2894-ch2-w05
   - pdx-g24r31-2894-ch2-w06
@@ -446,7 +478,7 @@ clusterConfig:
 
 During cluster discovery, the tool automatically identifies BlueField DPU devices (as opposed to SuperNICs or ConnectX NICs) by matching each device's `partNumber` against a known list of DPU product codes in [pkg/networkoperatorplugin/ns-product-ids](pkg/networkoperatorplugin/ns-product-ids). Devices matching a DPU product code are classified as **north-south** traffic (management/external), while all other devices are classified as **east-west** traffic (GPU interconnect).
 
-North-south PFs are included in the saved cluster configuration for visibility, but are **automatically filtered out** during template rendering so that only east-west PFs appear in the generated manifests. This ensures sequential naming (a, b, c, d) for resources like SriovNetworkNodePolicy and IPPool entries.
+North-south PFs are included in the saved cluster configuration for visibility, but are **automatically filtered out** during template rendering so that only east-west PFs appear in the generated manifests. Each east-west PF is assigned a sequential rail number (rail-0, rail-1, rail-2, ...) used for naming resources like SriovNetworkNodePolicy and IPPool entries.
 
 Example of mixed traffic types in the config:
 ```yaml
@@ -456,9 +488,11 @@ clusterConfig:
   - deviceID: a2dc
     pciAddress: "0000:19:00.0"
     traffic: east-west       # SuperNIC — included in manifests
+    rail: 0
   - deviceID: a2dc
     pciAddress: "0000:2a:00.0"
     traffic: east-west
+    rail: 1
   - deviceID: a2dc
     pciAddress: "0000:3b:00.0"
     traffic: north-south     # BlueField DPU — excluded from manifests

--- a/l8k-config.yaml
+++ b/l8k-config.yaml
@@ -44,14 +44,14 @@ hostdev:
   networkName: hostdev-network
 
 rdmaShared:
-  resourceName: rdma_shared_resource # with multiple pools, _a, _b, _c, prefixes are added to the resource name
+  resourceName: rdma_shared_resource # with multiple pools, _rail_0, _rail_1, etc. suffixes are added to the resource name
   hcaMax: 63
 
 ipoib:
-  networkName: ipoib-network # with multiple networks, -a, -b, -c, prefixes are added to the network name
+  networkName: ipoib-network # with multiple networks, -rail-0, -rail-1, etc. suffixes are added to the network name
 
 macvlan:
-  networkName: macvlan-network # with multiple networks, -a, -b, -c, prefixes are added to the network name
+  networkName: macvlan-network # with multiple networks, -rail-0, -rail-1, etc. suffixes are added to the network name
 
 spectrumX:
   nicType: "1023" # "1023" for ConnectX-8, "a2dc" for BlueField-3 SuperNIC
@@ -83,21 +83,25 @@ clusterConfig:
         rdmaDevice: "mlx5_0"
         networkInterface: "net1"
         traffic: east-west
+        rail: 0
       - deviceID: 1023
         pciAddress: 0000:75:00.0
         rdmaDevice: "mlx5_1"
         networkInterface: "net2"
         traffic: east-west
+        rail: 1
       - deviceID: 1023
         pciAddress: 0000:85:00.0
         rdmaDevice: "mlx5_2"
         networkInterface: "net3"
         traffic: east-west
+        rail: 2
       - deviceID: 1023
         pciAddress: 0000:f5:00.0
         rdmaDevice: "mlx5_3"
         networkInterface: "net4"
         traffic: east-west
+        rail: 3
       - deviceID: 1023
         pciAddress: 0000:6a:00.0
         rdmaDevice: "mlx5_4"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,6 +138,7 @@ type PFConfig struct {
 	PciAddress       string `yaml:"pciAddress"`
 	NetworkInterface string `yaml:"networkInterface"`
 	Traffic          string `yaml:"traffic"`
+	Rail             *int   `yaml:"rail,omitempty"`
 }
 
 // AggregateCapabilities computes the union of capabilities across all cluster config groups.

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -483,6 +483,16 @@ func buildClusterConfig(devices []nicop.NicDevice, nodeLabels map[string]map[str
 			return strings.Compare(a.PciAddress, b.PciAddress)
 		})
 
+		// Assign rail numbers sequentially to east-west PFs only (north-south are skipped).
+		railIndex := 0
+		for j := range pfs {
+			if pfs[j].Traffic == "east-west" {
+				r := railIndex
+				pfs[j].Rail = &r
+				railIndex++
+			}
+		}
+
 		slices.Sort(g.nodes)
 
 		// Extract machine/product type from common node labels

--- a/profiles/ipoib-rdma-shared/10-nicclusterpolicy.yaml
+++ b/profiles/ipoib-rdma-shared/10-nicclusterpolicy.yaml
@@ -42,7 +42,7 @@ spec:
           {{- range $i, $pf := .ClusterConfig.PFs}}
           {{- if eq $pf.Traffic "east-west"}}
           {
-            "resourceName": "{{$.RdmaShared.ResourceName}}_{{printf "%c" (add 97 $i)}}",
+            "resourceName": "{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}",
             "rdmaHcaMax": {{$.RdmaShared.HcaMax}},
             "selectors": {
               "ifNames": ["{{$pf.NetworkInterface}}"]

--- a/profiles/ipoib-rdma-shared/20-ippool.yaml
+++ b/profiles/ipoib-rdma-shared/20-ippool.yaml
@@ -5,7 +5,7 @@
 apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
-  name: {{$.NvIpam.PoolName}}-{{printf "%c" (add 97 $i)}}
+  name: {{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}
   namespace: {{$.NetworkOperator.Namespace}}
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}

--- a/profiles/ipoib-rdma-shared/30-ipoibnetwork.yaml
+++ b/profiles/ipoib-rdma-shared/30-ipoibnetwork.yaml
@@ -5,14 +5,14 @@
 apiVersion: mellanox.com/v1alpha1
 kind: IPoIBNetwork
 metadata:
-  name: {{$.Ipoib.NetworkName}}-{{printf "%c" (add 97 $i)}}
+  name: {{$.Ipoib.NetworkName}}-rail-{{$pf.Rail}}
 spec:
   networkNamespace: "default"
   master: "{{$pf.NetworkInterface}}"
   ipam: |
     {
       "type": "nv-ipam",
-      "poolName": "{{$.NvIpam.PoolName}}-{{printf "%c" (add 97 $i)}}"
+      "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}"
     }  
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end}}

--- a/profiles/ipoib-rdma-shared/40-pod.yaml
+++ b/profiles/ipoib-rdma-shared/40-pod.yaml
@@ -5,10 +5,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: ipoib-test-pod-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
+  name: ipoib-test-pod-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
   namespace: default
   annotations:
-    k8s.v1.cni.cncf.io/networks: {{$.Ipoib.NetworkName}}-{{printf "%c" (add 97 $i)}}
+    k8s.v1.cni.cncf.io/networks: {{$.Ipoib.NetworkName}}-rail-{{$pf.Rail}}
 spec:
   {{- if $.ClusterConfig.NodeSelector }}
   affinity:
@@ -36,9 +36,9 @@ spec:
         add: ["IPC_LOCK"]
     resources:
       requests:
-        rdma/{{$.RdmaShared.ResourceName}}-{{printf "%c" (add 97 $i)}}: 1
+        rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
       limits:
-        rdma/{{$.RdmaShared.ResourceName}}-{{printf "%c" (add 97 $i)}}: 1
+        rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{end}}
 {{- end}}

--- a/profiles/macvlan-rdma-shared/10-nicclusterpolicy.yaml
+++ b/profiles/macvlan-rdma-shared/10-nicclusterpolicy.yaml
@@ -41,7 +41,7 @@ spec:
           {{- range $i, $pf := .ClusterConfig.PFs}}
           {{- if eq $pf.Traffic "east-west"}}
           {
-            "resourceName": "{{$.RdmaShared.ResourceName}}_{{printf "%c" (add 97 $i)}}",
+            "resourceName": "{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}",
             "rdmaHcaMax": {{$.RdmaShared.HcaMax}},
             "selectors": {
               "ifNames": ["{{$pf.NetworkInterface}}"]

--- a/profiles/macvlan-rdma-shared/20-ippool.yaml
+++ b/profiles/macvlan-rdma-shared/20-ippool.yaml
@@ -5,7 +5,7 @@
 apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
-  name: {{$.NvIpam.PoolName}}-{{printf "%c" (add 97 $i)}}
+  name: {{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}
   namespace: {{$.NetworkOperator.Namespace}}
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}

--- a/profiles/macvlan-rdma-shared/30-macvlannetwork.yaml
+++ b/profiles/macvlan-rdma-shared/30-macvlannetwork.yaml
@@ -5,7 +5,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: MacvlanNetwork
 metadata:
-  name: {{$.Macvlan.NetworkName}}-{{printf "%c" (add 97 $i)}}
+  name: {{$.Macvlan.NetworkName}}-rail-{{$pf.Rail}}
 spec:
   networkNamespace: "default"
   master: "{{$pf.NetworkInterface}}"
@@ -14,7 +14,7 @@ spec:
   ipam: |
     {
       "type": "nv-ipam",
-      "poolName": "{{$.NvIpam.PoolName}}-{{printf "%c" (add 97 $i)}}"
+      "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}"
     }
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end}}
 {{- end}}

--- a/profiles/macvlan-rdma-shared/40-pod.yaml
+++ b/profiles/macvlan-rdma-shared/40-pod.yaml
@@ -5,10 +5,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: macvlan-test-pod-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
+  name: macvlan-test-pod-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
   namespace: default
   annotations:
-    k8s.v1.cni.cncf.io/networks: {{$.Macvlan.NetworkName}}-{{printf "%c" (add 97 $i)}}
+    k8s.v1.cni.cncf.io/networks: {{$.Macvlan.NetworkName}}-rail-{{$pf.Rail}}
 spec:
   {{- if $.ClusterConfig.NodeSelector }}
   affinity:
@@ -36,9 +36,9 @@ spec:
         add: ["IPC_LOCK"]
     resources:
       requests:
-        rdma/{{$.RdmaShared.ResourceName}}_{{printf "%c" (add 97 $i)}}: 1
+        rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
       limits:
-        rdma/{{$.RdmaShared.ResourceName}}_{{printf "%c" (add 97 $i)}}: 1
+        rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{end}}
 {{- end}}

--- a/profiles/sriov-ethernet-rdma/20-ippool.yaml
+++ b/profiles/sriov-ethernet-rdma/20-ippool.yaml
@@ -5,7 +5,7 @@
 apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
-  name: {{$.NvIpam.PoolName}}-{{printf "%c" (add 97 $i)}}
+  name: {{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}
   namespace: {{$.NetworkOperator.Namespace}}
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}

--- a/profiles/sriov-ethernet-rdma/30-sriovnetworknodepolicy.yaml
+++ b/profiles/sriov-ethernet-rdma/30-sriovnetworknodepolicy.yaml
@@ -5,7 +5,7 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: ethernet-sriov-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
+  name: ethernet-sriov-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
   namespace: {{$.NetworkOperator.Namespace}}
 spec:
   deviceType: netdevice
@@ -24,7 +24,7 @@ spec:
   linkType: Ethernet
   numVfs: {{$.Sriov.NumVfs}}
   priority: {{$.Sriov.Priority}}
-  resourceName: {{$.Sriov.ResourceName}}-{{printf "%c" (add 97 $i)}}
+  resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
 {{- end -}}

--- a/profiles/sriov-ethernet-rdma/40-sriovnetwork.yaml
+++ b/profiles/sriov-ethernet-rdma/40-sriovnetwork.yaml
@@ -5,16 +5,16 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: {{$.Sriov.NetworkName}}-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
+  name: {{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
   namespace: {{$.NetworkOperator.Namespace}}
 spec:
   ipam: |
     {
       "type": "nv-ipam",
-      "poolName": "{{$.NvIpam.PoolName}}-{{printf "%c" (add 97 $i)}}"
+      "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}"
     }
   networkNamespace: default
-  resourceName: {{$.Sriov.ResourceName}}-{{printf "%c" (add 97 $i)}}
+  resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
 {{- end -}}

--- a/profiles/sriov-ethernet-rdma/50-pod.yaml
+++ b/profiles/sriov-ethernet-rdma/50-pod.yaml
@@ -5,10 +5,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: sriov-test-pod-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
+  name: sriov-test-pod-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
   namespace: default
   annotations:
-    k8s.v1.cni.cncf.io/networks: {{$.Sriov.NetworkName}}-{{printf "%c" (add 97 $i)}}
+    k8s.v1.cni.cncf.io/networks: {{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}
 spec:
   {{- if $.ClusterConfig.NodeSelector }}
   affinity:
@@ -36,9 +36,9 @@ spec:
         add: ["IPC_LOCK"]
     resources:
       requests:
-        nvidia.com/{{$.Sriov.ResourceName}}-{{printf "%c" (add 97 $i)}}: '1'
+        nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
       limits:
-        nvidia.com/{{$.Sriov.ResourceName}}-{{printf "%c" (add 97 $i)}}: '1'
+        nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
 {{- end -}}

--- a/profiles/sriov-ib-rdma/20-ippool.yaml
+++ b/profiles/sriov-ib-rdma/20-ippool.yaml
@@ -5,7 +5,7 @@
 apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
-  name: {{$.NvIpam.PoolName}}-{{printf "%c" (add 97 $i)}}
+  name: {{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}
   namespace: {{$.NetworkOperator.Namespace}}
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}

--- a/profiles/sriov-ib-rdma/30-sriovnetworknodepolicy.yaml
+++ b/profiles/sriov-ib-rdma/30-sriovnetworknodepolicy.yaml
@@ -5,7 +5,7 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: infiniband-sriov-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
+  name: infiniband-sriov-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
   namespace: {{$.NetworkOperator.Namespace}}
 spec:
   deviceType: netdevice
@@ -24,7 +24,7 @@ spec:
   isRdma: true
   numVfs: {{$.Sriov.NumVfs}}
   priority: {{$.Sriov.Priority}}
-  resourceName: {{$.Sriov.ResourceName}}-{{printf "%c" (add 97 $i)}}
+  resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
 {{- end -}}

--- a/profiles/sriov-ib-rdma/40-sriovibnetwork.yaml
+++ b/profiles/sriov-ib-rdma/40-sriovibnetwork.yaml
@@ -5,15 +5,15 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovIBNetwork
 metadata:
-  name: {{$.Sriov.NetworkName}}-{{printf "%c" (add 97 $i)}}
+  name: {{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}
   namespace: {{$.NetworkOperator.Namespace}}
 spec:
   ipam: |
     {
       "type": "nv-ipam",
-      "poolName": "{{$.NvIpam.PoolName}}-{{printf "%c" (add 97 $i)}}"
+      "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}"
     }
-  resourceName: {{$.Sriov.ResourceName}}-{{printf "%c" (add 97 $i)}}
+  resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}
   linkState: enable
   networkNamespace: default
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}

--- a/profiles/sriov-ib-rdma/50-pod.yaml
+++ b/profiles/sriov-ib-rdma/50-pod.yaml
@@ -5,9 +5,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: sriov-ib-test-pod-{{printf "%c" (add 97 $i)}}{{suffix $.ClusterConfig.Identifier}}
+  name: sriov-ib-test-pod-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
   annotations:
-    k8s.v1.cni.cncf.io/networks: {{$.Sriov.NetworkName}}-{{printf "%c" (add 97 $i)}}
+    k8s.v1.cni.cncf.io/networks: {{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}
 spec:
   {{- if $.ClusterConfig.NodeSelector }}
   affinity:
@@ -35,9 +35,9 @@ spec:
         add: ["IPC_LOCK"]
     resources:
       requests:
-        nvidia.com/{{$.Sriov.ResourceName}}-{{printf "%c" (add 97 $i)}}: '1'
+        nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
       limits:
-        nvidia.com/{{$.Sriov.ResourceName}}-{{printf "%c" (add 97 $i)}}: '1'
+        nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end}}
 {{- end}}


### PR DESCRIPTION
Replace letter-based suffixes (a, b, c) with explicit rail numbers (rail-0, rail-1, rail-2) for all multirail resource naming. Rail numbers are assigned sequentially to east-west PFs during discovery; north-south PFs are skipped and omit the field entirely (Rail is *int, omitempty).

This makes resource names deterministic regardless of PF ordering and clearly communicates the rail topology in generated manifests.