### PR TITLE
Allow --user-config during discovery to supply base config

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ Flags:
       --network-operator-namespace string Override the network operator namespace from the config file
       --number-of-planes int              Number of planes for Spectrum-X (requires --spectrum-x)
       --prompt string                     Path to file with a prompt to use for LLM-assisted profile generation
-      --save-cluster-config string        Save discovered cluster configuration to the specified path (default "/opt/nvidia/k8s-launch-kit/cluster-config.yaml")
+      --save-cluster-config string        Save discovered cluster configuration to the specified path (defaults to --user-config path if set, otherwise /opt/nvidia/k8s-launch-kit/cluster-config.yaml)
       --save-deployment-files string      Save generated deployment files to the specified directory (default "/opt/nvidia/k8s-launch-kit/deployment")
       --spcx-version string               Spectrum-X firmware version (requires --spectrum-x)
       --spectrum-x                        Enable Spectrum X deployment
-      --user-config string                Use provided cluster configuration file instead of auto-discovery (skips cluster discovery)
+      --user-config string                Use provided cluster configuration file (as base config for discovery or as full config without discovery)
 
 Use "l8k [command] --help" for more information about a command.
 ```
@@ -126,6 +126,23 @@ Filter discovery to specific nodes using a label selector:
 ```bash
 l8k --discover-cluster-config --save-cluster-config ./my-cluster-config.yaml \
     --label-selector "feature.node.kubernetes.io/pci-15b3.present=true" \
+    --kubeconfig ~/.kube/config
+```
+
+### Discovery with User-Provided Base Config
+
+Use your own config file (with custom network operator version, subnets, etc.) as the base for discovery. Without `--save-cluster-config`, the file is rewritten in place with discovery results:
+
+```bash
+l8k --user-config ./my-config.yaml --discover-cluster-config \
+    --kubeconfig ~/.kube/config
+```
+
+Save discovery results to a separate file instead:
+
+```bash
+l8k --user-config ./my-config.yaml --discover-cluster-config \
+    --save-cluster-config ./discovered-config.yaml \
     --kubeconfig ~/.kube/config
 ```
 
@@ -169,7 +186,7 @@ l8k --user-config ./config.yaml \
 
 ## Configuration file
 
-During cluster discovery stage, Kubernetes Launch Kit creates a configuration file, which it later uses to generate deployment manifests from the templates. This config file can be edited by the user to customize their deployment configuration. The user can provide the custom config file to the tool using the `--user-config` cli flag.
+During cluster discovery stage, Kubernetes Launch Kit creates a configuration file, which it later uses to generate deployment manifests from the templates. This config file can be edited by the user to customize their deployment configuration. The user can provide the custom config file to the tool using the `--user-config` cli flag — either as a standalone config (skipping discovery) or as a base config combined with `--discover-cluster-config` (discovery takes network operator parameters from the file and adds discovered cluster config).
 
 Example of the configuration file discovered from the cluster:
 

--- a/pkg/app/launcher.go
+++ b/pkg/app/launcher.go
@@ -280,21 +280,18 @@ func (l *Launcher) executeWorkflow() error {
 
 // discoverClusterConfig handles cluster configuration discovery
 func (l *Launcher) discoverClusterConfig() error {
-	if l.options.UserConfig != "" {
-		l.ui.Info("Using provided configuration: %s", l.options.UserConfig)
-		l.logger.Info("Using provided user config", "path", l.options.UserConfig)
-		// TODO: Validate and load user config file
-		return nil
-	}
-
 	l.ui.Info("Discovering cluster capabilities")
 	l.logger.Info("Discovering cluster configuration")
 
-	// Load defaults from l8k-config.yaml (temporary default path)
+	// Load base config: from --user-config if provided, otherwise from built-in defaults
 	defaultsPath := "l8k-config.yaml"
+	if l.options.UserConfig != "" {
+		defaultsPath = l.options.UserConfig
+		l.ui.Info("Using base configuration: %s", defaultsPath)
+	}
 	defaults, err := config.LoadFullConfig(defaultsPath, l.logger)
 	if err != nil {
-		return fmt.Errorf("failed to load default config from %s: %w", defaultsPath, err)
+		return fmt.Errorf("failed to load base config from %s: %w", defaultsPath, err)
 	}
 
 	// Override namespace from CLI flag if provided
@@ -317,26 +314,35 @@ func (l *Launcher) discoverClusterConfig() error {
 
 	discoveredConfig := *defaults
 
-	// Ensure output path provided
-	if l.options.SaveClusterConfig == "" {
-		return fmt.Errorf("no output path provided for discovered cluster config (use --discover-cluster-config)")
+	// Compute effective save path:
+	// 1. --save-cluster-config if explicitly provided
+	// 2. --user-config path (rewrite in place) if provided
+	// 3. Default path as fallback
+	savePath := l.options.SaveClusterConfig
+	if savePath == "" {
+		if l.options.UserConfig != "" {
+			savePath = l.options.UserConfig
+		} else {
+			savePath = "/opt/nvidia/k8s-launch-kit/cluster-config.yaml"
+		}
 	}
+	l.options.SaveClusterConfig = savePath
 
 	// Marshal and save merged config to disk
 	data, err := yaml.Marshal(discoveredConfig)
 	if err != nil {
 		return fmt.Errorf("failed to marshal discovered config: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(l.options.SaveClusterConfig), 0755); err != nil {
-		return fmt.Errorf("failed to create output directory %s: %w", filepath.Dir(l.options.SaveClusterConfig), err)
+	if err := os.MkdirAll(filepath.Dir(savePath), 0755); err != nil {
+		return fmt.Errorf("failed to create output directory %s: %w", filepath.Dir(savePath), err)
 	}
-	if err := os.WriteFile(l.options.SaveClusterConfig, data, 0644); err != nil {
+	if err := os.WriteFile(savePath, data, 0644); err != nil {
 		l.ui.Error("Failed to save configuration: %v", err)
-		return fmt.Errorf("failed to write discovered config to %s: %w", l.options.SaveClusterConfig, err)
+		return fmt.Errorf("failed to write discovered config to %s: %w", savePath, err)
 	}
 
-	l.ui.Success("Configuration saved: %s", l.options.SaveClusterConfig)
-	l.logger.Info("Discovered cluster config saved", "path", l.options.SaveClusterConfig)
+	l.ui.Success("Configuration saved: %s", savePath)
+	l.logger.Info("Discovered cluster config saved", "path", savePath)
 	return nil
 }
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -156,8 +156,8 @@ func init() {
 
 	// Phase 1: Cluster discovery flags
 	rootCmd.Flags().BoolVar(&discoverClusterConfig, "discover-cluster-config", false, "Deploy a thin Network Operator profile to discover cluster capabilities")
-	rootCmd.Flags().StringVar(&saveClusterConfig, "save-cluster-config", "/opt/nvidia/k8s-launch-kit/cluster-config.yaml", "Save discovered cluster configuration to the specified path")
-	rootCmd.Flags().StringVar(&userConfig, "user-config", "", "Use provided cluster configuration file instead of auto-discovery (skips cluster discovery)")
+	rootCmd.Flags().StringVar(&saveClusterConfig, "save-cluster-config", "", "Save discovered cluster configuration to the specified path (defaults to --user-config path if set, otherwise /opt/nvidia/k8s-launch-kit/cluster-config.yaml)")
+	rootCmd.Flags().StringVar(&userConfig, "user-config", "", "Use provided cluster configuration file (as base config for discovery or as full config without discovery)")
 	rootCmd.Flags().StringVar(&networkOperatorNamespace, "network-operator-namespace", "", "Override the network operator namespace from the config file")
 
 	// Phase 2: Deployment generation flags
@@ -195,14 +195,9 @@ func validateConfig(options options.Options) error {
 		return fmt.Errorf("no plugins enabled, use --enabled-plugins to enable plugins")
 	}
 
-	// Either user-config or discover-cluster-config should be provided
+	// At least one of user-config or discover-cluster-config should be provided
 	if options.UserConfig == "" && !options.DiscoverClusterConfig {
 		return fmt.Errorf("either --user-config or --discover-cluster-config must be provided")
-	}
-
-	// Both user-config and discover-cluster-config cannot be provided together
-	if options.UserConfig != "" && options.DiscoverClusterConfig {
-		return fmt.Errorf("--user-config and --discover-cluster-config cannot be used together")
 	}
 
 	// If discover-cluster-config is provided, kubeconfig should be too


### PR DESCRIPTION
When --user-config is combined with --discover-cluster-config, the user config provides network operator parameters (version, namespace, etc.) as the base for discovery instead of the built-in l8k-config.yaml.

Save path priority: --save-cluster-config if set, otherwise the --user-config path is rewritten in place, otherwise the default path.