### PR TITLE
Quote NodeSelector values in ippool and example-daemonset templates

### DIFF
--- a/profiles/host-device-rdma/20-ippool.yaml
+++ b/profiles/host-device-rdma/20-ippool.yaml
@@ -20,7 +20,7 @@ spec:
         {{- if ne $value "" }}
         operator: In
         values:
-        - {{ $value }}
+        - "{{ printf "%v" $value }}"
         {{- else }}
         operator: Exists
         {{- end }}
@@ -48,7 +48,7 @@ spec:
         {{- if ne $value "" }}
         operator: In
         values:
-        - {{ $value }}
+        - "{{ printf "%v" $value }}"
         {{- else }}
         operator: Exists
         {{- end }}

--- a/profiles/host-device-rdma/40-example-daemonset.yaml
+++ b/profiles/host-device-rdma/40-example-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
                 {{- if ne $value "" }}
                 operator: In
                 values:
-                - {{ $value }}
+                - "{{ printf "%v" $value }}"
                 {{- else }}
                 operator: Exists
                 {{- end }}
@@ -81,7 +81,7 @@ spec:
                 {{- if ne $value "" }}
                 operator: In
                 values:
-                - {{ $value }}
+                - "{{ printf "%v" $value }}"
                 {{- else }}
                 operator: Exists
                 {{- end }}

--- a/profiles/ipoib-rdma-shared/20-ippool.yaml
+++ b/profiles/ipoib-rdma-shared/20-ippool.yaml
@@ -20,7 +20,7 @@ spec:
         {{- if ne $value "" }}
         operator: In
         values:
-        - {{ $value }}
+        - "{{ printf "%v" $value }}"
         {{- else }}
         operator: Exists
         {{- end }}
@@ -49,7 +49,7 @@ spec:
         {{- if ne $value "" }}
         operator: In
         values:
-        - {{ $value }}
+        - "{{ printf "%v" $value }}"
         {{- else }}
         operator: Exists
         {{- end }}

--- a/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
                 {{- if ne $value "" }}
                 operator: In
                 values:
-                - {{ $value }}
+                - "{{ printf "%v" $value }}"
                 {{- else }}
                 operator: Exists
                 {{- end }}
@@ -82,7 +82,7 @@ spec:
                 {{- if ne $value "" }}
                 operator: In
                 values:
-                - {{ $value }}
+                - "{{ printf "%v" $value }}"
                 {{- else }}
                 operator: Exists
                 {{- end }}

--- a/profiles/macvlan-rdma-shared/20-ippool.yaml
+++ b/profiles/macvlan-rdma-shared/20-ippool.yaml
@@ -20,7 +20,7 @@ spec:
         {{- if ne $value "" }}
         operator: In
         values:
-        - {{ $value }}
+        - "{{ printf "%v" $value }}"
         {{- else }}
         operator: Exists
         {{- end }}
@@ -49,7 +49,7 @@ spec:
         {{- if ne $value "" }}
         operator: In
         values:
-        - {{ $value }}
+        - "{{ printf "%v" $value }}"
         {{- else }}
         operator: Exists
         {{- end }}

--- a/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
                 {{- if ne $value "" }}
                 operator: In
                 values:
-                - {{ $value }}
+                - "{{ printf "%v" $value }}"
                 {{- else }}
                 operator: Exists
                 {{- end }}
@@ -82,7 +82,7 @@ spec:
                 {{- if ne $value "" }}
                 operator: In
                 values:
-                - {{ $value }}
+                - "{{ printf "%v" $value }}"
                 {{- else }}
                 operator: Exists
                 {{- end }}

--- a/profiles/sriov-ethernet-rdma/20-ippool.yaml
+++ b/profiles/sriov-ethernet-rdma/20-ippool.yaml
@@ -20,7 +20,7 @@ spec:
         {{- if ne $value "" }}
         operator: In
         values:
-        - {{ $value }}
+        - "{{ printf "%v" $value }}"
         {{- else }}
         operator: Exists
         {{- end }}
@@ -48,7 +48,7 @@ spec:
         {{- if ne $value "" }}
         operator: In
         values:
-        - {{ $value }}
+        - "{{ printf "%v" $value }}"
         {{- else }}
         operator: Exists
         {{- end }}

--- a/profiles/sriov-ethernet-rdma/50-example-daemonset.yaml
+++ b/profiles/sriov-ethernet-rdma/50-example-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
                 {{- if ne $value "" }}
                 operator: In
                 values:
-                - {{ $value }}
+                - "{{ printf "%v" $value }}"
                 {{- else }}
                 operator: Exists
                 {{- end }}
@@ -81,7 +81,7 @@ spec:
                 {{- if ne $value "" }}
                 operator: In
                 values:
-                - {{ $value }}
+                - "{{ printf "%v" $value }}"
                 {{- else }}
                 operator: Exists
                 {{- end }}

--- a/profiles/sriov-ib-rdma/20-ippool.yaml
+++ b/profiles/sriov-ib-rdma/20-ippool.yaml
@@ -20,7 +20,7 @@ spec:
         {{- if ne $value "" }}
         operator: In
         values:
-        - {{ $value }}
+        - "{{ printf "%v" $value }}"
         {{- else }}
         operator: Exists
         {{- end }}
@@ -48,7 +48,7 @@ spec:
         {{- if ne $value "" }}
         operator: In
         values:
-        - {{ $value }}
+        - "{{ printf "%v" $value }}"
         {{- else }}
         operator: Exists
         {{- end }}

--- a/profiles/sriov-ib-rdma/50-example-daemonset.yaml
+++ b/profiles/sriov-ib-rdma/50-example-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
                 {{- if ne $value "" }}
                 operator: In
                 values:
-                - {{ $value }}
+                - "{{ printf "%v" $value }}"
                 {{- else }}
                 operator: Exists
                 {{- end }}
@@ -81,7 +81,7 @@ spec:
                 {{- if ne $value "" }}
                 operator: In
                 values:
-                - {{ $value }}
+                - "{{ printf "%v" $value }}"
                 {{- else }}
                 operator: Exists
                 {{- end }}


### PR DESCRIPTION
Templates rendered `- {{ $value }}` directly from node-selector maps. When a value was a Go bool (from typed discovery data) YAML parsed the rendered `- true` / `- false` as a bool, which k8s NodeSelector matchExpressions rejects — the field requires []string.

Wrap every `{{ $value }}` list item with `- "{{ printf "%v" $value }}"`: `%v` coerces any type to its default string form, the surrounding quotes force string parsing even for `true`/`false`/numeric values.

20 occurrences across 10 files (ippool and example-daemonset for each of the five non-Spectrum-X profiles — 2 occurrences per file).

The provisioner's l8k stage currently applies the same substitution at build time as a workaround; this lands the same fix upstream so the workaround can eventually be retired.

Verified: make build, go test ./..., smoke render of testdata/grouping/same-ew-different-ns.yaml across sriov — rendered values come out quoted; no bare booleans left in the output.