### PR TITLE
Classify discovered OFED-dependent modules into third-party RDMA

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,41 +357,50 @@ The tool resolves configuration and profile paths in order: local directory firs
 
 The `docaDriver` section controls the OFED driver deployment in the NicClusterPolicy. Set `enable: true` to include the `ofedDriver` section in generated manifests, or `enable: false` to omit it. This can also be overridden via the `--enable-doca-driver` CLI flag.
 
-#### Third-Party RDMA Module Handling
+#### OFED-Dependent Module Handling
 
-When the DOCA/OFED driver loads on a node, it replaces the inbox MLX kernel modules (`mlx5_core`, `mlx5_ib`, `ib_core`, etc.) with its own versions. However, if third-party or distribution-specific kernel modules depend on the inbox MLX modules (e.g., `iw_cm`, `nfsrdma`), they will block the inbox modules from being unloaded, causing the DOCA driver to fail to load or leaving the system in an inconsistent state.
+When the DOCA/OFED driver loads on a node, it replaces the inbox MLX kernel modules (`mlx5_core`, `mlx5_ib`, `ib_core`, etc.) with its own versions. If other kernel modules depend on the inbox MLX modules, they will block the inbox modules from being unloaded, causing the DOCA driver to fail to load.
 
 During cluster discovery, the tool execs into `nic-configuration-daemon` pods and builds a full reverse dependency graph from `/sys/module/*/holders/` for all loaded modules, then BFS-traverses from each of the following MLX/OFED kernel modules to find all transitive non-MOFED dependents:
 
 `mlx5_core`, `mlx5_ib`, `ib_umad`, `ib_uverbs`, `ib_ipoib`, `rdma_cm`, `rdma_ucm`, `ib_core`, `ib_cm`
 
-Discovered third-party modules are saved per group as `thirdPartyRDMAModules` for user visibility and warnings only. When `unloadThirdPartyRDMAModules: true`, the generated NicClusterPolicy renders `UNLOAD_THIRD_PARTY_RDMA_MODULES: "true"` env var (a boolean flag, not a module list) in the ofedDriver section. The driver container has the 24 known third-party modules hardcoded.
+Discovered modules are classified into three categories:
 
-Module discovery always runs during cluster discovery (so results are saved for inspection), but the `UNLOAD_THIRD_PARTY_RDMA_MODULES` env var is only rendered when `unloadThirdPartyRDMAModules` is `true`. When multiple node groups are merged, their third-party RDMA modules are aggregated as a union.
+1. **mlx5-prefixed modules** (e.g. `mlx5_vdpa`, `mlx5_netdev`) — NVIDIA's own modules, silently filtered out.
+2. **Known storage-over-RDMA modules** (`ib_isert`, `nvme_rdma`, `nvmet_rdma`, `rpcrdma`, `xprtrdma`, `ib_srpt`) — saved per-group as `storageModules`. Discovery **automatically enables** `docaDriver.unloadStorageModules: true` when any are found. The generated NicClusterPolicy renders `UNLOAD_STORAGE_MODULES: "true"`.
+3. **Third-party RDMA modules** (everything else, e.g. `qedr`, `bnxt_re`, `rdma_rxe`) — saved per-group as `thirdPartyRDMAModules`. Discovery **automatically enables** `docaDriver.unloadThirdPartyRDMAModules: true` when any are found. The generated NicClusterPolicy renders `UNLOAD_THIRD_PARTY_RDMA_MODULES: "true"`. The driver container has 15 known third-party modules hardcoded.
 
+Both flags are auto-enabled during discovery so the DOCA driver can unload blocking modules. A warning is emitted after discovery and generation reminding you to verify that no running workloads depend on these modules. When multiple node groups are merged, both module lists are aggregated as unions.
+
+After discovery, the config will contain the discovered modules and auto-enabled flags:
 ```yaml
 docaDriver:
   enable: true
   version: doca3.3.0-26.01-1.0.0.0-0
-  unloadStorageModules: true
+  unloadStorageModules: true            # auto-enabled by discovery
   enableNFSRDMA: false
-  unloadThirdPartyRDMAModules: true   # Enable third-party RDMA module unloading
-```
+  unloadThirdPartyRDMAModules: true     # auto-enabled by discovery
 
-After discovery, the config will contain the discovered third-party modules:
-```yaml
 clusterConfig:
 - identifier: group-0
   thirdPartyRDMAModules:
-  - iw_cm
+  - rdma_rxe
+  storageModules:
+  - nvme_rdma
+  - ib_isert
 ```
 
 The generated NicClusterPolicy `ofedDriver` section will include:
 ```yaml
 env:
+  - name: UNLOAD_STORAGE_MODULES
+    value: "true"
   - name: UNLOAD_THIRD_PARTY_RDMA_MODULES
     value: "true"
 ```
+
+To disable automatic unloading, set the flags back to `false` in your config after discovery.
 
 ### NV-IPAM Subnet Configuration
 

--- a/pkg/app/discover.go
+++ b/pkg/app/discover.go
@@ -147,6 +147,7 @@ func (l *Launcher) discoverClusterConfig() error {
 	l.logger.Info("Discovered cluster config saved", "path", savePath)
 
 	warnThirdPartyRDMAModules(&discoveredConfig, "discover", l.ui)
+	warnStorageModules(&discoveredConfig, "discover", l.ui)
 
 	return nil
 }

--- a/pkg/app/generate.go
+++ b/pkg/app/generate.go
@@ -142,6 +142,7 @@ func (l *Launcher) executeGeneration(configPath string) error {
 	l.foundProfiles = foundProfiles
 
 	warnThirdPartyRDMAModules(fullConfig, "generate", l.ui)
+	warnStorageModules(fullConfig, "generate", l.ui)
 
 	return nil
 }

--- a/pkg/app/warnings.go
+++ b/pkg/app/warnings.go
@@ -23,12 +23,11 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 )
 
-// warnThirdPartyRDMAModules prints contextual warnings about discovered
-// third-party RDMA modules. The phase parameter selects which warnings
-// to emit: "discover" emits only the unload-disabled warning, while
-// "generate" emits both.
-func warnThirdPartyRDMAModules(cfg *config.LaunchKubernetesConfig, phase string, output ui.Output) {
-	if cfg.DOCADriver == nil || !cfg.DOCADriver.Enable {
+// warnThirdPartyRDMAModules warns about third-party RDMA modules that will be
+// unloaded. Discovery auto-enables the flag when modules are found, so this only
+// emits the "verify safety" warning when the flag is true and modules are present.
+func warnThirdPartyRDMAModules(cfg *config.LaunchKubernetesConfig, _ string, output ui.Output) {
+	if cfg.DOCADriver == nil || !cfg.DOCADriver.Enable || !cfg.DOCADriver.UnloadThirdPartyRDMAModules {
 		return
 	}
 
@@ -37,21 +36,31 @@ func warnThirdPartyRDMAModules(cfg *config.LaunchKubernetesConfig, phase string,
 			continue
 		}
 		moduleList := strings.Join(group.ThirdPartyRDMAModules, ", ")
+		output.Warning(
+			"unloadThirdPartyRDMAModules is enabled. The DOCA driver will unload known third-party RDMA modules "+
+				"(including [%s] found on group %s) before driver installation. "+
+				"Verify it is safe to unload these modules before deploying.",
+			moduleList, group.Identifier)
+	}
+}
 
-		if !cfg.DOCADriver.UnloadThirdPartyRDMAModules {
-			output.Warning(
-				"Third-party RDMA modules detected on group %s: [%s]. "+
-					"The DOCA driver container will fail to load because these modules hold references to inbox MLX drivers. "+
-					"Set docaDriver.unloadThirdPartyRDMAModules: true in your config to enable automatic unloading.",
-				group.Identifier, moduleList)
-		}
+// warnStorageModules warns about storage-over-RDMA modules that will be unloaded.
+// Discovery auto-enables the flag when modules are found, so this only emits the
+// "verify safety" warning when the flag is true and modules are present.
+func warnStorageModules(cfg *config.LaunchKubernetesConfig, _ string, output ui.Output) {
+	if cfg.DOCADriver == nil || !cfg.DOCADriver.Enable || !cfg.DOCADriver.UnloadStorageModules {
+		return
+	}
 
-		if cfg.DOCADriver.UnloadThirdPartyRDMAModules && phase == "generate" {
-			output.Warning(
-				"unloadThirdPartyRDMAModules is enabled. The DOCA driver will unload known third-party RDMA modules "+
-					"(including [%s] found on group %s) before driver installation. "+
-					"Verify it is safe to unload these modules before deploying the generated manifests.",
-				moduleList, group.Identifier)
+	for _, group := range cfg.ClusterConfig {
+		if len(group.StorageModules) == 0 {
+			continue
 		}
+		moduleList := strings.Join(group.StorageModules, ", ")
+		output.Warning(
+			"unloadStorageModules is enabled. The DOCA driver will unload known storage-over-RDMA modules "+
+				"(including [%s] found on group %s) before driver installation. "+
+				"Verify that no running workloads depend on these modules before deploying.",
+			moduleList, group.Identifier)
 	}
 }

--- a/pkg/app/warnings_test.go
+++ b/pkg/app/warnings_test.go
@@ -50,7 +50,7 @@ func (p *noopProgress) Fail(message string)    {}
 func TestWarnThirdPartyRDMAModules_DriverDisabled(t *testing.T) {
 	out := &testOutput{}
 	cfg := &config.LaunchKubernetesConfig{
-		DOCADriver: &config.DOCADriverConfig{Enable: false},
+		DOCADriver: &config.DOCADriverConfig{Enable: false, UnloadThirdPartyRDMAModules: true},
 		ClusterConfig: []config.ClusterConfig{
 			{Identifier: "g1", ThirdPartyRDMAModules: []string{"rdma_rxe"}},
 		},
@@ -71,22 +71,7 @@ func TestWarnThirdPartyRDMAModules_NilDriver(t *testing.T) {
 	assert.Empty(t, out.warnings)
 }
 
-func TestWarnThirdPartyRDMAModules_UnloadFalse_Discover(t *testing.T) {
-	out := &testOutput{}
-	cfg := &config.LaunchKubernetesConfig{
-		DOCADriver: &config.DOCADriverConfig{Enable: true, UnloadThirdPartyRDMAModules: false},
-		ClusterConfig: []config.ClusterConfig{
-			{Identifier: "g1", ThirdPartyRDMAModules: []string{"rdma_rxe", "ib_isert"}},
-		},
-	}
-	warnThirdPartyRDMAModules(cfg, "discover", out)
-	assert.Len(t, out.warnings, 1)
-	assert.Contains(t, out.warnings[0], "rdma_rxe, ib_isert")
-	assert.Contains(t, out.warnings[0], "g1")
-	assert.Contains(t, out.warnings[0], "unloadThirdPartyRDMAModules: true")
-}
-
-func TestWarnThirdPartyRDMAModules_UnloadFalse_Generate(t *testing.T) {
+func TestWarnThirdPartyRDMAModules_FlagFalse_NoWarning(t *testing.T) {
 	out := &testOutput{}
 	cfg := &config.LaunchKubernetesConfig{
 		DOCADriver: &config.DOCADriverConfig{Enable: true, UnloadThirdPartyRDMAModules: false},
@@ -94,12 +79,27 @@ func TestWarnThirdPartyRDMAModules_UnloadFalse_Generate(t *testing.T) {
 			{Identifier: "g1", ThirdPartyRDMAModules: []string{"rdma_rxe"}},
 		},
 	}
-	warnThirdPartyRDMAModules(cfg, "generate", out)
-	assert.Len(t, out.warnings, 1)
-	assert.Contains(t, out.warnings[0], "DOCA driver container will fail")
+	warnThirdPartyRDMAModules(cfg, "discover", out)
+	assert.Empty(t, out.warnings, "no warning when flag is false — discovery auto-enables it")
 }
 
-func TestWarnThirdPartyRDMAModules_UnloadTrue_Generate(t *testing.T) {
+func TestWarnThirdPartyRDMAModules_AutoEnabled_Discover(t *testing.T) {
+	out := &testOutput{}
+	cfg := &config.LaunchKubernetesConfig{
+		DOCADriver: &config.DOCADriverConfig{Enable: true, UnloadThirdPartyRDMAModules: true},
+		ClusterConfig: []config.ClusterConfig{
+			{Identifier: "g1", ThirdPartyRDMAModules: []string{"rdma_rxe"}},
+		},
+	}
+	warnThirdPartyRDMAModules(cfg, "discover", out)
+	assert.Len(t, out.warnings, 1)
+	assert.Contains(t, out.warnings[0], "unloadThirdPartyRDMAModules is enabled")
+	assert.Contains(t, out.warnings[0], "rdma_rxe")
+	assert.Contains(t, out.warnings[0], "g1")
+	assert.Contains(t, out.warnings[0], "Verify it is safe")
+}
+
+func TestWarnThirdPartyRDMAModules_AutoEnabled_Generate(t *testing.T) {
 	out := &testOutput{}
 	cfg := &config.LaunchKubernetesConfig{
 		DOCADriver: &config.DOCADriverConfig{Enable: true, UnloadThirdPartyRDMAModules: true},
@@ -110,27 +110,13 @@ func TestWarnThirdPartyRDMAModules_UnloadTrue_Generate(t *testing.T) {
 	warnThirdPartyRDMAModules(cfg, "generate", out)
 	assert.Len(t, out.warnings, 1)
 	assert.Contains(t, out.warnings[0], "unloadThirdPartyRDMAModules is enabled")
-	assert.Contains(t, out.warnings[0], "rdma_rxe")
-	assert.Contains(t, out.warnings[0], "g1")
 	assert.Contains(t, out.warnings[0], "Verify it is safe")
-}
-
-func TestWarnThirdPartyRDMAModules_UnloadTrue_Discover(t *testing.T) {
-	out := &testOutput{}
-	cfg := &config.LaunchKubernetesConfig{
-		DOCADriver: &config.DOCADriverConfig{Enable: true, UnloadThirdPartyRDMAModules: true},
-		ClusterConfig: []config.ClusterConfig{
-			{Identifier: "g1", ThirdPartyRDMAModules: []string{"rdma_rxe"}},
-		},
-	}
-	warnThirdPartyRDMAModules(cfg, "discover", out)
-	assert.Empty(t, out.warnings)
 }
 
 func TestWarnThirdPartyRDMAModules_NoModules(t *testing.T) {
 	out := &testOutput{}
 	cfg := &config.LaunchKubernetesConfig{
-		DOCADriver: &config.DOCADriverConfig{Enable: true},
+		DOCADriver: &config.DOCADriverConfig{Enable: true, UnloadThirdPartyRDMAModules: true},
 		ClusterConfig: []config.ClusterConfig{
 			{Identifier: "g1", ThirdPartyRDMAModules: nil},
 			{Identifier: "g2", ThirdPartyRDMAModules: []string{}},
@@ -143,10 +129,10 @@ func TestWarnThirdPartyRDMAModules_NoModules(t *testing.T) {
 func TestWarnThirdPartyRDMAModules_MultipleGroups(t *testing.T) {
 	out := &testOutput{}
 	cfg := &config.LaunchKubernetesConfig{
-		DOCADriver: &config.DOCADriverConfig{Enable: true, UnloadThirdPartyRDMAModules: false},
+		DOCADriver: &config.DOCADriverConfig{Enable: true, UnloadThirdPartyRDMAModules: true},
 		ClusterConfig: []config.ClusterConfig{
 			{Identifier: "group-a", ThirdPartyRDMAModules: []string{"rdma_rxe"}},
-			{Identifier: "group-b", ThirdPartyRDMAModules: []string{"ib_isert", "ib_srpt"}},
+			{Identifier: "group-b", ThirdPartyRDMAModules: []string{"qedr", "siw"}},
 		},
 	}
 	warnThirdPartyRDMAModules(cfg, "discover", out)
@@ -154,5 +140,70 @@ func TestWarnThirdPartyRDMAModules_MultipleGroups(t *testing.T) {
 	assert.Contains(t, out.warnings[0], "group-a")
 	assert.Contains(t, out.warnings[0], "rdma_rxe")
 	assert.Contains(t, out.warnings[1], "group-b")
-	assert.Contains(t, out.warnings[1], "ib_isert, ib_srpt")
+	assert.Contains(t, out.warnings[1], "qedr, siw")
+}
+
+func TestWarnStorageModules_FlagFalse_NoWarning(t *testing.T) {
+	out := &testOutput{}
+	cfg := &config.LaunchKubernetesConfig{
+		DOCADriver: &config.DOCADriverConfig{Enable: true, UnloadStorageModules: false},
+		ClusterConfig: []config.ClusterConfig{
+			{Identifier: "g1", StorageModules: []string{"nvme_rdma", "ib_isert"}},
+		},
+	}
+	warnStorageModules(cfg, "discover", out)
+	assert.Empty(t, out.warnings, "no warning when flag is false — discovery auto-enables it")
+}
+
+func TestWarnStorageModules_AutoEnabled_Discover(t *testing.T) {
+	out := &testOutput{}
+	cfg := &config.LaunchKubernetesConfig{
+		DOCADriver: &config.DOCADriverConfig{Enable: true, UnloadStorageModules: true},
+		ClusterConfig: []config.ClusterConfig{
+			{Identifier: "g1", StorageModules: []string{"nvme_rdma"}},
+		},
+	}
+	warnStorageModules(cfg, "discover", out)
+	assert.Len(t, out.warnings, 1)
+	assert.Contains(t, out.warnings[0], "unloadStorageModules is enabled")
+	assert.Contains(t, out.warnings[0], "nvme_rdma")
+	assert.Contains(t, out.warnings[0], "Verify")
+}
+
+func TestWarnStorageModules_AutoEnabled_Generate(t *testing.T) {
+	out := &testOutput{}
+	cfg := &config.LaunchKubernetesConfig{
+		DOCADriver: &config.DOCADriverConfig{Enable: true, UnloadStorageModules: true},
+		ClusterConfig: []config.ClusterConfig{
+			{Identifier: "g1", StorageModules: []string{"nvme_rdma"}},
+		},
+	}
+	warnStorageModules(cfg, "generate", out)
+	assert.Len(t, out.warnings, 1)
+	assert.Contains(t, out.warnings[0], "unloadStorageModules is enabled")
+	assert.Contains(t, out.warnings[0], "Verify")
+}
+
+func TestWarnStorageModules_NoModules(t *testing.T) {
+	out := &testOutput{}
+	cfg := &config.LaunchKubernetesConfig{
+		DOCADriver: &config.DOCADriverConfig{Enable: true, UnloadStorageModules: true},
+		ClusterConfig: []config.ClusterConfig{
+			{Identifier: "g1", StorageModules: nil},
+		},
+	}
+	warnStorageModules(cfg, "generate", out)
+	assert.Empty(t, out.warnings)
+}
+
+func TestWarnStorageModules_DriverDisabled(t *testing.T) {
+	out := &testOutput{}
+	cfg := &config.LaunchKubernetesConfig{
+		DOCADriver: &config.DOCADriverConfig{Enable: false, UnloadStorageModules: true},
+		ClusterConfig: []config.ClusterConfig{
+			{Identifier: "g1", StorageModules: []string{"nvme_rdma"}},
+		},
+	}
+	warnStorageModules(cfg, "discover", out)
+	assert.Empty(t, out.warnings)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -143,6 +143,7 @@ type ClusterConfig struct {
 	WorkerNodes          []string             `yaml:"workerNodes"`
 	NodeSelector         map[string]string    `yaml:"nodeSelector,omitempty"`
 	ThirdPartyRDMAModules []string            `yaml:"thirdPartyRDMAModules,omitempty"`
+	StorageModules        []string            `yaml:"storageModules,omitempty"`
 	RailPciAddresses     [][]string           `yaml:"-"` // Transient: per-rail merged PCI addresses (not serialized)
 }
 

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -235,21 +235,31 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 	}
 
 	// Discover OFED-dependent kernel modules per group via pod exec.
-	// Results are always saved to config for user inspection; the
-	// unloadThirdPartyRDMAModules flag only controls template rendering.
+	// Results are classified into third-party RDMA vs storage modules and
+	// saved to config for user inspection. mlx5-prefixed modules (NVIDIA's own)
+	// are silently filtered out.
 	if p.RESTConfig != nil {
 		for i := range defaultConfig.ClusterConfig {
 			group := &defaultConfig.ClusterConfig[i]
 			modules, err := discoverThirdPartyRDMAModules(ctx, p.RESTConfig,
 				defaultConfig.NetworkOperator.Namespace, group.WorkerNodes, dsPods)
 			if err != nil {
-				log.Log.Error(err, "failed to discover third-party RDMA modules", "group", group.Identifier)
-				uiOutput.Warning("Could not discover third-party RDMA modules for group %s: %v", group.Identifier, err)
+				log.Log.Error(err, "failed to discover OFED-dependent modules", "group", group.Identifier)
+				uiOutput.Warning("Could not discover OFED-dependent modules for group %s: %v", group.Identifier, err)
 				continue
 			}
-			if len(modules) > 0 {
-				group.ThirdPartyRDMAModules = modules
-				uiOutput.Info("Discovered %d third-party RDMA module(s) for group %s", len(modules), group.Identifier)
+			rdma, storage := classifyDiscoveredModules(modules)
+			if len(rdma) > 0 {
+				group.ThirdPartyRDMAModules = rdma
+				defaultConfig.DOCADriver.UnloadThirdPartyRDMAModules = true
+				uiOutput.Info("Discovered %d third-party RDMA module(s) for group %s — enabled unloadThirdPartyRDMAModules",
+					len(rdma), group.Identifier)
+			}
+			if len(storage) > 0 {
+				group.StorageModules = storage
+				defaultConfig.DOCADriver.UnloadStorageModules = true
+				uiOutput.Info("Discovered %d storage module(s) for group %s — enabled unloadStorageModules",
+					len(storage), group.Identifier)
 			}
 		}
 	}
@@ -911,6 +921,14 @@ var ofedTargetModules = []string{
 	"ib_ipoib", "rdma_cm", "rdma_ucm", "ib_core", "ib_cm",
 }
 
+// knownStorageModules is the set of storage-over-RDMA kernel modules handled by
+// UNLOAD_STORAGE_MODULES in the driver container. Must be kept in sync with
+// doca-driver-build's StorageModules (entrypoint/internal/config/config.go).
+var knownStorageModules = map[string]bool{
+	"ib_isert": true, "nvme_rdma": true, "nvmet_rdma": true,
+	"rpcrdma": true, "xprtrdma": true, "ib_srpt": true,
+}
+
 // discoverThirdPartyRDMAModules execs into a nic-configuration-daemon pod on one
 // of the group's nodes and discovers third-party RDMA modules that depend on
 // OFED target modules via the kernel module holder graph.
@@ -1023,6 +1041,23 @@ func parseModuleList(output string, exclude []string) []string {
 	}
 	sort.Strings(modules)
 	return modules
+}
+
+// classifyDiscoveredModules splits a list of discovered OFED-dependent modules into
+// third-party RDMA modules and storage modules. mlx5-prefixed modules (NVIDIA's own)
+// are silently dropped.
+func classifyDiscoveredModules(modules []string) (rdma, storage []string) {
+	for _, mod := range modules {
+		if strings.HasPrefix(mod, "mlx5") {
+			continue // NVIDIA module — always greenlit
+		}
+		if knownStorageModules[mod] {
+			storage = append(storage, mod)
+		} else {
+			rdma = append(rdma, mod)
+		}
+	}
+	return rdma, storage
 }
 
 // execInPod runs a command in a pod container and returns stdout.

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -553,6 +553,22 @@ func buildMergedGroup(groups []config.ClusterConfig, indices []int) config.Clust
 		slices.Sort(mergedDepMods)
 	}
 
+	// Merge storage modules (same union pattern)
+	storageModSet := map[string]bool{}
+	for _, idx := range indices {
+		for _, mod := range groups[idx].StorageModules {
+			storageModSet[mod] = true
+		}
+	}
+	var mergedStorageMods []string
+	if len(storageModSet) > 0 {
+		mergedStorageMods = make([]string, 0, len(storageModSet))
+		for mod := range storageModSet {
+			mergedStorageMods = append(mergedStorageMods, mod)
+		}
+		slices.Sort(mergedStorageMods)
+	}
+
 	return config.ClusterConfig{
 		Identifier:           sanitizeIdentifier(productType),
 		ProductType:          productType,
@@ -560,6 +576,7 @@ func buildMergedGroup(groups []config.ClusterConfig, indices []int) config.Clust
 		PFs:                  first.PFs, // Representative PFs from first group
 		WorkerNodes:          allNodes,
 		ThirdPartyRDMAModules: mergedDepMods,
+		StorageModules:        mergedStorageMods,
 		NodeSelector: map[string]string{
 			"nvidia.com/gpu.product": productType,
 		},

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -45,19 +45,20 @@ docaDriver:
   # DOCA driver container image version. Must match the operator version.
   version: doca3.3.0-26.01-1.0.0.0-0
 
-  # bool | default: true
-  # Unload in-tree storage kernel modules (e.g., ib_isert, ib_srpt) before
-  # loading OFED modules. Prevents module conflicts on storage nodes.
+  # bool | default: false, auto-enabled by discovery when storage modules are found
+  # Unload known storage-over-RDMA kernel modules (ib_isert, nvme_rdma, nvmet_rdma,
+  # rpcrdma, xprtrdma, ib_srpt) before loading OFED modules.
+  # Discovery automatically sets this to true when storage modules are detected.
   unloadStorageModules: true
 
   # bool | default: false
   # Enable NFS over RDMA kernel module support in the OFED driver.
   enableNFSRDMA: false
 
-  # bool | default: true
+  # bool | default: false, auto-enabled by discovery when third-party RDMA modules are found
   # When true, adds UNLOAD_THIRD_PARTY_RDMA_MODULES env var to the ofedDriver container.
-  # The list is populated from thirdPartyRDMAModules discovered per group.
-  # These modules are blacklisted and unloaded before OFED driver reload.
+  # Third-party RDMA modules are blacklisted and unloaded before OFED driver reload.
+  # Discovery automatically sets this to true when third-party RDMA modules are detected.
   unloadThirdPartyRDMAModules: true
 
 # ============================================================================


### PR DESCRIPTION
and storage categories, filter mlx5-prefixed modules

The BFS discovery previously lumped all non-MOFED dependents into thirdPartyRDMAModules. This caused misleading warnings: storage modules (ib_isert, nvme_rdma, etc.) need UNLOAD_STORAGE_MODULES, not UNLOAD_THIRD_PARTY_RDMA_MODULES.

Now classifyDiscoveredModules() splits BFS results into:
- Storage modules (saved as storageModules, warn about unloadStorageModules)
- Third-party RDMA modules (saved as thirdPartyRDMAModules, warn about unloadThirdPartyRDMAModules)
- mlx5-prefixed modules (NVIDIA's own, silently dropped)

Aligned with doca-driver-build and network-operator-init-container changes that separated these module categories.