### PR TITLE
Add OFED dependent module discovery and non-disruptive NICClusterPolicy patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,42 @@ During cluster discovery stage, Kubernetes Launch Kit creates a configuration fi
 
 The `docaDriver` section controls the OFED driver deployment in the NicClusterPolicy. Set `enable: true` to include the `ofedDriver` section in generated manifests, or `enable: false` to omit it. This can also be overridden via the `--enable-doca-driver` CLI flag.
 
+#### OFED Dependent Module Blacklisting
+
+When the DOCA/OFED driver loads on a node, it replaces the inbox MLX kernel modules (`mlx5_core`, `mlx5_ib`, `ib_core`, etc.) with its own versions. However, if third-party or distribution-specific kernel modules depend on the inbox MLX modules (e.g., `iw_cm`, `nfsrdma`), they will block the inbox modules from being unloaded, causing the DOCA driver to fail to load or leaving the system in an inconsistent state.
+
+To solve this, `blacklistDependentModules: true` enables a pre-flight check during cluster discovery. The tool execs into `nic-configuration-daemon` pods and inspects `/sys/module/*/holders/` for each of the following MLX/OFED kernel modules:
+
+`mlx5_core`, `mlx5_ib`, `ib_umad`, `ib_uverbs`, `ib_ipoib`, `rdma_cm`, `rdma_ucm`, `ib_core`, `ib_cm`
+
+Any kernel modules found as holders (dependents) of these — but not the MLX modules themselves — are saved per group as `ofedDependentModules`. During manifest generation, these modules are passed to the DOCA driver pod via the `OFED_BLACKLIST_MODULES` environment variable (semicolon-separated), which tells the driver to unload them before attempting to replace the inbox modules.
+
+Module discovery always runs during cluster discovery (so results are saved for inspection), but the `OFED_BLACKLIST_MODULES` env var is only rendered when `blacklistDependentModules` is `true`. When multiple node groups are merged, their dependent modules are aggregated as a union.
+
+```yaml
+docaDriver:
+  enable: true
+  version: doca3.3.0-26.01-1.0.0.0-0
+  unloadStorageModules: true
+  enableNFSRDMA: false
+  blacklistDependentModules: true   # Enable dependent module discovery and blacklisting
+```
+
+After discovery, the config will contain the discovered dependents:
+```yaml
+clusterConfig:
+- identifier: group-0
+  ofedDependentModules:
+  - iw_cm
+```
+
+The generated NicClusterPolicy `ofedDriver` section will include:
+```yaml
+env:
+  - name: OFED_BLACKLIST_MODULES
+    value: "iw_cm"
+```
+
 ### NV-IPAM Subnet Configuration
 
 The `nvIpam` section supports two modes for subnet configuration:
@@ -266,6 +302,7 @@ docaDriver:
   version: doca3.2.0-25.10-1.2.8.0-2
   unloadStorageModules: false
   enableNFSRDMA: false
+  blacklistDependentModules: false
 nvIpam:
   poolName: nv-ipam-pool
   subnets:

--- a/go.mod
+++ b/go.mod
@@ -51,13 +51,17 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkoukk/tiktoken-go v0.1.6 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
@@ -83,6 +87,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250122153221-138b5a5a4fd4 // indirect
 	google.golang.org/grpc v1.70.0 // indirect
 	google.golang.org/protobuf v1.36.7 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/Mellanox/nic-configuration-operator v1.3.1 h1:oH1BCIVeIilGCAmKB/dQRwV
 github.com/Mellanox/nic-configuration-operator v1.3.1/go.mod h1:0CVC/a2nx6LL85Iha9uJpoc1FMs1pS5Nu6/1GwMZd5I=
 github.com/NVIDIA/k8s-operator-libs v0.0.0-20250708070119-9dc24ccc10ee h1:IW3URIejZ85qDFoMXV1EzuHjjerGd8h0I5BvLGiuqa0=
 github.com/NVIDIA/k8s-operator-libs v0.0.0-20250708070119-9dc24ccc10ee/go.mod h1:8skFe7Dyub0FRpk5ysCM88ysFqJpIcw/4ZqLBWcevw8=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -79,6 +81,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.4 h1:XYIDZApgAnrN1c855gT
 github.com/googleapis/enterprise-certificate-proxy v0.3.4/go.mod h1:YKe7cfqYXjKGpGvmSg28/fFvhNzinZQm8DGnaburhGA=
 github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrkurSS/Q=
 github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -93,6 +97,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -100,6 +106,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.28.0 h1:Rrf+lVLmtlBIKv6KrIGJCjyY8N36vDVcutbGJkyqjJc=
 github.com/onsi/ginkgo/v2 v2.28.0/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=

--- a/l8k-config.yaml
+++ b/l8k-config.yaml
@@ -11,13 +11,14 @@ docaDriver:
   version: doca3.3.0-26.01-1.0.0.0-0
   unloadStorageModules: true
   enableNFSRDMA: false
+  blacklistDependentModules: true
 
 nvIpam:
   poolName: nv-ipam-pool
   # Option 1: Auto-generate subnets (used when subnets list is empty).
   # Each group gets its own unique subnet slice; gateway = network address + 1.
-  startingSubnet: "192.168.2.0"
-  mask: 24
+  startingSubnet: "192.168.0.0"
+  mask: 22
   offset: 1
   # Option 2: Manually list subnets (takes precedence if non-empty)
   # subnets:

--- a/pkg/app/launcher.go
+++ b/pkg/app/launcher.go
@@ -29,6 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"k8s.io/client-go/rest"
+
 	"github.com/nvidia/k8s-launch-kit/pkg/kubeclient"
 	"github.com/nvidia/k8s-launch-kit/pkg/llm"
 	applog "github.com/nvidia/k8s-launch-kit/pkg/log"
@@ -46,6 +48,7 @@ type Launcher struct {
 	logger     logr.Logger
 	plugins    map[string]plugin.Plugin
 	kubeClient client.Client
+	restConfig *rest.Config
 	ui         ui.Output
 }
 
@@ -69,26 +72,32 @@ func (l *Launcher) Run() error {
 		}
 	}
 
-	for _, plugin := range l.options.EnabledPlugins {
-		switch plugin {
+	for _, pluginName := range l.options.EnabledPlugins {
+		switch pluginName {
 		case networkoperatorplugin.PluginName:
-			l.plugins[plugin] = &networkoperatorplugin.NetworkOperatorPlugin{
+			l.plugins[pluginName] = &networkoperatorplugin.NetworkOperatorPlugin{
 				GroupFilter:   l.options.Group,
 				LabelSelector: parseLabelSelector(l.options.LabelSelector),
 			}
 		default:
-			err := fmt.Errorf("unknown plugin: %s", plugin)
+			err := fmt.Errorf("unknown plugin: %s", pluginName)
 			l.logger.Error(err, "Skipping plugin")
 			return err
 		}
 	}
 
 	if l.options.Kubeconfig != "" {
-		k8sClient, err := kubeclient.New(l.options.Kubeconfig)
+		k8sClient, restCfg, err := kubeclient.New(l.options.Kubeconfig)
 		if err != nil {
 			return fmt.Errorf("failed to create k8s client: %w", err)
 		}
 		l.kubeClient = k8sClient
+		l.restConfig = restCfg
+
+		// Pass REST config to network operator plugin for pod exec during discovery
+		if nop, ok := l.plugins[networkoperatorplugin.PluginName]; ok {
+			nop.(*networkoperatorplugin.NetworkOperatorPlugin).RESTConfig = restCfg
+		}
 	}
 
 	if err := l.executeWorkflow(); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,10 +53,11 @@ type NetworkOperatorConfig struct {
 }
 
 type DOCADriverConfig struct {
-	Enable               bool   `yaml:"enable"`
-	Version              string `yaml:"version"`
-	UnloadStorageModules bool   `yaml:"unloadStorageModules"`
-	EnableNFSRDMA        bool   `yaml:"enableNFSRDMA"`
+	Enable                    bool   `yaml:"enable"`
+	Version                   string `yaml:"version"`
+	UnloadStorageModules      bool   `yaml:"unloadStorageModules"`
+	EnableNFSRDMA             bool   `yaml:"enableNFSRDMA"`
+	BlacklistDependentModules bool   `yaml:"blacklistDependentModules"`
 }
 
 type NvIpamConfig struct {
@@ -128,15 +129,16 @@ type ProfileSpectrumX struct {
 }
 
 type ClusterConfig struct {
-	Identifier       string               `yaml:"identifier"`
-	MachineType      string               `yaml:"machineType,omitempty"`
-	ProductType      string               `yaml:"productType,omitempty"`
-	LabelSelector    map[string]string    `yaml:"labelSelector,omitempty"`
-	Capabilities     *ClusterCapabilities `yaml:"capabilities"`
-	PFs              []PFConfig           `yaml:"pfs"`
-	WorkerNodes      []string             `yaml:"workerNodes"`
-	NodeSelector     map[string]string    `yaml:"nodeSelector,omitempty"`
-	RailPciAddresses [][]string           `yaml:"-"` // Transient: per-rail merged PCI addresses (not serialized)
+	Identifier           string               `yaml:"identifier"`
+	MachineType          string               `yaml:"machineType,omitempty"`
+	ProductType          string               `yaml:"productType,omitempty"`
+	LabelSelector        map[string]string    `yaml:"labelSelector,omitempty"`
+	Capabilities         *ClusterCapabilities `yaml:"capabilities"`
+	PFs                  []PFConfig           `yaml:"pfs"`
+	WorkerNodes          []string             `yaml:"workerNodes"`
+	NodeSelector         map[string]string    `yaml:"nodeSelector,omitempty"`
+	OfedDependentModules []string             `yaml:"ofedDependentModules,omitempty"`
+	RailPciAddresses     [][]string           `yaml:"-"` // Transient: per-rail merged PCI addresses (not serialized)
 }
 
 type ClusterCapabilities struct {

--- a/pkg/kubeclient/kubeclient.go
+++ b/pkg/kubeclient/kubeclient.go
@@ -18,6 +18,7 @@ package kubeclient
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,12 +29,13 @@ import (
 )
 
 // New builds a controller-runtime client using the provided kubeconfig path
-// and registers required schemes.
-func New(kubeconfigPath string) (client.Client, error) {
+// and registers required schemes. It also returns the underlying REST config
+// for use with client-go APIs (e.g., pod exec).
+func New(kubeconfigPath string) (client.Client, *rest.Config, error) {
 	// Build REST config from kubeconfig path
 	restCfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Prepare scheme and client
@@ -43,5 +45,10 @@ func New(kubeconfigPath string) (client.Client, error) {
 	_ = netop.AddToScheme(scheme)
 	_ = nicop.AddToScheme(scheme)
 
-	return client.New(restCfg, client.Options{Scheme: scheme})
+	c, err := client.New(restCfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return c, restCfg, nil
 }

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -17,10 +17,12 @@
 package networkoperatorplugin
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -29,6 +31,10 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -106,7 +112,7 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 	}
 
 	reuseExisting := false
-	var savedPolicies []netop.NicClusterPolicy
+	patchedPolicyName := ""
 	if len(existingPolicies) > 0 {
 		// Check if any existing policy already has the nic-configuration daemon with the required version
 		requiredVersion := defaultConfig.NetworkOperator.ComponentVersion
@@ -123,55 +129,32 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 		}
 
 		if !reuseExisting {
-			// Existing policies detected but missing nic-configuration operator — ask user for permission to replace
-			uiOutput.Warning("Found %d existing NicClusterPolicy resource(s) on the cluster.", len(existingPolicies))
-			uiOutput.Info("The launch kit needs to deploy its own NicClusterPolicy for discovery.")
-			uiOutput.Info("The existing policy will be saved, deleted, and restored after discovery completes.")
+			// Patch existing policy to add NicConfigurationOperator (non-disruptive)
+			targetPolicy := existingPolicies[0]
+			uiOutput.Info("Patching existing NicClusterPolicy %q to add NicConfigurationOperator for discovery", targetPolicy.Name)
 
-			confirmed, err := uiOutput.Confirm("Do you agree to temporarily replace the existing NicClusterPolicy?")
-			if err != nil {
-				return fmt.Errorf("failed to get user confirmation: %w", err)
+			if err := PatchNicConfigOperatorIntoPolicy(ctx, c, targetPolicy.Name, policy.Spec.NicConfigurationOperator); err != nil {
+				return fmt.Errorf("failed to patch NicClusterPolicy with NicConfigurationOperator: %w", err)
 			}
-			if !confirmed {
-				return fmt.Errorf("discovery aborted: user declined to replace existing NicClusterPolicy")
-			}
-
-			// Deep-copy existing policies for later restoration
-			savedPolicies = make([]netop.NicClusterPolicy, len(existingPolicies))
-			copy(savedPolicies, existingPolicies)
-
-			if err := DeleteNicClusterPolicies(ctx, c, existingPolicies); err != nil {
-				return fmt.Errorf("failed to remove existing NicClusterPolicies: %w", err)
-			}
-
-			// Now create the thin discovery policy
-			if err := c.Create(ctx, policy); err != nil {
-				return fmt.Errorf("failed to create discovery NicClusterPolicy: %w", err)
-			}
-			if err := WaitNicClusterPolicyReady(ctx, c, policy.Name); err != nil {
+			if err := WaitNicClusterPolicyReady(ctx, c, targetPolicy.Name); err != nil {
 				return err
 			}
+			patchedPolicyName = targetPolicy.Name
 		}
 	} else {
 		uiOutput.Info("Deploying discovery profile")
 	}
 
-	// Defers run LIFO: restore must be registered first so it runs after cleanup.
-	// Order of execution: (1) delete thin discovery policy, (2) restore saved policies.
-	if len(savedPolicies) > 0 {
+	// Cleanup: remove NicConfigurationOperator we patched in, or delete the thin policy we created
+	if patchedPolicyName != "" {
 		defer func() {
-			uiOutput.Info("Restoring previously saved NicClusterPolicy resource(s)")
-			if err := RestoreNicClusterPolicies(ctx, c, savedPolicies); err != nil {
-				log.Log.Error(err, "failed to restore NicClusterPolicies after discovery")
-				uiOutput.Error("Failed to restore original NicClusterPolicy: %v", err)
-			} else {
-				uiOutput.Success("Original NicClusterPolicy restored successfully")
+			uiOutput.Info("Removing discovery NicConfigurationOperator from NicClusterPolicy %q", patchedPolicyName)
+			if err := RemoveNicConfigOperatorFromPolicy(ctx, c, patchedPolicyName); err != nil {
+				log.Log.Error(err, "failed to remove NicConfigurationOperator after discovery")
+				uiOutput.Error("Failed to remove NicConfigurationOperator: %v", err)
 			}
 		}()
-	}
-
-	// Only clean up the discovery policy if we created it (not reusing an existing one)
-	if !reuseExisting {
+	} else if !reuseExisting {
 		defer func() {
 			if err := DeleteNicClusterPolicy(ctx, c, "nic-cluster-policy"); err != nil {
 				log.Log.Error(err, "failed to delete NicClusterPolicy after discovery")
@@ -183,8 +166,8 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 
 	// After creation, list pods in the target namespace and ensure all pods
 	// from the nic-configuration-daemon DaemonSet are Ready.
-	// Returns the set of node names running daemon pods.
-	expectedNodes, err := checkDaemonSetPodsReady(ctx, c, defaultConfig.NetworkOperator.Namespace, "nic-configuration-daemon")
+	// Returns the set of node names running daemon pods and the pods themselves.
+	expectedNodes, dsPods, err := checkDaemonSetPodsReady(ctx, c, defaultConfig.NetworkOperator.Namespace, "nic-configuration-daemon")
 	if err != nil {
 		return err
 	}
@@ -224,15 +207,36 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 		uiOutput.Warning(w)
 	}
 
+	// Discover OFED-dependent kernel modules per group via pod exec.
+	// Results are always saved to config for user inspection; the
+	// blacklistDependentModules flag only controls template rendering.
+	if p.RESTConfig != nil {
+		for i := range defaultConfig.ClusterConfig {
+			group := &defaultConfig.ClusterConfig[i]
+			modules, err := discoverOfedDependentModules(ctx, p.RESTConfig,
+				defaultConfig.NetworkOperator.Namespace, group.WorkerNodes, dsPods)
+			if err != nil {
+				log.Log.Error(err, "failed to discover OFED-dependent modules", "group", group.Identifier)
+				uiOutput.Warning("Could not discover OFED modules for group %s: %v", group.Identifier, err)
+				continue
+			}
+			if len(modules) > 0 {
+				group.OfedDependentModules = modules
+				uiOutput.Info("Discovered %d OFED-dependent module(s) for group %s", len(modules), group.Identifier)
+			}
+		}
+	}
+
 	return nil
 }
 
 // checkDaemonSetPodsReady verifies that all pods owned by the given DaemonSet
-// in the provided namespace are Ready. Returns the list of node names running those pods.
-func checkDaemonSetPodsReady(ctx context.Context, c client.Client, namespace, daemonSetName string) ([]string, error) {
+// in the provided namespace are Ready. Returns the list of node names running
+// those pods and the pods themselves (for later use in pod exec).
+func checkDaemonSetPodsReady(ctx context.Context, c client.Client, namespace, daemonSetName string) ([]string, []corev1.Pod, error) {
 	podList := &corev1.PodList{}
 	if err := c.List(ctx, podList, client.InNamespace(namespace)); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var dsPods []corev1.Pod
@@ -246,20 +250,20 @@ func checkDaemonSetPodsReady(ctx context.Context, c client.Client, namespace, da
 	}
 
 	if len(dsPods) == 0 {
-		return nil, fmt.Errorf("no pods found for DaemonSet %q in namespace %q", daemonSetName, namespace)
+		return nil, nil, fmt.Errorf("no pods found for DaemonSet %q in namespace %q", daemonSetName, namespace)
 	}
 
 	nodes := make([]string, 0, len(dsPods))
 	for _, pod := range dsPods {
 		if !isPodReady(&pod) {
-			return nil, fmt.Errorf("pod %q from DaemonSet %q is not Ready", pod.Name, daemonSetName)
+			return nil, nil, fmt.Errorf("pod %q from DaemonSet %q is not Ready", pod.Name, daemonSetName)
 		}
 		if pod.Spec.NodeName != "" {
 			nodes = append(nodes, pod.Spec.NodeName)
 		}
 	}
 
-	return nodes, nil
+	return nodes, dsPods, nil
 }
 
 func isPodReady(pod *corev1.Pod) bool {
@@ -806,4 +810,127 @@ func isNoisyLabel(key string) bool {
 		}
 	}
 	return false
+}
+
+// ofedTargetModules is the list of MLX/OFED kernel modules to check for during
+// pre-flight discovery. These modules (and any modules that depend on them) may
+// need to be blacklisted when the DOCA driver is deployed.
+var ofedTargetModules = []string{
+	"mlx5_core", "mlx5_ib", "ib_umad", "ib_uverbs",
+	"ib_ipoib", "rdma_cm", "rdma_ucm", "ib_core", "ib_cm",
+}
+
+// discoverOfedDependentModules execs into a nic-configuration-daemon pod on one
+// of the group's nodes and discovers which OFED target modules are loaded along
+// with their holder (dependent) modules.
+func discoverOfedDependentModules(ctx context.Context, restConfig *rest.Config,
+	namespace string, groupNodes []string, dsPods []corev1.Pod) ([]string, error) {
+
+	if len(groupNodes) == 0 {
+		return nil, nil
+	}
+
+	// Find a daemon pod running on one of the group's nodes.
+	// All nodes in a group have identical hardware, so one is sufficient.
+	nodeSet := make(map[string]bool, len(groupNodes))
+	for _, n := range groupNodes {
+		nodeSet[n] = true
+	}
+
+	var targetPod *corev1.Pod
+	for i := range dsPods {
+		if nodeSet[dsPods[i].Spec.NodeName] {
+			targetPod = &dsPods[i]
+			break
+		}
+	}
+	if targetPod == nil {
+		return nil, fmt.Errorf("no nic-configuration-daemon pod found on group nodes")
+	}
+
+	// Build a shell script that outputs only holder (dependent) module names,
+	// excluding the target modules themselves. One module name per line.
+	modList := strings.Join(ofedTargetModules, " ")
+	script := fmt.Sprintf(`for mod in %s; do
+  if [ -d /sys/module/$mod ]; then
+    for dep in /sys/module/$mod/holders/*; do
+      [ -e "$dep" ] && echo "$(basename $dep)"
+    done
+  fi
+done | sort -u`, modList)
+
+	containerName := ""
+	if len(targetPod.Spec.Containers) > 0 {
+		containerName = targetPod.Spec.Containers[0].Name
+	}
+
+	output, err := execInPod(ctx, restConfig, namespace, targetPod.Name, containerName,
+		[]string{"/bin/sh", "-c", script})
+	if err != nil {
+		return nil, fmt.Errorf("exec in pod %q failed: %w", targetPod.Name, err)
+	}
+
+	return parseModuleList(output, ofedTargetModules), nil
+}
+
+// parseModuleList splits newline-separated module names, deduplicates, sorts them,
+// and filters out any modules in the exclude list (the OFED target modules themselves).
+func parseModuleList(output string, exclude []string) []string {
+	excludeSet := make(map[string]bool, len(exclude))
+	for _, m := range exclude {
+		excludeSet[m] = true
+	}
+	seen := map[string]bool{}
+	for _, line := range strings.Split(output, "\n") {
+		mod := strings.TrimSpace(line)
+		if mod != "" && !excludeSet[mod] {
+			seen[mod] = true
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	modules := make([]string, 0, len(seen))
+	for mod := range seen {
+		modules = append(modules, mod)
+	}
+	sort.Strings(modules)
+	return modules
+}
+
+// execInPod runs a command in a pod container and returns stdout.
+func execInPod(ctx context.Context, restConfig *rest.Config,
+	namespace, podName, containerName string, command []string) (string, error) {
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: containerName,
+			Command:   command,
+			Stdout:    true,
+			Stderr:    true,
+		}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
+	if err != nil {
+		return "", fmt.Errorf("failed to create SPDY executor: %w", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}); err != nil {
+		return "", fmt.Errorf("exec stream failed (stderr: %s): %w", stderr.String(), err)
+	}
+
+	return stdout.String(), nil
 }

--- a/pkg/networkoperatorplugin/helper.go
+++ b/pkg/networkoperatorplugin/helper.go
@@ -135,3 +135,44 @@ func DeleteNicClusterPolicy(ctx context.Context, c client.Client, name string) e
 	}
 	return nil
 }
+
+// PatchNicConfigOperatorIntoPolicy patches an existing NicClusterPolicy to add
+// the NicConfigurationOperator section via server-side apply, preserving all
+// other fields (ofedDriver, secondaryNetwork, etc.).
+func PatchNicConfigOperatorIntoPolicy(ctx context.Context, c client.Client, policyName string, nicConfigOp *netop.NicConfigurationOperatorSpec) error {
+	// Build a minimal apply-configuration containing only the field we want to own.
+	patch := &netop.NicClusterPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "mellanox.com/v1alpha1",
+			Kind:       "NicClusterPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: policyName,
+		},
+		Spec: netop.NicClusterPolicySpec{
+			NicConfigurationOperator: nicConfigOp,
+		},
+	}
+
+	return c.Patch(ctx, patch, client.Apply, client.FieldOwner("l8k-discovery"), client.ForceOwnership)
+}
+
+// RemoveNicConfigOperatorFromPolicy removes the NicConfigurationOperator section
+// that was added during discovery by fetching the policy and updating it.
+func RemoveNicConfigOperatorFromPolicy(ctx context.Context, c client.Client, policyName string) error {
+	policy := &netop.NicClusterPolicy{}
+	if err := c.Get(ctx, client.ObjectKey{Name: policyName}, policy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get NicClusterPolicy %q for cleanup: %w", policyName, err)
+	}
+
+	policy.Spec.NicConfigurationOperator = nil
+	if err := c.Update(ctx, policy); err != nil {
+		return fmt.Errorf("failed to remove NicConfigurationOperator from %q: %w", policyName, err)
+	}
+
+	log.Log.Info("Removed NicConfigurationOperator from NicClusterPolicy after discovery", "name", policyName)
+	return nil
+}

--- a/pkg/networkoperatorplugin/networkoperator.go
+++ b/pkg/networkoperatorplugin/networkoperator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
 	"github.com/nvidia/k8s-launch-kit/pkg/plugin"
 	"github.com/nvidia/k8s-launch-kit/pkg/profiles"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -35,6 +36,7 @@ const (
 type NetworkOperatorPlugin struct {
 	GroupFilter   string
 	LabelSelector map[string]string
+	RESTConfig    *rest.Config
 }
 
 func (p *NetworkOperatorPlugin) GetName() string {

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -34,6 +34,9 @@ var templateFuncs = template.FuncMap{
 	"add": func(a, b int) int { return a + b },
 	"sub": func(a, b int) int { return a - b },
 	"gt":  func(a, b int) bool { return a > b },
+	"joinModules": func(modules []string) string {
+		return strings.Join(modules, ";")
+	},
 	"untilStep": func(start, stop, step int) []int {
 		result := []int{}
 		for i := start; i < stop; i += step {
@@ -505,12 +508,29 @@ func buildMergedGroup(groups []config.ClusterConfig, indices []int) config.Clust
 		}
 	}
 
+	// Merge OFED-dependent modules (union across all groups, deduplicated and sorted)
+	depModSet := map[string]bool{}
+	for _, idx := range indices {
+		for _, mod := range groups[idx].OfedDependentModules {
+			depModSet[mod] = true
+		}
+	}
+	var mergedDepMods []string
+	if len(depModSet) > 0 {
+		mergedDepMods = make([]string, 0, len(depModSet))
+		for mod := range depModSet {
+			mergedDepMods = append(mergedDepMods, mod)
+		}
+		slices.Sort(mergedDepMods)
+	}
+
 	return config.ClusterConfig{
-		Identifier:   sanitizeIdentifier(productType),
-		ProductType:  productType,
-		Capabilities: caps,
-		PFs:          first.PFs, // Representative PFs from first group
-		WorkerNodes:  allNodes,
+		Identifier:           sanitizeIdentifier(productType),
+		ProductType:          productType,
+		Capabilities:         caps,
+		PFs:                  first.PFs, // Representative PFs from first group
+		WorkerNodes:          allNodes,
+		OfedDependentModules: mergedDepMods,
 		NodeSelector: map[string]string{
 			"nvidia.com/gpu.product": productType,
 		},

--- a/pkg/networkoperatorplugin/templates_test.go
+++ b/pkg/networkoperatorplugin/templates_test.go
@@ -921,3 +921,137 @@ func indexOf(s, substr string) int {
 	}
 	return -1
 }
+
+func TestJoinModules(t *testing.T) {
+	joinModulesFunc := templateFuncs["joinModules"].(func([]string) string)
+
+	t.Run("single module", func(t *testing.T) {
+		result := joinModulesFunc([]string{"iw_cm"})
+		assert.Equal(t, "iw_cm", result)
+	})
+
+	t.Run("multiple modules semicolon separated", func(t *testing.T) {
+		result := joinModulesFunc([]string{"iw_cm", "nfsrdma", "xprtrdma"})
+		assert.Equal(t, "iw_cm;nfsrdma;xprtrdma", result)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		result := joinModulesFunc([]string{})
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestMergeCompatibleGroups_MergesOfedDependentModules(t *testing.T) {
+	rail0 := 0
+	rail1 := 1
+
+	t.Run("merges modules from all groups deduplicated and sorted", func(t *testing.T) {
+		groups := []config.ClusterConfig{
+			{
+				Identifier:  "group-0",
+				ProductType: "NVIDIA-H200",
+				PFs: []config.PFConfig{
+					{DeviceID: "a2dc", PciAddress: "0000:19:00.0", Traffic: "east-west", Rail: &rail0},
+					{DeviceID: "a2dc", PciAddress: "0000:2a:00.0", Traffic: "east-west", Rail: &rail1},
+				},
+				WorkerNodes:          []string{"node-1"},
+				OfedDependentModules: []string{"iw_cm", "nfsrdma"},
+			},
+			{
+				Identifier:  "group-1",
+				ProductType: "NVIDIA-H200",
+				PFs: []config.PFConfig{
+					{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", Traffic: "east-west", Rail: &rail0},
+					{DeviceID: "a2dc", PciAddress: "0000:3c:00.0", Traffic: "east-west", Rail: &rail1},
+				},
+				WorkerNodes:          []string{"node-2"},
+				OfedDependentModules: []string{"iw_cm", "xprtrdma"},
+			},
+		}
+
+		merged, _ := mergeCompatibleGroups(groups, false)
+		assert.Len(t, merged, 1)
+		assert.Equal(t, []string{"iw_cm", "nfsrdma", "xprtrdma"}, merged[0].OfedDependentModules)
+	})
+
+	t.Run("no modules when source groups have none", func(t *testing.T) {
+		groups := []config.ClusterConfig{
+			{
+				Identifier:  "group-0",
+				ProductType: "NVIDIA-H200",
+				PFs: []config.PFConfig{
+					{DeviceID: "a2dc", PciAddress: "0000:19:00.0", Traffic: "east-west", Rail: &rail0},
+				},
+				WorkerNodes: []string{"node-1"},
+			},
+			{
+				Identifier:  "group-1",
+				ProductType: "NVIDIA-H200",
+				PFs: []config.PFConfig{
+					{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", Traffic: "east-west", Rail: &rail0},
+				},
+				WorkerNodes: []string{"node-2"},
+			},
+		}
+
+		merged, _ := mergeCompatibleGroups(groups, false)
+		assert.Len(t, merged, 1)
+		assert.Nil(t, merged[0].OfedDependentModules)
+	})
+
+	t.Run("unmerged groups keep their own modules", func(t *testing.T) {
+		groups := []config.ClusterConfig{
+			{
+				Identifier:           "group-0",
+				ProductType:          "NVIDIA-H200",
+				PFs:                  []config.PFConfig{{DeviceID: "a2dc", PciAddress: "0000:19:00.0", Traffic: "east-west", Rail: &rail0}},
+				WorkerNodes:          []string{"node-1"},
+				OfedDependentModules: []string{"iw_cm"},
+			},
+			{
+				Identifier:           "group-1",
+				ProductType:          "NVIDIA-A100", // different product
+				PFs:                  []config.PFConfig{{DeviceID: "1017", PciAddress: "0000:1a:00.0", Traffic: "east-west", Rail: &rail0}},
+				WorkerNodes:          []string{"node-2"},
+				OfedDependentModules: []string{"xprtrdma"},
+			},
+		}
+
+		merged, _ := mergeCompatibleGroups(groups, false)
+		assert.Len(t, merged, 2)
+		assert.Equal(t, []string{"iw_cm"}, merged[0].OfedDependentModules)
+		assert.Equal(t, []string{"xprtrdma"}, merged[1].OfedDependentModules)
+	})
+}
+
+func TestParseModuleList(t *testing.T) {
+	exclude := []string{"mlx5_core", "mlx5_ib", "ib_umad", "ib_uverbs", "ib_ipoib", "rdma_cm", "rdma_ucm", "ib_core", "ib_cm"}
+
+	t.Run("filters out target modules", func(t *testing.T) {
+		output := "iw_cm\nmlx5_core\nib_core\nnfsrdma\n"
+		result := parseModuleList(output, exclude)
+		assert.Equal(t, []string{"iw_cm", "nfsrdma"}, result)
+	})
+
+	t.Run("empty output returns nil", func(t *testing.T) {
+		result := parseModuleList("", exclude)
+		assert.Nil(t, result)
+	})
+
+	t.Run("only target modules returns nil", func(t *testing.T) {
+		result := parseModuleList("mlx5_core\nib_core\n", exclude)
+		assert.Nil(t, result)
+	})
+
+	t.Run("handles whitespace and blank lines", func(t *testing.T) {
+		output := "  iw_cm  \n\n  xprtrdma\n  \n"
+		result := parseModuleList(output, exclude)
+		assert.Equal(t, []string{"iw_cm", "xprtrdma"}, result)
+	})
+
+	t.Run("deduplicates", func(t *testing.T) {
+		output := "iw_cm\niw_cm\niw_cm\n"
+		result := parseModuleList(output, exclude)
+		assert.Equal(t, []string{"iw_cm"}, result)
+	})
+}

--- a/profiles/host-device-rdma/10-nicclusterpolicy.yaml
+++ b/profiles/host-device-rdma/10-nicclusterpolicy.yaml
@@ -13,6 +13,12 @@ spec:
         value: "{{.DOCADriver.UnloadStorageModules}}"
       - name: ENABLE_NFSRDMA
         value: "{{.DOCADriver.EnableNFSRDMA}}"
+      {{- if and .DOCADriver.BlacklistDependentModules .ClusterConfig }}
+      {{- if .ClusterConfig.OfedDependentModules }}
+      - name: OFED_BLACKLIST_MODULES
+        value: "{{joinModules .ClusterConfig.OfedDependentModules}}"
+      {{- end }}
+      {{- end }}
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/profiles/ipoib-rdma-shared/10-nicclusterpolicy.yaml
+++ b/profiles/ipoib-rdma-shared/10-nicclusterpolicy.yaml
@@ -13,6 +13,12 @@ spec:
         value: "{{.DOCADriver.UnloadStorageModules}}"
       - name: ENABLE_NFSRDMA
         value: "{{.DOCADriver.EnableNFSRDMA}}"
+      {{- if and .DOCADriver.BlacklistDependentModules .ClusterConfig }}
+      {{- if .ClusterConfig.OfedDependentModules }}
+      - name: OFED_BLACKLIST_MODULES
+        value: "{{joinModules .ClusterConfig.OfedDependentModules}}"
+      {{- end }}
+      {{- end }}
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/profiles/macvlan-rdma-shared/10-nicclusterpolicy.yaml
+++ b/profiles/macvlan-rdma-shared/10-nicclusterpolicy.yaml
@@ -13,6 +13,12 @@ spec:
         value: "{{.DOCADriver.UnloadStorageModules}}"
       - name: ENABLE_NFSRDMA
         value: "{{.DOCADriver.EnableNFSRDMA}}"
+      {{- if and .DOCADriver.BlacklistDependentModules .ClusterConfig }}
+      {{- if .ClusterConfig.OfedDependentModules }}
+      - name: OFED_BLACKLIST_MODULES
+        value: "{{joinModules .ClusterConfig.OfedDependentModules}}"
+      {{- end }}
+      {{- end }}
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/profiles/sriov-ethernet-rdma/10-nicclusterpolicy.yaml
+++ b/profiles/sriov-ethernet-rdma/10-nicclusterpolicy.yaml
@@ -13,6 +13,12 @@ spec:
         value: "{{.DOCADriver.UnloadStorageModules}}"
       - name: ENABLE_NFSRDMA
         value: "{{.DOCADriver.EnableNFSRDMA}}"
+      {{- if and .DOCADriver.BlacklistDependentModules .ClusterConfig }}
+      {{- if .ClusterConfig.OfedDependentModules }}
+      - name: OFED_BLACKLIST_MODULES
+        value: "{{joinModules .ClusterConfig.OfedDependentModules}}"
+      {{- end }}
+      {{- end }}
     upgradePolicy:
       autoUpgrade: true
       drain:

--- a/profiles/sriov-ib-rdma/10-nicclusterpolicy.yaml
+++ b/profiles/sriov-ib-rdma/10-nicclusterpolicy.yaml
@@ -13,6 +13,12 @@ spec:
         value: "{{.DOCADriver.UnloadStorageModules}}"
       - name: ENABLE_NFSRDMA
         value: "{{.DOCADriver.EnableNFSRDMA}}"
+      {{- if and .DOCADriver.BlacklistDependentModules .ClusterConfig }}
+      {{- if .ClusterConfig.OfedDependentModules }}
+      - name: OFED_BLACKLIST_MODULES
+        value: "{{joinModules .ClusterConfig.OfedDependentModules}}"
+      {{- end }}
+      {{- end }}
     upgradePolicy:
       autoUpgrade: true
       drain:


### PR DESCRIPTION
During discovery, exec into nic-configuration-daemon pods to identify kernel modules that depend on MLX/OFED drivers (holders of mlx5_core, ib_core, etc.) and save them per group as ofedDependentModules. When blacklistDependentModules is enabled, render OFED_BLACKLIST_MODULES env var in the generated NicClusterPolicy.

Replace the disruptive delete/recreate flow for existing NICClusterPolicies with server-side apply patching (field owner l8k-discovery), preserving user's existing driver configurations during discovery.

- Add BlacklistDependentModules to DOCADriverConfig
- Add OfedDependentModules to ClusterConfig
- Add PatchNicConfigOperatorIntoPolicy/RemoveNicConfigOperatorFromPolicy helpers
- Add pod exec infrastructure (execInPod, discoverOfedDependentModules)
- Return *rest.Config from kubeclient.New for remotecommand support
- Merge OfedDependentModules as union during group merging
- Add joinModules template func (semicolon-separated)
- Add OFED_BLACKLIST_MODULES to all 5 ofedDriver profile templates
- Filter out target MLX modules from discovery output (only save dependents)
- Add tests for parseModuleList, joinModules, and module merging