### PR TITLE
Quote string-typed template substitutions in profile templates

### DIFF
--- a/profiles/host-device-rdma/10-nicclusterpolicy.yaml
+++ b/profiles/host-device-rdma/10-nicclusterpolicy.yaml
@@ -14,26 +14,26 @@ spec:
   nicConfigurationOperator:
     operator:
       image: nic-configuration-operator
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     configurationDaemon:
       image: nic-configuration-operator-daemon
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     logLevel: info
   {{- end }}
   nvIpam:
     image: nvidia-k8s-ipam
-    repository: {{.NetworkOperator.Repository}}
-    version: {{.NetworkOperator.ComponentVersion}}
+    repository: "{{.NetworkOperator.Repository}}"
+    version: "{{.NetworkOperator.ComponentVersion}}"
     imagePullSecrets: []
     enableWebhook: false
   secondaryNetwork:
     cniPlugins:
       image: plugins
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     multus:
       image: multus-cni
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"

--- a/profiles/host-device-rdma/11-nicnodepolicy.yaml
+++ b/profiles/host-device-rdma/11-nicnodepolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicNodePolicy
 metadata:
-  name: {{.ClusterConfig.Identifier | nnpName}}
+  name: "{{.ClusterConfig.Identifier | nnpName}}"
 spec:
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:
@@ -12,14 +12,14 @@ spec:
   {{- if .DOCADriver.Enable }}
   ofedDriver:
     image: doca-driver
-    repository: {{.NetworkOperator.Repository}}
+    repository: "{{.NetworkOperator.Repository}}"
     {{- if .NetworkOperator.ImagePullSecrets }}
     imagePullSecrets:
     {{- range .NetworkOperator.ImagePullSecrets }}
       - {{ . }}
     {{- end }}
     {{- end }}
-    version: {{.DOCADriver.Version}}
+    version: "{{.DOCADriver.Version}}"
     env:
       - name: UNLOAD_STORAGE_MODULES
         value: "{{.DOCADriver.UnloadStorageModules}}"
@@ -49,14 +49,14 @@ spec:
   {{- end }}
   sriovDevicePlugin:
     image: sriov-network-device-plugin
-    repository: {{.NetworkOperator.Repository}}
+    repository: "{{.NetworkOperator.Repository}}"
     {{- if .NetworkOperator.ImagePullSecrets }}
     imagePullSecrets:
     {{- range .NetworkOperator.ImagePullSecrets }}
       - {{ . }}
     {{- end }}
     {{- end }}
-    version: {{.NetworkOperator.ComponentVersion}}
+    version: "{{.NetworkOperator.ComponentVersion}}"
     config: |
       {
         "resourceList": [

--- a/profiles/host-device-rdma/20-ippool.yaml
+++ b/profiles/host-device-rdma/20-ippool.yaml
@@ -6,7 +6,7 @@ apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
   name: {{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.NetworkOperator.Namespace}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
   perNodeBlockSize: 50
@@ -34,7 +34,7 @@ apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
   name: {{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
   perNodeBlockSize: 50

--- a/profiles/host-device-rdma/35-nicinterfacenametemplate.yaml
+++ b/profiles/host-device-rdma/35-nicinterfacenametemplate.yaml
@@ -3,7 +3,7 @@ apiVersion: configuration.net.nvidia.com/v1alpha1
 kind: NicInterfaceNameTemplate
 metadata:
   name: nic-rename{{suffix .ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:

--- a/profiles/host-device-rdma/40-example-daemonset.yaml
+++ b/profiles/host-device-rdma/40-example-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: hostdev-test{{suffix .ClusterConfig.Identifier}}
-  namespace: {{$.PodNamespace}}
+  namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -58,7 +58,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: hostdev-test{{suffix .ClusterConfig.Identifier}}
-  namespace: {{$.PodNamespace}}
+  namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:

--- a/profiles/ipoib-rdma-shared/10-nicclusterpolicy.yaml
+++ b/profiles/ipoib-rdma-shared/10-nicclusterpolicy.yaml
@@ -14,30 +14,30 @@ spec:
   nicConfigurationOperator:
     operator:
       image: nic-configuration-operator
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     configurationDaemon:
       image: nic-configuration-operator-daemon
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     logLevel: info
   {{- end }}
   nvIpam:
     image: nvidia-k8s-ipam
-    repository: {{.NetworkOperator.Repository}}
-    version: {{.NetworkOperator.ComponentVersion}}
+    repository: "{{.NetworkOperator.Repository}}"
+    version: "{{.NetworkOperator.ComponentVersion}}"
     imagePullSecrets: []
     enableWebhook: false
   secondaryNetwork:
     cniPlugins:
       image: plugins
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     multus:
       image: multus-cni
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     ipoib:
       image: ipoib-cni
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"

--- a/profiles/ipoib-rdma-shared/11-nicnodepolicy.yaml
+++ b/profiles/ipoib-rdma-shared/11-nicnodepolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicNodePolicy
 metadata:
-  name: {{.ClusterConfig.Identifier | nnpName}}
+  name: "{{.ClusterConfig.Identifier | nnpName}}"
 spec:
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:
@@ -12,14 +12,14 @@ spec:
   {{- if .DOCADriver.Enable }}
   ofedDriver:
     image: doca-driver
-    repository: {{.NetworkOperator.Repository}}
+    repository: "{{.NetworkOperator.Repository}}"
     {{- if .NetworkOperator.ImagePullSecrets }}
     imagePullSecrets:
     {{- range .NetworkOperator.ImagePullSecrets }}
       - {{ . }}
     {{- end }}
     {{- end }}
-    version: {{.DOCADriver.Version}}
+    version: "{{.DOCADriver.Version}}"
     env:
       - name: UNLOAD_STORAGE_MODULES
         value: "{{.DOCADriver.UnloadStorageModules}}"
@@ -49,14 +49,14 @@ spec:
   {{- end }}
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
-    repository: {{.NetworkOperator.Repository}}
+    repository: "{{.NetworkOperator.Repository}}"
     {{- if .NetworkOperator.ImagePullSecrets }}
     imagePullSecrets:
     {{- range .NetworkOperator.ImagePullSecrets }}
       - {{ . }}
     {{- end }}
     {{- end }}
-    version: {{.NetworkOperator.ComponentVersion}}
+    version: "{{.NetworkOperator.ComponentVersion}}"
     config: |
       {
         "configList": [

--- a/profiles/ipoib-rdma-shared/20-ippool.yaml
+++ b/profiles/ipoib-rdma-shared/20-ippool.yaml
@@ -6,7 +6,7 @@ apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
   name: {{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.NetworkOperator.Namespace}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
   perNodeBlockSize: 50
@@ -35,7 +35,7 @@ apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
   name: {{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
   perNodeBlockSize: 50

--- a/profiles/ipoib-rdma-shared/35-nicinterfacenametemplate.yaml
+++ b/profiles/ipoib-rdma-shared/35-nicinterfacenametemplate.yaml
@@ -3,7 +3,7 @@ apiVersion: configuration.net.nvidia.com/v1alpha1
 kind: NicInterfaceNameTemplate
 metadata:
   name: nic-rename{{suffix .ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:

--- a/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ipoib-test{{suffix .ClusterConfig.Identifier}}
-  namespace: {{$.PodNamespace}}
+  namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -59,7 +59,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ipoib-test{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.PodNamespace}}
+  namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:

--- a/profiles/macvlan-rdma-shared/10-nicclusterpolicy.yaml
+++ b/profiles/macvlan-rdma-shared/10-nicclusterpolicy.yaml
@@ -14,26 +14,26 @@ spec:
   nicConfigurationOperator:
     operator:
       image: nic-configuration-operator
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     configurationDaemon:
       image: nic-configuration-operator-daemon
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     logLevel: info
   {{- end }}
   nvIpam:
     image: nvidia-k8s-ipam
-    repository: {{.NetworkOperator.Repository}}
-    version: {{.NetworkOperator.ComponentVersion}}
+    repository: "{{.NetworkOperator.Repository}}"
+    version: "{{.NetworkOperator.ComponentVersion}}"
     imagePullSecrets: []
     enableWebhook: false
   secondaryNetwork:
     cniPlugins:
       image: plugins
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     multus:
       image: multus-cni
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"

--- a/profiles/macvlan-rdma-shared/11-nicnodepolicy.yaml
+++ b/profiles/macvlan-rdma-shared/11-nicnodepolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicNodePolicy
 metadata:
-  name: {{.ClusterConfig.Identifier | nnpName}}
+  name: "{{.ClusterConfig.Identifier | nnpName}}"
 spec:
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:
@@ -12,14 +12,14 @@ spec:
   {{- if .DOCADriver.Enable }}
   ofedDriver:
     image: doca-driver
-    repository: {{.NetworkOperator.Repository}}
+    repository: "{{.NetworkOperator.Repository}}"
     {{- if .NetworkOperator.ImagePullSecrets }}
     imagePullSecrets:
     {{- range .NetworkOperator.ImagePullSecrets }}
       - {{ . }}
     {{- end }}
     {{- end }}
-    version: {{.DOCADriver.Version}}
+    version: "{{.DOCADriver.Version}}"
     env:
       - name: UNLOAD_STORAGE_MODULES
         value: "{{.DOCADriver.UnloadStorageModules}}"
@@ -49,14 +49,14 @@ spec:
   {{- end }}
   rdmaSharedDevicePlugin:
     image: k8s-rdma-shared-dev-plugin
-    repository: {{.NetworkOperator.Repository}}
+    repository: "{{.NetworkOperator.Repository}}"
     {{- if .NetworkOperator.ImagePullSecrets }}
     imagePullSecrets:
     {{- range .NetworkOperator.ImagePullSecrets }}
       - {{ . }}
     {{- end }}
     {{- end }}
-    version: {{.NetworkOperator.ComponentVersion}}
+    version: "{{.NetworkOperator.ComponentVersion}}"
     config: |
       {
         "configList": [

--- a/profiles/macvlan-rdma-shared/20-ippool.yaml
+++ b/profiles/macvlan-rdma-shared/20-ippool.yaml
@@ -6,7 +6,7 @@ apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
   name: {{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.NetworkOperator.Namespace}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
   perNodeBlockSize: 50
@@ -35,7 +35,7 @@ apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
   name: {{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
   perNodeBlockSize: 50

--- a/profiles/macvlan-rdma-shared/35-nicinterfacenametemplate.yaml
+++ b/profiles/macvlan-rdma-shared/35-nicinterfacenametemplate.yaml
@@ -3,7 +3,7 @@ apiVersion: configuration.net.nvidia.com/v1alpha1
 kind: NicInterfaceNameTemplate
 metadata:
   name: nic-rename{{suffix .ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:

--- a/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: macvlan-test{{suffix .ClusterConfig.Identifier}}
-  namespace: {{$.PodNamespace}}
+  namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -59,7 +59,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: macvlan-test{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.PodNamespace}}
+  namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:

--- a/profiles/spectrum-x/10-nicclusterpolicy.yaml
+++ b/profiles/spectrum-x/10-nicclusterpolicy.yaml
@@ -13,12 +13,12 @@ spec:
   nicConfigurationOperator:
     operator:
       image: nic-configuration-operator
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     configurationDaemon:
       image: nic-configuration-operator-daemon
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     nicFirmwareStorage:
       create: true
       pvcName: nic-fw-storage-pvc
@@ -27,17 +27,17 @@ spec:
     logLevel: info
   nvIpam:
     image: nvidia-k8s-ipam
-    repository: {{.NetworkOperator.Repository}}
-    version: {{.NetworkOperator.ComponentVersion}}
+    repository: "{{.NetworkOperator.Repository}}"
+    version: "{{.NetworkOperator.ComponentVersion}}"
     enableWebhook: false
   spectrumXOperator:
     image: spectrum-x-operator
-    repository: {{.NetworkOperator.Repository}}
-    version: {{.NetworkOperator.ComponentVersion}}
+    repository: "{{.NetworkOperator.Repository}}"
+    version: "{{.NetworkOperator.ComponentVersion}}"
     xPlane:
       image: xplane
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
       {{- if .NetworkOperator.ImagePullSecrets }}
       imagePullSecrets:
       {{- range .NetworkOperator.ImagePullSecrets }}
@@ -47,9 +47,9 @@ spec:
   secondaryNetwork:
     cniPlugins:
       image: plugins
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     multus:
       image: multus-cni
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"

--- a/profiles/spectrum-x/30-nicconfigurationtemplate.yaml
+++ b/profiles/spectrum-x/30-nicconfigurationtemplate.yaml
@@ -2,7 +2,7 @@ apiVersion: configuration.net.nvidia.com/v1alpha1
 kind: NicConfigurationTemplate
 metadata:
   name: spectrum-x-configuration{{suffix .ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:
@@ -11,13 +11,13 @@ spec:
     {{- end }}
   {{- end }}
   nicSelector:
-    nicType: {{.SpectrumX.NicType}}  # "1023" for ConnectX-8, "1025" for ConnectX-9, "a2dc" for BlueField-3 SuperNIC
+    nicType: "{{.SpectrumX.NicType}}"  # "1023" for ConnectX-8, "1025" for ConnectX-9, "a2dc" for BlueField-3 SuperNIC
   template:
     numVfs: 1
     linkType: Ethernet
     spectrumXOptimized:
       enabled: true
       version: "{{.Profile.SpectrumX.SPCXVersion}}"
-      multiplaneMode: {{.Profile.SpectrumX.MultiplaneMode}}  # swplb, hwplb, uniplane
+      multiplaneMode: "{{.Profile.SpectrumX.MultiplaneMode}}"  # swplb, hwplb, uniplane
       numberOfPlanes: {{.Profile.SpectrumX.NumberOfPlanes}}
       overlay: "{{.SpectrumX.Overlay}}"

--- a/profiles/spectrum-x/35-nicinterfacenametemplate.yaml
+++ b/profiles/spectrum-x/35-nicinterfacenametemplate.yaml
@@ -2,7 +2,7 @@ apiVersion: configuration.net.nvidia.com/v1alpha1
 kind: NicInterfaceNameTemplate
 metadata:
   name: nic-rename-for-spectrum-x{{suffix .ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:

--- a/profiles/spectrum-x/60-cidrpool.yaml
+++ b/profiles/spectrum-x/60-cidrpool.yaml
@@ -14,7 +14,7 @@ apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: CIDRPool
 metadata:
   name: rail-{{$railIdx}}-plane-{{$planeIdx}}
-  namespace: {{$.NetworkOperator.Namespace}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   # TODO: rail subnet for this plane (/15 for 2-tier, /11 for 3-tier topology)
   cidr: TODO_RAIL_{{$railIdx}}_PLANE_{{$planeIdx}}_CIDR
@@ -40,7 +40,7 @@ apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: CIDRPool
 metadata:
   name: rail-{{$railIdx}}
-  namespace: {{$.NetworkOperator.Namespace}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   # TODO: rail subnet (/15 for 2-tier, /11 for 3-tier topology)
   cidr: TODO_RAIL_{{$railIdx}}_CIDR

--- a/profiles/spectrum-x/80-spectrumxrailpoolconfig.yaml
+++ b/profiles/spectrum-x/80-spectrumxrailpoolconfig.yaml
@@ -5,7 +5,7 @@ apiVersion: spectrumx.net.nvidia.com/v1alpha2
 kind: SpectrumXRailPoolConfig
 metadata:
   name: rails{{suffix .ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   withBCM: false
   draEnabled: true
@@ -15,7 +15,7 @@ spec:
     {{ $key }}: "{{ $value }}"
     {{- end }}
   {{- end }}
-  networkNamespace: {{.PodNamespace}}
+  networkNamespace: "{{.PodNamespace}}"
   numVfs: 1
   railTopology:
   {{- range $railIdx := untilStep 0 $railCount 1 }}

--- a/profiles/spectrum-x/90-example-daemonset.yaml
+++ b/profiles/spectrum-x/90-example-daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: spectrum-x-test{{suffix .ClusterConfig.Identifier}}
-  namespace: {{$.PodNamespace}}
+  namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:

--- a/profiles/sriov-ethernet-rdma/10-nicclusterpolicy.yaml
+++ b/profiles/sriov-ethernet-rdma/10-nicclusterpolicy.yaml
@@ -14,25 +14,25 @@ spec:
   nicConfigurationOperator:
     operator:
       image: nic-configuration-operator
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     configurationDaemon:
       image: nic-configuration-operator-daemon
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     logLevel: info
   {{- end }}
   nvIpam:
     image: nvidia-k8s-ipam
-    repository: {{.NetworkOperator.Repository}}
-    version: {{.NetworkOperator.ComponentVersion}}
+    repository: "{{.NetworkOperator.Repository}}"
+    version: "{{.NetworkOperator.ComponentVersion}}"
     enableWebhook: false
   secondaryNetwork:
     cniPlugins:
       image: plugins
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     multus:
       image: multus-cni
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"

--- a/profiles/sriov-ethernet-rdma/11-nicnodepolicy.yaml
+++ b/profiles/sriov-ethernet-rdma/11-nicnodepolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicNodePolicy
 metadata:
-  name: {{.ClusterConfig.Identifier | nnpName}}
+  name: "{{.ClusterConfig.Identifier | nnpName}}"
 spec:
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:
@@ -12,14 +12,14 @@ spec:
   {{- if .DOCADriver.Enable }}
   ofedDriver:
     image: doca-driver
-    repository: {{.NetworkOperator.Repository}}
+    repository: "{{.NetworkOperator.Repository}}"
     {{- if .NetworkOperator.ImagePullSecrets }}
     imagePullSecrets:
     {{- range .NetworkOperator.ImagePullSecrets }}
       - {{ . }}
     {{- end }}
     {{- end }}
-    version: {{.DOCADriver.Version}}
+    version: "{{.DOCADriver.Version}}"
     env:
       - name: UNLOAD_STORAGE_MODULES
         value: "{{.DOCADriver.UnloadStorageModules}}"

--- a/profiles/sriov-ethernet-rdma/20-ippool.yaml
+++ b/profiles/sriov-ethernet-rdma/20-ippool.yaml
@@ -6,7 +6,7 @@ apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
   name: {{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.NetworkOperator.Namespace}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
   perNodeBlockSize: 50
@@ -34,7 +34,7 @@ apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
   name: {{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
   perNodeBlockSize: 50

--- a/profiles/sriov-ethernet-rdma/30-sriovnetworknodepolicy.yaml
+++ b/profiles/sriov-ethernet-rdma/30-sriovnetworknodepolicy.yaml
@@ -6,7 +6,7 @@ apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
   name: ethernet-sriov-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.NetworkOperator.Namespace}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   deviceType: netdevice
   mtu: {{$.Sriov.EthernetMtu}}
@@ -44,7 +44,7 @@ apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
   name: ethernet-sriov{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   deviceType: netdevice
   mtu: {{.Sriov.EthernetMtu}}

--- a/profiles/sriov-ethernet-rdma/35-nicinterfacenametemplate.yaml
+++ b/profiles/sriov-ethernet-rdma/35-nicinterfacenametemplate.yaml
@@ -3,7 +3,7 @@ apiVersion: configuration.net.nvidia.com/v1alpha1
 kind: NicInterfaceNameTemplate
 metadata:
   name: nic-rename{{suffix .ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:

--- a/profiles/sriov-ethernet-rdma/40-sriovnetwork.yaml
+++ b/profiles/sriov-ethernet-rdma/40-sriovnetwork.yaml
@@ -6,14 +6,14 @@ apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
   name: {{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.NetworkOperator.Namespace}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   ipam: |
     {
       "type": "nv-ipam",
       "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}"
     }
-  networkNamespace: {{$.PodNamespace}}
+  networkNamespace: "{{$.PodNamespace}}"
   resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.Identifier}}
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
@@ -23,13 +23,13 @@ apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
   name: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   ipam: |
     {
       "type": "nv-ipam",
       "poolName": "{{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}"
     }
-  networkNamespace: {{$.PodNamespace}}
+  networkNamespace: "{{$.PodNamespace}}"
   resourceName: {{.Sriov.ResourceName}}{{resourceSuffix $.ClusterConfig.Identifier}}
 {{- end}}

--- a/profiles/sriov-ethernet-rdma/50-example-daemonset.yaml
+++ b/profiles/sriov-ethernet-rdma/50-example-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: sriov-test{{suffix .ClusterConfig.Identifier}}
-  namespace: {{$.PodNamespace}}
+  namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -58,7 +58,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: sriov-test{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.PodNamespace}}
+  namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:

--- a/profiles/sriov-ib-rdma/10-nicclusterpolicy.yaml
+++ b/profiles/sriov-ib-rdma/10-nicclusterpolicy.yaml
@@ -14,26 +14,26 @@ spec:
   nicConfigurationOperator:
     operator:
       image: nic-configuration-operator
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     configurationDaemon:
       image: nic-configuration-operator-daemon
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     logLevel: info
   {{- end }}
   nvIpam:
     image: nvidia-k8s-ipam
-    repository: {{.NetworkOperator.Repository}}
-    version: {{.NetworkOperator.ComponentVersion}}
+    repository: "{{.NetworkOperator.Repository}}"
+    version: "{{.NetworkOperator.ComponentVersion}}"
     imagePullSecrets: []
     enableWebhook: false
   secondaryNetwork:
     cniPlugins:
       image: plugins
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
     multus:
       image: multus-cni
-      repository: {{.NetworkOperator.Repository}}
-      version: {{.NetworkOperator.ComponentVersion}}
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"

--- a/profiles/sriov-ib-rdma/11-nicnodepolicy.yaml
+++ b/profiles/sriov-ib-rdma/11-nicnodepolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicNodePolicy
 metadata:
-  name: {{.ClusterConfig.Identifier | nnpName}}
+  name: "{{.ClusterConfig.Identifier | nnpName}}"
 spec:
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:
@@ -12,14 +12,14 @@ spec:
   {{- if .DOCADriver.Enable }}
   ofedDriver:
     image: doca-driver
-    repository: {{.NetworkOperator.Repository}}
+    repository: "{{.NetworkOperator.Repository}}"
     {{- if .NetworkOperator.ImagePullSecrets }}
     imagePullSecrets:
     {{- range .NetworkOperator.ImagePullSecrets }}
       - {{ . }}
     {{- end }}
     {{- end }}
-    version: {{.DOCADriver.Version}}
+    version: "{{.DOCADriver.Version}}"
     env:
       - name: UNLOAD_STORAGE_MODULES
         value: "{{.DOCADriver.UnloadStorageModules}}"

--- a/profiles/sriov-ib-rdma/20-ippool.yaml
+++ b/profiles/sriov-ib-rdma/20-ippool.yaml
@@ -6,7 +6,7 @@ apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
   name: {{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.NetworkOperator.Namespace}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
   perNodeBlockSize: 50
@@ -34,7 +34,7 @@ apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: IPPool
 metadata:
   name: {{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
   perNodeBlockSize: 50

--- a/profiles/sriov-ib-rdma/30-sriovnetworknodepolicy.yaml
+++ b/profiles/sriov-ib-rdma/30-sriovnetworknodepolicy.yaml
@@ -6,7 +6,7 @@ apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
   name: infiniband-sriov-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.NetworkOperator.Namespace}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   deviceType: netdevice
   mtu: {{$.Sriov.InfinibandMtu}}
@@ -44,7 +44,7 @@ apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
   name: infiniband-sriov{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   deviceType: netdevice
   mtu: {{.Sriov.InfinibandMtu}}

--- a/profiles/sriov-ib-rdma/35-nicinterfacenametemplate.yaml
+++ b/profiles/sriov-ib-rdma/35-nicinterfacenametemplate.yaml
@@ -3,7 +3,7 @@ apiVersion: configuration.net.nvidia.com/v1alpha1
 kind: NicInterfaceNameTemplate
 metadata:
   name: nic-rename{{suffix .ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:

--- a/profiles/sriov-ib-rdma/40-sriovibnetwork.yaml
+++ b/profiles/sriov-ib-rdma/40-sriovibnetwork.yaml
@@ -6,7 +6,7 @@ apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovIBNetwork
 metadata:
   name: {{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.NetworkOperator.Namespace}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   ipam: |
     {
@@ -15,7 +15,7 @@ spec:
     }
   resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.Identifier}}
   linkState: enable
-  networkNamespace: {{$.PodNamespace}}
+  networkNamespace: "{{$.PodNamespace}}"
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
 {{- end -}}
@@ -24,7 +24,7 @@ apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovIBNetwork
 metadata:
   name: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{.NetworkOperator.Namespace}}
+  namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   ipam: |
     {
@@ -33,5 +33,5 @@ spec:
     }
   resourceName: {{.Sriov.ResourceName}}{{resourceSuffix $.ClusterConfig.Identifier}}
   linkState: enable
-  networkNamespace: {{$.PodNamespace}}
+  networkNamespace: "{{$.PodNamespace}}"
 {{- end}}

--- a/profiles/sriov-ib-rdma/50-example-daemonset.yaml
+++ b/profiles/sriov-ib-rdma/50-example-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: sriov-ib-test{{suffix .ClusterConfig.Identifier}}
-  namespace: {{$.PodNamespace}}
+  namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -58,7 +58,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: sriov-ib-test{{suffix $.ClusterConfig.Identifier}}
-  namespace: {{$.PodNamespace}}
+  namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
YAML parses unquoted numeric-looking substitutions as numbers, silently coercing values like nicType="1023" into the integer 1023 which downstream CRDs reject. Defensively quote every template value that is backed by a Go `string` field: version, repository, namespace, networkNamespace, nicType, multiplaneMode, and the nnpName-derived NNP metadata.name. Leaves actual int fields (numberOfPlanes, priority, pfsPerNic) unquoted.

Fixes the user-reported `nicType: {{.SpectrumX.NicType}}` issue in spectrum-x/30-nicconfigurationtemplate.yaml; the same class of bug was latent in every other profile for any future user who set a numeric- only componentVersion, docaDriver.version, or namespace.