### PR TITLE
Propagate imagePullSecrets to NicNodePolicy sub-specs

### DIFF
--- a/profiles/host-device-rdma/11-nicnodepolicy.yaml
+++ b/profiles/host-device-rdma/11-nicnodepolicy.yaml
@@ -13,6 +13,12 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: {{.NetworkOperator.Repository}}
+    {{- if .NetworkOperator.ImagePullSecrets }}
+    imagePullSecrets:
+    {{- range .NetworkOperator.ImagePullSecrets }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
     version: {{.DOCADriver.Version}}
     env:
       - name: UNLOAD_STORAGE_MODULES
@@ -42,6 +48,12 @@ spec:
   sriovDevicePlugin:
     image: sriov-network-device-plugin
     repository: {{.NetworkOperator.Repository}}
+    {{- if .NetworkOperator.ImagePullSecrets }}
+    imagePullSecrets:
+    {{- range .NetworkOperator.ImagePullSecrets }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
     version: {{.NetworkOperator.ComponentVersion}}
     config: |
       {

--- a/profiles/ipoib-rdma-shared/11-nicnodepolicy.yaml
+++ b/profiles/ipoib-rdma-shared/11-nicnodepolicy.yaml
@@ -13,6 +13,12 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: {{.NetworkOperator.Repository}}
+    {{- if .NetworkOperator.ImagePullSecrets }}
+    imagePullSecrets:
+    {{- range .NetworkOperator.ImagePullSecrets }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
     version: {{.DOCADriver.Version}}
     env:
       - name: UNLOAD_STORAGE_MODULES
@@ -42,6 +48,12 @@ spec:
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
     repository: {{.NetworkOperator.Repository}}
+    {{- if .NetworkOperator.ImagePullSecrets }}
+    imagePullSecrets:
+    {{- range .NetworkOperator.ImagePullSecrets }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
     version: {{.NetworkOperator.ComponentVersion}}
     config: |
       {

--- a/profiles/macvlan-rdma-shared/11-nicnodepolicy.yaml
+++ b/profiles/macvlan-rdma-shared/11-nicnodepolicy.yaml
@@ -13,6 +13,12 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: {{.NetworkOperator.Repository}}
+    {{- if .NetworkOperator.ImagePullSecrets }}
+    imagePullSecrets:
+    {{- range .NetworkOperator.ImagePullSecrets }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
     version: {{.DOCADriver.Version}}
     env:
       - name: UNLOAD_STORAGE_MODULES
@@ -42,6 +48,12 @@ spec:
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
     repository: {{.NetworkOperator.Repository}}
+    {{- if .NetworkOperator.ImagePullSecrets }}
+    imagePullSecrets:
+    {{- range .NetworkOperator.ImagePullSecrets }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
     version: {{.NetworkOperator.ComponentVersion}}
     config: |
       {

--- a/profiles/sriov-ethernet-rdma/11-nicnodepolicy.yaml
+++ b/profiles/sriov-ethernet-rdma/11-nicnodepolicy.yaml
@@ -13,6 +13,12 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: {{.NetworkOperator.Repository}}
+    {{- if .NetworkOperator.ImagePullSecrets }}
+    imagePullSecrets:
+    {{- range .NetworkOperator.ImagePullSecrets }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
     version: {{.DOCADriver.Version}}
     env:
       - name: UNLOAD_STORAGE_MODULES

--- a/profiles/sriov-ib-rdma/11-nicnodepolicy.yaml
+++ b/profiles/sriov-ib-rdma/11-nicnodepolicy.yaml
@@ -13,6 +13,12 @@ spec:
   ofedDriver:
     image: doca-driver
     repository: {{.NetworkOperator.Repository}}
+    {{- if .NetworkOperator.ImagePullSecrets }}
+    imagePullSecrets:
+    {{- range .NetworkOperator.ImagePullSecrets }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
     version: {{.DOCADriver.Version}}
     env:
       - name: UNLOAD_STORAGE_MODULES


### PR DESCRIPTION
networkOperator.imagePullSecrets was only rendered into NicClusterPolicy spec.global, leaving every NicNodePolicy sub-spec that references networkOperator.repository (ofedDriver, sriovDevicePlugin, rdmaSharedDevicePlugin) without pull secrets. Pods created by those CRs then ImagePullBackOff on private registries (e.g. nvcr.io/nvstaging/mellanox) even when the target secret existed in the namespace.

Inject the same imagePullSecrets block already used in the NicClusterPolicy template, right after each `repository:` line, across all five profiles. Guarded by `{{- if .NetworkOperator.ImagePullSecrets }}` so omitting the field in config renders nothing (unchanged behavior for users without private registries).

Verified: make build, go test ./pkg/networkoperatorplugin/..., and smoke renders against testdata/grouping/same-ew-different-ns.yaml across sriov, host_device, and rdma_shared deployment types.