### PR TITLE
Skip empty template output when guard condition is false

### DIFF
--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -138,6 +138,10 @@ func ProcessTemplate(templatePath string, cfg *config.LaunchKubernetesConfig, gr
 		if err := tmpl.Execute(&buf, cfg); err != nil {
 			return nil, fmt.Errorf("failed to execute template %s: %w", templatePath, err)
 		}
+		// Skip empty output (e.g., template guarded by a false condition)
+		if strings.TrimSpace(buf.String()) == "" {
+			return map[string]string{}, nil
+		}
 		return map[string]string{baseName: buf.String()}, nil
 	}
 
@@ -254,7 +258,10 @@ func ProcessTemplate(templatePath string, cfg *config.LaunchKubernetesConfig, gr
 		if id != "" {
 			fileName = fmt.Sprintf("%s-%s%s", nameNoExt, id, ext)
 		}
-		results[fileName] = buf.String()
+		// Skip empty output (e.g., template guarded by a false condition)
+		if strings.TrimSpace(buf.String()) != "" {
+			results[fileName] = buf.String()
+		}
 	}
 
 	return results, nil

--- a/profiles/ipoib-rdma-shared/35-nicinterfacenametemplate.yaml
+++ b/profiles/ipoib-rdma-shared/35-nicinterfacenametemplate.yaml
@@ -1,0 +1,18 @@
+{{- if and .NicConfigurationOperator .NicConfigurationOperator.DeployNicInterfaceNameTemplate .Profile.Multirail -}}
+apiVersion: configuration.net.nvidia.com/v1alpha1
+kind: NicInterfaceNameTemplate
+metadata:
+  name: nic-rename{{suffix .ClusterConfig.Identifier}}
+  namespace: {{.NetworkOperator.Namespace}}
+spec:
+  {{- if .ClusterConfig.NodeSelector }}
+  nodeSelector:
+    {{- range $key, $value := .ClusterConfig.NodeSelector }}
+    {{ $key }}: "{{ $value }}"
+    {{- end }}
+  {{- end }}
+  rdmaDevicePrefix: "{{.NicConfigurationOperator.RdmaPrefix}}"
+  netDevicePrefix: "{{.NicConfigurationOperator.NetdevPrefix}}"
+  pfsPerNic: {{pfsPerNic .ClusterConfig.PFs}}
+  railPciAddresses: [{{- $first := true }}{{- range $railIdx, $rail := .ClusterConfig.PFs }}{{- if eq $rail.Traffic "east-west" }}{{- if not $first }}, {{end}}{{- $first = false }}["{{$rail.PciAddress}}"]{{- end }}{{- end }}]
+{{- end }}

--- a/profiles/macvlan-rdma-shared/35-nicinterfacenametemplate.yaml
+++ b/profiles/macvlan-rdma-shared/35-nicinterfacenametemplate.yaml
@@ -1,0 +1,18 @@
+{{- if and .NicConfigurationOperator .NicConfigurationOperator.DeployNicInterfaceNameTemplate .Profile.Multirail -}}
+apiVersion: configuration.net.nvidia.com/v1alpha1
+kind: NicInterfaceNameTemplate
+metadata:
+  name: nic-rename{{suffix .ClusterConfig.Identifier}}
+  namespace: {{.NetworkOperator.Namespace}}
+spec:
+  {{- if .ClusterConfig.NodeSelector }}
+  nodeSelector:
+    {{- range $key, $value := .ClusterConfig.NodeSelector }}
+    {{ $key }}: "{{ $value }}"
+    {{- end }}
+  {{- end }}
+  rdmaDevicePrefix: "{{.NicConfigurationOperator.RdmaPrefix}}"
+  netDevicePrefix: "{{.NicConfigurationOperator.NetdevPrefix}}"
+  pfsPerNic: {{pfsPerNic .ClusterConfig.PFs}}
+  railPciAddresses: [{{- $first := true }}{{- range $railIdx, $rail := .ClusterConfig.PFs }}{{- if eq $rail.Traffic "east-west" }}{{- if not $first }}, {{end}}{{- $first = false }}["{{$rail.PciAddress}}"]{{- end }}{{- end }}]
+{{- end }}


### PR DESCRIPTION
ProcessTemplate now skips rendered output that is empty after trimming whitespace. This prevents generating empty files when a template is guarded by a false condition (e.g.,
deployNicInterfaceNameTemplate: false).