### PR TITLE
Classify BF3 SuperNICs as east-west and treat non-matching PFs as OOB

### DIFF
--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -80,6 +80,17 @@ func isNorthSouthDevice(partNumber string) bool {
 	return nsProductIDs[partNumber]
 }
 
+// isBlueField3Device returns true if the PCI device ID is BlueField-3
+// (Mellanox vendor 15b3, device 0xa2dc). BF3 is the only BlueField
+// generation where both DPU and SuperNIC SKUs share a device ID, so
+// classification has to fall back to part number against ns-product-ids.
+// Older (BF2) and newer (BF4+) generations use distinct device IDs and
+// stay on the default path — DPUs match ns-product-ids and become
+// north-south; anything else flows through the frequency heuristic.
+func isBlueField3Device(deviceID string) bool {
+	return strings.EqualFold(deviceID, "a2dc")
+}
+
 func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c client.Client, defaultConfig *config.LaunchKubernetesConfig) error {
 	uiOutput := ui.FromContext(ctx)
 
@@ -493,8 +504,14 @@ type nodePFEntry struct {
 	RdmaDevice       string
 	NetworkInterface string
 	IsNorthSouth     bool // true when device is a DPU (not a SuperNIC)
-	PSID             string
-	PartNumber       string
+	// IsExplicitEastWest is true when Stage 1 classified this PF as a
+	// BlueField SuperNIC (BF chip + part number not in ns-product-ids).
+	// The frequency heuristic must not flip it back to north-south, and
+	// its presence triggers the "any non-matching unpinned PF on this
+	// node is OOB / north-south" rule.
+	IsExplicitEastWest bool
+	PSID               string
+	PartNumber         string
 }
 
 // fetchNodeLabels lists all Kubernetes nodes and returns a map of nodeName → labels.
@@ -537,27 +554,62 @@ func isPowerOfTwo(n int) bool {
 	return n >= 2 && (n&(n-1)) == 0
 }
 
-// classifyByPartNumberFrequency applies a heuristic for nodes with 5+ PFs:
-// the most common part number (preferring power-of-2 counts) is east-west,
-// and all other part numbers are reclassified as north-south.
-// PFs already marked north-south by product ID matching are not changed.
+// classifyByPartNumberFrequency refines per-node PF traffic classification
+// after Stage 1's deterministic rules (DPU list, BF SuperNIC). Two paths:
+//
+//  1. If any PF on the node is explicitly east-west (Stage 1 BF SuperNIC
+//     pin), every other PF whose part number doesn't match an explicit-EW
+//     part number is reclassified as north-south (treated as OOB / mgmt).
+//     PFs already pinned north-south or explicit east-west are not touched.
+//     This handles the common case where a node has BF SuperNICs for
+//     east-west GPU traffic and a separate non-BF NIC (e.g. ConnectX-6 Lx)
+//     wired up as the OOB management interface.
+//
+//  2. No explicit-EW pins: fall back to the original 5+-PF frequency
+//     heuristic — the most common part number (preferring power-of-2
+//     counts) is east-west; minority part numbers become north-south.
+//     The tally only considers unpinned PFs, so DPU part numbers don't
+//     skew the tiebreak.
+//
 // Returns warning messages for the caller to display to the user.
 func classifyByPartNumberFrequency(nodeMap map[string]*nodeInfo) []string {
 	var warnings []string
 	for nodeName, ni := range nodeMap {
+		// Path 1: explicit east-west pins exist for this node.
+		ewPartNumbers := map[string]bool{}
+		for _, pf := range ni.pfs {
+			if pf.IsExplicitEastWest && pf.PartNumber != "" {
+				ewPartNumbers[pf.PartNumber] = true
+			}
+		}
+		if len(ewPartNumbers) > 0 {
+			for i := range ni.pfs {
+				if ni.pfs[i].IsNorthSouth || ni.pfs[i].IsExplicitEastWest {
+					continue
+				}
+				if !ewPartNumbers[ni.pfs[i].PartNumber] {
+					ni.pfs[i].IsNorthSouth = true
+				}
+			}
+			continue
+		}
+
+		// Path 2: fall back to the legacy frequency heuristic.
 		if len(ni.pfs) < 5 {
 			continue
 		}
 
-		// Count PFs by part number (skip empty)
+		// Count PFs by part number, ignoring already-pinned ones so DPU
+		// part numbers (Stage 1 north-south) don't poison the tiebreak.
 		partCounts := map[string]int{}
 		for _, pf := range ni.pfs {
-			if pf.PartNumber != "" {
-				partCounts[pf.PartNumber]++
+			if pf.IsNorthSouth || pf.PartNumber == "" {
+				continue
 			}
+			partCounts[pf.PartNumber]++
 		}
 		if len(partCounts) <= 1 {
-			// All PFs have the same (or empty) part number — nothing to classify
+			// All unpinned PFs share a part number — nothing to classify.
 			continue
 		}
 
@@ -631,19 +683,29 @@ func buildClusterConfig(devices []nicop.NicDevice, nodeLabels map[string]map[str
 			nodeMap[nodeName] = &nodeInfo{}
 		}
 		ni := nodeMap[nodeName]
-		// Match part number against known DPU product IDs for north-south classification.
-		northSouth := isNorthSouthDevice(d.Status.PartNumber)
+		// Stage 1 classification:
+		//   - Part number in ns-product-ids → BlueField DPU → north-south.
+		//   - BlueField-3 chip (deviceID a2dc) with part number NOT in
+		//     ns-product-ids → BlueField-3 SuperNIC → explicit east-west.
+		//     BF3 is special-cased because DPU and SuperNIC SKUs share the
+		//     same device ID; BF2/BF4 use distinct device IDs and DPUs
+		//     among them are already covered by the ns-product-ids match.
+		//   - Anything else → unclassified (default east-west, may be
+		//     reclassified by the frequency heuristic in Stage 1.5).
+		isDPU := isNorthSouthDevice(d.Status.PartNumber)
+		isBF3SuperNIC := !isDPU && isBlueField3Device(d.Status.Type)
 		for _, p := range d.Status.Ports {
 			entry := nodePFEntry{
 				pfFingerprint: pfFingerprint{
 					DeviceID:   d.Status.Type,
 					PciAddress: p.PCI,
 				},
-				RdmaDevice:       p.RdmaInterface,
-				NetworkInterface: p.NetworkInterface,
-				IsNorthSouth:     northSouth,
-				PSID:             d.Status.PSID,
-				PartNumber:       d.Status.PartNumber,
+				RdmaDevice:         p.RdmaInterface,
+				NetworkInterface:   p.NetworkInterface,
+				IsNorthSouth:       isDPU,
+				IsExplicitEastWest: isBF3SuperNIC,
+				PSID:               d.Status.PSID,
+				PartNumber:         d.Status.PartNumber,
 			}
 			ni.pfs = append(ni.pfs, entry)
 			if p.RdmaInterface != "" {

--- a/pkg/networkoperatorplugin/discovery_test.go
+++ b/pkg/networkoperatorplugin/discovery_test.go
@@ -288,6 +288,133 @@ func TestClassifyDiscoveredModules(t *testing.T) {
 	}
 }
 
+func TestIsBlueField3Device(t *testing.T) {
+	cases := []struct {
+		deviceID string
+		want     bool
+	}{
+		{"a2dc", true},
+		{"A2DC", true}, // case-insensitive
+		{"a2d2", false}, // BF2
+		{"a2d6", false}, // hypothetical BF4
+		{"101f", false}, // ConnectX-6 Lx
+		{"1023", false}, // ConnectX-8
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.deviceID, func(t *testing.T) {
+			assert.Equal(t, tc.want, isBlueField3Device(tc.deviceID))
+		})
+	}
+}
+
+// TestClassifyByPartNumberFrequency_BFSuperNICTriggersOOBRule reproduces the
+// cluster-config the user reported: 6 PFs, three part numbers each appearing
+// twice. After Stage 1 (BF3 SuperNIC explicit-EW pin + ns-product-ids DPU
+// match), the heuristic must:
+//   - keep the BF3 DPU PFs north-south,
+//   - keep the BF3 SuperNIC PFs east-west,
+//   - flip the unpinned ConnectX-6 Lx PFs (used as OOB) to north-south.
+func TestClassifyByPartNumberFrequency_BFSuperNICTriggersOOBRule(t *testing.T) {
+	bfDPU := nodePFEntry{
+		pfFingerprint: pfFingerprint{DeviceID: "a2dc", PciAddress: "0000:0d:00.0"},
+		IsNorthSouth:  true, // pinned by ns-product-ids match
+		PartNumber:    "900-9D3B6-00CV-AA0",
+	}
+	bfSuperNIC := nodePFEntry{
+		pfFingerprint:      pfFingerprint{DeviceID: "a2dc", PciAddress: "0000:37:00.0"},
+		IsExplicitEastWest: true, // pinned by BF3 SuperNIC rule
+		PartNumber:         "900-9D3D4-00EN-HA0",
+	}
+	oobNIC := nodePFEntry{
+		pfFingerprint: pfFingerprint{DeviceID: "101f", PciAddress: "0000:22:00.0"},
+		PartNumber:    "0DN78C",
+	}
+
+	ni := &nodeInfo{pfs: []nodePFEntry{
+		bfDPU, bfDPU, bfSuperNIC, bfSuperNIC, oobNIC, oobNIC,
+	}}
+	classifyByPartNumberFrequency(map[string]*nodeInfo{"node-1": ni})
+
+	for i, pf := range ni.pfs {
+		switch pf.PartNumber {
+		case "900-9D3B6-00CV-AA0":
+			assert.True(t, pf.IsNorthSouth, "BF3 DPU PF[%d] should remain north-south", i)
+			assert.False(t, pf.IsExplicitEastWest)
+		case "900-9D3D4-00EN-HA0":
+			assert.False(t, pf.IsNorthSouth, "BF3 SuperNIC PF[%d] must NOT be flipped to north-south", i)
+			assert.True(t, pf.IsExplicitEastWest)
+		case "0DN78C":
+			assert.True(t, pf.IsNorthSouth, "ConnectX-6 Lx OOB PF[%d] should be flipped to north-south", i)
+			assert.False(t, pf.IsExplicitEastWest)
+		}
+	}
+}
+
+// TestClassifyByPartNumberFrequency_NoExplicitEWFallsBackToFrequency verifies
+// the legacy 5+-PF heuristic still runs when no BF3 SuperNIC is present.
+func TestClassifyByPartNumberFrequency_NoExplicitEWFallsBackToFrequency(t *testing.T) {
+	majority := nodePFEntry{
+		pfFingerprint: pfFingerprint{DeviceID: "1023"},
+		PartNumber:    "AAA-major",
+	}
+	minority := nodePFEntry{
+		pfFingerprint: pfFingerprint{DeviceID: "1023"},
+		PartNumber:    "BBB-minor",
+	}
+
+	ni := &nodeInfo{pfs: []nodePFEntry{
+		majority, majority, majority, majority, minority,
+	}}
+	classifyByPartNumberFrequency(map[string]*nodeInfo{"node-1": ni})
+
+	for _, pf := range ni.pfs {
+		if pf.PartNumber == "AAA-major" {
+			assert.False(t, pf.IsNorthSouth, "majority part number stays east-west")
+		} else {
+			assert.True(t, pf.IsNorthSouth, "minority part number flipped to north-south")
+		}
+	}
+}
+
+// TestClassifyByPartNumberFrequency_DPUExcludedFromTiebreak verifies that PFs
+// already pinned north-south (via ns-product-ids) don't poison the alphabetic
+// tiebreak in the legacy heuristic.
+func TestClassifyByPartNumberFrequency_DPUExcludedFromTiebreak(t *testing.T) {
+	// Without exclusion, the DPU part number "AAA-dpu" would win the
+	// alphabetic tiebreak and the real EW NICs would get reclassified as
+	// north-south.
+	dpu := nodePFEntry{
+		pfFingerprint: pfFingerprint{DeviceID: "a2dc"},
+		IsNorthSouth:  true,
+		PartNumber:    "AAA-dpu",
+	}
+	ew := nodePFEntry{
+		pfFingerprint: pfFingerprint{DeviceID: "1023"},
+		PartNumber:    "BBB-ew",
+	}
+	mgmt := nodePFEntry{
+		pfFingerprint: pfFingerprint{DeviceID: "101f"},
+		PartNumber:    "CCC-mgmt",
+	}
+
+	ni := &nodeInfo{pfs: []nodePFEntry{
+		dpu, dpu, ew, ew, ew, ew, mgmt,
+	}}
+	classifyByPartNumberFrequency(map[string]*nodeInfo{"node-1": ni})
+
+	for _, pf := range ni.pfs {
+		switch pf.PartNumber {
+		case "AAA-dpu":
+			assert.True(t, pf.IsNorthSouth)
+		case "BBB-ew":
+			assert.False(t, pf.IsNorthSouth, "EW majority must stay east-west")
+		case "CCC-mgmt":
+			assert.True(t, pf.IsNorthSouth, "minority flipped to north-south")
+		}
+	}
+}
+
 // TestKnownStorageModules_MatchesMofedmodules is a regression guard: the
 // classification set MUST be derived exactly from the shared
 // mofedmodules.DefaultStorageModules slice. If this assertion fails, the set


### PR DESCRIPTION
The old per-PF rule only marked devices whose part number was in ns-product-ids as north-south; everything else defaulted to east-west. On a node with a mix of BF3 DPU + BF3 SuperNIC + a non-BF NIC used as the OOB management interface, the 5+-PF frequency heuristic broke ties alphabetically across all part numbers (including the already- classified DPU one), occasionally promoting the OOB part number to "majority east-west" and flipping the real BF3 SuperNICs to north-south.

Stage 1 now pins BF3 SuperNICs (deviceID a2dc + part number not in ns-product-ids) as explicit east-west. BF2/BF4 are unaffected — their DPUs match ns-product-ids and become north-south as before; non-DPU SKUs flow through the heuristic.

Stage 1.5 grows a new "OOB" path: if any PF on the node is explicit-EW, every unpinned PF whose part number doesn't match an explicit-EW part number is flipped to north-south. The legacy frequency heuristic is unchanged for nodes without explicit-EW pins, except the tally now skips already-pinned PFs so DPU part numbers can't skew the alphabetic tiebreak.