### PR TITLE
Group CLI flags into labelled sections in --help output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/zapr v1.3.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1
 	golang.org/x/term v0.42.0
@@ -54,7 +55,6 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/pkg/app/discover.go
+++ b/pkg/app/discover.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
+	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 	"gopkg.in/yaml.v2"
 )
@@ -101,6 +102,13 @@ func (l *Launcher) discoverClusterConfig() error {
 	if len(l.options.ImagePullSecrets) > 0 {
 		defaults.NetworkOperator.ImagePullSecrets = l.options.ImagePullSecrets
 		l.logger.Info("Using CLI override for image pull secrets", "secrets", l.options.ImagePullSecrets)
+	}
+
+	// Apply --network-operator-release so the saved cluster-config.yaml
+	// reflects the user's chosen release line, not whatever the default
+	// l8k-config.yaml shipped with.
+	if err := networkoperatorplugin.ApplyNetworkOperatorRelease(l.options, defaults); err != nil {
+		return apperrors.NewValidationError(err.Error(), err, "Run 'l8k --help' for supported releases")
 	}
 
 	defaults.ClusterConfig = nil

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -105,4 +105,13 @@ func init() {
 	discoverCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Filter nodes by label")
 	discoverCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for NicClusterPolicy (comma-separated)")
 	discoverCmd.Flags().StringVar(&enabledPlugins, "enabled-plugins", "network-operator", "Comma-separated list of plugins to enable")
+
+	setFlagGroup(discoverCmd, "kubeconfig", GroupCommon)
+	setFlagGroup(discoverCmd, "user-config", GroupCommon)
+	setFlagGroup(discoverCmd, "network-operator-namespace", GroupCommon)
+	setFlagGroup(discoverCmd, "network-operator-release", GroupCommon)
+	setFlagGroup(discoverCmd, "node-selector", GroupCommon)
+	setFlagGroup(discoverCmd, "image-pull-secrets", GroupCommon)
+	setFlagGroup(discoverCmd, "enabled-plugins", GroupCommon)
+	setFlagGroup(discoverCmd, "save-cluster-config", GroupDiscovery)
 }

--- a/pkg/cmd/flaggroups.go
+++ b/pkg/cmd/flaggroups.go
@@ -1,0 +1,182 @@
+// Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const flagGroupAnnotation = "flagGroup"
+
+// Group keys are prefixed with their render order so the constant value
+// also encodes ordering, leaving groupOrder as the single source of truth
+// for what gets rendered.
+const (
+	GroupCommon        = "1-common"
+	GroupDiscovery     = "2-discovery"
+	GroupProfile       = "3-profile"
+	GroupSpectrumX     = "4-spectrumx"
+	GroupGeneration    = "5-generation"
+	GroupDeploy        = "6-deploy"
+	GroupOutputLogging = "7-output-logging"
+)
+
+var groupOrder = []string{
+	GroupCommon,
+	GroupDiscovery,
+	GroupProfile,
+	GroupSpectrumX,
+	GroupGeneration,
+	GroupDeploy,
+	GroupOutputLogging,
+}
+
+var groupTitles = map[string]string{
+	GroupCommon:        "Common Flags",
+	GroupDiscovery:     "Discovery Flags",
+	GroupProfile:       "Profile Selection Flags",
+	GroupSpectrumX:     "Spectrum-X Flags",
+	GroupGeneration:    "Generation Output Flags",
+	GroupDeploy:        "Deploy Flags",
+	GroupOutputLogging: "Output & Logging Flags",
+}
+
+// setFlagGroup tags the named flag on cmd with the given group key.
+// Looks up local flags first and falls back to persistent flags — cobra
+// only merges persistent flags into Flags() at Execute time, so during
+// init() Flags().Lookup misses anything registered via PersistentFlags.
+// No-op when the flag is not registered on cmd, so a subcommand's init()
+// can call it for every flag it might own without guarding each call.
+func setFlagGroup(cmd *cobra.Command, name, group string) {
+	flag := cmd.Flags().Lookup(name)
+	if flag == nil {
+		flag = cmd.PersistentFlags().Lookup(name)
+	}
+	if flag == nil {
+		return
+	}
+	if flag.Annotations == nil {
+		flag.Annotations = map[string][]string{}
+	}
+	flag.Annotations[flagGroupAnnotation] = []string{group}
+}
+
+// groupedFlagUsages renders cmd's flags as labelled sections — one
+// section per non-empty declared group plus a trailing "Other Flags"
+// bucket for any flag missing an annotation. Walks LocalFlags and
+// InheritedFlags so persistent flags from a parent command are sectioned
+// alongside the subcommand's own flags.
+func groupedFlagUsages(cmd *cobra.Command) string {
+	buckets := map[string]*pflag.FlagSet{}
+	add := func(group string, f *pflag.Flag) {
+		fs, ok := buckets[group]
+		if !ok {
+			fs = pflag.NewFlagSet(group, pflag.ContinueOnError)
+			buckets[group] = fs
+		}
+		fs.AddFlag(f)
+	}
+
+	visit := func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		group := ""
+		if vals := f.Annotations[flagGroupAnnotation]; len(vals) > 0 {
+			group = vals[0]
+		}
+		// Cobra auto-injects --help on every command at Execute time,
+		// after init() has run, so it can't be tagged via setFlagGroup.
+		// Bin it alongside the other meta flags.
+		if group == "" && f.Name == "help" {
+			group = GroupOutputLogging
+		}
+		add(group, f)
+	}
+
+	cmd.LocalFlags().VisitAll(visit)
+	cmd.InheritedFlags().VisitAll(visit)
+
+	var buf bytes.Buffer
+	first := true
+	section := func(title string, fs *pflag.FlagSet) {
+		usage := strings.TrimRight(fs.FlagUsagesWrapped(0), " \n")
+		if usage == "" {
+			return
+		}
+		if !first {
+			buf.WriteString("\n\n")
+		}
+		first = false
+		fmt.Fprintf(&buf, "%s:\n%s", title, usage)
+	}
+
+	for _, group := range groupOrder {
+		if fs, ok := buckets[group]; ok {
+			section(groupTitles[group], fs)
+		}
+	}
+	if fs, ok := buckets[""]; ok {
+		section("Other Flags", fs)
+	}
+
+	return buf.String()
+}
+
+// installGroupedUsage swaps in a usage template that calls
+// groupedFlagUsages instead of cobra's default Flags / Global Flags
+// pair. Cobra's Command.UsageTemplate() walks up to the parent when
+// unset, so installing this on root propagates it to every subcommand.
+func installGroupedUsage(root *cobra.Command) {
+	cobra.AddTemplateFunc("groupedFlagUsages", groupedFlagUsages)
+	root.SetUsageTemplate(groupedUsageTemplate)
+}
+
+// groupedUsageTemplate mirrors cobra's defaultUsageTemplate verbatim
+// except for the two FlagUsages sections, which are replaced by a
+// single groupedFlagUsages call.
+const groupedUsageTemplate = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if or .HasAvailableLocalFlags .HasAvailableInheritedFlags}}
+
+{{groupedFlagUsages . | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`

--- a/pkg/cmd/flaggroups_test.go
+++ b/pkg/cmd/flaggroups_test.go
@@ -1,0 +1,130 @@
+// Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetFlagGroup_NoOpWhenFlagAbsent(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	require.NotPanics(t, func() {
+		setFlagGroup(cmd, "missing", GroupCommon)
+	})
+}
+
+func TestSetFlagGroup_TagsExistingFlag(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	var v string
+	cmd.Flags().StringVar(&v, "alpha", "", "alpha flag")
+
+	setFlagGroup(cmd, "alpha", GroupCommon)
+
+	flag := cmd.Flags().Lookup("alpha")
+	require.NotNil(t, flag)
+	require.Equal(t, []string{GroupCommon}, flag.Annotations[flagGroupAnnotation])
+}
+
+func TestGroupedFlagUsages_RendersGroupsInOrderWithBlankLines(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	var common, profile, deploy string
+	cmd.Flags().StringVar(&common, "common-flag", "", "common help")
+	cmd.Flags().StringVar(&profile, "profile-flag", "", "profile help")
+	cmd.Flags().StringVar(&deploy, "deploy-flag", "", "deploy help")
+
+	setFlagGroup(cmd, "common-flag", GroupCommon)
+	setFlagGroup(cmd, "profile-flag", GroupProfile)
+	setFlagGroup(cmd, "deploy-flag", GroupDeploy)
+
+	out := groupedFlagUsages(cmd)
+
+	commonIdx := strings.Index(out, "Common Flags:")
+	profileIdx := strings.Index(out, "Profile Selection Flags:")
+	deployIdx := strings.Index(out, "Deploy Flags:")
+	require.NotEqual(t, -1, commonIdx, "Common Flags section missing:\n%s", out)
+	require.NotEqual(t, -1, profileIdx, "Profile Selection Flags section missing:\n%s", out)
+	require.NotEqual(t, -1, deployIdx, "Deploy Flags section missing:\n%s", out)
+	assert.Less(t, commonIdx, profileIdx, "Common must precede Profile Selection")
+	assert.Less(t, profileIdx, deployIdx, "Profile Selection must precede Deploy")
+
+	// Each section's flag lands under its own heading.
+	commonSection := out[commonIdx:profileIdx]
+	assert.Contains(t, commonSection, "--common-flag")
+	assert.NotContains(t, commonSection, "--profile-flag")
+	assert.NotContains(t, commonSection, "--deploy-flag")
+
+	// Sections are visually separated by a blank line.
+	assert.Contains(t, out, "\n\nProfile Selection Flags:")
+	assert.Contains(t, out, "\n\nDeploy Flags:")
+}
+
+func TestGroupedFlagUsages_UntaggedFlagFallsIntoOtherFlags(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	var tagged, untagged string
+	cmd.Flags().StringVar(&tagged, "tagged", "", "tagged help")
+	cmd.Flags().StringVar(&untagged, "stray", "", "stray help")
+
+	setFlagGroup(cmd, "tagged", GroupCommon)
+
+	out := groupedFlagUsages(cmd)
+	assert.Contains(t, out, "Common Flags:")
+	assert.Contains(t, out, "Other Flags:")
+
+	otherIdx := strings.Index(out, "Other Flags:")
+	require.NotEqual(t, -1, otherIdx)
+	assert.Contains(t, out[otherIdx:], "--stray")
+}
+
+func TestGroupedFlagUsages_OmitsHiddenFlags(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	var visible, hidden string
+	cmd.Flags().StringVar(&visible, "visible", "", "visible help")
+	cmd.Flags().StringVar(&hidden, "secret", "", "secret help")
+	require.NoError(t, cmd.Flags().MarkHidden("secret"))
+
+	setFlagGroup(cmd, "visible", GroupCommon)
+	setFlagGroup(cmd, "secret", GroupCommon)
+
+	out := groupedFlagUsages(cmd)
+	assert.Contains(t, out, "--visible")
+	assert.NotContains(t, out, "--secret")
+}
+
+func TestGroupedFlagUsages_IncludesInheritedFlagsFromParent(t *testing.T) {
+	parent := &cobra.Command{Use: "parent"}
+	child := &cobra.Command{Use: "child", Run: func(_ *cobra.Command, _ []string) {}}
+	parent.AddCommand(child)
+
+	var inherited string
+	parent.PersistentFlags().StringVar(&inherited, "global-output", "", "global help")
+	setFlagGroup(parent, "global-output", GroupOutputLogging)
+
+	var local string
+	child.Flags().StringVar(&local, "local-flag", "", "local help")
+	setFlagGroup(child, "local-flag", GroupCommon)
+
+	out := groupedFlagUsages(child)
+	assert.Contains(t, out, "Common Flags:")
+	assert.Contains(t, out, "--local-flag")
+	assert.Contains(t, out, "Output & Logging Flags:")
+	assert.Contains(t, out, "--global-output")
+}

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -174,4 +174,30 @@ func init() {
 	generateCmd.Flags().BoolVar(&deploy, "deploy", false, "Also deploy after generating")
 	generateCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Kubeconfig (required with --deploy, falls back to $KUBECONFIG)")
 	generateCmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "Preview what would be deployed")
+
+	setFlagGroup(generateCmd, "user-config", GroupCommon)
+	setFlagGroup(generateCmd, "kubeconfig", GroupCommon)
+	setFlagGroup(generateCmd, "network-operator-namespace", GroupCommon)
+	setFlagGroup(generateCmd, "network-operator-release", GroupCommon)
+	setFlagGroup(generateCmd, "image-pull-secrets", GroupCommon)
+	setFlagGroup(generateCmd, "enabled-plugins", GroupCommon)
+
+	setFlagGroup(generateCmd, "fabric", GroupProfile)
+	setFlagGroup(generateCmd, "deployment-type", GroupProfile)
+	setFlagGroup(generateCmd, "multirail", GroupProfile)
+	setFlagGroup(generateCmd, "spectrum-x", GroupProfile)
+	setFlagGroup(generateCmd, "ai", GroupProfile)
+	setFlagGroup(generateCmd, "group", GroupProfile)
+
+	setFlagGroup(generateCmd, "spcx-version", GroupSpectrumX)
+	setFlagGroup(generateCmd, "multiplane-mode", GroupSpectrumX)
+	setFlagGroup(generateCmd, "number-of-planes", GroupSpectrumX)
+
+	setFlagGroup(generateCmd, "save-deployment-files", GroupGeneration)
+	setFlagGroup(generateCmd, "pod-namespace", GroupGeneration)
+	setFlagGroup(generateCmd, "enable-doca-driver", GroupGeneration)
+	setFlagGroup(generateCmd, "workload-manifest", GroupGeneration)
+
+	setFlagGroup(generateCmd, "deploy", GroupDeploy)
+	setFlagGroup(generateCmd, "dry-run", GroupDeploy)
 }

--- a/pkg/cmd/preset.go
+++ b/pkg/cmd/preset.go
@@ -116,4 +116,8 @@ func init() {
 	presetUpdateCmd.Flags().StringVar(&presetDir, "dir", "", "Destination directory for downloaded presets (default: auto-resolve)")
 	presetUpdateCmd.Flags().StringVar(&presetRepo, "repo", "nvidia/k8s-launch-kit", "GitHub repository to download presets from")
 	presetUpdateCmd.Flags().StringVar(&presetBranch, "branch", "main", "Git branch to download presets from")
+
+	setFlagGroup(presetUpdateCmd, "dir", GroupCommon)
+	setFlagGroup(presetUpdateCmd, "repo", GroupCommon)
+	setFlagGroup(presetUpdateCmd, "branch", GroupCommon)
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -114,6 +114,14 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
   # Get tool capabilities as JSON (for AI agents)
   l8k schema`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// Bare `l8k` invocation: print help instead of erroring on the
+		// missing-config validation. Any flag or positional argument
+		// signals the user wanted the full-pipeline behaviour.
+		if cmd.Flags().NFlag() == 0 && len(args) == 0 {
+			_ = cmd.Help()
+			return
+		}
+
 		enabledPlugins := parseEnabledPlugins(enabledPlugins)
 		// Create application options from CLI flags
 		opts := options.Options{
@@ -230,6 +238,48 @@ func init() {
 	// Logging flags
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "Enable logging at specified level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Write logs to file instead of stderr")
+
+	// Group the flags into labelled sections in --help output. The phase
+	// comments above describe the same grouping; this propagates the intent
+	// into the rendered help. installGroupedUsage propagates the template
+	// to every subcommand via cobra's parent lookup.
+	setFlagGroup(rootCmd, "enabled-plugins", GroupCommon)
+	setFlagGroup(rootCmd, "user-config", GroupCommon)
+	setFlagGroup(rootCmd, "kubeconfig", GroupCommon)
+	setFlagGroup(rootCmd, "network-operator-namespace", GroupCommon)
+	setFlagGroup(rootCmd, "network-operator-release", GroupCommon)
+	setFlagGroup(rootCmd, "node-selector", GroupCommon)
+	setFlagGroup(rootCmd, "image-pull-secrets", GroupCommon)
+
+	setFlagGroup(rootCmd, "discover-cluster-config", GroupDiscovery)
+	setFlagGroup(rootCmd, "save-cluster-config", GroupDiscovery)
+
+	setFlagGroup(rootCmd, "fabric", GroupProfile)
+	setFlagGroup(rootCmd, "deployment-type", GroupProfile)
+	setFlagGroup(rootCmd, "multirail", GroupProfile)
+	setFlagGroup(rootCmd, "spectrum-x", GroupProfile)
+	setFlagGroup(rootCmd, "ai", GroupProfile)
+	setFlagGroup(rootCmd, "group", GroupProfile)
+
+	setFlagGroup(rootCmd, "spcx-version", GroupSpectrumX)
+	setFlagGroup(rootCmd, "multiplane-mode", GroupSpectrumX)
+	setFlagGroup(rootCmd, "number-of-planes", GroupSpectrumX)
+
+	setFlagGroup(rootCmd, "save-deployment-files", GroupGeneration)
+	setFlagGroup(rootCmd, "pod-namespace", GroupGeneration)
+	setFlagGroup(rootCmd, "enable-doca-driver", GroupGeneration)
+	setFlagGroup(rootCmd, "workload-manifest", GroupGeneration)
+
+	setFlagGroup(rootCmd, "deploy", GroupDeploy)
+	setFlagGroup(rootCmd, "dry-run", GroupDeploy)
+
+	setFlagGroup(rootCmd, "output", GroupOutputLogging)
+	setFlagGroup(rootCmd, "yes", GroupOutputLogging)
+	setFlagGroup(rootCmd, "quiet", GroupOutputLogging)
+	setFlagGroup(rootCmd, "log-level", GroupOutputLogging)
+	setFlagGroup(rootCmd, "log-file", GroupOutputLogging)
+
+	installGroupedUsage(rootCmd)
 }
 
 // validateConfig validates the CLI flag combinations

--- a/pkg/cmd/sosreport.go
+++ b/pkg/cmd/sosreport.go
@@ -111,4 +111,7 @@ func init() {
 
 	sosreportCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (falls back to $KUBECONFIG)")
 	sosreportCmd.Flags().StringVar(&sosreportOutputDir, "output-dir", "./sosreport", "Directory to save the sosreport")
+
+	setFlagGroup(sosreportCmd, "kubeconfig", GroupCommon)
+	setFlagGroup(sosreportCmd, "output-dir", GroupGeneration)
 }

--- a/pkg/networkoperatorplugin/networkoperator.go
+++ b/pkg/networkoperatorplugin/networkoperator.go
@@ -70,40 +70,46 @@ func (p *NetworkOperatorPlugin) BuildProfileFromOptions(options options.Options,
 	return nil
 }
 
-// ApplyOptionsToConfig applies CLI options to the configuration, overriding file values.
-// CLI flags take precedence over config file values for any explicitly set option.
-func (p *NetworkOperatorPlugin) ApplyOptionsToConfig(options options.Options, fullConfig *config.LaunchKubernetesConfig) error {
-	// Apply network operator release selection. Source precedence:
-	//   1. --network-operator-release CLI flag
-	//   2. networkOperator.selectedRelease from the config file
-	// When set, looks up the release in the embedded catalog and overwrites
-	// version/componentVersion/repository on NetworkOperator and version on
-	// DOCADriver — explicit values in the config file are intentionally
-	// replaced so the catalog is the single source of truth for the chosen
-	// release. Validation in pkg/cmd/root.go has already rejected unknown
-	// releases supplied via CLI by this point; config-file values are
-	// validated here.
+// ApplyNetworkOperatorRelease resolves the effective Network Operator
+// release (CLI flag > networkOperator.selectedRelease in config) and writes
+// the catalog-derived version, componentVersion, repository, and DOCA
+// driver version onto fullConfig. Shared between the generate flow's
+// ApplyOptionsToConfig and the discover flow that also needs to honour
+// --network-operator-release when emitting cluster-config.yaml. CLI-side
+// validation in pkg/cmd/root.go has already rejected unknown releases
+// supplied via flag; config-file values are validated here.
+func ApplyNetworkOperatorRelease(options options.Options, fullConfig *config.LaunchKubernetesConfig) error {
 	effectiveRelease := options.NetworkOperatorRelease
 	if effectiveRelease == "" && fullConfig.NetworkOperator != nil {
 		effectiveRelease = fullConfig.NetworkOperator.SelectedRelease
 	}
-	if effectiveRelease != "" {
-		rel, ok := LookupRelease(effectiveRelease)
-		if !ok {
-			return fmt.Errorf("unsupported network operator release %q; supported: %v",
-				effectiveRelease, SupportedReleases())
-		}
-		if fullConfig.NetworkOperator == nil {
-			fullConfig.NetworkOperator = &config.NetworkOperatorConfig{}
-		}
-		fullConfig.NetworkOperator.SelectedRelease = effectiveRelease
-		fullConfig.NetworkOperator.Version = rel.NetworkOperator.Version
-		fullConfig.NetworkOperator.ComponentVersion = rel.NetworkOperator.ComponentVersion
-		fullConfig.NetworkOperator.Repository = rel.NetworkOperator.Repository
-		if fullConfig.DOCADriver == nil {
-			fullConfig.DOCADriver = &config.DOCADriverConfig{}
-		}
-		fullConfig.DOCADriver.Version = rel.DOCADriver.Version
+	if effectiveRelease == "" {
+		return nil
+	}
+	rel, ok := LookupRelease(effectiveRelease)
+	if !ok {
+		return fmt.Errorf("unsupported network operator release %q; supported: %v",
+			effectiveRelease, SupportedReleases())
+	}
+	if fullConfig.NetworkOperator == nil {
+		fullConfig.NetworkOperator = &config.NetworkOperatorConfig{}
+	}
+	fullConfig.NetworkOperator.SelectedRelease = effectiveRelease
+	fullConfig.NetworkOperator.Version = rel.NetworkOperator.Version
+	fullConfig.NetworkOperator.ComponentVersion = rel.NetworkOperator.ComponentVersion
+	fullConfig.NetworkOperator.Repository = rel.NetworkOperator.Repository
+	if fullConfig.DOCADriver == nil {
+		fullConfig.DOCADriver = &config.DOCADriverConfig{}
+	}
+	fullConfig.DOCADriver.Version = rel.DOCADriver.Version
+	return nil
+}
+
+// ApplyOptionsToConfig applies CLI options to the configuration, overriding file values.
+// CLI flags take precedence over config file values for any explicitly set option.
+func (p *NetworkOperatorPlugin) ApplyOptionsToConfig(options options.Options, fullConfig *config.LaunchKubernetesConfig) error {
+	if err := ApplyNetworkOperatorRelease(options, fullConfig); err != nil {
+		return err
 	}
 
 	// Apply network operator namespace override from CLI


### PR DESCRIPTION
Cobra's default usage template renders all flags as one alphabetised block, which made `l8k --help` (32 flags on root) hard to scan. Add a small grouping mechanism in pkg/cmd/flaggroups.go: each flag is tagged with a group key via SetFlagGroup, and a custom usage template calls groupedFlagUsages to render one section per group plus a fallback bucket. Seven sections — Common, Discovery, Profile Selection, Spectrum-X, Generation Output, Deploy, Output & Logging — mirror the // Phase 0/1/2/3 author comments and propagate to every subcommand via cobra's parent template lookup. No flag names, defaults, or parsing change.