### PR TITLE
Discover machine type and GPU product from hardware when GPU operator…

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,26 @@ clusterConfig:
     traffic: north-south     # BlueField DPU — excluded from manifests
 ```
 
+### Machine and GPU Product Type
+
+During discovery, each node group's `machineType` and `productType` are populated from GPU operator node labels (`nvidia.com/gpu.machine` and `nvidia.com/gpu.product`). When these labels are absent — for example, when the GPU operator is not deployed — the tool falls back to probing hardware directly from a `nic-configuration-daemon` pod on one of the group's nodes:
+
+- **Machine type**: read from `/sys/class/dmi/id/product_name`
+- **GPU product type**: parsed from `nvidia-smi -q` output (the first `Product Name` field)
+
+Values are sanitized to match the GPU operator label format (spaces replaced with dashes). If either probe fails (e.g., `nvidia-smi` not installed, DMI not readable), the corresponding field is left empty and discovery continues without error.
+
+Example of discovered hardware types in the config:
+```yaml
+clusterConfig:
+- identifier: group-0
+  machineType: ThinkSystem-SR680a-V3
+  productType: NVIDIA-H100-NVL
+  workerNodes:
+  - node-1
+  - node-2
+```
+
 ### NIC Interface Name Templates
 
 The `nicConfigurationOperator.deployNicInterfaceNameTemplate` setting controls whether a `NicInterfaceNameTemplate` CR is deployed to rename NIC interfaces to predictable, rail-based names (e.g., `eth_r0`, `eth_r1`). When set to `true`, the tool treats it as "enable when needed" rather than "always enable". The NicInterfaceNameTemplate CR and associated `nicConfigurationOperator` section in NicClusterPolicy are only deployed when one of the following conditions is met:

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -241,6 +241,25 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 	if p.RESTConfig != nil {
 		for i := range defaultConfig.ClusterConfig {
 			group := &defaultConfig.ClusterConfig[i]
+
+			// Fill in missing machine/GPU product types by probing hardware
+			// directly when GPU operator node labels are absent.
+			needMachine := group.MachineType == ""
+			needProduct := group.ProductType == ""
+			if needMachine || needProduct {
+				machine, product := discoverHardwareTypes(ctx, p.RESTConfig,
+					defaultConfig.NetworkOperator.Namespace, group.WorkerNodes, dsPods,
+					needMachine, needProduct)
+				if needMachine && machine != "" {
+					group.MachineType = machine
+					uiOutput.Info("Discovered machine type for group %s: %s", group.Identifier, machine)
+				}
+				if needProduct && product != "" {
+					group.ProductType = product
+					uiOutput.Info("Discovered GPU product type for group %s: %s", group.Identifier, product)
+				}
+			}
+
 			modules, err := discoverThirdPartyRDMAModules(ctx, p.RESTConfig,
 				defaultConfig.NetworkOperator.Namespace, group.WorkerNodes, dsPods)
 			if err != nil {
@@ -929,6 +948,97 @@ var knownStorageModules = map[string]bool{
 	"rpcrdma": true, "xprtrdma": true, "ib_srpt": true,
 }
 
+// parseMachineTypeFromDMI extracts and sanitizes a machine type string from
+// raw /sys/class/dmi/id/product_name content. It trims whitespace/newlines
+// and replaces spaces with dashes to match GPU operator label format.
+// Returns empty string if input is blank after trimming.
+func parseMachineTypeFromDMI(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	return strings.ReplaceAll(s, " ", "-")
+}
+
+// parseGPUProductFromNvidiaSmi extracts the first "Product Name" value from
+// nvidia-smi -q output and sanitizes it to match GPU operator label format
+// (spaces replaced with dashes). Returns empty string if no product name found.
+func parseGPUProductFromNvidiaSmi(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, "Product Name") {
+			continue
+		}
+		parts := strings.SplitN(line, " : ", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		name := strings.TrimSpace(parts[1])
+		if name == "" {
+			continue
+		}
+		return strings.ReplaceAll(name, " ", "-")
+	}
+	return ""
+}
+
+// discoverHardwareTypes attempts to discover machineType and productType by
+// probing hardware directly when label-derived values are empty. It execs into
+// a nic-configuration-daemon pod on one of the group's nodes.
+// Returns (machineType, productType) — either or both may still be empty if
+// discovery fails or hardware info is unavailable.
+func discoverHardwareTypes(ctx context.Context, restConfig *rest.Config,
+	namespace string, groupNodes []string, dsPods []corev1.Pod,
+	needMachine, needProduct bool) (machineType, productType string) {
+
+	targetPod := findDaemonPod(groupNodes, dsPods)
+	if targetPod == nil {
+		log.Log.Info("No nic-configuration-daemon pod found on group nodes; skipping hardware type probing")
+		return "", ""
+	}
+
+	containerName := ""
+	if len(targetPod.Spec.Containers) > 0 {
+		containerName = targetPod.Spec.Containers[0].Name
+	}
+
+	if needMachine {
+		output, err := execInPod(ctx, restConfig, namespace, targetPod.Name, containerName,
+			[]string{"/bin/sh", "-c", "cat /sys/class/dmi/id/product_name 2>/dev/null"})
+		if err != nil {
+			log.Log.Error(err, "failed to read machine type from DMI", "pod", targetPod.Name)
+		} else {
+			machineType = parseMachineTypeFromDMI(output)
+		}
+	}
+
+	if needProduct {
+		output, err := execInPod(ctx, restConfig, namespace, targetPod.Name, containerName,
+			[]string{"/bin/sh", "-c", "LD_LIBRARY_PATH=/host/usr/lib/x86_64-linux-gnu:/host/usr/lib/aarch64-linux-gnu:$LD_LIBRARY_PATH /host/usr/bin/nvidia-smi -q 2>/dev/null"})
+		if err != nil {
+			log.Log.Error(err, "failed to read GPU product type from nvidia-smi", "pod", targetPod.Name)
+		} else {
+			productType = parseGPUProductFromNvidiaSmi(output)
+		}
+	}
+
+	return machineType, productType
+}
+
+// findDaemonPod returns a nic-configuration-daemon pod running on one of the
+// given nodes. Returns nil if no pod is found on any of the nodes.
+func findDaemonPod(groupNodes []string, dsPods []corev1.Pod) *corev1.Pod {
+	nodeSet := make(map[string]bool, len(groupNodes))
+	for _, n := range groupNodes {
+		nodeSet[n] = true
+	}
+	for i := range dsPods {
+		if nodeSet[dsPods[i].Spec.NodeName] {
+			return &dsPods[i]
+		}
+	}
+	return nil
+}
+
 // discoverThirdPartyRDMAModules execs into a nic-configuration-daemon pod on one
 // of the group's nodes and discovers third-party RDMA modules that depend on
 // OFED target modules via the kernel module holder graph.
@@ -941,18 +1051,7 @@ func discoverThirdPartyRDMAModules(ctx context.Context, restConfig *rest.Config,
 
 	// Find a daemon pod running on one of the group's nodes.
 	// All nodes in a group have identical hardware, so one is sufficient.
-	nodeSet := make(map[string]bool, len(groupNodes))
-	for _, n := range groupNodes {
-		nodeSet[n] = true
-	}
-
-	var targetPod *corev1.Pod
-	for i := range dsPods {
-		if nodeSet[dsPods[i].Spec.NodeName] {
-			targetPod = &dsPods[i]
-			break
-		}
-	}
+	targetPod := findDaemonPod(groupNodes, dsPods)
 	if targetPod == nil {
 		return nil, fmt.Errorf("no nic-configuration-daemon pod found on group nodes")
 	}

--- a/pkg/networkoperatorplugin/discovery_test.go
+++ b/pkg/networkoperatorplugin/discovery_test.go
@@ -101,3 +101,110 @@ func TestAlternateNamespace(t *testing.T) {
 	assert.Equal(t, "nvidia-network-operator", alternateNamespace("network-operator"))
 	assert.Equal(t, "", alternateNamespace("custom-namespace"))
 }
+
+func TestParseMachineTypeFromDMI(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"normal value", "DGXH100 880G\n", "DGXH100-880G"},
+		{"trailing whitespace", "  DGXH100 880G  \n\n", "DGXH100-880G"},
+		{"no spaces", "DGX-A100\n", "DGX-A100"},
+		{"empty", "", ""},
+		{"whitespace only", "  \n", ""},
+		{"multiple spaces", "ThinkSystem SR680a V3\n", "ThinkSystem-SR680a-V3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseMachineTypeFromDMI(tt.raw))
+		})
+	}
+}
+
+func TestParseGPUProductFromNvidiaSmi(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name: "single GPU",
+			output: `GPU 00000000:E1:00.0
+    Product Name                          : NVIDIA H100 NVL
+    Product Brand                         : NVIDIA
+`,
+			want: "NVIDIA-H100-NVL",
+		},
+		{
+			name: "multiple GPUs returns first",
+			output: `GPU 00000000:E1:00.0
+    Product Name                          : NVIDIA H100 NVL
+GPU 00000000:E2:00.0
+    Product Name                          : NVIDIA A100 80GB
+`,
+			want: "NVIDIA-H100-NVL",
+		},
+		{
+			name:   "no product name",
+			output: "Driver Version: 550.90\nCUDA Version: 12.4\n",
+			want:   "",
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   "",
+		},
+		{
+			name:   "extra whitespace",
+			output: "    Product Name                          : NVIDIA H100 NVL   \n",
+			want:   "NVIDIA-H100-NVL",
+		},
+		{
+			name:   "SXM variant",
+			output: "    Product Name                          : NVIDIA H100 80GB HBM3\n",
+			want:   "NVIDIA-H100-80GB-HBM3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseGPUProductFromNvidiaSmi(tt.output))
+		})
+	}
+}
+
+func TestFindDaemonPod(t *testing.T) {
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "daemon-pod-1"},
+			Spec:       corev1.PodSpec{NodeName: "node-1"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "daemon-pod-2"},
+			Spec:       corev1.PodSpec{NodeName: "node-2"},
+		},
+	}
+
+	t.Run("pod found on matching node", func(t *testing.T) {
+		result := findDaemonPod([]string{"node-2", "node-3"}, pods)
+		require.NotNil(t, result)
+		assert.Equal(t, "daemon-pod-2", result.Name)
+	})
+
+	t.Run("no matching node", func(t *testing.T) {
+		result := findDaemonPod([]string{"node-5"}, pods)
+		assert.Nil(t, result)
+	})
+
+	t.Run("empty nodes list", func(t *testing.T) {
+		result := findDaemonPod([]string{}, pods)
+		assert.Nil(t, result)
+	})
+
+	t.Run("empty pods list", func(t *testing.T) {
+		result := findDaemonPod([]string{"node-1"}, []corev1.Pod{})
+		assert.Nil(t, result)
+	})
+}


### PR DESCRIPTION
… labels are absent

During discovery, machineType and productType are read from GPU operator node labels (nvidia.com/gpu.machine, nvidia.com/gpu.product). When these labels are missing — e.g. the GPU operator is not deployed — the fields were left empty, which prevented group merging and degraded config quality.

Add a fallback that probes hardware directly by execing into a nic-configuration-daemon pod:
- Machine type: read from /sys/class/dmi/id/product_name
- GPU product: parsed from nvidia-smi -q output (first Product Name field), using host-mounted binary with both x86_64 and aarch64 library paths

Values are sanitized (spaces replaced with dashes) to match the GPU operator label format. Failures are non-fatal — if either probe fails, the field stays empty and discovery continues without error.

Also extract findDaemonPod() helper from discoverThirdPartyRDMAModules() for reuse by the new discoverHardwareTypes() function.