### PR TITLE
Add --image-pull-secrets CLI flag for NicClusterPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Flags:
       --fabric string                     Select the fabric type to deploy (infiniband, ethernet)
       --group string                      Generate templates for a specific group only (e.g., group-0)
   -h, --help                              help for l8k
+      --image-pull-secrets strings        Image pull secret names for NicClusterPolicy (comma-separated)
       --kubeconfig string                 Path to kubeconfig file for cluster deployment (required when using --deploy)
       --node-selector string             Filter nodes for discovery by label (default "feature.node.kubernetes.io/pci-15b3.present=true")
       --llm-api-key string                API key for the LLM API (required when using --prompt)

--- a/pkg/app/discover.go
+++ b/pkg/app/discover.go
@@ -97,6 +97,12 @@ func (l *Launcher) discoverClusterConfig() error {
 		l.logger.Info("Using CLI override for network operator namespace", "namespace", l.options.NetworkOperatorNamespace)
 	}
 
+	// Override image pull secrets from CLI flag if provided
+	if len(l.options.ImagePullSecrets) > 0 {
+		defaults.NetworkOperator.ImagePullSecrets = l.options.ImagePullSecrets
+		l.logger.Info("Using CLI override for image pull secrets", "secrets", l.options.ImagePullSecrets)
+	}
+
 	defaults.ClusterConfig = nil
 	defaults.Profile = nil
 

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -70,6 +70,7 @@ east-west vs north-south NICs, and probes OFED dependent modules.`,
 			SaveClusterConfig:       saveClusterConfig,
 			NetworkOperatorNamespace: networkOperatorNamespace,
 			NodeSelector:            nodeSelector,
+			ImagePullSecrets:        imagePullSecrets,
 			EnabledPlugins:           parseEnabledPlugins(enabledPlugins),
 			OutputFormat:             outputFormat,
 			Yes:                      yesFlag,
@@ -95,5 +96,6 @@ func init() {
 	discoverCmd.Flags().StringVar(&saveClusterConfig, "save-cluster-config", "", "Output path for cluster-config.yaml")
 	discoverCmd.Flags().StringVar(&networkOperatorNamespace, "network-operator-namespace", "", "Override operator namespace (default: nvidia-network-operator)")
 	discoverCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Filter nodes by label")
+	discoverCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for NicClusterPolicy (comma-separated)")
 	discoverCmd.Flags().StringVar(&enabledPlugins, "enabled-plugins", "network-operator", "Comma-separated list of plugins to enable")
 }

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -91,6 +91,7 @@ Optionally deploy the generated manifests with --deploy.`,
 			NumberOfPlanes:          numberOfPlanes,
 			Group:                   group,
 			NodeSelector:            nodeSelector,
+			ImagePullSecrets:        imagePullSecrets,
 			PodNamespace:            podNamespace,
 			SaveDeploymentFiles:     saveDeploymentFiles,
 			Deploy:                  deploy,
@@ -160,6 +161,7 @@ func init() {
 	generateCmd.Flags().BoolVar(&enableDocaDriver, "enable-doca-driver", false, "Enable DOCA driver deployment")
 	generateCmd.Flags().StringVar(&workloadManifest, "workload-manifest", "", "Path to a custom workload manifest YAML")
 	generateCmd.Flags().StringVar(&networkOperatorNamespace, "network-operator-namespace", "", "Override operator namespace")
+	generateCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for NicClusterPolicy (comma-separated)")
 	generateCmd.Flags().StringVar(&enabledPlugins, "enabled-plugins", "network-operator", "Comma-separated list of plugins to enable")
 
 	// Deploy (optional)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -64,6 +64,7 @@ var (
 	networkOperatorNamespace    string
 	group                       string
 	nodeSelector                string
+	imagePullSecrets            []string
 	podNamespace                string
 	sosreportPath               string
 	llmThrottle                 bool
@@ -138,6 +139,7 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
 			Prompt:                prompt,
 			Group:                group,
 			NodeSelector:         nodeSelector,
+			ImagePullSecrets:     imagePullSecrets,
 			PodNamespace:         podNamespace,
 			SaveDeploymentFiles:   saveDeploymentFiles,
 			Deploy:                deploy,
@@ -220,6 +222,7 @@ func init() {
 	rootCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes for Spectrum-X (requires --spectrum-x)")
 	rootCmd.Flags().StringVar(&group, "group", "", "Generate templates for a specific group only (e.g., group-0)")
 	rootCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Filter nodes for discovery by label (e.g., key=value,key2=value2)")
+	rootCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for NicClusterPolicy (comma-separated)")
 	rootCmd.Flags().StringVar(&prompt, "prompt", "", "Path to file with a prompt to use for LLM-assisted profile generation")
 	rootCmd.Flags().StringVar(&llmApiKey, "llm-api-key", "", "API key for the LLM API (required when using --prompt)")
 	rootCmd.Flags().StringVar(&llmApiUrl, "llm-api-url", "", "API URL for the LLM API")

--- a/pkg/cmd/root_options_test.go
+++ b/pkg/cmd/root_options_test.go
@@ -432,3 +432,40 @@ func TestMissingInvalidParams(t *testing.T) {
 		assert.Contains(t, reason, "multirail")
 	})
 }
+
+func TestImagePullSecretsOptionFlow(t *testing.T) {
+	plugin := &networkoperatorplugin.NetworkOperatorPlugin{}
+
+	t.Run("CLI image-pull-secrets flows through to config", func(t *testing.T) {
+		fullConfig := &config.LaunchKubernetesConfig{
+			NetworkOperator: &config.NetworkOperatorConfig{
+				Repository: "nvcr.io/nvidia/mellanox",
+			},
+			Profile: &config.Profile{
+				Fabric:     "ethernet",
+				Deployment: "sriov",
+			},
+		}
+		opts := options.Options{
+			ImagePullSecrets: []string{"registry-secret", "other-secret"},
+		}
+		err := plugin.ApplyOptionsToConfig(opts, fullConfig)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"registry-secret", "other-secret"}, fullConfig.NetworkOperator.ImagePullSecrets)
+	})
+
+	t.Run("empty CLI preserves config image-pull-secrets", func(t *testing.T) {
+		fullConfig := &config.LaunchKubernetesConfig{
+			NetworkOperator: &config.NetworkOperatorConfig{
+				ImagePullSecrets: []string{"existing-secret"},
+			},
+			Profile: &config.Profile{
+				Fabric:     "ethernet",
+				Deployment: "sriov",
+			},
+		}
+		err := plugin.ApplyOptionsToConfig(options.Options{}, fullConfig)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"existing-secret"}, fullConfig.NetworkOperator.ImagePullSecrets)
+	})
+}

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -174,6 +174,10 @@ var schemaCmd = &cobra.Command{
 					Default:     "feature.node.kubernetes.io/pci-15b3.present=true",
 					Description: "Filter nodes for discovery by label (e.g., key=value,key2=value2)",
 				},
+				"--image-pull-secrets": {
+					Type:        "[]string",
+					Description: "Image pull secret names for NicClusterPolicy (comma-separated)",
+				},
 			},
 		}
 		data, _ := json.MarshalIndent(s, "", "  ")

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -89,14 +89,16 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 		Spec: netop.NicClusterPolicySpec{
 			NicConfigurationOperator: &netop.NicConfigurationOperatorSpec{
 				Operator: &netop.ImageSpec{
-					Repository: defaultConfig.NetworkOperator.Repository,
-					Image:      "nic-configuration-operator",
-					Version:    defaultConfig.NetworkOperator.ComponentVersion,
+					Repository:       defaultConfig.NetworkOperator.Repository,
+					Image:            "nic-configuration-operator",
+					Version:          defaultConfig.NetworkOperator.ComponentVersion,
+					ImagePullSecrets: defaultConfig.NetworkOperator.ImagePullSecrets,
 				},
 				ConfigurationDaemon: &netop.ImageSpec{
-					Repository: defaultConfig.NetworkOperator.Repository,
-					Image:      "nic-configuration-operator-daemon",
-					Version:    defaultConfig.NetworkOperator.ComponentVersion,
+					Repository:       defaultConfig.NetworkOperator.Repository,
+					Image:            "nic-configuration-operator-daemon",
+					Version:          defaultConfig.NetworkOperator.ComponentVersion,
+					ImagePullSecrets: defaultConfig.NetworkOperator.ImagePullSecrets,
 				},
 			},
 		},

--- a/pkg/networkoperatorplugin/networkoperator.go
+++ b/pkg/networkoperatorplugin/networkoperator.go
@@ -82,6 +82,14 @@ func (p *NetworkOperatorPlugin) ApplyOptionsToConfig(options options.Options, fu
 		fullConfig.NetworkOperator.Namespace = options.NetworkOperatorNamespace
 	}
 
+	// Apply image pull secrets override from CLI
+	if len(options.ImagePullSecrets) > 0 {
+		if fullConfig.NetworkOperator == nil {
+			fullConfig.NetworkOperator = &config.NetworkOperatorConfig{}
+		}
+		fullConfig.NetworkOperator.ImagePullSecrets = options.ImagePullSecrets
+	}
+
 	// Apply pod namespace override from CLI
 	if options.PodNamespace != "" {
 		fullConfig.PodNamespace = options.PodNamespace

--- a/pkg/networkoperatorplugin/networkoperator_test.go
+++ b/pkg/networkoperatorplugin/networkoperator_test.go
@@ -444,4 +444,39 @@ func TestApplyOptionsToConfig(t *testing.T) {
 		assert.Equal(t, "hwplb", cfg.Profile.SpectrumX.MultiplaneMode)
 		assert.Equal(t, 2, cfg.Profile.SpectrumX.NumberOfPlanes)
 	})
+
+	t.Run("CLI image-pull-secrets overrides config", func(t *testing.T) {
+		cfg := &config.LaunchKubernetesConfig{
+			NetworkOperator: &config.NetworkOperatorConfig{
+				ImagePullSecrets: []string{"old-secret"},
+			},
+			Profile: &config.Profile{},
+		}
+		err := p.ApplyOptionsToConfig(options.Options{ImagePullSecrets: []string{"new-secret"}}, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"new-secret"}, cfg.NetworkOperator.ImagePullSecrets)
+	})
+
+	t.Run("empty CLI image-pull-secrets preserves config", func(t *testing.T) {
+		cfg := &config.LaunchKubernetesConfig{
+			NetworkOperator: &config.NetworkOperatorConfig{
+				ImagePullSecrets: []string{"existing"},
+			},
+			Profile: &config.Profile{},
+		}
+		err := p.ApplyOptionsToConfig(options.Options{}, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"existing"}, cfg.NetworkOperator.ImagePullSecrets)
+	})
+
+	t.Run("CLI image-pull-secrets creates NetworkOperator if nil", func(t *testing.T) {
+		cfg := &config.LaunchKubernetesConfig{
+			NetworkOperator: nil,
+			Profile:         &config.Profile{},
+		}
+		err := p.ApplyOptionsToConfig(options.Options{ImagePullSecrets: []string{"my-secret"}}, cfg)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.NetworkOperator)
+		assert.Equal(t, []string{"my-secret"}, cfg.NetworkOperator.ImagePullSecrets)
+	})
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -26,7 +26,8 @@ type Options struct {
 	UserConfig              string // Path to user-provided config (skips discovery)
 	DiscoverClusterConfig   bool   // Whether to discover cluster config
 	SaveClusterConfig       string // Path to save discovered config
-	NetworkOperatorNamespace string // Override namespace for Network Operator (optional)
+	NetworkOperatorNamespace string   // Override namespace for Network Operator (optional)
+	ImagePullSecrets        []string // Image pull secret names for NicClusterPolicy
 
 	// Phase 2: Deployment Generation
 	Fabric              string // Fabric type to deploy

--- a/skills/k8s-launch-kit-discover/SKILL.md
+++ b/skills/k8s-launch-kit-discover/SKILL.md
@@ -37,6 +37,7 @@ l8k discover --save-cluster-config <OUTPUT> [--kubeconfig <PATH>]
 | `--network-operator-namespace` | — | `nvidia-network-operator` | Override operator namespace |
 | `--user-config` | — | — | Base config to merge with discovered hardware |
 | `--node-selector` | — | — | Restrict to matching nodes |
+| `--image-pull-secrets` | — | — | Image pull secret names for NicClusterPolicy (comma-separated) |
 
 ## Examples
 

--- a/skills/k8s-launch-kit-shared/SKILL.md
+++ b/skills/k8s-launch-kit-shared/SKILL.md
@@ -62,6 +62,7 @@ The root command `l8k --discover-cluster-config ...` still works for backward-co
 | `--network-operator-namespace <NS>` | Override network operator namespace (default: `nvidia-network-operator`) |
 | `--pod-namespace <NS>` | Namespace for pods and network resources (default: `default`) |
 | `--node-selector <LABELS>` | Restrict to nodes matching labels (comma-separated, ANDed) |
+| `--image-pull-secrets <NAMES>` | Image pull secret names for NicClusterPolicy (comma-separated) |
 
 ## Agent / JSON Mode
 


### PR DESCRIPTION
Private registries require imagePullSecrets to pull operator images. Previously this could only be set via the config file, and the discovery NicClusterPolicy never included them, causing discovery to fail on clusters with private registries.

Add --image-pull-secrets flag to root, discover, and generate commands. Pass secrets to both ImageSpec structs on the discovery NicClusterPolicy so the nic-configuration-operator images can be pulled. Also apply the override in ApplyOptionsToConfig for the generate path.