### PR TITLE
Add predefined cluster topology presets for known machine types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Build binary
+        run: make build
+
+      - name: Build all platforms
+        run: make build-all
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v -race -count=1 ./...
+
+      - name: Run tests with coverage
+        run: |
+          go test -coverprofile=coverage.out ./...
+          go tool cover -func=coverage.out
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.11

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+linters:
+  disable:
+    - errcheck

--- a/docs/presets.rst
+++ b/docs/presets.rst
@@ -1,0 +1,177 @@
+Predefined Cluster Configuration Presets
+========================================
+
+Overview
+--------
+
+l8k supports **predefined topology presets** for known server machine types. Presets provide authoritative hardware topology data that replaces heuristic-based discovery results, including:
+
+- **Traffic classification** (east-west vs north-south) for each NIC port
+- **Rail assignments** for east-west ports
+- **NUMA node affinity** for each NIC port
+- **GPU proximity** (which GPU each NIC is physically closest to)
+
+When a cluster node's machine type matches a preset and its PCI topology validates against the discovered hardware, the preset is automatically applied during discovery.
+
+How It Works
+------------
+
+During ``l8k discover``, after determining a node group's machine type (from GPU operator labels or DMI data), l8k checks the local presets directory for a matching entry:
+
+1. **Lookup**: Searches for ``<presets-dir>/<machine-type>/topology.yaml``
+2. **Validation**: Compares PCI addresses and device IDs between the preset and discovered NicDevices
+3. **Application**: If validation passes, overrides traffic classification, rail assignments, and adds NUMA/GPU topology metadata
+4. **Fallback**: If no preset matches or validation fails, falls back to dynamic heuristic-based discovery
+
+The preset directory is resolved using the same lookup chain as profiles:
+
+- ``./presets`` (current working directory)
+- ``/usr/local/share/l8k/presets`` (default install)
+- ``<binary-dir>/../share/l8k/presets`` (custom prefix install)
+
+Validation
+----------
+
+Preset validation ensures the preset matches the actual hardware present in the cluster. The following checks are performed:
+
+.. list-table::
+   :widths: 20 40 20
+   :header-rows: 1
+
+   * - Check
+     - Description
+     - On Mismatch
+   * - PF count
+     - Number of PFs in preset must match discovered count
+     - Preset rejected
+   * - PCI addresses
+     - Every PCI address must match between preset and discovered hardware
+     - Preset rejected
+   * - Device IDs
+     - Device ID at each PCI address must match
+     - Preset rejected
+   * - Part numbers
+     - Part numbers may differ across vendor SKUs
+     - Warning logged, discovered value used
+   * - PSIDs
+     - PSIDs may differ across firmware versions
+     - Warning logged, discovered value used
+
+Available Presets
+-----------------
+
+The following presets are bundled with l8k:
+
+.. list-table::
+   :widths: 30 20 20 15
+   :header-rows: 1
+
+   * - Machine Type
+     - GPU Product
+     - NIC Model
+     - Rails
+   * - PowerEdge-XE9680
+     - NVIDIA H200
+     - BlueField-3 SuperNIC (ConnectX-7)
+     - 8
+   * - ThinkSystem-SR680a-V3
+     - NVIDIA H200
+     - BlueField-3 VPI (ConnectX-7)
+     - 8
+   * - UCSC-885A-M8-H22
+     - NVIDIA H200
+     - BlueField-3 E-series SuperNIC (ConnectX-7)
+     - 8
+
+Managing Presets
+----------------
+
+List local presets
+^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   l8k preset list
+
+Download latest presets
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Download the latest presets from the GitHub repository:
+
+.. code-block:: bash
+
+   l8k preset update
+
+By default, presets are downloaded from the ``main`` branch of ``nvidia/k8s-launch-kit``. You can customize this:
+
+.. code-block:: bash
+
+   # Custom repository and branch
+   l8k preset update --repo myorg/k8s-launch-kit --branch develop
+
+   # Custom destination directory
+   l8k preset update --dir /opt/l8k/presets
+
+For authenticated requests (to avoid GitHub API rate limits), set the ``GITHUB_TOKEN`` environment variable:
+
+.. code-block:: bash
+
+   export GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+   l8k preset update
+
+Install script
+^^^^^^^^^^^^^^
+
+The install script (``scripts/install.sh``) automatically installs bundled presets and optionally downloads the latest from GitHub:
+
+.. code-block:: bash
+
+   # Default: installs bundled presets and downloads latest
+   scripts/install.sh
+
+   # Skip downloading latest presets (use bundled only)
+   scripts/install.sh --skip-presets-update
+
+Topology YAML Format
+--------------------
+
+Each preset is a ``topology.yaml`` file in a machine-type-named directory. The format is a superset of the ``clusterConfig.pfs`` schema with additional topology metadata:
+
+.. code-block:: yaml
+
+   machineType: PowerEdge-XE9680
+   productType: NVIDIA-H200
+   nicModel: BlueField-3 B3140H E-series HHHL SuperNIC (ConnectX-7)
+   gpuInterconnect: NV18
+   numaNodes: 2
+
+   pfs:
+     - deviceID: a2dc
+       pciAddress: 0000:1a:00.0
+       traffic: east-west
+       rail: 0
+       numaNode: 0             # NUMA node affinity
+       connectedGPU: GPU0      # Physically closest GPU
+       gpuProximity: PIX       # PCI proximity level
+       psid: mt_0000001069
+       partNumber: 0KK4NR
+     - deviceID: a2dc
+       pciAddress: 0000:9d:00.0
+       traffic: north-south    # DPU/management NIC
+       numaNode: 1
+       connectedGPU: ""
+       gpuProximity: NODE
+       psid: mt_0000000884
+       partNumber: 0HFWRM
+
+Adding New Presets
+------------------
+
+To add a preset for a new machine type:
+
+1. Run the topology collector on a representative node of that machine type
+2. Create a directory named after the machine type (matching DMI ``product_name`` with spaces replaced by dashes)
+3. Place the ``topology.yaml`` file in that directory
+4. Submit a pull request to the repository
+
+The machine type string must match exactly what ``/sys/class/dmi/id/product_name`` returns (after space-to-dash sanitization), or the ``nvidia.com/gpu.machine`` node label value.

--- a/pkg/cmd/chat.go
+++ b/pkg/cmd/chat.go
@@ -105,5 +105,5 @@ func init() {
 	chatCmd.Flags().StringVar(&networkOperatorNamespace, "network-operator-namespace", "", "Override operator namespace")
 	chatCmd.Flags().StringVar(&enabledPlugins, "enabled-plugins", "network-operator", "Comma-separated list of plugins to enable")
 
-	chatCmd.MarkFlagRequired("llm-api-key")
+	_ = chatCmd.MarkFlagRequired("llm-api-key")
 }

--- a/pkg/cmd/preset.go
+++ b/pkg/cmd/preset.go
@@ -1,0 +1,119 @@
+// Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/presets"
+)
+
+var (
+	presetDir    string
+	presetRepo   string
+	presetBranch string
+)
+
+var presetCmd = &cobra.Command{
+	Use:   "preset",
+	Short: "Manage predefined cluster configuration presets",
+	Long: `Manage predefined topology presets for known machine types.
+
+Presets provide authoritative traffic classification, rail assignments, and
+NUMA/GPU topology metadata for known hardware configurations. During cluster
+discovery, presets are automatically matched and applied when the machine type
+matches and PCI topology validates.`,
+}
+
+var presetListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available local presets",
+	Long:  "List all predefined topology presets available in the local presets directory.",
+	Example: `  l8k preset list
+  l8k preset list --output json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		names, err := presets.ListPresets()
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
+			return
+		}
+
+		dir, _ := presets.GetPresetsDir()
+		if dir == "" {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No presets directory found.")
+			return
+		}
+
+		if len(names) == 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "No presets found in %s\n", dir)
+			return
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Available presets (%s):\n", dir)
+		for _, name := range names {
+			fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", name)
+		}
+	},
+}
+
+var presetUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Download latest presets from GitHub",
+	Long: `Download the latest predefined topology presets from the GitHub repository.
+
+Uses the GitHub API to list and fetch preset files. Set GITHUB_TOKEN
+environment variable for authenticated requests (avoids rate limits).`,
+	Example: `  l8k preset update
+  l8k preset update --repo nvidia/k8s-launch-kit --branch main
+  l8k preset update --dir /usr/local/share/l8k/presets`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		opts := presets.DownloadOptions{
+			Repo:   presetRepo,
+			Branch: presetBranch,
+			Dir:    presetDir,
+		}
+
+		downloaded, err := presets.DownloadPresets(context.Background(), opts)
+		if err != nil {
+			return fmt.Errorf("preset update failed: %w", err)
+		}
+
+		if len(downloaded) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No presets found in remote repository.")
+			return nil
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Downloaded %d preset(s):\n", len(downloaded))
+		for _, name := range downloaded {
+			fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", name)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(presetCmd)
+	presetCmd.AddCommand(presetListCmd)
+	presetCmd.AddCommand(presetUpdateCmd)
+
+	presetUpdateCmd.Flags().StringVar(&presetDir, "dir", "", "Destination directory for downloaded presets (default: auto-resolve)")
+	presetUpdateCmd.Flags().StringVar(&presetRepo, "repo", "nvidia/k8s-launch-kit", "GitHub repository to download presets from")
+	presetUpdateCmd.Flags().StringVar(&presetBranch, "branch", "main", "Git branch to download presets from")
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,6 +138,7 @@ type ClusterConfig struct {
 	Identifier           string               `yaml:"identifier"`
 	MachineType          string               `yaml:"machineType,omitempty"`
 	ProductType          string               `yaml:"productType,omitempty"`
+	PresetApplied        bool                 `yaml:"presetApplied,omitempty"`
 	Capabilities         *ClusterCapabilities `yaml:"capabilities"`
 	PFs                  []PFConfig           `yaml:"pfs"`
 	WorkerNodes          []string             `yaml:"workerNodes"`
@@ -166,6 +167,10 @@ type PFConfig struct {
 	Rail             *int   `yaml:"rail,omitempty"`
 	PSID             string `yaml:"psid,omitempty"`
 	PartNumber       string `yaml:"partNumber,omitempty"`
+	// Topology fields (populated from presets when available)
+	NumaNode     *int   `yaml:"numaNode,omitempty"`
+	ConnectedGPU string `yaml:"connectedGPU,omitempty"`
+	GPUProximity string `yaml:"gpuProximity,omitempty"`
 }
 
 // AggregateCapabilities computes the union of capabilities across all cluster config groups.

--- a/pkg/fwresolver/resolver.go
+++ b/pkg/fwresolver/resolver.go
@@ -110,7 +110,7 @@ func ResolveURLs(ctx context.Context, logger logr.Logger, psidInfos []PSIDInfo, 
 	if err != nil {
 		return nil, fmt.Errorf("firmware API request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/fwresolver/resolver_test.go
+++ b/pkg/fwresolver/resolver_test.go
@@ -51,7 +51,7 @@ func TestResolveURLs_Found(t *testing.T) {
 			{Found: 0, PSID: "MT_0000000222", URL: ""},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
@@ -72,7 +72,7 @@ func TestResolveURLs_Found(t *testing.T) {
 func TestResolveURLs_NetworkError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("internal error"))
+		_, _ = w.Write([]byte("internal error"))
 	}))
 	defer server.Close()
 
@@ -87,7 +87,7 @@ func TestResolveURLs_NetworkError(t *testing.T) {
 func TestResolveURLs_InvalidJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte("not-valid-json"))
+		_, _ = w.Write([]byte("not-valid-json"))
 	}))
 	defer server.Close()
 

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -166,9 +166,7 @@ func trimMarkdownJSON(s string) string {
 	}
 
 	// Check for ``` at the end
-	if strings.HasSuffix(s, "```") {
-		s = strings.TrimSuffix(s, "```")
-	}
+	s = strings.TrimSuffix(s, "```")
 
 	return strings.TrimSpace(s)
 }

--- a/pkg/llm/toolexec.go
+++ b/pkg/llm/toolexec.go
@@ -139,7 +139,7 @@ func listDirectory(dirPath string) string {
 	}
 
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("Directory listing of %s:\n", dirPath))
+	fmt.Fprintf(&sb, "Directory listing of %s:\n", dirPath)
 	for _, entry := range entries {
 		suffix := ""
 		if entry.IsDir() {
@@ -147,10 +147,10 @@ func listDirectory(dirPath string) string {
 		}
 		info, err := entry.Info()
 		if err != nil {
-			sb.WriteString(fmt.Sprintf("  %s%s\n", entry.Name(), suffix))
+			fmt.Fprintf(&sb, "  %s%s\n", entry.Name(), suffix)
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("  %s%s (%d bytes)\n", entry.Name(), suffix, info.Size()))
+		fmt.Fprintf(&sb, "  %s%s (%d bytes)\n", entry.Name(), suffix, info.Size())
 	}
 	return sb.String()
 }
@@ -162,7 +162,7 @@ func readFileContent(filePath string, size int64) string {
 		if err != nil {
 			return fmt.Sprintf("Error: cannot open file: %v", err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		n, err := f.Read(data)
 		if err != nil {
 			return fmt.Sprintf("Error: cannot read file: %v", err)

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -29,6 +29,7 @@ import (
 	netop "github.com/Mellanox/network-operator/api/v1alpha1"
 	nicop "github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/nvidia/k8s-launch-kit/pkg/presets"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -257,6 +258,26 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 				if needProduct && product != "" {
 					group.ProductType = product
 					uiOutput.Info("Discovered GPU product type for group %s: %s", group.Identifier, product)
+				}
+			}
+
+			// Try to enrich with a predefined topology preset for this machine type.
+			// Presets provide authoritative traffic classification, rail assignments,
+			// and NUMA/GPU topology metadata for known hardware configurations.
+			if group.MachineType != "" {
+				preset, presetErr := presets.LoadPreset(group.MachineType)
+				if presetErr != nil {
+					log.Log.Error(presetErr, "failed to load preset", "machineType", group.MachineType)
+					uiOutput.Warning("Failed to load preset for %s: %v", group.MachineType, presetErr)
+				} else if preset != nil {
+					if presetErr := presets.ValidatePreset(preset, group.PFs); presetErr != nil {
+						log.Log.Info("Preset did not match discovered hardware",
+							"machineType", group.MachineType, "error", presetErr)
+						uiOutput.Info("Preset for %s did not match discovered hardware: %v", group.MachineType, presetErr)
+					} else {
+						presets.ApplyPreset(preset, group)
+						uiOutput.Info("Applied preset configuration for %s", group.MachineType)
+					}
 				}
 			}
 
@@ -816,11 +837,9 @@ func computeNodeSelectors(groups []config.ClusterConfig, nodeLabels map[string]m
 
 	// Deprioritize feature.node.kubernetes.io/* labels — only include them
 	// if the remaining labels can't differentiate all groups on their own.
-	var primaryKeys, fallbackKeys []string
+	var primaryKeys []string
 	for _, k := range differingKeys {
-		if strings.HasPrefix(k, "feature.node.kubernetes.io/") {
-			fallbackKeys = append(fallbackKeys, k)
-		} else {
+		if !strings.HasPrefix(k, "feature.node.kubernetes.io/") {
 			primaryKeys = append(primaryKeys, k)
 		}
 	}

--- a/pkg/presets/download.go
+++ b/pkg/presets/download.go
@@ -1,0 +1,196 @@
+// Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package presets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	defaultRepo   = "nvidia/k8s-launch-kit"
+	defaultBranch = "main"
+	httpTimeout   = 30 * time.Second
+)
+
+// githubEntry represents a single entry from the GitHub contents API response.
+type githubEntry struct {
+	Name string `json:"name"`
+	Type string `json:"type"` // "file" or "dir"
+}
+
+// DownloadOptions configures the preset download behavior.
+type DownloadOptions struct {
+	Repo       string // GitHub repository (default: nvidia/k8s-launch-kit)
+	Branch     string // Git branch (default: main)
+	Dir        string // Destination directory (empty = auto-resolve via GetPresetsDir)
+	HTTPClient *http.Client
+}
+
+// DefaultDownloadOptions returns DownloadOptions with default values.
+func DefaultDownloadOptions() DownloadOptions {
+	return DownloadOptions{
+		Repo:   defaultRepo,
+		Branch: defaultBranch,
+	}
+}
+
+// DownloadPresets fetches the latest topology presets from a GitHub repository
+// and writes them to the local presets directory.
+// It returns the list of machine types that were downloaded.
+func DownloadPresets(ctx context.Context, opts DownloadOptions) ([]string, error) {
+	return downloadPresetsWithBaseURL(ctx, opts, "")
+}
+
+// downloadPresetsWithBaseURL is the internal implementation of DownloadPresets.
+// When baseURL is non-empty, it replaces the default GitHub API and raw content
+// hosts — used by tests with httptest servers.
+func downloadPresetsWithBaseURL(ctx context.Context, opts DownloadOptions, baseURL string) ([]string, error) {
+	if opts.Repo == "" {
+		opts.Repo = defaultRepo
+	}
+	if opts.Branch == "" {
+		opts.Branch = defaultBranch
+	}
+
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: httpTimeout}
+	}
+
+	destDir := opts.Dir
+	if destDir == "" {
+		// Try to resolve existing presets dir, fall back to default install location
+		dir, err := GetPresetsDir()
+		if err != nil {
+			return nil, err
+		}
+		if dir != "" {
+			destDir = dir
+		} else {
+			destDir = "/usr/local/share/l8k/presets"
+		}
+	}
+
+	// Step 1: List machine type directories from GitHub
+	apiHost := "https://api.github.com"
+	rawHost := "https://raw.githubusercontent.com"
+	if baseURL != "" {
+		apiHost = baseURL
+		rawHost = baseURL
+	}
+
+	apiURL := fmt.Sprintf("%s/repos/%s/contents/presets?ref=%s", apiHost, opts.Repo, opts.Branch)
+	entries, err := listGitHubDir(ctx, client, apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list presets from GitHub: %w", err)
+	}
+
+	// Step 2: Download topology.yaml for each machine type directory
+	var downloaded []string
+	for _, entry := range entries {
+		if entry.Type != "dir" {
+			continue
+		}
+
+		rawURL := fmt.Sprintf("%s/%s/%s/presets/%s/topology.yaml",
+			rawHost, opts.Repo, opts.Branch, entry.Name)
+
+		data, err := fetchURL(ctx, client, rawURL)
+		if err != nil {
+			return downloaded, fmt.Errorf("failed to download preset %s: %w", entry.Name, err)
+		}
+
+		// Create machine type directory and write topology.yaml
+		machineDir := filepath.Join(destDir, entry.Name)
+		if err := os.MkdirAll(machineDir, 0o755); err != nil {
+			return downloaded, fmt.Errorf("failed to create directory %s: %w", machineDir, err)
+		}
+
+		topoPath := filepath.Join(machineDir, "topology.yaml")
+		if err := os.WriteFile(topoPath, data, 0o644); err != nil {
+			return downloaded, fmt.Errorf("failed to write %s: %w", topoPath, err)
+		}
+
+		downloaded = append(downloaded, entry.Name)
+	}
+
+	return downloaded, nil
+}
+
+// listGitHubDir fetches a GitHub contents API endpoint and returns the entries.
+func listGitHubDir(ctx context.Context, client *http.Client, url string) ([]githubEntry, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	// Use GITHUB_TOKEN for authenticated requests if available
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var entries []githubEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return nil, fmt.Errorf("failed to parse GitHub API response: %w", err)
+	}
+
+	return entries, nil
+}
+
+// fetchURL performs a GET request and returns the response body.
+func fetchURL(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use GITHUB_TOKEN for authenticated requests if available
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d for %s", resp.StatusCode, url)
+	}
+
+	return io.ReadAll(resp.Body)
+}

--- a/pkg/presets/download_test.go
+++ b/pkg/presets/download_test.go
@@ -1,0 +1,520 @@
+// Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package presets
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// --- DownloadPresets tests ---
+
+func TestDownloadPresets_Success(t *testing.T) {
+	// Set up a mock GitHub API server
+	mux := http.NewServeMux()
+
+	// Mock the contents API listing
+	mux.HandleFunc("/repos/test/repo/contents/presets", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("ref") != "main" {
+			t.Errorf("expected ref=main, got %q", r.URL.Query().Get("ref"))
+		}
+		entries := []githubEntry{
+			{Name: "MachineA", Type: "dir"},
+			{Name: "MachineB", Type: "dir"},
+			{Name: "README.md", Type: "file"}, // should be skipped
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(entries)
+	})
+
+	// Mock raw content downloads
+	mux.HandleFunc("/test/repo/main/presets/MachineA/topology.yaml", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("machineType: MachineA\npfs: []\n"))
+	})
+	mux.HandleFunc("/test/repo/main/presets/MachineB/topology.yaml", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("machineType: MachineB\npfs:\n  - deviceID: a2dc\n    pciAddress: \"0000:1a:00.0\"\n"))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	destDir := filepath.Join(t.TempDir(), "presets")
+
+	// Patch URLs to use test server — create a custom download function
+	opts := DownloadOptions{
+		Repo:       "test/repo",
+		Branch:     "main",
+		Dir:        destDir,
+		HTTPClient: server.Client(),
+	}
+
+	// Override the download to use our test server URLs
+	downloaded, err := downloadPresetsWithBaseURL(context.Background(), opts, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sort.Strings(downloaded)
+	if len(downloaded) != 2 {
+		t.Fatalf("expected 2 downloads, got %d: %v", len(downloaded), downloaded)
+	}
+	if downloaded[0] != "MachineA" || downloaded[1] != "MachineB" {
+		t.Errorf("unexpected downloads: %v", downloaded)
+	}
+
+	// Verify files were written
+	dataA, err := os.ReadFile(filepath.Join(destDir, "MachineA", "topology.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read MachineA: %v", err)
+	}
+	if !strings.Contains(string(dataA), "machineType: MachineA") {
+		t.Errorf("MachineA content mismatch: %s", string(dataA))
+	}
+
+	dataB, err := os.ReadFile(filepath.Join(destDir, "MachineB", "topology.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read MachineB: %v", err)
+	}
+	if !strings.Contains(string(dataB), "machineType: MachineB") {
+		t.Errorf("MachineB content mismatch: %s", string(dataB))
+	}
+}
+
+func TestDownloadPresets_EmptyRepo(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test/repo/contents/presets", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]githubEntry{})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	opts := DownloadOptions{
+		Repo:       "test/repo",
+		Branch:     "main",
+		Dir:        t.TempDir(),
+		HTTPClient: server.Client(),
+	}
+
+	downloaded, err := downloadPresetsWithBaseURL(context.Background(), opts, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(downloaded) != 0 {
+		t.Errorf("expected 0 downloads, got %d", len(downloaded))
+	}
+}
+
+func TestDownloadPresets_APIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test/repo/contents/presets", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message": "Not Found"}`))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	opts := DownloadOptions{
+		Repo:       "test/repo",
+		Branch:     "main",
+		Dir:        t.TempDir(),
+		HTTPClient: server.Client(),
+	}
+
+	_, err := downloadPresetsWithBaseURL(context.Background(), opts, server.URL)
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected 404 in error, got: %v", err)
+	}
+}
+
+func TestDownloadPresets_FileDownloadError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test/repo/contents/presets", func(w http.ResponseWriter, r *http.Request) {
+		entries := []githubEntry{
+			{Name: "MachineA", Type: "dir"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(entries)
+	})
+	// No handler for the raw content — will 404
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	opts := DownloadOptions{
+		Repo:       "test/repo",
+		Branch:     "main",
+		Dir:        t.TempDir(),
+		HTTPClient: server.Client(),
+	}
+
+	_, err := downloadPresetsWithBaseURL(context.Background(), opts, server.URL)
+	if err == nil {
+		t.Fatal("expected error for missing topology.yaml, got nil")
+	}
+	if !strings.Contains(err.Error(), "MachineA") {
+		t.Errorf("expected MachineA in error, got: %v", err)
+	}
+}
+
+func TestDownloadPresets_CustomBranch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test/repo/contents/presets", func(w http.ResponseWriter, r *http.Request) {
+		ref := r.URL.Query().Get("ref")
+		if ref != "develop" {
+			t.Errorf("expected ref=develop, got %q", ref)
+		}
+		entries := []githubEntry{
+			{Name: "TestMachine", Type: "dir"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(entries)
+	})
+	mux.HandleFunc("/test/repo/develop/presets/TestMachine/topology.yaml", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("machineType: TestMachine\n"))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	opts := DownloadOptions{
+		Repo:       "test/repo",
+		Branch:     "develop",
+		Dir:        t.TempDir(),
+		HTTPClient: server.Client(),
+	}
+
+	downloaded, err := downloadPresetsWithBaseURL(context.Background(), opts, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(downloaded) != 1 || downloaded[0] != "TestMachine" {
+		t.Errorf("expected [TestMachine], got %v", downloaded)
+	}
+}
+
+func TestDownloadPresets_OverwritesExisting(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test/repo/contents/presets", func(w http.ResponseWriter, r *http.Request) {
+		entries := []githubEntry{
+			{Name: "MachineA", Type: "dir"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(entries)
+	})
+	mux.HandleFunc("/test/repo/main/presets/MachineA/topology.yaml", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("machineType: MachineA\nproductType: UPDATED\n"))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	destDir := t.TempDir()
+
+	// Create an existing preset that should be overwritten
+	existingDir := filepath.Join(destDir, "MachineA")
+	_ = os.MkdirAll(existingDir, 0o755)
+	_ = os.WriteFile(filepath.Join(existingDir, "topology.yaml"), []byte("machineType: MachineA\nproductType: OLD\n"), 0o644)
+
+	opts := DownloadOptions{
+		Repo:       "test/repo",
+		Branch:     "main",
+		Dir:        destDir,
+		HTTPClient: server.Client(),
+	}
+
+	_, err := downloadPresetsWithBaseURL(context.Background(), opts, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(existingDir, "topology.yaml"))
+	if !strings.Contains(string(data), "UPDATED") {
+		t.Errorf("expected file to be overwritten with UPDATED, got: %s", string(data))
+	}
+}
+
+func TestDownloadPresets_OnlyDownloadsDirs(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test/repo/contents/presets", func(w http.ResponseWriter, r *http.Request) {
+		entries := []githubEntry{
+			{Name: "README.md", Type: "file"},
+			{Name: ".gitkeep", Type: "file"},
+			{Name: "ValidMachine", Type: "dir"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(entries)
+	})
+	mux.HandleFunc("/test/repo/main/presets/ValidMachine/topology.yaml", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("machineType: ValidMachine\n"))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	opts := DownloadOptions{
+		Repo:       "test/repo",
+		Branch:     "main",
+		Dir:        t.TempDir(),
+		HTTPClient: server.Client(),
+	}
+
+	downloaded, err := downloadPresetsWithBaseURL(context.Background(), opts, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(downloaded) != 1 || downloaded[0] != "ValidMachine" {
+		t.Errorf("expected only ValidMachine, got %v", downloaded)
+	}
+}
+
+func TestDownloadPresets_GithubTokenHeader(t *testing.T) {
+	tokenSeen := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test/repo/contents/presets", func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth == "Bearer test-token-123" {
+			tokenSeen = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]githubEntry{})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// Set GITHUB_TOKEN
+	t.Setenv("GITHUB_TOKEN", "test-token-123")
+
+	opts := DownloadOptions{
+		Repo:       "test/repo",
+		Branch:     "main",
+		Dir:        t.TempDir(),
+		HTTPClient: server.Client(),
+	}
+
+	_, err := downloadPresetsWithBaseURL(context.Background(), opts, server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !tokenSeen {
+		t.Error("expected Authorization header with GITHUB_TOKEN, but it was not sent")
+	}
+}
+
+func TestDownloadPresets_InvalidJSON(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test/repo/contents/presets", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not valid json"))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	opts := DownloadOptions{
+		Repo:       "test/repo",
+		Branch:     "main",
+		Dir:        t.TempDir(),
+		HTTPClient: server.Client(),
+	}
+
+	_, err := downloadPresetsWithBaseURL(context.Background(), opts, server.URL)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestDownloadPresets_ContextCancellation(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/test/repo/contents/presets", func(w http.ResponseWriter, r *http.Request) {
+		// Simulate slow response — context should cancel before this completes
+		<-r.Context().Done()
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	opts := DownloadOptions{
+		Repo:       "test/repo",
+		Branch:     "main",
+		Dir:        t.TempDir(),
+		HTTPClient: server.Client(),
+	}
+
+	_, err := downloadPresetsWithBaseURL(ctx, opts, server.URL)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+}
+
+func TestDownloadPresets_DefaultOptions(t *testing.T) {
+	opts := DefaultDownloadOptions()
+	if opts.Repo != "nvidia/k8s-launch-kit" {
+		t.Errorf("expected default repo nvidia/k8s-launch-kit, got %q", opts.Repo)
+	}
+	if opts.Branch != "main" {
+		t.Errorf("expected default branch main, got %q", opts.Branch)
+	}
+	if opts.Dir != "" {
+		t.Errorf("expected empty default dir, got %q", opts.Dir)
+	}
+}
+
+// --- listGitHubDir tests ---
+
+func TestListGitHubDir_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test-endpoint", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") != "application/vnd.github.v3+json" {
+			t.Errorf("expected GitHub API Accept header, got %q", r.Header.Get("Accept"))
+		}
+		entries := []githubEntry{
+			{Name: "dir1", Type: "dir"},
+			{Name: "file1.txt", Type: "file"},
+		}
+		_ = json.NewEncoder(w).Encode(entries)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	entries, err := listGitHubDir(context.Background(), server.Client(), server.URL+"/test-endpoint")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Name != "dir1" || entries[0].Type != "dir" {
+		t.Errorf("unexpected entry[0]: %+v", entries[0])
+	}
+}
+
+func TestListGitHubDir_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test-endpoint", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	_, err := listGitHubDir(context.Background(), server.Client(), server.URL+"/test-endpoint")
+	if err == nil {
+		t.Fatal("expected error for 500, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected 500 in error, got: %v", err)
+	}
+}
+
+func TestListGitHubDir_RateLimited(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test-endpoint", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message": "API rate limit exceeded"}`))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	_, err := listGitHubDir(context.Background(), server.Client(), server.URL+"/test-endpoint")
+	if err == nil {
+		t.Fatal("expected error for rate limit, got nil")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("expected 403 in error, got: %v", err)
+	}
+}
+
+// --- fetchURL tests ---
+
+func TestFetchURL_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test-file", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("file content here"))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	data, err := fetchURL(context.Background(), server.Client(), server.URL+"/test-file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != "file content here" {
+		t.Errorf("expected 'file content here', got %q", string(data))
+	}
+}
+
+func TestFetchURL_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	_, err := fetchURL(context.Background(), server.Client(), server.URL+"/missing")
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected 404 in error, got: %v", err)
+	}
+}
+
+func TestFetchURL_WithGithubToken(t *testing.T) {
+	tokenSeen := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test-file", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer my-token" {
+			tokenSeen = true
+		}
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	t.Setenv("GITHUB_TOKEN", "my-token")
+
+	_, err := fetchURL(context.Background(), server.Client(), server.URL+"/test-file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !tokenSeen {
+		t.Error("expected Authorization header, not found")
+	}
+}

--- a/pkg/presets/presets.go
+++ b/pkg/presets/presets.go
@@ -1,0 +1,184 @@
+// Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package presets
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Topology represents a predefined cluster topology preset loaded from a
+// topology.yaml file. It is intentionally separate from config.ClusterConfig
+// to carry additional topology metadata (NUMA, GPU affinity) without
+// polluting the core config.
+type Topology struct {
+	MachineType     string     `yaml:"machineType"`
+	Manufacturer    string     `yaml:"manufacturer,omitempty"`
+	ProductType     string     `yaml:"productType,omitempty"`
+	NicModel        string     `yaml:"nicModel,omitempty"`
+	GPUInterconnect string     `yaml:"gpuInterconnect,omitempty"`
+	NumaNodes       int        `yaml:"numaNodes,omitempty"`
+	PFs             []PresetPF `yaml:"pfs"`
+}
+
+// PresetPF describes a single physical function in a topology preset.
+// It is a superset of config.PFConfig with additional topology fields.
+type PresetPF struct {
+	DeviceID         string `yaml:"deviceID"`
+	PciAddress       string `yaml:"pciAddress"`
+	RdmaDevice       string `yaml:"rdmaDevice"`
+	NetworkInterface string `yaml:"networkInterface"`
+	Traffic          string `yaml:"traffic"`
+	Rail             *int   `yaml:"rail,omitempty"`
+	NumaNode         *int   `yaml:"numaNode,omitempty"`
+	ConnectedGPU     string `yaml:"connectedGPU,omitempty"`
+	GPUProximity     string `yaml:"gpuProximity,omitempty"`
+	PSID             string `yaml:"psid,omitempty"`
+	PartNumber       string `yaml:"partNumber,omitempty"`
+}
+
+// GetPresetsDir resolves the presets directory using a lookup chain:
+// 1. ./presets (CWD — container/repo root)
+// 2. /usr/local/share/l8k/presets (default install)
+// 3. <binary-dir>/../share/l8k/presets (custom prefix install)
+//
+// Returns ("", nil) if no presets directory is found — presets are optional.
+func GetPresetsDir() (string, error) {
+	candidates := []string{
+		"presets",
+		"/usr/local/share/l8k/presets",
+	}
+	if exe, err := os.Executable(); err == nil {
+		candidates = append(candidates, filepath.Join(filepath.Dir(exe), "..", "share", "l8k", "presets"))
+	}
+	for _, p := range candidates {
+		if info, err := os.Stat(p); err == nil && info.IsDir() {
+			return p, nil
+		}
+	}
+	return "", nil
+}
+
+// LoadPreset loads a topology preset for the given machine type.
+// Returns (nil, nil) if no presets directory exists or no preset matches
+// the machine type. Returns an error only on parse failure.
+func LoadPreset(machineType string) (*Topology, error) {
+	dir, err := GetPresetsDir()
+	if err != nil {
+		return nil, err
+	}
+	if dir == "" {
+		return nil, nil
+	}
+
+	path := filepath.Join(dir, machineType, "topology.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read preset %s: %w", path, err)
+	}
+
+	var t Topology
+	if err := yaml.Unmarshal(data, &t); err != nil {
+		return nil, fmt.Errorf("failed to parse preset %s: %w", path, err)
+	}
+
+	return &t, nil
+}
+
+// ListPresets returns the names (machine types) of all available presets
+// in the presets directory. Returns nil if no presets directory exists.
+func ListPresets() ([]string, error) {
+	dir, err := GetPresetsDir()
+	if err != nil {
+		return nil, err
+	}
+	if dir == "" {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read presets directory %s: %w", dir, err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		// Only include directories that contain a topology.yaml
+		topoPath := filepath.Join(dir, e.Name(), "topology.yaml")
+		if _, err := os.Stat(topoPath); err == nil {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// ApplyPreset enriches a discovered ClusterConfig group with data from a
+// validated preset. It matches PFs by PCI address and overrides topology-
+// derived fields (traffic, rail, NUMA, GPU affinity) while preserving
+// live-state fields (RDMA device, network interface, PSID, part number).
+func ApplyPreset(preset *Topology, group *config.ClusterConfig) {
+	// Build lookup map from preset PFs keyed by PCI address
+	presetMap := make(map[string]*PresetPF, len(preset.PFs))
+	for i := range preset.PFs {
+		presetMap[preset.PFs[i].PciAddress] = &preset.PFs[i]
+	}
+
+	for i := range group.PFs {
+		pf := &group.PFs[i]
+		pp, ok := presetMap[pf.PciAddress]
+		if !ok {
+			continue
+		}
+
+		// Override topology-derived fields (preset is authoritative)
+		pf.Traffic = pp.Traffic
+		pf.Rail = pp.Rail
+		pf.NumaNode = pp.NumaNode
+		pf.ConnectedGPU = pp.ConnectedGPU
+		pf.GPUProximity = pp.GPUProximity
+
+		// Log part number / PSID mismatches as warnings but keep discovered values
+		if pp.PartNumber != "" && pf.PartNumber != "" && pp.PartNumber != pf.PartNumber {
+			log.Log.V(1).Info("Preset part number differs from discovered — using discovered value",
+				"pciAddress", pf.PciAddress, "preset", pp.PartNumber, "discovered", pf.PartNumber)
+		}
+		if pp.PSID != "" && pf.PSID != "" && pp.PSID != pf.PSID {
+			log.Log.V(1).Info("Preset PSID differs from discovered — using discovered value",
+				"pciAddress", pf.PciAddress, "preset", pp.PSID, "discovered", pf.PSID)
+		}
+	}
+
+	// Fill in product type from preset if discovery didn't find one
+	if group.ProductType == "" && preset.ProductType != "" {
+		group.ProductType = preset.ProductType
+	}
+
+	group.PresetApplied = true
+}

--- a/pkg/presets/presets_test.go
+++ b/pkg/presets/presets_test.go
@@ -1,0 +1,819 @@
+// Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package presets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+// intPtr returns a pointer to the given int value.
+func intPtr(i int) *int { return &i }
+
+// --- GetPresetsDir tests ---
+
+func TestGetPresetsDir_CWD(t *testing.T) {
+	// Create a temporary presets directory in CWD
+	tmpDir := t.TempDir()
+	presetsDir := filepath.Join(tmpDir, "presets")
+	if err := os.Mkdir(presetsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Change to temp dir so CWD lookup finds ./presets
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	dir, err := GetPresetsDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dir != "presets" {
+		t.Errorf("expected 'presets', got %q", dir)
+	}
+}
+
+func TestGetPresetsDir_NotFound(t *testing.T) {
+	// Use a temp dir with no presets subdirectory
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	dir, err := GetPresetsDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dir != "" {
+		t.Errorf("expected empty string for missing presets dir, got %q", dir)
+	}
+}
+
+func TestGetPresetsDir_SkipsFiles(t *testing.T) {
+	// Create a file named 'presets' (not a directory) — should not match
+	tmpDir := t.TempDir()
+	presetsFile := filepath.Join(tmpDir, "presets")
+	if err := os.WriteFile(presetsFile, []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	dir, err := GetPresetsDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dir != "" {
+		t.Errorf("expected empty string when 'presets' is a file, got %q", dir)
+	}
+}
+
+// --- LoadPreset tests ---
+
+func TestLoadPreset_Found(t *testing.T) {
+	tmpDir := t.TempDir()
+	machineDir := filepath.Join(tmpDir, "presets", "PowerEdge-XE9680")
+	if err := os.MkdirAll(machineDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	topoYAML := `machineType: PowerEdge-XE9680
+productType: NVIDIA-H200
+nicModel: BlueField-3 SuperNIC
+gpuInterconnect: NV18
+numaNodes: 2
+pfs:
+  - deviceID: a2dc
+    pciAddress: "0000:1a:00.0"
+    traffic: east-west
+    rail: 0
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+  - deviceID: a2dc
+    pciAddress: "0000:3c:00.0"
+    traffic: east-west
+    rail: 1
+    numaNode: 0
+    connectedGPU: GPU1
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+`
+	if err := os.WriteFile(filepath.Join(machineDir, "topology.yaml"), []byte(topoYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	topo, err := LoadPreset("PowerEdge-XE9680")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if topo == nil {
+		t.Fatal("expected topology, got nil")
+	}
+	if topo.MachineType != "PowerEdge-XE9680" {
+		t.Errorf("expected MachineType=PowerEdge-XE9680, got %q", topo.MachineType)
+	}
+	if topo.ProductType != "NVIDIA-H200" {
+		t.Errorf("expected ProductType=NVIDIA-H200, got %q", topo.ProductType)
+	}
+	if topo.NicModel != "BlueField-3 SuperNIC" {
+		t.Errorf("expected NicModel, got %q", topo.NicModel)
+	}
+	if topo.GPUInterconnect != "NV18" {
+		t.Errorf("expected GPUInterconnect=NV18, got %q", topo.GPUInterconnect)
+	}
+	if topo.NumaNodes != 2 {
+		t.Errorf("expected NumaNodes=2, got %d", topo.NumaNodes)
+	}
+	if len(topo.PFs) != 2 {
+		t.Fatalf("expected 2 PFs, got %d", len(topo.PFs))
+	}
+	pf := topo.PFs[0]
+	if pf.DeviceID != "a2dc" {
+		t.Errorf("PF[0] DeviceID: expected a2dc, got %q", pf.DeviceID)
+	}
+	if pf.PciAddress != "0000:1a:00.0" {
+		t.Errorf("PF[0] PciAddress: expected 0000:1a:00.0, got %q", pf.PciAddress)
+	}
+	if pf.Traffic != "east-west" {
+		t.Errorf("PF[0] Traffic: expected east-west, got %q", pf.Traffic)
+	}
+	if pf.Rail == nil || *pf.Rail != 0 {
+		t.Errorf("PF[0] Rail: expected 0, got %v", pf.Rail)
+	}
+	if pf.NumaNode == nil || *pf.NumaNode != 0 {
+		t.Errorf("PF[0] NumaNode: expected 0, got %v", pf.NumaNode)
+	}
+	if pf.ConnectedGPU != "GPU0" {
+		t.Errorf("PF[0] ConnectedGPU: expected GPU0, got %q", pf.ConnectedGPU)
+	}
+	if pf.GPUProximity != "PIX" {
+		t.Errorf("PF[0] GPUProximity: expected PIX, got %q", pf.GPUProximity)
+	}
+}
+
+func TestLoadPreset_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "presets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	topo, err := LoadPreset("NonExistent-Machine")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if topo != nil {
+		t.Errorf("expected nil for missing preset, got %+v", topo)
+	}
+}
+
+func TestLoadPreset_NoPresetsDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	topo, err := LoadPreset("PowerEdge-XE9680")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if topo != nil {
+		t.Errorf("expected nil when no presets dir, got %+v", topo)
+	}
+}
+
+func TestLoadPreset_InvalidYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	machineDir := filepath.Join(tmpDir, "presets", "BadMachine")
+	if err := os.MkdirAll(machineDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(machineDir, "topology.yaml"), []byte("{{invalid yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	topo, err := LoadPreset("BadMachine")
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+	if topo != nil {
+		t.Errorf("expected nil topology on error, got %+v", topo)
+	}
+}
+
+func TestLoadPreset_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	machineDir := filepath.Join(tmpDir, "presets", "EmptyMachine")
+	if err := os.MkdirAll(machineDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(machineDir, "topology.yaml"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	topo, err := LoadPreset("EmptyMachine")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Empty YAML unmarshals to zero-value struct — not nil
+	if topo == nil {
+		t.Fatal("expected non-nil topology for empty YAML")
+	}
+	if len(topo.PFs) != 0 {
+		t.Errorf("expected 0 PFs, got %d", len(topo.PFs))
+	}
+}
+
+func TestLoadPreset_DirectoryWithoutTopologyYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	machineDir := filepath.Join(tmpDir, "presets", "NoTopology")
+	if err := os.MkdirAll(machineDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Directory exists but no topology.yaml inside
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	topo, err := LoadPreset("NoTopology")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if topo != nil {
+		t.Errorf("expected nil when topology.yaml is missing, got %+v", topo)
+	}
+}
+
+// --- ListPresets tests ---
+
+func TestListPresets(t *testing.T) {
+	tmpDir := t.TempDir()
+	presetsDir := filepath.Join(tmpDir, "presets")
+
+	// Create 3 valid presets and 1 invalid (no topology.yaml)
+	for _, name := range []string{"Alpha", "Beta", "Gamma"} {
+		dir := filepath.Join(presetsDir, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "topology.yaml"), []byte("machineType: "+name), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Dir without topology.yaml
+	if err := os.MkdirAll(filepath.Join(presetsDir, "Invalid"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// File (not dir) in presets directory
+	if err := os.WriteFile(filepath.Join(presetsDir, "README.md"), []byte("# presets"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	names, err := ListPresets()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 3 {
+		t.Fatalf("expected 3 presets, got %d: %v", len(names), names)
+	}
+	expected := []string{"Alpha", "Beta", "Gamma"}
+	for i, name := range names {
+		if name != expected[i] {
+			t.Errorf("names[%d]: expected %q, got %q", i, expected[i], name)
+		}
+	}
+}
+
+func TestListPresets_NoPresetsDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	names, err := ListPresets()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if names != nil {
+		t.Errorf("expected nil for missing presets dir, got %v", names)
+	}
+}
+
+// --- ValidatePreset tests ---
+
+func TestValidatePreset_ExactMatch(t *testing.T) {
+	preset := &Topology{
+		PFs: []PresetPF{
+			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0"},
+			{DeviceID: "a2dc", PciAddress: "0000:3c:00.0"},
+			{DeviceID: "101f", PciAddress: "0000:5a:00.0"},
+		},
+	}
+	discovered := []config.PFConfig{
+		{DeviceID: "a2dc", PciAddress: "0000:1a:00.0"},
+		{DeviceID: "a2dc", PciAddress: "0000:3c:00.0"},
+		{DeviceID: "101f", PciAddress: "0000:5a:00.0"},
+	}
+
+	if err := ValidatePreset(preset, discovered); err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidatePreset_DifferentOrderStillMatches(t *testing.T) {
+	preset := &Topology{
+		PFs: []PresetPF{
+			{DeviceID: "a2dc", PciAddress: "0000:3c:00.0"},
+			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0"},
+		},
+	}
+	discovered := []config.PFConfig{
+		{DeviceID: "a2dc", PciAddress: "0000:1a:00.0"},
+		{DeviceID: "a2dc", PciAddress: "0000:3c:00.0"},
+	}
+
+	if err := ValidatePreset(preset, discovered); err != nil {
+		t.Errorf("expected no error for different order, got: %v", err)
+	}
+}
+
+func TestValidatePreset_PFCountMismatch(t *testing.T) {
+	preset := &Topology{
+		PFs: []PresetPF{
+			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0"},
+			{DeviceID: "a2dc", PciAddress: "0000:3c:00.0"},
+		},
+	}
+	discovered := []config.PFConfig{
+		{DeviceID: "a2dc", PciAddress: "0000:1a:00.0"},
+	}
+
+	err := ValidatePreset(preset, discovered)
+	if err == nil {
+		t.Fatal("expected PF count mismatch error, got nil")
+	}
+	if !containsSubstring(err.Error(), "PF count mismatch") {
+		t.Errorf("expected PF count mismatch in error, got: %v", err)
+	}
+}
+
+func TestValidatePreset_PciAddressMismatch_PresetHasExtra(t *testing.T) {
+	preset := &Topology{
+		PFs: []PresetPF{
+			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0"},
+			{DeviceID: "a2dc", PciAddress: "0000:ff:00.0"}, // not in discovered
+		},
+	}
+	discovered := []config.PFConfig{
+		{DeviceID: "a2dc", PciAddress: "0000:1a:00.0"},
+		{DeviceID: "a2dc", PciAddress: "0000:3c:00.0"}, // not in preset
+	}
+
+	err := ValidatePreset(preset, discovered)
+	if err == nil {
+		t.Fatal("expected PCI address mismatch error, got nil")
+	}
+	if !containsSubstring(err.Error(), "PCI address mismatch") {
+		t.Errorf("expected PCI address mismatch in error, got: %v", err)
+	}
+	if !containsSubstring(err.Error(), "0000:ff:00.0") {
+		t.Errorf("expected missing preset address in error, got: %v", err)
+	}
+	if !containsSubstring(err.Error(), "0000:3c:00.0") {
+		t.Errorf("expected missing discovered address in error, got: %v", err)
+	}
+}
+
+func TestValidatePreset_DeviceIDMismatch(t *testing.T) {
+	preset := &Topology{
+		PFs: []PresetPF{
+			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0"},
+			{DeviceID: "1023", PciAddress: "0000:3c:00.0"}, // different device ID
+		},
+	}
+	discovered := []config.PFConfig{
+		{DeviceID: "a2dc", PciAddress: "0000:1a:00.0"},
+		{DeviceID: "101f", PciAddress: "0000:3c:00.0"}, // different device ID
+	}
+
+	err := ValidatePreset(preset, discovered)
+	if err == nil {
+		t.Fatal("expected device ID mismatch error, got nil")
+	}
+	if !containsSubstring(err.Error(), "device ID mismatch") {
+		t.Errorf("expected device ID mismatch in error, got: %v", err)
+	}
+	if !containsSubstring(err.Error(), "0000:3c:00.0") {
+		t.Errorf("expected PCI address in error, got: %v", err)
+	}
+}
+
+func TestValidatePreset_PartNumberDifference_Passes(t *testing.T) {
+	// Part number mismatch should NOT cause validation failure
+	preset := &Topology{
+		PFs: []PresetPF{
+			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", PartNumber: "DELL-PART-123"},
+		},
+	}
+	discovered := []config.PFConfig{
+		{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", PartNumber: "LENOVO-PART-456"},
+	}
+
+	if err := ValidatePreset(preset, discovered); err != nil {
+		t.Errorf("expected no error for part number difference, got: %v", err)
+	}
+}
+
+func TestValidatePreset_PSIDDifference_Passes(t *testing.T) {
+	// PSID mismatch should NOT cause validation failure
+	preset := &Topology{
+		PFs: []PresetPF{
+			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", PSID: "mt_0000001069"},
+		},
+	}
+	discovered := []config.PFConfig{
+		{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", PSID: "mt_0000009999"},
+	}
+
+	if err := ValidatePreset(preset, discovered); err != nil {
+		t.Errorf("expected no error for PSID difference, got: %v", err)
+	}
+}
+
+func TestValidatePreset_EmptyPFs(t *testing.T) {
+	preset := &Topology{PFs: []PresetPF{}}
+	discovered := []config.PFConfig{}
+
+	if err := ValidatePreset(preset, discovered); err != nil {
+		t.Errorf("expected no error for empty PFs, got: %v", err)
+	}
+}
+
+func TestValidatePreset_MultipleMismatches(t *testing.T) {
+	// Multiple device ID mismatches at different PCI addresses
+	preset := &Topology{
+		PFs: []PresetPF{
+			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0"},
+			{DeviceID: "a2dc", PciAddress: "0000:3c:00.0"},
+		},
+	}
+	discovered := []config.PFConfig{
+		{DeviceID: "101f", PciAddress: "0000:1a:00.0"},
+		{DeviceID: "1023", PciAddress: "0000:3c:00.0"},
+	}
+
+	err := ValidatePreset(preset, discovered)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// Should mention both addresses
+	if !containsSubstring(err.Error(), "0000:1a:00.0") || !containsSubstring(err.Error(), "0000:3c:00.0") {
+		t.Errorf("expected both mismatched addresses in error, got: %v", err)
+	}
+}
+
+// --- ApplyPreset tests ---
+
+func TestApplyPreset_OverridesTopologyFields(t *testing.T) {
+	preset := &Topology{
+		ProductType: "NVIDIA-H200",
+		PFs: []PresetPF{
+			{
+				DeviceID:     "a2dc",
+				PciAddress:   "0000:1a:00.0",
+				Traffic:      "east-west",
+				Rail:         intPtr(0),
+				NumaNode:     intPtr(0),
+				ConnectedGPU: "GPU0",
+				GPUProximity: "PIX",
+				PartNumber:   "PRESET-PART",
+				PSID:         "preset-psid",
+			},
+			{
+				DeviceID:     "a2dc",
+				PciAddress:   "0000:9d:00.0",
+				Traffic:      "north-south",
+				NumaNode:     intPtr(1),
+				ConnectedGPU: "",
+				GPUProximity: "NODE",
+				PartNumber:   "PRESET-NS-PART",
+				PSID:         "preset-ns-psid",
+			},
+		},
+	}
+
+	group := &config.ClusterConfig{
+		ProductType: "", // should be filled from preset
+		PFs: []config.PFConfig{
+			{
+				DeviceID:         "a2dc",
+				PciAddress:       "0000:1a:00.0",
+				RdmaDevice:       "mlx5_0",
+				NetworkInterface: "eth2",
+				Traffic:          "north-south", // wrong — will be corrected by preset
+				PSID:             "discovered-psid",
+				PartNumber:       "discovered-part",
+			},
+			{
+				DeviceID:         "a2dc",
+				PciAddress:       "0000:9d:00.0",
+				RdmaDevice:       "mlx5_4",
+				NetworkInterface: "eth7",
+				Traffic:          "east-west", // wrong — will be corrected
+				Rail:             intPtr(3),   // wrong — will be corrected
+				PSID:             "discovered-ns-psid",
+				PartNumber:       "discovered-ns-part",
+			},
+		},
+	}
+
+	ApplyPreset(preset, group)
+
+	// Verify preset-authoritative fields were overridden
+	pf0 := group.PFs[0]
+	if pf0.Traffic != "east-west" {
+		t.Errorf("PF[0] Traffic: expected east-west, got %q", pf0.Traffic)
+	}
+	if pf0.Rail == nil || *pf0.Rail != 0 {
+		t.Errorf("PF[0] Rail: expected 0, got %v", pf0.Rail)
+	}
+	if pf0.NumaNode == nil || *pf0.NumaNode != 0 {
+		t.Errorf("PF[0] NumaNode: expected 0, got %v", pf0.NumaNode)
+	}
+	if pf0.ConnectedGPU != "GPU0" {
+		t.Errorf("PF[0] ConnectedGPU: expected GPU0, got %q", pf0.ConnectedGPU)
+	}
+	if pf0.GPUProximity != "PIX" {
+		t.Errorf("PF[0] GPUProximity: expected PIX, got %q", pf0.GPUProximity)
+	}
+
+	pf1 := group.PFs[1]
+	if pf1.Traffic != "north-south" {
+		t.Errorf("PF[1] Traffic: expected north-south, got %q", pf1.Traffic)
+	}
+	if pf1.Rail != nil {
+		t.Errorf("PF[1] Rail: expected nil (north-south), got %v", pf1.Rail)
+	}
+	if pf1.NumaNode == nil || *pf1.NumaNode != 1 {
+		t.Errorf("PF[1] NumaNode: expected 1, got %v", pf1.NumaNode)
+	}
+	if pf1.GPUProximity != "NODE" {
+		t.Errorf("PF[1] GPUProximity: expected NODE, got %q", pf1.GPUProximity)
+	}
+
+	// Verify discovery-authoritative fields were preserved
+	if pf0.RdmaDevice != "mlx5_0" {
+		t.Errorf("PF[0] RdmaDevice: expected mlx5_0 (preserved), got %q", pf0.RdmaDevice)
+	}
+	if pf0.NetworkInterface != "eth2" {
+		t.Errorf("PF[0] NetworkInterface: expected eth2 (preserved), got %q", pf0.NetworkInterface)
+	}
+	if pf0.PSID != "discovered-psid" {
+		t.Errorf("PF[0] PSID: expected discovered-psid (preserved), got %q", pf0.PSID)
+	}
+	if pf0.PartNumber != "discovered-part" {
+		t.Errorf("PF[0] PartNumber: expected discovered-part (preserved), got %q", pf0.PartNumber)
+	}
+
+	if pf1.RdmaDevice != "mlx5_4" {
+		t.Errorf("PF[1] RdmaDevice: expected mlx5_4 (preserved), got %q", pf1.RdmaDevice)
+	}
+	if pf1.PSID != "discovered-ns-psid" {
+		t.Errorf("PF[1] PSID: expected discovered-ns-psid (preserved), got %q", pf1.PSID)
+	}
+	if pf1.PartNumber != "discovered-ns-part" {
+		t.Errorf("PF[1] PartNumber: expected discovered-ns-part (preserved), got %q", pf1.PartNumber)
+	}
+
+	// Verify product type was filled from preset
+	if group.ProductType != "NVIDIA-H200" {
+		t.Errorf("ProductType: expected NVIDIA-H200, got %q", group.ProductType)
+	}
+
+	// Verify preset applied flag
+	if !group.PresetApplied {
+		t.Error("expected PresetApplied=true")
+	}
+}
+
+func TestApplyPreset_PreservesExistingProductType(t *testing.T) {
+	preset := &Topology{
+		ProductType: "NVIDIA-H200",
+		PFs:         []PresetPF{},
+	}
+	group := &config.ClusterConfig{
+		ProductType: "NVIDIA-H100-NVL", // already set — should NOT be overwritten
+		PFs:         []config.PFConfig{},
+	}
+
+	ApplyPreset(preset, group)
+
+	if group.ProductType != "NVIDIA-H100-NVL" {
+		t.Errorf("ProductType: expected NVIDIA-H100-NVL (preserved), got %q", group.ProductType)
+	}
+}
+
+func TestApplyPreset_UnmatchedPCIAddress(t *testing.T) {
+	// PF in group has no match in preset — should be left unchanged
+	preset := &Topology{
+		PFs: []PresetPF{
+			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", Traffic: "east-west", Rail: intPtr(0)},
+		},
+	}
+	group := &config.ClusterConfig{
+		PFs: []config.PFConfig{
+			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", Traffic: "north-south"},
+			{DeviceID: "101f", PciAddress: "0000:99:00.0", Traffic: "east-west", Rail: intPtr(5)},
+		},
+	}
+
+	ApplyPreset(preset, group)
+
+	// First PF should be updated
+	if group.PFs[0].Traffic != "east-west" {
+		t.Errorf("PF[0] Traffic: expected east-west, got %q", group.PFs[0].Traffic)
+	}
+
+	// Second PF should remain unchanged (no match in preset)
+	if group.PFs[1].Traffic != "east-west" {
+		t.Errorf("PF[1] Traffic: expected east-west (unchanged), got %q", group.PFs[1].Traffic)
+	}
+	if group.PFs[1].Rail == nil || *group.PFs[1].Rail != 5 {
+		t.Errorf("PF[1] Rail: expected 5 (unchanged), got %v", group.PFs[1].Rail)
+	}
+}
+
+func TestApplyPreset_LargePreset_PowerEdgeXE9680(t *testing.T) {
+	// Test with a realistic preset matching the PowerEdge-XE9680 topology
+	tmpDir := t.TempDir()
+	presetsDir := filepath.Join(tmpDir, "presets")
+
+	// Copy the actual preset file from the repo
+	srcPath := filepath.Join("..", "..", "presets", "PowerEdge-XE9680", "topology.yaml")
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		t.Skipf("skipping: cannot read real preset file: %v", err)
+	}
+
+	machineDir := filepath.Join(presetsDir, "PowerEdge-XE9680")
+	if err := os.MkdirAll(machineDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(machineDir, "topology.yaml"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	preset, err := LoadPreset("PowerEdge-XE9680")
+	if err != nil {
+		t.Fatalf("LoadPreset failed: %v", err)
+	}
+	if preset == nil {
+		t.Fatal("expected preset, got nil")
+	}
+
+	// Build matching discovered PFs (same PCI addresses and device IDs)
+	discovered := make([]config.PFConfig, len(preset.PFs))
+	for i, pp := range preset.PFs {
+		discovered[i] = config.PFConfig{
+			DeviceID:         pp.DeviceID,
+			PciAddress:       pp.PciAddress,
+			RdmaDevice:       "mlx5_" + pp.PciAddress, // synthetic
+			NetworkInterface: "eth" + pp.PciAddress,    // synthetic
+			Traffic:          "east-west",              // deliberately wrong for some
+			PSID:             "discovered-psid-" + pp.PciAddress,
+			PartNumber:       "discovered-part-" + pp.PciAddress,
+		}
+	}
+
+	// Validation should pass
+	if err := ValidatePreset(preset, discovered); err != nil {
+		t.Fatalf("validation failed: %v", err)
+	}
+
+	group := &config.ClusterConfig{
+		PFs:         discovered,
+		WorkerNodes: []string{"node-1", "node-2"},
+	}
+	ApplyPreset(preset, group)
+
+	// Verify key topology assertions
+	if !group.PresetApplied {
+		t.Error("expected PresetApplied=true")
+	}
+
+	// Count east-west and north-south
+	var ew, ns int
+	for _, pf := range group.PFs {
+		switch pf.Traffic {
+		case "east-west":
+			ew++
+		case "north-south":
+			ns++
+		}
+	}
+
+	// PowerEdge-XE9680 has 8 east-west and 2 north-south PFs
+	if ew != 8 {
+		t.Errorf("expected 8 east-west PFs, got %d", ew)
+	}
+	if ns != 2 {
+		t.Errorf("expected 2 north-south PFs, got %d", ns)
+	}
+
+	// Verify rail numbers are set for east-west, nil for north-south
+	maxRail := -1
+	for _, pf := range group.PFs {
+		if pf.Traffic == "east-west" {
+			if pf.Rail == nil {
+				t.Errorf("east-west PF %s has nil rail", pf.PciAddress)
+			} else if *pf.Rail > maxRail {
+				maxRail = *pf.Rail
+			}
+		}
+		if pf.Traffic == "north-south" && pf.Rail != nil {
+			t.Errorf("north-south PF %s has rail=%d, expected nil", pf.PciAddress, *pf.Rail)
+		}
+	}
+	if maxRail != 7 {
+		t.Errorf("expected max rail=7, got %d", maxRail)
+	}
+
+	// Verify NUMA nodes are populated
+	for _, pf := range group.PFs {
+		if pf.NumaNode == nil {
+			t.Errorf("PF %s has nil NumaNode after preset application", pf.PciAddress)
+		}
+	}
+
+	// Verify discovery fields are preserved
+	for _, pf := range group.PFs {
+		if pf.PSID == "" || !containsSubstring(pf.PSID, "discovered-psid-") {
+			t.Errorf("PF %s PSID was not preserved: %q", pf.PciAddress, pf.PSID)
+		}
+		if pf.PartNumber == "" || !containsSubstring(pf.PartNumber, "discovered-part-") {
+			t.Errorf("PF %s PartNumber was not preserved: %q", pf.PciAddress, pf.PartNumber)
+		}
+	}
+}
+
+// helper
+func containsSubstring(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && contains(s, sub))
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/presets/validate.go
+++ b/pkg/presets/validate.go
@@ -1,0 +1,100 @@
+// Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package presets
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+// ValidatePreset checks whether a topology preset matches the discovered
+// hardware. It validates PF count, PCI address set, and device IDs.
+// Part numbers and PSIDs are not strict-match criteria — mismatches are
+// expected across vendor SKUs and firmware versions.
+//
+// Returns nil on successful validation, or an error describing the mismatch.
+func ValidatePreset(preset *Topology, discoveredPFs []config.PFConfig) error {
+	// Step 1: PF count must match
+	if len(preset.PFs) != len(discoveredPFs) {
+		return fmt.Errorf("PF count mismatch: preset has %d, discovered %d",
+			len(preset.PFs), len(discoveredPFs))
+	}
+
+	// Step 2: PCI address sets must match exactly
+	presetAddrs := make(map[string]string, len(preset.PFs))  // pciAddr -> deviceID
+	for _, pf := range preset.PFs {
+		presetAddrs[pf.PciAddress] = pf.DeviceID
+	}
+
+	discoveredAddrs := make(map[string]string, len(discoveredPFs)) // pciAddr -> deviceID
+	for _, pf := range discoveredPFs {
+		discoveredAddrs[pf.PciAddress] = pf.DeviceID
+	}
+
+	// Find addresses in preset but not in discovered
+	var missingFromDiscovered []string
+	for addr := range presetAddrs {
+		if _, ok := discoveredAddrs[addr]; !ok {
+			missingFromDiscovered = append(missingFromDiscovered, addr)
+		}
+	}
+
+	// Find addresses in discovered but not in preset
+	var missingFromPreset []string
+	for addr := range discoveredAddrs {
+		if _, ok := presetAddrs[addr]; !ok {
+			missingFromPreset = append(missingFromPreset, addr)
+		}
+	}
+
+	if len(missingFromDiscovered) > 0 || len(missingFromPreset) > 0 {
+		sort.Strings(missingFromDiscovered)
+		sort.Strings(missingFromPreset)
+
+		var parts []string
+		if len(missingFromDiscovered) > 0 {
+			parts = append(parts, fmt.Sprintf("preset PCI addresses not found in discovered hardware: %s",
+				strings.Join(missingFromDiscovered, ", ")))
+		}
+		if len(missingFromPreset) > 0 {
+			parts = append(parts, fmt.Sprintf("discovered PCI addresses not in preset: %s",
+				strings.Join(missingFromPreset, ", ")))
+		}
+		return fmt.Errorf("PCI address mismatch: %s", strings.Join(parts, "; "))
+	}
+
+	// Step 3: Device IDs must match at each PCI address
+	var deviceMismatches []string
+	for addr, presetDevID := range presetAddrs {
+		discoveredDevID := discoveredAddrs[addr]
+		if presetDevID != discoveredDevID {
+			deviceMismatches = append(deviceMismatches, fmt.Sprintf(
+				"%s: preset=%s, discovered=%s", addr, presetDevID, discoveredDevID))
+		}
+	}
+
+	if len(deviceMismatches) > 0 {
+		sort.Strings(deviceMismatches)
+		return fmt.Errorf("device ID mismatch at PCI address(es): %s",
+			strings.Join(deviceMismatches, "; "))
+	}
+
+	return nil
+}

--- a/pkg/ui/json_output.go
+++ b/pkg/ui/json_output.go
@@ -75,7 +75,7 @@ func (o *JSONOutput) appendMessage(level, format string, args ...interface{}) {
 	o.messages = append(o.messages, entry)
 	o.mu.Unlock()
 	// Also write to stderr so humans can follow along
-	fmt.Fprintf(o.stderr, "[%s] %s\n", level, msg)
+	_, _ = fmt.Fprintf(o.stderr, "[%s] %s\n", level, msg)
 }
 
 func (o *JSONOutput) Info(format string, args ...interface{}) {

--- a/pkg/ui/progress.go
+++ b/pkg/ui/progress.go
@@ -77,7 +77,7 @@ func (p *standardProgress) spin() {
 
 			if p.output.isTTY {
 				// Use carriage return and clear line to update same line
-				fmt.Fprintf(p.output.writer, "\r\033[K%s %s%s", spinnerChars[p.spinIndex], p.message, timeStr)
+				_, _ = fmt.Fprintf(p.output.writer, "\r\033[K%s %s%s", spinnerChars[p.spinIndex], p.message, timeStr)
 				p.spinIndex = (p.spinIndex + 1) % len(spinnerChars)
 			}
 			p.mu.Unlock()
@@ -98,7 +98,7 @@ func (p *standardProgress) Update(message string) {
 
 	// For non-TTY, print the update as a new line
 	if !p.output.isTTY {
-		fmt.Fprintf(p.output.writer, "  %s\n", message)
+		_, _ = fmt.Fprintf(p.output.writer, "  %s\n", message)
 	}
 }
 
@@ -108,12 +108,12 @@ func (p *standardProgress) Success(message string) {
 
 	symbol := "✓"
 	if p.output.colorEnabled {
-		fmt.Fprintf(p.output.writer, "\r\033[K\033[32m%s\033[0m %s\n", symbol, message)
+		_, _ = fmt.Fprintf(p.output.writer, "\r\033[K\033[32m%s\033[0m %s\n", symbol, message)
 	} else {
 		if p.output.isTTY {
-			fmt.Fprintf(p.output.writer, "\r\033[K%s %s\n", symbol, message)
+			_, _ = fmt.Fprintf(p.output.writer, "\r\033[K%s %s\n", symbol, message)
 		} else {
-			fmt.Fprintf(p.output.writer, "%s %s\n", symbol, message)
+			_, _ = fmt.Fprintf(p.output.writer, "%s %s\n", symbol, message)
 		}
 	}
 }
@@ -124,12 +124,12 @@ func (p *standardProgress) Fail(message string) {
 
 	symbol := "✗"
 	if p.output.colorEnabled {
-		fmt.Fprintf(p.output.writer, "\r\033[K\033[31m%s\033[0m %s\n", symbol, message)
+		_, _ = fmt.Fprintf(p.output.writer, "\r\033[K\033[31m%s\033[0m %s\n", symbol, message)
 	} else {
 		if p.output.isTTY {
-			fmt.Fprintf(p.output.writer, "\r\033[K%s %s\n", symbol, message)
+			_, _ = fmt.Fprintf(p.output.writer, "\r\033[K%s %s\n", symbol, message)
 		} else {
-			fmt.Fprintf(p.output.writer, "%s %s\n", symbol, message)
+			_, _ = fmt.Fprintf(p.output.writer, "%s %s\n", symbol, message)
 		}
 	}
 }
@@ -149,7 +149,7 @@ func (p *standardProgress) stop() {
 	// Clear the spinner line in TTY mode
 	if p.output.isTTY {
 		// Move to beginning of line and clear
-		fmt.Fprintf(p.output.writer, "\r\033[K")
+		_, _ = fmt.Fprintf(p.output.writer, "\r\033[K")
 	}
 }
 

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -116,7 +116,7 @@ func NewSilent() Output {
 
 // Info displays an informational message
 func (o *StandardOutput) Info(format string, args ...interface{}) {
-	fmt.Fprintf(o.writer, format+"\n", args...)
+	_, _ = fmt.Fprintf(o.writer, format+"\n", args...)
 }
 
 // Success displays a success message
@@ -124,11 +124,11 @@ func (o *StandardOutput) Success(format string, args ...interface{}) {
 	symbol := "✓"
 	if o.colorEnabled {
 		// Green checkmark
-		fmt.Fprintf(o.writer, "\033[32m%s\033[0m ", symbol)
+		_, _ = fmt.Fprintf(o.writer, "\033[32m%s\033[0m ", symbol)
 	} else {
-		fmt.Fprintf(o.writer, "%s ", symbol)
+		_, _ = fmt.Fprintf(o.writer, "%s ", symbol)
 	}
-	fmt.Fprintf(o.writer, format+"\n", args...)
+	_, _ = fmt.Fprintf(o.writer, format+"\n", args...)
 }
 
 // Warning displays a warning message
@@ -136,11 +136,11 @@ func (o *StandardOutput) Warning(format string, args ...interface{}) {
 	symbol := "⚠"
 	if o.colorEnabled {
 		// Yellow warning
-		fmt.Fprintf(o.writer, "\033[33m%s\033[0m ", symbol)
+		_, _ = fmt.Fprintf(o.writer, "\033[33m%s\033[0m ", symbol)
 	} else {
-		fmt.Fprintf(o.writer, "%s ", symbol)
+		_, _ = fmt.Fprintf(o.writer, "%s ", symbol)
 	}
-	fmt.Fprintf(o.writer, format+"\n", args...)
+	_, _ = fmt.Fprintf(o.writer, format+"\n", args...)
 }
 
 // Error displays an error message
@@ -148,11 +148,11 @@ func (o *StandardOutput) Error(format string, args ...interface{}) {
 	symbol := "✗"
 	if o.colorEnabled {
 		// Red X
-		fmt.Fprintf(o.writer, "\033[31m%s\033[0m ", symbol)
+		_, _ = fmt.Fprintf(o.writer, "\033[31m%s\033[0m ", symbol)
 	} else {
-		fmt.Fprintf(o.writer, "%s ", symbol)
+		_, _ = fmt.Fprintf(o.writer, "%s ", symbol)
 	}
-	fmt.Fprintf(o.writer, format+"\n", args...)
+	_, _ = fmt.Fprintf(o.writer, format+"\n", args...)
 }
 
 // StartProgress starts a progress indicator
@@ -170,9 +170,9 @@ func (o *StandardOutput) Header(text string) {
 	border := strings.Repeat("═", width)
 	padding := (width - len(text)) / 2
 
-	fmt.Fprintf(o.writer, "\n%s\n", border)
-	fmt.Fprintf(o.writer, "%s%s\n", strings.Repeat(" ", padding), text)
-	fmt.Fprintf(o.writer, "%s\n\n", border)
+	_, _ = fmt.Fprintf(o.writer, "\n%s\n", border)
+	_, _ = fmt.Fprintf(o.writer, "%s%s\n", strings.Repeat(" ", padding), text)
+	_, _ = fmt.Fprintf(o.writer, "%s\n\n", border)
 }
 
 // Confirm displays a yes/no prompt and waits for user input.
@@ -184,7 +184,7 @@ func (o *StandardOutput) Confirm(prompt string) (bool, error) {
 	if !o.isTTY {
 		return false, nil
 	}
-	fmt.Fprintf(o.writer, "%s [y/N]: ", prompt)
+	_, _ = fmt.Fprintf(o.writer, "%s [y/N]: ", prompt)
 	reader := bufio.NewReader(os.Stdin)
 	input, err := reader.ReadString('\n')
 	if err != nil {
@@ -198,11 +198,11 @@ func (o *StandardOutput) Confirm(prompt string) (bool, error) {
 func (o *StandardOutput) Section(text string) {
 	if o.colorEnabled {
 		// Bold text
-		fmt.Fprintf(o.writer, "\n\033[1m%s\033[0m\n", text)
+		_, _ = fmt.Fprintf(o.writer, "\n\033[1m%s\033[0m\n", text)
 	} else {
-		fmt.Fprintf(o.writer, "\n%s\n", text)
+		_, _ = fmt.Fprintf(o.writer, "\n%s\n", text)
 	}
 
 	// Underline with dashes
-	fmt.Fprintf(o.writer, "%s\n\n", strings.Repeat("─", len(text)))
+	_, _ = fmt.Fprintf(o.writer, "%s\n\n", strings.Repeat("─", len(text)))
 }

--- a/presets/PowerEdge-XE9680/topology.yaml
+++ b/presets/PowerEdge-XE9680/topology.yaml
@@ -1,0 +1,118 @@
+machineType: PowerEdge-XE9680
+productType: NVIDIA-H200
+nicModel: BlueField-3 B3140H E-series HHHL SuperNIC (ConnectX-7)
+gpuInterconnect: NV18
+numaNodes: 2
+
+pfs:
+  # --- NUMA 0: GPUs 0-3, CPUs 0,2,4,6,8,10 ---
+  - deviceID: a2dc
+    rdmaDevice: rocep26s0f0
+    pciAddress: 0000:1a:00.0
+    networkInterface: eth2
+    traffic: east-west
+    rail: 0
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+  - deviceID: a2dc
+    rdmaDevice: rocep60s0f0
+    pciAddress: 0000:3c:00.0
+    networkInterface: eth3
+    traffic: east-west
+    rail: 1
+    numaNode: 0
+    connectedGPU: GPU1
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+  - deviceID: a2dc
+    rdmaDevice: rocep77s0f0
+    pciAddress: 0000:4d:00.0
+    networkInterface: eth4
+    traffic: east-west
+    rail: 2
+    numaNode: 0
+    connectedGPU: GPU2
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+  - deviceID: a2dc
+    rdmaDevice: rocep94s0f0
+    pciAddress: 0000:5e:00.0
+    networkInterface: eth5
+    traffic: east-west
+    rail: 3
+    numaNode: 0
+    connectedGPU: GPU3
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+
+  # --- NUMA 1: GPUs 4-7, CPUs 1,3,5,7,9,11 ---
+  - deviceID: a2dc
+    rdmaDevice: rocep156s0f0
+    pciAddress: 0000:9c:00.0
+    networkInterface: eth6
+    traffic: east-west
+    rail: 4
+    numaNode: 1
+    connectedGPU: GPU4
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+  - deviceID: a2dc
+    rdmaDevice: rocep157s0f0
+    pciAddress: 0000:9d:00.0
+    networkInterface: eth7
+    traffic: north-south
+    numaNode: 1
+    connectedGPU: GPU4
+    gpuProximity: PIX
+    psid: mt_0000000884
+    partNumber: 0HFWRM
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:9d:00.1
+    networkInterface: eth8
+    traffic: north-south
+    numaNode: 1
+    connectedGPU: GPU4
+    gpuProximity: PIX
+    psid: mt_0000000884
+    partNumber: 0HFWRM
+  - deviceID: a2dc
+    rdmaDevice: rocep188s0f0
+    pciAddress: 0000:bc:00.0
+    networkInterface: eth9
+    traffic: east-west
+    rail: 5
+    numaNode: 1
+    connectedGPU: GPU5
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+  - deviceID: a2dc
+    rdmaDevice: rocep204s0f0
+    pciAddress: 0000:cc:00.0
+    networkInterface: eth10
+    traffic: east-west
+    rail: 6
+    numaNode: 1
+    connectedGPU: GPU6
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+  - deviceID: a2dc
+    rdmaDevice: rocep220s0f0
+    pciAddress: 0000:dc:00.0
+    networkInterface: eth11
+    traffic: east-west
+    rail: 7
+    numaNode: 1
+    connectedGPU: GPU7
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 0KK4NR

--- a/presets/ThinkSystem-SR680a-V3/topology.yaml
+++ b/presets/ThinkSystem-SR680a-V3/topology.yaml
@@ -1,0 +1,143 @@
+machineType: ThinkSystem-SR680a-V3
+manufacturer: Lenovo
+productType: NVIDIA-H200
+nicModel: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16 (ConnectX-7)
+gpuInterconnect: NV18
+numaNodes: 2
+
+pfs:
+  # --- NUMA 0: GPUs 0-3, CPUs 0-55,112-167 ---
+  - deviceID: a2dc
+    rdmaDevice: rocep25s0f0
+    pciAddress: 0000:19:00.0
+    networkInterface: eth0
+    traffic: east-west
+    rail: 0
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: PIX
+    psid: ""
+    partNumber: SN37B82788
+  - deviceID: a2dc
+    rdmaDevice: rocep42s0f0
+    pciAddress: 0000:2a:00.0
+    networkInterface: eth1
+    traffic: east-west
+    rail: 1
+    numaNode: 0
+    connectedGPU: GPU1
+    gpuProximity: PIX
+    psid: ""
+    partNumber: SN37B82788
+  - deviceID: a2dc
+    rdmaDevice: rocep59s0f0
+    pciAddress: 0000:3b:00.0
+    networkInterface: eth2
+    traffic: east-west
+    rail: 2
+    numaNode: 0
+    connectedGPU: GPU2
+    gpuProximity: PIX
+    psid: ""
+    partNumber: SN37B82788
+  - deviceID: a2dc
+    rdmaDevice: rocep76s0f0
+    pciAddress: 0000:4c:00.0
+    networkInterface: eth3
+    traffic: east-west
+    rail: 3
+    numaNode: 0
+    connectedGPU: GPU3
+    gpuProximity: PIX
+    psid: ""
+    partNumber: SN37B82788
+
+  # --- N-S: ConnectX-6 Lx dual-port 10/25GbE (NUMA 0) ---
+  - deviceID: "101f"
+    rdmaDevice: rocep90s0f0
+    pciAddress: 0000:5a:00.0
+    networkInterface: eth4
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: ""
+    partNumber: SN37A28487
+  - deviceID: "101f"
+    rdmaDevice: rocep90s0f1
+    pciAddress: 0000:5a:00.1
+    networkInterface: eth5
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: ""
+    partNumber: SN37A28487
+
+  # --- NUMA 1: GPUs 4-7, CPUs 56-111,168-223 ---
+  - deviceID: a2dc
+    rdmaDevice: rocep155s0f0
+    pciAddress: 0000:9b:00.0
+    networkInterface: eth6
+    traffic: east-west
+    rail: 4
+    numaNode: 1
+    connectedGPU: GPU4
+    gpuProximity: PIX
+    psid: ""
+    partNumber: SN37B82788
+  - deviceID: a2dc
+    rdmaDevice: rocep171s0f0
+    pciAddress: 0000:ab:00.0
+    networkInterface: eth7
+    traffic: east-west
+    rail: 5
+    numaNode: 1
+    connectedGPU: GPU5
+    gpuProximity: PIX
+    psid: ""
+    partNumber: SN37B82788
+  - deviceID: a2dc
+    rdmaDevice: rocep193s0f0
+    pciAddress: 0000:c1:00.0
+    networkInterface: eth8
+    traffic: east-west
+    rail: 6
+    numaNode: 1
+    connectedGPU: GPU6
+    gpuProximity: PIX
+    psid: ""
+    partNumber: SN37B82788
+  - deviceID: a2dc
+    rdmaDevice: rocep203s0f0
+    pciAddress: 0000:cb:00.0
+    networkInterface: eth9
+    traffic: east-west
+    rail: 7
+    numaNode: 1
+    connectedGPU: GPU7
+    gpuProximity: PIX
+    psid: ""
+    partNumber: SN37B82788
+
+  # --- N-S bond slave: BF3 dual-port (NUMA 1) ---
+  - deviceID: a2dc
+    rdmaDevice: rocep216s0f0
+    pciAddress: 0000:d8:00.0
+    networkInterface: eth10
+    traffic: north-south
+    numaNode: 1
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: ""
+    partNumber: SN37B36732
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:d8:00.1
+    networkInterface: eth11
+    traffic: north-south
+    numaNode: 1
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: ""
+    partNumber: SN37B36732

--- a/presets/UCSC-885A-M8-H22/topology.yaml
+++ b/presets/UCSC-885A-M8-H22/topology.yaml
@@ -1,0 +1,121 @@
+machineType: UCSC-885A-M8-H22
+manufacturer: Cisco Systems, Inc.
+productType: NVIDIA-H200
+nicModel: BlueField-3 E-series SuperNIC 400GbE/NDR (ConnectX-7)
+gpuInterconnect: NV18
+numaNodes: 2
+
+pfs:
+  # --- NUMA 0: GPUs 0-3, CPUs 0-63,128-191 ---
+  - deviceID: a2dc
+    rdmaDevice: rocep9s0f0
+    pciAddress: 0000:09:00.0
+    networkInterface: eth3
+    traffic: east-west
+    rail: 0
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: PIX
+    psid: ""
+    partNumber: 900-9D3D4-00NN-HA0
+  - deviceID: a2dc
+    rdmaDevice: rocep35s0f0
+    pciAddress: 0000:23:00.0
+    networkInterface: eth7
+    traffic: east-west
+    rail: 1
+    numaNode: 0
+    connectedGPU: GPU1
+    gpuProximity: PIX
+    psid: ""
+    partNumber: 900-9D3D4-00NN-HA0
+  - deviceID: a2dc
+    rdmaDevice: rocep83s0f0
+    pciAddress: 0000:53:00.0
+    networkInterface: eth4
+    traffic: east-west
+    rail: 2
+    numaNode: 0
+    connectedGPU: GPU2
+    gpuProximity: PIX
+    psid: ""
+    partNumber: 900-9D3D4-00NN-HA0
+  - deviceID: a2dc
+    rdmaDevice: rocep105s0f0
+    pciAddress: 0000:69:00.0
+    networkInterface: eth2
+    traffic: east-west
+    rail: 3
+    numaNode: 0
+    connectedGPU: GPU3
+    gpuProximity: PIX
+    psid: ""
+    partNumber: 900-9D3D4-00NN-HA0
+
+  # --- N-S DPU (dual-port, NUMA 0) ---
+  - deviceID: a2dc
+    rdmaDevice: rocep53s0f0
+    pciAddress: 0000:35:00.0
+    networkInterface: eth5
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: ""
+    partNumber: 900-9D3B6-00SV-AA0
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:35:00.1
+    networkInterface: eth6
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: ""
+    partNumber: 900-9D3B6-00SV-AA0
+
+  # --- NUMA 1: GPUs 4-7, CPUs 64-127,192-255 ---
+  - deviceID: a2dc
+    rdmaDevice: rocep143s0f0
+    pciAddress: 0000:8f:00.0
+    networkInterface: eth9
+    traffic: east-west
+    rail: 4
+    numaNode: 1
+    connectedGPU: GPU4
+    gpuProximity: PIX
+    psid: ""
+    partNumber: 900-9D3D4-00NN-HA0
+  - deviceID: a2dc
+    rdmaDevice: rocep156s0f0
+    pciAddress: 0000:9c:00.0
+    networkInterface: eth11
+    traffic: east-west
+    rail: 5
+    numaNode: 1
+    connectedGPU: GPU5
+    gpuProximity: PIX
+    psid: ""
+    partNumber: 900-9D3D4-00NN-HA0
+  - deviceID: a2dc
+    rdmaDevice: rocep205s0f0
+    pciAddress: 0000:cd:00.0
+    networkInterface: eth10
+    traffic: east-west
+    rail: 6
+    numaNode: 1
+    connectedGPU: GPU6
+    gpuProximity: PIX
+    psid: ""
+    partNumber: 900-9D3D4-00NN-HA0
+  - deviceID: a2dc
+    rdmaDevice: rocep241s0f0
+    pciAddress: 0000:f1:00.0
+    networkInterface: eth8
+    traffic: east-west
+    rail: 7
+    numaNode: 1
+    connectedGPU: GPU7
+    gpuProximity: PIX
+    psid: ""
+    partNumber: 900-9D3D4-00NN-HA0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,12 +25,14 @@
 # Install layout:
 #   <prefix>/bin/l8k                       # Binary
 #   <prefix>/share/l8k/profiles/           # Profile templates
+#   <prefix>/share/l8k/presets/            # Predefined cluster topology presets
 #   <prefix>/share/l8k/l8k-config.yaml    # Default configuration
 
 set -euo pipefail
 
 PREFIX="/usr/local"
 DEV_ENV=false
+SKIP_PRESETS_UPDATE=false
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 while [[ $# -gt 0 ]]; do
@@ -43,17 +45,22 @@ while [[ $# -gt 0 ]]; do
             PREFIX="$2"
             shift 2
             ;;
+        --skip-presets-update)
+            SKIP_PRESETS_UPDATE=true
+            shift
+            ;;
         -h|--help)
-            echo "Usage: install.sh [--dev-env] [--prefix /path]"
+            echo "Usage: install.sh [--dev-env] [--prefix /path] [--skip-presets-update]"
             echo ""
             echo "Options:"
-            echo "  --dev-env    Create symlinks instead of copies (for development)"
-            echo "  --prefix     Install prefix (default: /usr/local)"
+            echo "  --dev-env              Create symlinks instead of copies (for development)"
+            echo "  --prefix               Install prefix (default: /usr/local)"
+            echo "  --skip-presets-update   Skip downloading latest presets from GitHub"
             exit 0
             ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: install.sh [--dev-env] [--prefix /path]"
+            echo "Usage: install.sh [--dev-env] [--prefix /path] [--skip-presets-update]"
             exit 1
             ;;
     esac
@@ -75,6 +82,7 @@ if [ "$DEV_ENV" = true ]; then
     ln -sfn "${REPO_ROOT}/build/l8k" "${BIN_DIR}/l8k"
     mkdir -p "${SHARE_DIR}"
     ln -sfn "${REPO_ROOT}/profiles" "${SHARE_DIR}/profiles"
+    ln -sfn "${REPO_ROOT}/presets" "${SHARE_DIR}/presets"
     ln -sfn "${REPO_ROOT}/l8k-config.yaml" "${SHARE_DIR}/l8k-config.yaml"
 else
     echo "Installing l8k..."
@@ -83,6 +91,8 @@ else
     mkdir -p "${SHARE_DIR}"
     rm -rf "${SHARE_DIR}/profiles"
     cp -r "${REPO_ROOT}/profiles" "${SHARE_DIR}/profiles"
+    rm -rf "${SHARE_DIR}/presets"
+    cp -r "${REPO_ROOT}/presets" "${SHARE_DIR}/presets"
     cp "${REPO_ROOT}/l8k-config.yaml" "${SHARE_DIR}/l8k-config.yaml"
 fi
 
@@ -90,4 +100,14 @@ echo ""
 echo "Installed successfully:"
 echo "  Binary:   ${BIN_DIR}/l8k"
 echo "  Profiles: ${SHARE_DIR}/profiles"
+echo "  Presets:  ${SHARE_DIR}/presets"
 echo "  Config:   ${SHARE_DIR}/l8k-config.yaml"
+
+# Try to download latest presets from GitHub (non-fatal on failure)
+if [ "$SKIP_PRESETS_UPDATE" = false ] && [ "$DEV_ENV" = false ]; then
+    echo ""
+    echo "Downloading latest presets from GitHub..."
+    "${BIN_DIR}/l8k" preset update --dir "${SHARE_DIR}/presets" 2>/dev/null \
+        && echo "Presets updated successfully." \
+        || echo "[WARNING] Could not download presets (offline?). Using bundled presets."
+fi


### PR DESCRIPTION
Presets provide authoritative traffic classification, rail assignments, and NUMA/GPU topology metadata for known hardware configurations, replacing heuristic-based discovery results when a machine type matches.

During discovery, after machine type is determined, l8k checks the presets directory for a matching topology.yaml. If found and PCI topology validates (address set + device IDs), the preset enriches the discovered ClusterConfig. Validation is strict on hardware identity but lenient on firmware state (PSID/part number mismatches use the discovered live values).

Includes presets for PowerEdge-XE9680, ThinkSystem-SR680a-V3, and UCSC-885A-M8-H22. Adds `l8k preset list` and `l8k preset update` commands for managing presets, CI workflow for build/test/lint on PR, and documentation in docs/presets.rst.