### PR TITLE
Add `l8k generate --for <preset>` for ahead-of-time manifest generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,37 +148,50 @@ Available Commands:
   sosreport   Collect diagnostic sosreport from a Kubernetes cluster
   version     Print the version number
 
-Flags:
-      --ai                                  Enable AI deployment
-      --deploy                              Deploy the generated files to the Kubernetes cluster
-      --deployment-type string              Select the deployment type (sriov, rdma_shared, host_device)
-      --discover-cluster-config             Deploy a thin Network Operator profile to discover cluster capabilities
-      --dry-run                             Preview what would be deployed without applying changes to the cluster
-      --enable-doca-driver                  Enable DOCA driver deployment (overrides config file docaDriver.enable)
+Common Flags:
       --enabled-plugins string              Comma-separated list of plugins to enable (default "network-operator")
-      --fabric string                       Select the fabric type to deploy (infiniband, ethernet)
-      --group string                        Generate templates for a specific group only (e.g., group-0)
-  -h, --help                                help for l8k
       --image-pull-secrets strings          Image pull secret names for NicClusterPolicy (comma-separated)
       --kubeconfig string                   Path to kubeconfig file for cluster deployment (required when using --deploy)
-      --log-file string                     Write logs to file instead of stderr
-      --log-level string                    Enable logging at specified level (debug, info, warn, error)
-      --multiplane-mode string              Spectrum-X multiplane mode: swplb, hwplb, uniplane (requires --spectrum-x)
-      --multirail                           Enable multirail deployment
       --network-operator-namespace string   Override the network operator namespace from the config file
       --network-operator-release string     Network Operator release line to deploy (MAJOR.MINOR). Selects component image tags + repository from a built-in catalog and drives version-gated template sections. Supported: 25.10, 26.1, 26.4
       --node-selector string                Filter nodes for discovery by label (e.g., key=value,key2=value2) (default "feature.node.kubernetes.io/pci-15b3.present=true")
-      --number-of-planes int                Number of planes for Spectrum-X (requires --spectrum-x)
-      --output string                       Output format: text (default, human-readable) or json (structured, for automation and AI agents) (default "text")
-      --pod-namespace string                Namespace for pods and network resources (overrides config podNamespace, default: 'default')
-  -q, --quiet                               Suppress informational output (errors still shown)
-      --save-cluster-config string          Save discovered cluster configuration to the specified path (defaults to --user-config path if set, otherwise ./cluster-config.yaml)
-      --save-deployment-files string        Save generated deployment files to the specified directory (default "./deployment")
-      --spcx-version string                 Spectrum-X firmware version (requires --spectrum-x)
-      --spectrum-x                          Enable Spectrum X deployment
       --user-config string                  Use provided cluster configuration file (as base config for discovery or as full config without discovery)
-      --workload-manifest string            Path to a custom workload manifest YAML (replaces the profile's default example workload)
-  -y, --yes                                 Auto-confirm all prompts without interactive input
+
+Discovery Flags:
+      --discover-cluster-config      Deploy a thin Network Operator profile to discover cluster capabilities
+      --save-cluster-config string   Save discovered cluster configuration to the specified path (defaults to --user-config path if set, otherwise ./cluster-config.yaml)
+
+Profile Selection Flags:
+      --ai                       Enable AI deployment
+      --deployment-type string   Select the deployment type (sriov, rdma_shared, host_device)
+      --fabric string            Select the fabric type to deploy (infiniband, ethernet)
+      --for string               Generate for a known server preset (replaces clusterConfig from the preset). Requires --node-selector. Available: PowerEdge-XE9680, ThinkSystem-SR680a-V3, UCSC-885A-M8-H22
+      --group string             Generate templates for a specific group only (e.g., group-0)
+      --multirail                Enable multirail deployment
+      --spectrum-x               Enable Spectrum X deployment
+
+Spectrum-X Flags:
+      --multiplane-mode string   Spectrum-X multiplane mode: swplb, hwplb, uniplane (requires --spectrum-x)
+      --number-of-planes int     Number of planes for Spectrum-X (requires --spectrum-x)
+      --spcx-version string      Spectrum-X firmware version (requires --spectrum-x)
+
+Generation Output Flags:
+      --enable-doca-driver             Enable DOCA driver deployment (overrides config file docaDriver.enable)
+      --pod-namespace string           Namespace for pods and network resources (overrides config podNamespace, default: 'default')
+      --save-deployment-files string   Save generated deployment files to the specified directory (default "./deployment")
+      --workload-manifest string       Path to a custom workload manifest YAML (replaces the profile's default example workload)
+
+Deploy Flags:
+      --deploy    Deploy the generated files to the Kubernetes cluster
+      --dry-run   Preview what would be deployed without applying changes to the cluster
+
+Output & Logging Flags:
+  -h, --help               help for l8k
+      --log-file string    Write logs to file instead of stderr
+      --log-level string   Enable logging at specified level (debug, info, warn, error)
+      --output string      Output format: text (default, human-readable) or json (structured, for automation and AI agents) (default "text")
+  -q, --quiet              Suppress informational output (errors still shown)
+  -y, --yes                Auto-confirm all prompts without interactive input
 
 Use "l8k [command] --help" for more information about a command.
 ```
@@ -293,6 +306,24 @@ l8k generate --user-config ./config.yaml \
     --group group-0 \
     --save-deployment-files ./deployments
 ```
+
+### Generate Deployment Files Without Cluster Access (`--for`)
+
+When you have a known server SKU, use `--for <preset-name>` to skip cluster discovery and synthesize the `clusterConfig` from a topology preset. List available presets with `l8k preset list`. The `--node-selector` flag is required since the synthesized clusterConfig has no live worker-node list:
+
+```bash
+# List available presets (each shows machineType + gpuType)
+l8k preset list
+
+# Generate from a known SKU (no kubeconfig needed)
+l8k generate --user-config ./config.yaml \
+    --for ThinkSystem-SR680a-V3 \
+    --node-selector "nvidia.com/gpu.product=NVIDIA-H200" \
+    --fabric ethernet --deployment-type sriov \
+    --save-deployment-files ./deployments
+```
+
+The preset YAML must declare a `capabilities.nodes.{sriov,rdma,ib}` block to be usable with `--for`; presets shipped with l8k already have one. See [docs/presets.rst](docs/presets.rst) for the full preset format and how to add new ones.
 
 ### Troubleshooting Network Operator Issues
 
@@ -817,7 +848,7 @@ clusterConfig:
 
 ### Machine and GPU Product Type
 
-During discovery, each node group's `machineType` and `productType` are populated from GPU operator node labels (`nvidia.com/gpu.machine` and `nvidia.com/gpu.product`). When these labels are absent — for example, when the GPU operator is not deployed — the tool falls back to probing hardware directly from a `nic-configuration-daemon` pod on one of the group's nodes:
+During discovery, each node group's `machineType` and `gpuType` are populated from GPU operator node labels (`nvidia.com/gpu.machine` and `nvidia.com/gpu.product`). When these labels are absent — for example, when the GPU operator is not deployed — the tool falls back to probing hardware directly from a `nic-configuration-daemon` pod on one of the group's nodes:
 
 - **Machine type**: read from `/sys/class/dmi/id/product_name`
 - **GPU product type**: parsed from `nvidia-smi -q` output (the first `Product Name` field)
@@ -829,7 +860,7 @@ Example of discovered hardware types in the config:
 clusterConfig:
 - identifier: group-0
   machineType: ThinkSystem-SR680a-V3
-  productType: NVIDIA-H100-NVL
+  gpuType: NVIDIA-H100-NVL
   workerNodes:
   - node-1
   - node-2

--- a/docs/presets.rst
+++ b/docs/presets.rst
@@ -11,28 +11,61 @@ l8k supports **predefined topology presets** for known server machine types. Pre
 - **NUMA node affinity** for each NIC port
 - **GPU proximity** (which GPU each NIC is physically closest to)
 
-When a cluster node's machine type matches a preset and its PCI topology validates against the discovered hardware, the preset is automatically applied during discovery.
+Presets serve two distinct flows:
 
-How It Works
+1. **Discovery overlay** — When ``l8k discover`` runs, the matched preset's authoritative topology fields override what discovery's heuristics inferred.
+2. **Ahead-of-time generation (`--for`)** — ``l8k generate --for <preset-name>`` skips cluster discovery entirely and builds the ``clusterConfig`` directly from the preset's static description.
+
+Lookup Model
 ------------
 
-During ``l8k discover``, after determining a node group's machine type (from GPU operator labels or DMI data), l8k checks the local presets directory for a matching entry:
+Presets are matched on the pair ``(machineType, gpuType)``. Both fields are **required** in every ``topology.yaml``; a preset that omits either is rejected at load time. Lookup is **exact-match** — there is no any-GPU fallback. A preset with ``machineType: PowerEdge-XE9680`` and ``gpuType: NVIDIA-H200`` matches only nodes whose discovered values are exactly that pair.
 
-1. **Lookup**: Searches for ``<presets-dir>/<machine-type>/topology.yaml``
-2. **Validation**: Compares PCI addresses and device IDs between the preset and discovered NicDevices
-3. **Application**: If validation passes, overrides traffic classification, rail assignments, and adds NUMA/GPU topology metadata
-4. **Fallback**: If no preset matches or validation fails, falls back to dynamic heuristic-based discovery
+This makes multi-variant presets straightforward: the same physical chassis with different GPU SKUs gets different presets. Directory naming for variants is free-form (composite names like ``PowerEdge-XE9680-H200`` and ``PowerEdge-XE9680-B200`` are recommended), but the directory name is **only** used by ``--for`` and ``l8k preset list``. The matching keys live inside the YAML.
 
-The preset directory is resolved using the same lookup chain as profiles:
+The presets directory is resolved using the same lookup chain as profiles:
 
 - ``./presets`` (current working directory)
 - ``/usr/local/share/l8k/presets`` (default install)
 - ``<binary-dir>/../share/l8k/presets`` (custom prefix install)
 
-Validation
-----------
+How Discovery Uses Presets
+--------------------------
 
-Preset validation ensures the preset matches the actual hardware present in the cluster. The following checks are performed:
+During ``l8k discover``, after determining a node group's ``machineType`` and ``gpuType`` (from GPU operator labels or DMI/``nvidia-smi`` fallback), l8k:
+
+1. **Looks up** a preset whose YAML declares the exact same ``(machineType, gpuType)`` pair.
+2. **Validates** PCI addresses and device IDs between the preset and discovered NicDevices.
+3. **Applies** the preset's authoritative topology fields, preserving live state (RDMA device, network interface, PSID, part number).
+4. **Falls back** to heuristic discovery if no preset matches or validation fails.
+
+Generating From a Preset (``--for``)
+------------------------------------
+
+When you have a known SKU and want to render manifests ahead of time — without ``kubectl`` access to the cluster — pass ``--for <preset-name>`` to ``l8k generate``:
+
+.. code-block:: bash
+
+   l8k generate --user-config cluster-config.yaml \
+     --for ThinkSystem-SR680a-V3 \
+     --node-selector "nvidia.com/gpu.product=NVIDIA-H200" \
+     --fabric ethernet --deployment-type sriov \
+     --save-deployment-files ./output
+
+Behaviour:
+
+- ``--for`` takes the **directory name** (one of the values shown by ``l8k preset list``).
+- ``--node-selector`` is **required**: the synthesized clusterConfig has no live worker-node list, so the selector is the only way to identify which nodes the manifests should target at apply time.
+- ``--for`` and ``--discover-cluster-config`` are mutually exclusive.
+- The preset's topology becomes the **entire** ``clusterConfig`` section (replacing whatever was in the user config). The rest of the user config (``networkOperator``, ``podNamespace``, etc.) is preserved.
+- Profile selection (``FindApplicableProfile``) reads the preset's declared ``capabilities`` block to match a profile — so a preset used with ``--for`` must declare it (see below).
+
+The synthesized ``ClusterConfig`` group has its ``Identifier`` set to the preset directory name. This guarantees that two variants of the same machine type produce distinct ``NicNodePolicy`` names.
+
+Validation (Discovery Path)
+---------------------------
+
+Preset validation during ``l8k discover`` ensures the preset matches the actual hardware present in the cluster. The following checks are performed:
 
 .. list-table::
    :widths: 20 40 20
@@ -66,22 +99,22 @@ The following presets are bundled with l8k:
    :widths: 30 20 20 15
    :header-rows: 1
 
-   * - Machine Type
-     - GPU Product
+   * - Directory
+     - Machine Type
+     - GPU Type
      - NIC Model
-     - Rails
    * - PowerEdge-XE9680
-     - NVIDIA H200
+     - PowerEdge-XE9680
+     - NVIDIA-H200
      - BlueField-3 SuperNIC (ConnectX-7)
-     - 8
    * - ThinkSystem-SR680a-V3
-     - NVIDIA H200
+     - ThinkSystem-SR680a-V3
+     - NVIDIA-H200
      - BlueField-3 VPI (ConnectX-7)
-     - 8
    * - UCSC-885A-M8-H22
-     - NVIDIA H200
+     - UCSC-885A-M8-H22
+     - NVIDIA-H200
      - BlueField-3 E-series SuperNIC (ConnectX-7)
-     - 8
 
 Managing Presets
 ----------------
@@ -92,6 +125,16 @@ List local presets
 .. code-block:: bash
 
    l8k preset list
+
+Output shows each preset's directory name plus the ``machineType`` / ``gpuType`` it matches:
+
+.. code-block:: text
+
+   Available presets (presets):
+     NAME                    MACHINETYPE              GPUTYPE
+     PowerEdge-XE9680        PowerEdge-XE9680         NVIDIA-H200
+     ThinkSystem-SR680a-V3   ThinkSystem-SR680a-V3    NVIDIA-H200
+     UCSC-885A-M8-H22        UCSC-885A-M8-H22         NVIDIA-H200
 
 Download latest presets
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -135,19 +178,33 @@ The install script (``scripts/install.sh``) automatically installs bundled prese
 Topology YAML Format
 --------------------
 
-Each preset is a ``topology.yaml`` file in a machine-type-named directory. The format is a superset of the ``clusterConfig.pfs`` schema with additional topology metadata:
+Each preset is a ``topology.yaml`` file in a directory whose name uniquely identifies the variant. The schema:
 
 .. code-block:: yaml
 
+   # Required matching keys (both must be non-empty)
    machineType: PowerEdge-XE9680
-   productType: NVIDIA-H200
+   gpuType: NVIDIA-H200
+
+   # Optional metadata
+   manufacturer: Dell
    nicModel: BlueField-3 B3140H E-series HHHL SuperNIC (ConnectX-7)
    gpuInterconnect: NV18
    numaNodes: 2
 
+   # Optional: required when this preset is used via `l8k generate --for`.
+   # Discovery-time ApplyPreset ignores this block.
+   capabilities:
+     nodes:
+       sriov: true
+       rdma: true
+       ib: false
+
    pfs:
      - deviceID: a2dc
        pciAddress: 0000:1a:00.0
+       rdmaDevice: rocep26s0f0
+       networkInterface: eth2
        traffic: east-west
        rail: 0
        numaNode: 0             # NUMA node affinity
@@ -159,19 +216,21 @@ Each preset is a ``topology.yaml`` file in a machine-type-named directory. The f
        pciAddress: 0000:9d:00.0
        traffic: north-south    # DPU/management NIC
        numaNode: 1
-       connectedGPU: ""
        gpuProximity: NODE
        psid: mt_0000000884
        partNumber: 0HFWRM
 
+The ``capabilities`` block is the only schema addition required for ``--for``. It mirrors ``config.ClusterCapabilities``: ``capabilities.nodes.{sriov, rdma, ib}`` describe what the underlying hardware can do, and ``FindApplicableProfile`` uses it to match a profile.
+
 Adding New Presets
 ------------------
 
-To add a preset for a new machine type:
+To add a preset for a new ``(machineType, gpuType)`` pair:
 
-1. Run the topology collector on a representative node of that machine type
-2. Create a directory named after the machine type (matching DMI ``product_name`` with spaces replaced by dashes)
-3. Place the ``topology.yaml`` file in that directory
-4. Submit a pull request to the repository
+1. Run the topology collector on a representative node of that hardware combination.
+2. Create a directory named to uniquely identify the variant (composite name recommended, e.g. ``PowerEdge-XE9680-B200``).
+3. Place the ``topology.yaml`` in that directory with both ``machineType`` and ``gpuType`` declared.
+4. If the preset should be usable with ``l8k generate --for``, add the ``capabilities.nodes`` block.
+5. Submit a pull request to the repository.
 
-The machine type string must match exactly what ``/sys/class/dmi/id/product_name`` returns (after space-to-dash sanitization), or the ``nvidia.com/gpu.machine`` node label value.
+The ``machineType`` string must match exactly what ``/sys/class/dmi/id/product_name`` returns (after space-to-dash sanitization), or the ``nvidia.com/gpu.machine`` node label value. The ``gpuType`` string must match the ``nvidia.com/gpu.product`` label or the sanitized ``nvidia-smi -q`` product name.

--- a/pkg/app/generate.go
+++ b/pkg/app/generate.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
+	"github.com/nvidia/k8s-launch-kit/pkg/presets"
 	"github.com/nvidia/k8s-launch-kit/pkg/profiles"
 )
 
@@ -73,6 +74,33 @@ func (l *Launcher) executeGeneration(configPath string) error {
 				return fmt.Errorf("failed to apply options to config for plugin %s: %w", plugin.GetName(), err)
 			}
 		}
+	}
+
+	// --for: replace clusterConfig with a synthesized group from a preset.
+	// This is the explicit ahead-of-time generation path that skips live
+	// discovery in favor of a static preset description. The CLI layer has
+	// already enforced --node-selector being set; here we do the substitution
+	// before the rest of the pipeline runs.
+	if l.options.ForPreset != "" {
+		preset, err := presets.LoadPresetByDir(l.options.ForPreset)
+		if err != nil {
+			return apperrors.NewValidationError(
+				fmt.Sprintf("invalid --for value %q", l.options.ForPreset),
+				err,
+				"Run 'l8k preset list' to see available presets",
+			)
+		}
+		selectorMap := parseNodeSelector(l.options.NodeSelector)
+		cc, synthErr := presets.SynthesizeClusterConfig(l.options.ForPreset, preset, selectorMap)
+		if synthErr != nil {
+			return apperrors.NewValidationError(
+				fmt.Sprintf("preset %q cannot be used with --for", l.options.ForPreset),
+				synthErr,
+				"Add a 'capabilities.nodes.{sriov,rdma,ib}' block to the preset's topology.yaml",
+			)
+		}
+		fullConfig.ClusterConfig = []config.ClusterConfig{cc}
+		l.ui.Info("Using preset %q (clusterConfig replaced from preset)", l.options.ForPreset)
 	}
 
 	// Capture profile info for JSON result

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -30,6 +30,14 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
 )
 
+// generateNodeSelector is the per-subcommand node selector value. It must be
+// distinct from the root command's `nodeSelector` package variable: both
+// commands bind a `--node-selector` flag, and StringVar sets the default at
+// init time — so a single shared var would make the root command's default
+// (`feature.node.kubernetes.io/pci-15b3.present=true`) leak into the generate
+// flow and break the `--for` requires `--node-selector` validation.
+var generateNodeSelector string
+
 var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "Generate deployment manifests for a network profile",
@@ -64,7 +72,14 @@ Optionally deploy the generated manifests with --deploy.`,
   l8k generate --user-config cluster-config.yaml \
     --fabric ethernet --deployment-type sriov \
     --save-deployment-files ./output \
-    --output json --yes 2>/dev/null`,
+    --output json --yes 2>/dev/null
+
+  # Generate from a known server preset (no cluster discovery required)
+  l8k generate --user-config cluster-config.yaml \
+    --for ThinkSystem-SR680a-V3 \
+    --node-selector "feature.node.kubernetes.io/pci-15b3.present=true" \
+    --fabric ethernet --deployment-type sriov \
+    --save-deployment-files ./output`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Resolve user config: explicit flag > ./cluster-config.yaml > default config path
 		if userConfig == "" {
@@ -92,7 +107,8 @@ Optionally deploy the generated manifests with --deploy.`,
 			MultiplaneMode:          multiplaneMode,
 			NumberOfPlanes:          numberOfPlanes,
 			Group:                   group,
-			NodeSelector:            nodeSelector,
+			NodeSelector:            generateNodeSelector,
+			ForPreset:               forPreset,
 			ImagePullSecrets:        imagePullSecrets,
 			PodNamespace:            podNamespace,
 			SaveDeploymentFiles:     saveDeploymentFiles,
@@ -115,6 +131,16 @@ Optionally deploy the generated manifests with --deploy.`,
 
 		if err := applySpectrumXDefaults(&opts); err != nil {
 			exitWithError(apperrors.NewValidationError(err.Error(), err, "Check --spectrum-x flag combinations"), opts.OutputFormat)
+		}
+
+		// --for requires --node-selector since the preset has no live worker-node
+		// list to target.
+		if opts.ForPreset != "" && opts.NodeSelector == "" {
+			exitWithError(apperrors.NewValidationError(
+				"--for requires --node-selector",
+				fmt.Errorf("preset %q has no live worker-node list; supply a node selector to identify target nodes", opts.ForPreset),
+				"Specify --node-selector key1=val1,key2=val2",
+			), opts.OutputFormat)
 		}
 
 		// Resolve kubeconfig if deploy is requested
@@ -157,6 +183,8 @@ func init() {
 	generateCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Multiplane mode: swplb, hwplb, uniplane (requires --spectrum-x)")
 	generateCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes (requires --spectrum-x)")
 	generateCmd.Flags().StringVar(&group, "group", "", "Generate for a specific group only (e.g., group-0)")
+	generateCmd.Flags().StringVar(&forPreset, "for", "", forFlagHelp())
+	generateCmd.Flags().StringVar(&generateNodeSelector, "node-selector", "", "Node selector for the synthesized clusterConfig when --for is used (e.g., key=value,key2=value2). Required with --for.")
 
 	// Output
 	generateCmd.Flags().StringVar(&saveDeploymentFiles, "save-deployment-files", "", "Output directory for generated YAMLs")
@@ -188,6 +216,8 @@ func init() {
 	setFlagGroup(generateCmd, "spectrum-x", GroupProfile)
 	setFlagGroup(generateCmd, "ai", GroupProfile)
 	setFlagGroup(generateCmd, "group", GroupProfile)
+	setFlagGroup(generateCmd, "for", GroupProfile)
+	setFlagGroup(generateCmd, "node-selector", GroupProfile)
 
 	setFlagGroup(generateCmd, "spcx-version", GroupSpectrumX)
 	setFlagGroup(generateCmd, "multiplane-mode", GroupSpectrumX)

--- a/pkg/cmd/preset.go
+++ b/pkg/cmd/preset.go
@@ -49,7 +49,7 @@ var presetListCmd = &cobra.Command{
 	Example: `  l8k preset list
   l8k preset list --output json`,
 	Run: func(cmd *cobra.Command, args []string) {
-		names, err := presets.ListPresets()
+		summaries, skipped, err := presets.ListPresetSummaries()
 		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
 			return
@@ -61,14 +61,36 @@ var presetListCmd = &cobra.Command{
 			return
 		}
 
-		if len(names) == 0 {
+		if len(summaries) == 0 && len(skipped) == 0 {
 			fmt.Fprintf(cmd.OutOrStdout(), "No presets found in %s\n", dir)
 			return
 		}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "Available presets (%s):\n", dir)
-		for _, name := range names {
-			fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", name)
+		if len(summaries) > 0 {
+			nameW, machineW := len("NAME"), len("MACHINETYPE")
+			for _, s := range summaries {
+				if len(s.DirName) > nameW {
+					nameW = len(s.DirName)
+				}
+				if len(s.MachineType) > machineW {
+					machineW = len(s.MachineType)
+				}
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Available presets (%s):\n", dir)
+			fmt.Fprintf(cmd.OutOrStdout(), "  %-*s  %-*s  %s\n", nameW, "NAME", machineW, "MACHINETYPE", "GPUTYPE")
+			for _, s := range summaries {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %-*s  %-*s  %s\n", nameW, s.DirName, machineW, s.MachineType, s.GPUType)
+			}
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "No valid presets found in %s\n", dir)
+		}
+
+		if len(skipped) > 0 {
+			fmt.Fprintf(cmd.ErrOrStderr(), "\n%d preset(s) skipped:\n", len(skipped))
+			for _, s := range skipped {
+				fmt.Fprintf(cmd.ErrOrStderr(), "  %s — %s\n", s.DirName, s.Reason)
+			}
 		}
 	},
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -32,6 +32,7 @@ import (
 	applog "github.com/nvidia/k8s-launch-kit/pkg/log"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
+	"github.com/nvidia/k8s-launch-kit/pkg/presets"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 )
 
@@ -66,7 +67,18 @@ var (
 	quietFlag                   bool
 	workloadManifest            string
 	dryRunFlag                  bool
+	forPreset                   string
 )
+
+// forFlagHelp builds the help string for `--for`. Computed at init() time so
+// users see the live list of available preset directories alongside `--help`.
+func forFlagHelp() string {
+	names, _ := presets.ListPresets()
+	if len(names) == 0 {
+		return "Generate for a known server preset (replaces clusterConfig from the preset). Requires --node-selector. No presets installed; run 'l8k preset update' to fetch them."
+	}
+	return fmt.Sprintf("Generate for a known server preset (replaces clusterConfig from the preset). Requires --node-selector. Available: %s", strings.Join(names, ", "))
+}
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -139,6 +151,7 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
 			NumberOfPlanes:        numberOfPlanes,
 			Group:                group,
 			NodeSelector:         nodeSelector,
+			ForPreset:            forPreset,
 			ImagePullSecrets:     imagePullSecrets,
 			PodNamespace:         podNamespace,
 			SaveDeploymentFiles:   saveDeploymentFiles,
@@ -219,6 +232,7 @@ func init() {
 	rootCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes for Spectrum-X (requires --spectrum-x)")
 	rootCmd.Flags().StringVar(&group, "group", "", "Generate templates for a specific group only (e.g., group-0)")
 	rootCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Filter nodes for discovery by label (e.g., key=value,key2=value2)")
+	rootCmd.Flags().StringVar(&forPreset, "for", "", forFlagHelp())
 	rootCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for NicClusterPolicy (comma-separated)")
 	rootCmd.Flags().StringVar(&saveDeploymentFiles, "save-deployment-files", "./deployment", "Save generated deployment files to the specified directory")
 	rootCmd.Flags().StringVar(&podNamespace, "pod-namespace", "", "Namespace for pods and network resources (overrides config podNamespace, default: 'default')")
@@ -260,6 +274,7 @@ func init() {
 	setFlagGroup(rootCmd, "spectrum-x", GroupProfile)
 	setFlagGroup(rootCmd, "ai", GroupProfile)
 	setFlagGroup(rootCmd, "group", GroupProfile)
+	setFlagGroup(rootCmd, "for", GroupProfile)
 
 	setFlagGroup(rootCmd, "spcx-version", GroupSpectrumX)
 	setFlagGroup(rootCmd, "multiplane-mode", GroupSpectrumX)
@@ -318,6 +333,18 @@ func validateConfig(options *options.Options) error {
 	// At least one of user-config or discover-cluster-config should be provided
 	if options.UserConfig == "" && !options.DiscoverClusterConfig {
 		return fmt.Errorf("either --user-config or --discover-cluster-config must be provided")
+	}
+
+	// --for synthesizes clusterConfig from a static preset, so it cannot be
+	// combined with discovery, and it always needs a node selector to identify
+	// which nodes the rendered manifests target.
+	if options.ForPreset != "" {
+		if options.DiscoverClusterConfig {
+			return fmt.Errorf("--for and --discover-cluster-config are mutually exclusive")
+		}
+		if options.NodeSelector == "" {
+			return fmt.Errorf("--for requires --node-selector (specify which nodes the synthesized clusterConfig should target)")
+		}
 	}
 
 	// Resolve kubeconfig from flag or $KUBECONFIG env var for cluster operations

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -154,3 +154,42 @@ func TestValidateConfig_DryRunWithDeployPasses(t *testing.T) {
 	err := validateConfig(&opts)
 	assert.NoError(t, err)
 }
+
+func TestValidateConfig_ForRequiresNodeSelector(t *testing.T) {
+	opts := options.Options{
+		UserConfig:     "config.yaml",
+		EnabledPlugins: []string{"network-operator"},
+		OutputFormat:   "text",
+		ForPreset:      "PowerEdge-XE9680",
+		// NodeSelector intentionally empty
+	}
+	err := validateConfig(&opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--for requires --node-selector")
+}
+
+func TestValidateConfig_ForRejectsDiscovery(t *testing.T) {
+	opts := options.Options{
+		UserConfig:            "config.yaml",
+		EnabledPlugins:        []string{"network-operator"},
+		OutputFormat:          "text",
+		ForPreset:             "PowerEdge-XE9680",
+		NodeSelector:          "key=val",
+		DiscoverClusterConfig: true,
+	}
+	err := validateConfig(&opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestValidateConfig_ForWithNodeSelectorPasses(t *testing.T) {
+	opts := options.Options{
+		UserConfig:     "config.yaml",
+		EnabledPlugins: []string{"network-operator"},
+		OutputFormat:   "text",
+		ForPreset:      "PowerEdge-XE9680",
+		NodeSelector:   "nvidia.com/gpu.product=NVIDIA-H200",
+	}
+	err := validateConfig(&opts)
+	assert.NoError(t, err)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -152,7 +152,7 @@ type ProfileSpectrumX struct {
 type ClusterConfig struct {
 	Identifier           string               `yaml:"identifier"`
 	MachineType          string               `yaml:"machineType,omitempty"`
-	ProductType          string               `yaml:"productType,omitempty"`
+	GPUType          string               `yaml:"gpuType,omitempty"`
 	PresetApplied        bool                 `yaml:"presetApplied,omitempty"`
 	Capabilities         *ClusterCapabilities `yaml:"capabilities"`
 	PFs                  []PFConfig           `yaml:"pfs"`

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -259,7 +259,7 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 			// Fill in missing machine/GPU product types by probing hardware
 			// directly when GPU operator node labels are absent.
 			needMachine := group.MachineType == ""
-			needProduct := group.ProductType == ""
+			needProduct := group.GPUType == ""
 			if needMachine || needProduct {
 				machine, product := discoverHardwareTypes(ctx, p.RESTConfig,
 					defaultConfig.NetworkOperator.Namespace, group.WorkerNodes, dsPods,
@@ -269,7 +269,7 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 					uiOutput.Info("Discovered machine type for group %s: %s", group.Identifier, machine)
 				}
 				if needProduct && product != "" {
-					group.ProductType = product
+					group.GPUType = product
 					uiOutput.Info("Discovered GPU product type for group %s: %s", group.Identifier, product)
 				}
 			}
@@ -282,19 +282,24 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 			discoverGPUTopology(ctx, p.RESTConfig,
 				defaultConfig.NetworkOperator.Namespace, group, dsPods)
 
-			// Try to enrich with a predefined topology preset for this machine type.
-			// Presets provide authoritative traffic classification, rail assignments,
-			// and NUMA/GPU topology metadata for known hardware configurations.
-			if group.MachineType != "" {
-				preset, presetErr := presets.LoadPreset(group.MachineType)
+			// Try to enrich with a predefined topology preset for this (machine,
+			// GPU) pair. Presets provide authoritative traffic classification,
+			// rail assignments, and NUMA/GPU topology metadata for known
+			// hardware configurations. Lookup is exact-match on (machineType,
+			// gpuType) — both must be known for a preset to apply.
+			if group.MachineType != "" && group.GPUType != "" {
+				preset, presetErr := presets.LoadPreset(group.MachineType, group.GPUType)
 				if presetErr != nil {
-					log.Log.Error(presetErr, "failed to load preset", "machineType", group.MachineType)
-					uiOutput.Warning("Failed to load preset for %s: %v", group.MachineType, presetErr)
+					log.Log.Error(presetErr, "failed to load preset",
+						"machineType", group.MachineType, "gpuType", group.GPUType)
+					uiOutput.Warning("Failed to load preset for %s/%s: %v",
+						group.MachineType, group.GPUType, presetErr)
 				} else if preset != nil {
 					if presetErr := presets.ValidatePreset(preset, group.PFs); presetErr != nil {
 						log.Log.Info("Preset did not match discovered hardware",
-							"machineType", group.MachineType, "error", presetErr)
-						uiOutput.Info("Preset for %s did not match discovered hardware: %v", group.MachineType, presetErr)
+							"machineType", group.MachineType, "gpuType", group.GPUType, "error", presetErr)
+						uiOutput.Info("Preset for %s/%s did not match discovered hardware: %v",
+							group.MachineType, group.GPUType, presetErr)
 					} else {
 						presets.ApplyPreset(preset, group)
 						uiOutput.Info("Applied preset configuration for %s", group.MachineType)
@@ -827,12 +832,12 @@ func buildClusterConfig(devices []nicop.NicDevice, nodeLabels map[string]map[str
 		// Extract machine/product type from common node labels
 		commonLabels := computeCommonLabels(g.nodes, nodeLabels)
 		machineType := commonLabels["nvidia.com/gpu.machine"]
-		productType := commonLabels["nvidia.com/gpu.product"]
+		gpuType := commonLabels["nvidia.com/gpu.product"]
 
 		cc := config.ClusterConfig{
 			Identifier:    identifier,
 			MachineType:   machineType,
-			ProductType:   productType,
+			GPUType:   gpuType,
 			NodeSelector:  nodeSelector,
 			Capabilities: &config.ClusterCapabilities{
 				Nodes: &config.NodesCapabilities{
@@ -1074,14 +1079,14 @@ func parseGPUProductFromNvidiaSmi(output string) string {
 	return ""
 }
 
-// discoverHardwareTypes attempts to discover machineType and productType by
+// discoverHardwareTypes attempts to discover machineType and gpuType by
 // probing hardware directly when label-derived values are empty. It execs into
 // a nic-configuration-daemon pod on one of the group's nodes.
-// Returns (machineType, productType) — either or both may still be empty if
+// Returns (machineType, gpuType) — either or both may still be empty if
 // discovery fails or hardware info is unavailable.
 func discoverHardwareTypes(ctx context.Context, restConfig *rest.Config,
 	namespace string, groupNodes []string, dsPods []corev1.Pod,
-	needMachine, needProduct bool) (machineType, productType string) {
+	needMachine, needProduct bool) (machineType, gpuType string) {
 
 	targetPod := findDaemonPod(groupNodes, dsPods)
 	if targetPod == nil {
@@ -1116,17 +1121,17 @@ func discoverHardwareTypes(ctx context.Context, restConfig *rest.Config,
 		if err != nil {
 			log.Log.Error(err, "failed to exec nvidia-smi probe", "pod", targetPod.Name)
 		} else {
-			productType = parseGPUProductFromNvidiaSmi(output)
+			gpuType = parseGPUProductFromNvidiaSmi(output)
 		}
 
-		if productType == "" {
+		if gpuType == "" {
 			sysfsOutput, sysfsErr := execInPod(ctx, restConfig, namespace, targetPod.Name, containerName,
 				[]string{"/bin/sh", "-c", sysfsNvidiaGPUIDCmd})
 			if sysfsErr != nil {
 				log.Log.Error(sysfsErr, "failed to exec sysfs GPU probe", "pod", targetPod.Name)
 			} else {
-				productType = parseGPUProductFromSysfs(sysfsOutput)
-				if productType == "" && strings.TrimSpace(sysfsOutput) != "" {
+				gpuType = parseGPUProductFromSysfs(sysfsOutput)
+				if gpuType == "" && strings.TrimSpace(sysfsOutput) != "" {
 					log.Log.Info("GPU product type not resolved from sysfs device ID",
 						"pod", targetPod.Name, "unresolvedID", strings.TrimSpace(sysfsOutput))
 				}
@@ -1134,7 +1139,7 @@ func discoverHardwareTypes(ctx context.Context, restConfig *rest.Config,
 		}
 	}
 
-	return machineType, productType
+	return machineType, gpuType
 }
 
 // sysfsNvidiaGPUIDCmd emits the first NVIDIA (vendor 10de) GPU device ID found
@@ -1153,7 +1158,7 @@ const sysfsNvidiaGPUIDCmd = `for d in /sys/bus/pci/devices/*; do
 done`
 
 // parseGPUProductFromSysfs resolves a single-line sysfs device-ID output
-// (e.g. "0x2335\n") to a canonical ProductType via the embedded pci.ids table.
+// (e.g. "0x2335\n") to a canonical GPUType via the embedded pci.ids table.
 // Returns empty for blank input or an unknown device ID.
 func parseGPUProductFromSysfs(output string) string {
 	id := strings.TrimSpace(output)

--- a/pkg/networkoperatorplugin/grouping_test.go
+++ b/pkg/networkoperatorplugin/grouping_test.go
@@ -119,7 +119,7 @@ func TestSpectrumXGrouping(t *testing.T) {
 	}{
 		{
 			// Two groups that share every east-west PCI address but have different
-			// north-south DPU PCIs. Merge keys on (productType, east-west rail count)
+			// north-south DPU PCIs. Merge keys on (gpuType, east-west rail count)
 			// — both match — and hasRailPciConflict only looks at east-west PFs, so
 			// no conflict. After merging, every rail's RailPciAddresses has a single
 			// address (source groups agreed), so mergedGroupsAgreeOnPci returns true
@@ -136,14 +136,14 @@ func TestSpectrumXGrouping(t *testing.T) {
 			},
 		},
 		{
-			// Three groups with the same productType and east-west rail count but
+			// Three groups with the same gpuType and east-west rail count but
 			// DIFFERENT east-west PCI layouts per machine. mergeCompatibleGroups
 			// still merges them because name templates are enabled (hadPciConflicts
 			// is tolerated). The merged rail pool uses stable renamed pfNames
 			// (eth_p*_r*), so the cross-group PCI differences don't break selection.
 			// Since source groups disagree on PCI, mergedGroupsAgreeOnPci is false
 			// and rendering falls back to per-unmerged-group name templates.
-			name:           "mixed same productType different PCIs: one merged rail pool, three name templates",
+			name:           "mixed same gpuType different PCIs: one merged rail pool, three name templates",
 			configFile:     "mixed-same-type.yaml",
 			planes:         1,
 			multiplaneMode: "none",
@@ -160,13 +160,13 @@ func TestSpectrumXGrouping(t *testing.T) {
 		},
 		{
 			// Two groups of gpu-model-y (8 east-west rails each) + one group of
-			// gpu-model-z (4 east-west rails). Merge key is (productType, rail count):
+			// gpu-model-z (4 east-west rails). Merge key is (gpuType, rail count):
 			//   - (gpu-model-y, 8) pulls the two y-groups together
 			//   - (gpu-model-z, 4) stays alone as group-2
 			// Result: two rail pools (one per merged bucket), three name templates
 			// (two per-machine for the merged y-pair since their PCIs differ, one
 			// for the unmerged z group).
-			name:           "true heterogeneous: two productTypes, only one pair merges",
+			name:           "true heterogeneous: two gpuTypes, only one pair merges",
 			configFile:     "true-heterogeneous.yaml",
 			planes:         1,
 			multiplaneMode: "none",
@@ -216,7 +216,7 @@ func TestSpectrumXGrouping(t *testing.T) {
 }
 
 func TestSpectrumXGrouping_MergedRailPoolContent(t *testing.T) {
-	// The merged y-model rail pool must select by productType (covers all y-model
+	// The merged y-model rail pool must select by gpuType (covers all y-model
 	// nodes across machine types) and reference renamed netdev names rather than
 	// raw PCI addresses, since source groups disagree on PCI.
 	rendered := renderSpectrumX(t, "true-heterogeneous.yaml", "none", 1)
@@ -225,7 +225,7 @@ func TestSpectrumXGrouping_MergedRailPoolContent(t *testing.T) {
 	require.True(t, ok, "merged y-model rail pool manifest should exist")
 
 	require.Contains(t, merged, `nvidia.com/gpu.product: "gpu-model-y"`,
-		"merged rail pool must select by productType so it covers all y-model machines")
+		"merged rail pool must select by gpuType so it covers all y-model machines")
 	require.Contains(t, merged, `pfNames: ["eth_p0_r0"]`,
 		"merged rail pool must reference the renamed netdev names, not raw PCI")
 	require.NotContains(t, merged, "0000:19:00.0",

--- a/pkg/networkoperatorplugin/internal/pciids/pciids.go
+++ b/pkg/networkoperatorplugin/internal/pciids/pciids.go
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package pciids resolves NVIDIA PCI device IDs (vendor 10de) to canonical
-// ProductType strings, using a trimmed pci.ids snapshot embedded at build time.
+// GPUType strings, using a trimmed pci.ids snapshot embedded at build time.
 package pciids
 
 import (
@@ -59,7 +59,7 @@ func parseVendorBlock(input string) map[string]string {
 	return out
 }
 
-// LookupNVIDIA returns a canonical ProductType for a given NVIDIA PCI device ID,
+// LookupNVIDIA returns a canonical GPUType for a given NVIDIA PCI device ID,
 // in the same shape as parseGPUProductFromNvidiaSmi output (e.g. "NVIDIA-H200-SXM-141GB").
 // Returns "" for unknown IDs. The input is a hex string, optionally prefixed with
 // "0x", case-insensitive (e.g. "2335", "0x2335", "0X2335").
@@ -73,7 +73,7 @@ func LookupNVIDIA(deviceID string) string {
 	return canonicalize(name)
 }
 
-// canonicalize converts a pci.ids device name into the ProductType shape used
+// canonicalize converts a pci.ids device name into the GPUType shape used
 // elsewhere in k8s-launch-kit (matches parseGPUProductFromNvidiaSmi).
 // When a bracketed marketing name is present (e.g. "GH100 [H200 SXM 141GB]"),
 // the bracket contents are preferred over the chip codename. The final string

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -677,33 +677,33 @@ func sanitizeIdentifier(s string) string {
 	return s
 }
 
-// mergeCompatibleGroups merges ClusterConfig groups that share the same productType
-// and number of east-west rails into a single group per productType.
+// mergeCompatibleGroups merges ClusterConfig groups that share the same gpuType
+// and number of east-west rails into a single group per gpuType.
 // For each merged group:
-//   - Identifier = sanitized productType (lowercase, spaces→hyphens)
-//   - NodeSelector = {"nvidia.com/gpu.product": productType}
+//   - Identifier = sanitized gpuType (lowercase, spaces→hyphens)
+//   - NodeSelector = {"nvidia.com/gpu.product": gpuType}
 //   - RailPciAddresses = per-rail list of all PCI addresses from source groups
 //   - WorkerNodes = union of all worker nodes
 //   - Capabilities = aggregated (union)
 //
-// Groups with empty productType are never merged.
+// Groups with empty gpuType are never merged.
 // Single-entry buckets are returned as-is.
 func mergeCompatibleGroups(groups []config.ClusterConfig, useNameTemplates bool) ([]config.ClusterConfig, bool) {
 	type mergeKey struct {
-		productType string
+		gpuType string
 		railCount   int
 	}
 
-	// Group indices by (productType, railCount)
+	// Group indices by (gpuType, railCount)
 	bucketOrder := []mergeKey{}
 	buckets := map[mergeKey][]int{}
 
 	for i, g := range groups {
 		ewCount := len(filterEastWestPFs(g.PFs))
-		key := mergeKey{productType: g.ProductType, railCount: ewCount}
-		if g.ProductType == "" {
-			// Never merge groups without a productType — use a unique key per group
-			key = mergeKey{productType: fmt.Sprintf("__empty_%d", i), railCount: ewCount}
+		key := mergeKey{gpuType: g.GPUType, railCount: ewCount}
+		if g.GPUType == "" {
+			// Never merge groups without a gpuType — use a unique key per group
+			key = mergeKey{gpuType: fmt.Sprintf("__empty_%d", i), railCount: ewCount}
 		}
 		if _, exists := buckets[key]; !exists {
 			bucketOrder = append(bucketOrder, key)
@@ -716,8 +716,8 @@ func mergeCompatibleGroups(groups []config.ClusterConfig, useNameTemplates bool)
 	for _, key := range bucketOrder {
 		indices := buckets[key]
 
-		if len(indices) == 1 || groups[indices[0]].ProductType == "" {
-			// No merge: single group or empty productType
+		if len(indices) == 1 || groups[indices[0]].GPUType == "" {
+			// No merge: single group or empty gpuType
 			result = append(result, groups[indices[0]])
 			continue
 		}
@@ -766,10 +766,10 @@ func hasRailPciConflict(groups []config.ClusterConfig, indices []int) bool {
 }
 
 // buildMergedGroup creates a single ClusterConfig from multiple groups that share
-// the same productType and east-west rail count.
+// the same gpuType and east-west rail count.
 func buildMergedGroup(groups []config.ClusterConfig, indices []int) config.ClusterConfig {
 	first := groups[indices[0]]
-	productType := first.ProductType
+	gpuType := first.GPUType
 
 	// Collect east-west PFs per group (all have the same count)
 	ewPFsByGroup := make([][]config.PFConfig, len(indices))
@@ -849,15 +849,15 @@ func buildMergedGroup(groups []config.ClusterConfig, indices []int) config.Clust
 	}
 
 	return config.ClusterConfig{
-		Identifier:           sanitizeIdentifier(productType),
-		ProductType:          productType,
+		Identifier:           sanitizeIdentifier(gpuType),
+		GPUType:          gpuType,
 		Capabilities:         caps,
 		PFs:                  first.PFs, // Representative PFs from first group
 		WorkerNodes:          allNodes,
 		ThirdPartyRDMAModules: mergedDepMods,
 		StorageModules:        mergedStorageMods,
 		NodeSelector: map[string]string{
-			"nvidia.com/gpu.product": productType,
+			"nvidia.com/gpu.product": gpuType,
 		},
 		RailPciAddresses: railPciAddresses,
 	}

--- a/pkg/networkoperatorplugin/templates_test.go
+++ b/pkg/networkoperatorplugin/templates_test.go
@@ -466,11 +466,11 @@ func TestSanitizeIdentifier(t *testing.T) {
 }
 
 func TestMergeCompatibleGroups(t *testing.T) {
-	t.Run("all groups same productType and rail count", func(t *testing.T) {
+	t.Run("all groups same gpuType and rail count", func(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					ewPF("0000:19:00.0", 0),
 					ewPF("0000:2a:00.0", 1),
@@ -480,7 +480,7 @@ func TestMergeCompatibleGroups(t *testing.T) {
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					ewPF("0000:1a:00.0", 0),
 					ewPF("0000:3c:00.0", 1),
@@ -490,7 +490,7 @@ func TestMergeCompatibleGroups(t *testing.T) {
 			},
 			{
 				Identifier:  "group-2",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					ewPF("0000:09:00.0", 0),
 					ewPF("0000:23:00.0", 1),
@@ -505,7 +505,7 @@ func TestMergeCompatibleGroups(t *testing.T) {
 		assert.Len(t, result, 1)
 		merged := result[0]
 		assert.Equal(t, "nvidia-h200", merged.Identifier)
-		assert.Equal(t, "NVIDIA-H200", merged.ProductType)
+		assert.Equal(t, "NVIDIA-H200", merged.GPUType)
 		assert.Equal(t, map[string]string{"nvidia.com/gpu.product": "NVIDIA-H200"}, merged.NodeSelector)
 		assert.Equal(t, []string{"node-a", "node-b", "node-c", "node-d", "node-e"}, merged.WorkerNodes)
 
@@ -520,17 +520,17 @@ func TestMergeCompatibleGroups(t *testing.T) {
 		assert.Equal(t, []string{"0000:2a:00.0", "0000:3c:00.0", "0000:23:00.0"}, merged.RailPciAddresses[1])
 	})
 
-	t.Run("different productTypes no merge", func(t *testing.T) {
+	t.Run("different gpuTypes no merge", func(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs:         []config.PFConfig{ewPF("0000:19:00.0", 0)},
 				WorkerNodes: []string{"node-a"},
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "NVIDIA-A100",
+				GPUType: "NVIDIA-A100",
 				PFs:         []config.PFConfig{ewPF("0000:1a:00.0", 0)},
 				WorkerNodes: []string{"node-b"},
 			},
@@ -545,11 +545,11 @@ func TestMergeCompatibleGroups(t *testing.T) {
 		assert.Nil(t, result[1].RailPciAddresses)
 	})
 
-	t.Run("same productType different rail count no merge", func(t *testing.T) {
+	t.Run("same gpuType different rail count no merge", func(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					ewPF("0000:19:00.0", 0),
 					ewPF("0000:2a:00.0", 1),
@@ -558,7 +558,7 @@ func TestMergeCompatibleGroups(t *testing.T) {
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs:         []config.PFConfig{ewPF("0000:1a:00.0", 0)},
 				WorkerNodes: []string{"node-b"},
 			},
@@ -575,20 +575,20 @@ func TestMergeCompatibleGroups(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs:         []config.PFConfig{ewPF("0000:19:00.0", 0)},
 				WorkerNodes: []string{"node-a"},
 				Capabilities: &config.ClusterCapabilities{Nodes: &config.NodesCapabilities{Rdma: true}},
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "NVIDIA-A100",
+				GPUType: "NVIDIA-A100",
 				PFs:         []config.PFConfig{ewPF("0000:1a:00.0", 0)},
 				WorkerNodes: []string{"node-b"},
 			},
 			{
 				Identifier:  "group-2",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs:         []config.PFConfig{ewPF("0000:09:00.0", 0)},
 				WorkerNodes: []string{"node-c"},
 				Capabilities: &config.ClusterCapabilities{Nodes: &config.NodesCapabilities{Rdma: true}},
@@ -612,7 +612,7 @@ func TestMergeCompatibleGroups(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs:         []config.PFConfig{ewPF("0000:19:00.0", 0)},
 				WorkerNodes: []string{"node-a"},
 			},
@@ -625,17 +625,17 @@ func TestMergeCompatibleGroups(t *testing.T) {
 		assert.Nil(t, result[0].RailPciAddresses)
 	})
 
-	t.Run("empty productType no merge", func(t *testing.T) {
+	t.Run("empty gpuType no merge", func(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "",
+				GPUType: "",
 				PFs:         []config.PFConfig{ewPF("0000:19:00.0", 0)},
 				WorkerNodes: []string{"node-a"},
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "",
+				GPUType: "",
 				PFs:         []config.PFConfig{ewPF("0000:1a:00.0", 0)},
 				WorkerNodes: []string{"node-b"},
 			},
@@ -653,14 +653,14 @@ func TestMergeCompatibleGroups(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs:         []config.PFConfig{ewPF("0000:19:00.0", 0), nsPF},
 				WorkerNodes: []string{"node-a"},
 				Capabilities: &config.ClusterCapabilities{Nodes: &config.NodesCapabilities{Rdma: true}},
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs:         []config.PFConfig{ewPF("0000:1a:00.0", 0), nsPF},
 				WorkerNodes: []string{"node-b"},
 				Capabilities: &config.ClusterCapabilities{Nodes: &config.NodesCapabilities{Rdma: true}},
@@ -680,13 +680,13 @@ func TestMergeCompatibleGroups(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs:         []config.PFConfig{ewPF("0000:19:00.0", 0)},
 				WorkerNodes: []string{"node-a"},
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs:         []config.PFConfig{ewPF("0000:1a:00.0", 0)},
 				WorkerNodes: []string{"node-b"},
 			},
@@ -702,7 +702,7 @@ func TestMergeCompatibleGroups(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					ewPF("0000:19:00.0", 0),
 					ewPF("0000:9c:00.0", 1),
@@ -711,7 +711,7 @@ func TestMergeCompatibleGroups(t *testing.T) {
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					ewPF("0000:9c:00.0", 0), // same PCI at different rail
 					ewPF("0000:cd:00.0", 1),
@@ -733,7 +733,7 @@ func TestMergeCompatibleGroups(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-GB300",
+				GPUType: "NVIDIA-GB300",
 				PFs: []config.PFConfig{
 					ewPF("0000:03:00.0", 0),
 					ewPF("0000:03:00.1", 1),
@@ -742,7 +742,7 @@ func TestMergeCompatibleGroups(t *testing.T) {
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "NVIDIA-GB300",
+				GPUType: "NVIDIA-GB300",
 				PFs: []config.PFConfig{
 					ewPF("0000:03:00.0", 0),
 					ewPF("0000:03:00.1", 1),
@@ -765,19 +765,19 @@ func TestMergeCompatibleGroups(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs:         []config.PFConfig{ewPF("0000:19:00.0", 0)},
 				WorkerNodes: []string{"node-a"},
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs:         []config.PFConfig{ewPF("0000:19:00.0", 0)},
 				WorkerNodes: []string{"node-b"},
 			},
 			{
 				Identifier:  "group-2",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs:         []config.PFConfig{ewPF("0000:1a:00.0", 0)},
 				WorkerNodes: []string{"node-c"},
 			},
@@ -795,7 +795,7 @@ func TestMergeCompatibleGroups(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					ewPF("0000:19:00.0", 0),
 					ewPF("0000:9b:00.0", 1),
@@ -804,7 +804,7 @@ func TestMergeCompatibleGroups(t *testing.T) {
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					ewPF("0000:1a:00.0", 0),
 					ewPF("0000:9c:00.0", 1), // this address...
@@ -813,7 +813,7 @@ func TestMergeCompatibleGroups(t *testing.T) {
 			},
 			{
 				Identifier:  "group-2",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					ewPF("0000:9c:00.0", 0), // ...appears at a different rail here
 					ewPF("0000:cd:00.0", 1),
@@ -994,7 +994,7 @@ func TestMergeCompatibleGroups_MergesThirdPartyRDMAModules(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					{DeviceID: "a2dc", PciAddress: "0000:19:00.0", Traffic: "east-west", Rail: &rail0},
 					{DeviceID: "a2dc", PciAddress: "0000:2a:00.0", Traffic: "east-west", Rail: &rail1},
@@ -1004,7 +1004,7 @@ func TestMergeCompatibleGroups_MergesThirdPartyRDMAModules(t *testing.T) {
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", Traffic: "east-west", Rail: &rail0},
 					{DeviceID: "a2dc", PciAddress: "0000:3c:00.0", Traffic: "east-west", Rail: &rail1},
@@ -1023,7 +1023,7 @@ func TestMergeCompatibleGroups_MergesThirdPartyRDMAModules(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:  "group-0",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					{DeviceID: "a2dc", PciAddress: "0000:19:00.0", Traffic: "east-west", Rail: &rail0},
 				},
@@ -1031,7 +1031,7 @@ func TestMergeCompatibleGroups_MergesThirdPartyRDMAModules(t *testing.T) {
 			},
 			{
 				Identifier:  "group-1",
-				ProductType: "NVIDIA-H200",
+				GPUType: "NVIDIA-H200",
 				PFs: []config.PFConfig{
 					{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", Traffic: "east-west", Rail: &rail0},
 				},
@@ -1048,14 +1048,14 @@ func TestMergeCompatibleGroups_MergesThirdPartyRDMAModules(t *testing.T) {
 		groups := []config.ClusterConfig{
 			{
 				Identifier:           "group-0",
-				ProductType:          "NVIDIA-H200",
+				GPUType:          "NVIDIA-H200",
 				PFs:                  []config.PFConfig{{DeviceID: "a2dc", PciAddress: "0000:19:00.0", Traffic: "east-west", Rail: &rail0}},
 				WorkerNodes:          []string{"node-1"},
 				ThirdPartyRDMAModules: []string{"iw_cm"},
 			},
 			{
 				Identifier:           "group-1",
-				ProductType:          "NVIDIA-A100", // different product
+				GPUType:          "NVIDIA-A100", // different product
 				PFs:                  []config.PFConfig{{DeviceID: "1017", PciAddress: "0000:1a:00.0", Traffic: "east-west", Rail: &rail0}},
 				WorkerNodes:          []string{"node-2"},
 				ThirdPartyRDMAModules: []string{"xprtrdma"},

--- a/pkg/networkoperatorplugin/testdata/grouping/mixed-same-type.yaml
+++ b/pkg/networkoperatorplugin/testdata/grouping/mixed-same-type.yaml
@@ -44,7 +44,7 @@ podNamespace: default
 clusterConfig:
 - identifier: group-0
   machineType: machine-a
-  productType: gpu-model-y
+  gpuType: gpu-model-y
   labelSelector:
     feature.node.kubernetes.io/pci-15b3.present: "true"
   capabilities:
@@ -169,7 +169,7 @@ clusterConfig:
   - iw_cm
 - identifier: group-1
   machineType: machine-b
-  productType: gpu-model-y
+  gpuType: gpu-model-y
   labelSelector:
     feature.node.kubernetes.io/pci-15b3.present: "true"
   capabilities:
@@ -278,7 +278,7 @@ clusterConfig:
   - iw_cm
 - identifier: group-2
   machineType: machine-c
-  productType: gpu-model-y
+  gpuType: gpu-model-y
   labelSelector:
     feature.node.kubernetes.io/pci-15b3.present: "true"
   capabilities:

--- a/pkg/networkoperatorplugin/testdata/grouping/same-ew-different-ns.yaml
+++ b/pkg/networkoperatorplugin/testdata/grouping/same-ew-different-ns.yaml
@@ -46,7 +46,7 @@ podNamespace: default
 clusterConfig:
 - identifier: group-0
   machineType: machine-x
-  productType: gpu-model-x
+  gpuType: gpu-model-x
   capabilities:
     nodes:
       sriov: true
@@ -203,7 +203,7 @@ clusterConfig:
   - iw_cm
 - identifier: group-1
   machineType: machine-x
-  productType: gpu-model-x
+  gpuType: gpu-model-x
   capabilities:
     nodes:
       sriov: true

--- a/pkg/networkoperatorplugin/testdata/grouping/true-heterogeneous.yaml
+++ b/pkg/networkoperatorplugin/testdata/grouping/true-heterogeneous.yaml
@@ -44,7 +44,7 @@ podNamespace: default
 clusterConfig:
 - identifier: group-0
   machineType: machine-a
-  productType: gpu-model-y
+  gpuType: gpu-model-y
   labelSelector:
     feature.node.kubernetes.io/pci-15b3.present: "true"
   capabilities:
@@ -169,7 +169,7 @@ clusterConfig:
   - iw_cm
 - identifier: group-1
   machineType: machine-b
-  productType: gpu-model-y
+  gpuType: gpu-model-y
   labelSelector:
     feature.node.kubernetes.io/pci-15b3.present: "true"
   capabilities:
@@ -278,7 +278,7 @@ clusterConfig:
   - iw_cm
 - identifier: group-2
   machineType: machine-c
-  productType: gpu-model-z
+  gpuType: gpu-model-z
   labelSelector:
     feature.node.kubernetes.io/pci-15b3.present: "true"
   capabilities:

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -44,6 +44,11 @@ type Options struct {
 	NumberOfPlanes      int    // Number of planes for Spectrum-X (default: 4)
 	Group               string // Generate templates for a specific group identifier only
 	NodeSelector        string // Filter nodes for discovery and manifests (e.g., "key1=val1,key2=val2")
+	// ForPreset is the directory name of a topology preset under presets/. When
+	// set, generate replaces fullConfig.ClusterConfig with a single group
+	// synthesized from the preset (skipping cluster discovery). Requires
+	// NodeSelector since the preset has no live worker-node list.
+	ForPreset           string
 	PodNamespace        string // Namespace for pods and network resources (overrides config)
 	SaveDeploymentFiles string // Directory to save generated files
 

--- a/pkg/presets/download_test.go
+++ b/pkg/presets/download_test.go
@@ -229,7 +229,7 @@ func TestDownloadPresets_OverwritesExisting(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(entries)
 	})
 	mux.HandleFunc("/test/repo/main/presets/MachineA/topology.yaml", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("machineType: MachineA\nproductType: UPDATED\n"))
+		_, _ = w.Write([]byte("machineType: MachineA\ngpuType: UPDATED\n"))
 	})
 
 	server := httptest.NewServer(mux)
@@ -240,7 +240,7 @@ func TestDownloadPresets_OverwritesExisting(t *testing.T) {
 	// Create an existing preset that should be overwritten
 	existingDir := filepath.Join(destDir, "MachineA")
 	_ = os.MkdirAll(existingDir, 0o755)
-	_ = os.WriteFile(filepath.Join(existingDir, "topology.yaml"), []byte("machineType: MachineA\nproductType: OLD\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(existingDir, "topology.yaml"), []byte("machineType: MachineA\ngpuType: OLD\n"), 0o644)
 
 	opts := DownloadOptions{
 		Repo:       "test/repo",

--- a/pkg/presets/presets.go
+++ b/pkg/presets/presets.go
@@ -31,14 +31,18 @@ import (
 // topology.yaml file. It is intentionally separate from config.ClusterConfig
 // to carry additional topology metadata (NUMA, GPU affinity) without
 // polluting the core config.
+//
+// Both MachineType and GPUType are required. A topology.yaml that omits either
+// is rejected at load time so downstream code can rely on them as matching keys.
 type Topology struct {
-	MachineType     string     `yaml:"machineType"`
-	Manufacturer    string     `yaml:"manufacturer,omitempty"`
-	ProductType     string     `yaml:"productType,omitempty"`
-	NicModel        string     `yaml:"nicModel,omitempty"`
-	GPUInterconnect string     `yaml:"gpuInterconnect,omitempty"`
-	NumaNodes       int        `yaml:"numaNodes,omitempty"`
-	PFs             []PresetPF `yaml:"pfs"`
+	MachineType     string                      `yaml:"machineType"`
+	Manufacturer    string                      `yaml:"manufacturer,omitempty"`
+	GPUType         string                      `yaml:"gpuType"`
+	NicModel        string                      `yaml:"nicModel,omitempty"`
+	GPUInterconnect string                      `yaml:"gpuInterconnect,omitempty"`
+	NumaNodes       int                         `yaml:"numaNodes,omitempty"`
+	Capabilities    *config.ClusterCapabilities `yaml:"capabilities,omitempty"`
+	PFs             []PresetPF                  `yaml:"pfs"`
 }
 
 // PresetPF describes a single physical function in a topology preset.
@@ -55,6 +59,15 @@ type PresetPF struct {
 	GPUProximity     string `yaml:"gpuProximity,omitempty"`
 	PSID             string `yaml:"psid,omitempty"`
 	PartNumber       string `yaml:"partNumber,omitempty"`
+}
+
+// presetEntry pairs a parsed topology with the directory name that produced it.
+// The directory name is the user-visible identifier (used by --for and
+// `l8k preset list`); the topology fields are the matching keys used by
+// LoadPreset.
+type presetEntry struct {
+	DirName  string
+	Topology Topology
 }
 
 // GetPresetsDir resolves the presets directory using a lookup chain:
@@ -79,72 +92,215 @@ func GetPresetsDir() (string, error) {
 	return "", nil
 }
 
-// LoadPreset loads a topology preset for the given machine type.
-// Returns (nil, nil) if no presets directory exists or no preset matches
-// the machine type. Returns an error only on parse failure.
-func LoadPreset(machineType string) (*Topology, error) {
-	dir, err := GetPresetsDir()
-	if err != nil {
-		return nil, err
-	}
-	if dir == "" {
-		return nil, nil
-	}
-
-	path := filepath.Join(dir, machineType, "topology.yaml")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to read preset %s: %w", path, err)
-	}
-
-	var t Topology
-	if err := yaml.Unmarshal(data, &t); err != nil {
-		return nil, fmt.Errorf("failed to parse preset %s: %w", path, err)
-	}
-
-	return &t, nil
+// SkippedPreset describes a preset directory that loadAllPresets rejected.
+// It is surfaced by l8k preset list so the user can see WHY a preset they
+// expect to find isn't appearing — silent skipping would otherwise look
+// indistinguishable from "no presets installed".
+type SkippedPreset struct {
+	DirName string
+	Path    string
+	Reason  string
 }
 
-// ListPresets returns the names (machine types) of all available presets
-// in the presets directory. Returns nil if no presets directory exists.
-func ListPresets() ([]string, error) {
+// loadAllPresets returns every valid preset under the resolved presets dir,
+// sorted by directory name, plus a list of skipped entries with reasons.
+// Invalid entries (parse error, missing machineType, missing gpuType) are
+// skipped rather than failing the whole load — keeps the lookup robust to
+// stale or partial preset directories. Returns (nil, nil, nil) if no
+// presets dir exists.
+func loadAllPresets() ([]presetEntry, []SkippedPreset, error) {
 	dir, err := GetPresetsDir()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if dir == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read presets directory %s: %w", dir, err)
+		return nil, nil, fmt.Errorf("failed to read presets directory %s: %w", dir, err)
 	}
 
-	var names []string
+	var out []presetEntry
+	var skipped []SkippedPreset
+	skip := func(name, path, reason string) {
+		log.Log.V(1).Info("Skipping preset", "preset", name, "path", path, "reason", reason)
+		skipped = append(skipped, SkippedPreset{DirName: name, Path: path, Reason: reason})
+	}
+
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
 		}
-		// Only include directories that contain a topology.yaml
 		topoPath := filepath.Join(dir, e.Name(), "topology.yaml")
-		if _, err := os.Stat(topoPath); err == nil {
-			names = append(names, e.Name())
+		data, err := os.ReadFile(topoPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// No topology.yaml — silent skip; the directory just
+				// isn't a preset and that's expected (e.g. README).
+				continue
+			}
+			skip(e.Name(), topoPath, fmt.Sprintf("read failed: %v", err))
+			continue
+		}
+
+		var t Topology
+		if err := yaml.Unmarshal(data, &t); err != nil {
+			skip(e.Name(), topoPath, fmt.Sprintf("parse failed: %v", err))
+			continue
+		}
+		if t.MachineType == "" {
+			skip(e.Name(), topoPath, "missing required field 'machineType'")
+			continue
+		}
+		if t.GPUType == "" {
+			// The most common reason today: the YAML still has the old
+			// 'productType:' key from before the rename. Mention it
+			// explicitly so users know how to fix without reading code.
+			skip(e.Name(), topoPath,
+				"missing required field 'gpuType' (old 'productType' key was renamed to 'gpuType' — reinstall presets or rename the key)")
+			continue
+		}
+
+		out = append(out, presetEntry{DirName: e.Name(), Topology: t})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].DirName < out[j].DirName })
+	return out, skipped, nil
+}
+
+// LoadPreset returns the topology preset whose YAML declares both machineType
+// and gpuType equal to the arguments. Lookup is exact-match — there is no
+// "any-GPU" fallback. Returns (nil, nil) when no preset matches or no presets
+// directory exists.
+func LoadPreset(machineType, gpuType string) (*Topology, error) {
+	all, _, err := loadAllPresets()
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []presetEntry
+	for _, p := range all {
+		if p.Topology.MachineType == machineType && p.Topology.GPUType == gpuType {
+			matches = append(matches, p)
 		}
 	}
-	sort.Strings(names)
+
+	if len(matches) == 0 {
+		return nil, nil
+	}
+	if len(matches) > 1 {
+		names := make([]string, 0, len(matches))
+		for _, m := range matches {
+			names = append(names, m.DirName)
+		}
+		log.Log.V(1).Info("Multiple presets match (machineType, gpuType); picking first by directory name",
+			"machineType", machineType, "gpuType", gpuType, "candidates", names, "picked", matches[0].DirName)
+	}
+	t := matches[0].Topology
+	return &t, nil
+}
+
+// LoadPresetByDir returns the topology preset stored at <presets-dir>/<dirName>.
+// This is the lookup used by `--for`: the user passes a directory name (which
+// `l8k preset list` shows) and we hand back the parsed topology. Returns
+// (nil, error) with a typed error listing available presets when the directory
+// is missing or the preset is invalid.
+func LoadPresetByDir(dirName string) (*Topology, error) {
+	all, skipped, err := loadAllPresets()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range all {
+		if p.DirName == dirName {
+			t := p.Topology
+			return &t, nil
+		}
+	}
+
+	// Did the requested name match a preset that loadAllPresets rejected?
+	// If so, surface the rejection reason so the user knows it's not just
+	// a typo.
+	for _, s := range skipped {
+		if s.DirName == dirName {
+			return nil, fmt.Errorf("preset %q exists but was rejected at load time: %s", dirName, s.Reason)
+		}
+	}
+
+	available := make([]string, 0, len(all))
+	for _, p := range all {
+		available = append(available, p.DirName)
+	}
+	if len(available) == 0 {
+		if len(skipped) > 0 {
+			return nil, fmt.Errorf("unknown preset %q: %d preset(s) on disk but all were rejected at load time (see warnings); run 'l8k preset list' to inspect",
+				dirName, len(skipped))
+		}
+		return nil, fmt.Errorf("unknown preset %q: no presets are installed (run 'l8k preset update')", dirName)
+	}
+	return nil, fmt.Errorf("unknown preset %q; available: %v", dirName, available)
+}
+
+// ListPresets returns the directory names of all valid presets, sorted.
+// Returns nil if no presets directory exists. Invalid presets (missing
+// machineType / gpuType, parse failures) are filtered out with a warning.
+func ListPresets() ([]string, error) {
+	all, _, err := loadAllPresets()
+	if err != nil {
+		return nil, err
+	}
+	if all == nil {
+		return nil, nil
+	}
+	names := make([]string, 0, len(all))
+	for _, p := range all {
+		names = append(names, p.DirName)
+	}
 	return names, nil
+}
+
+// ListPresetSummaries returns a summary row per valid preset: directory name
+// plus the (machineType, gpuType) pair declared in its YAML. Used by
+// `l8k preset list`.
+type PresetSummary struct {
+	DirName     string
+	MachineType string
+	GPUType     string
+}
+
+// ListPresetSummaries returns one summary per valid preset (sorted by
+// directory name) plus the list of skipped/invalid presets so callers can
+// surface rejection reasons.
+func ListPresetSummaries() ([]PresetSummary, []SkippedPreset, error) {
+	all, skipped, err := loadAllPresets()
+	if err != nil {
+		return nil, nil, err
+	}
+	if all == nil && skipped == nil {
+		return nil, nil, nil
+	}
+	out := make([]PresetSummary, 0, len(all))
+	for _, p := range all {
+		out = append(out, PresetSummary{
+			DirName:     p.DirName,
+			MachineType: p.Topology.MachineType,
+			GPUType:     p.Topology.GPUType,
+		})
+	}
+	return out, skipped, nil
 }
 
 // ApplyPreset enriches a discovered ClusterConfig group with data from a
 // validated preset. It matches PFs by PCI address and overrides topology-
 // derived fields (traffic, rail, NUMA, GPU affinity) while preserving
 // live-state fields (RDMA device, network interface, PSID, part number).
+//
+// GPUType is no longer filled in from the preset: by the time ApplyPreset
+// runs, the discovered group's GPUType is what was passed to LoadPreset, so
+// it already matches the preset's GPUType exactly.
 func ApplyPreset(preset *Topology, group *config.ClusterConfig) {
-	// Build lookup map from preset PFs keyed by PCI address
 	presetMap := make(map[string]*PresetPF, len(preset.PFs))
 	for i := range preset.PFs {
 		presetMap[preset.PFs[i].PciAddress] = &preset.PFs[i]
@@ -157,14 +313,12 @@ func ApplyPreset(preset *Topology, group *config.ClusterConfig) {
 			continue
 		}
 
-		// Override topology-derived fields (preset is authoritative)
 		pf.Traffic = pp.Traffic
 		pf.Rail = pp.Rail
 		pf.NumaNode = pp.NumaNode
 		pf.ConnectedGPU = pp.ConnectedGPU
 		pf.GPUProximity = pp.GPUProximity
 
-		// Log part number / PSID mismatches as warnings but keep discovered values
 		if pp.PartNumber != "" && pf.PartNumber != "" && pp.PartNumber != pf.PartNumber {
 			log.Log.V(1).Info("Preset part number differs from discovered — using discovered value",
 				"pciAddress", pf.PciAddress, "preset", pp.PartNumber, "discovered", pf.PartNumber)
@@ -173,11 +327,6 @@ func ApplyPreset(preset *Topology, group *config.ClusterConfig) {
 			log.Log.V(1).Info("Preset PSID differs from discovered — using discovered value",
 				"pciAddress", pf.PciAddress, "preset", pp.PSID, "discovered", pf.PSID)
 		}
-	}
-
-	// Fill in product type from preset if discovery didn't find one
-	if group.ProductType == "" && preset.ProductType != "" {
-		group.ProductType = preset.ProductType
 	}
 
 	group.PresetApplied = true

--- a/pkg/presets/presets_test.go
+++ b/pkg/presets/presets_test.go
@@ -98,7 +98,7 @@ func TestLoadPreset_Found(t *testing.T) {
 	}
 
 	topoYAML := `machineType: PowerEdge-XE9680
-productType: NVIDIA-H200
+gpuType: NVIDIA-H200
 nicModel: BlueField-3 SuperNIC
 gpuInterconnect: NV18
 numaNodes: 2
@@ -130,7 +130,7 @@ pfs:
 	defer func() { _ = os.Chdir(origDir) }()
 	_ = os.Chdir(tmpDir)
 
-	topo, err := LoadPreset("PowerEdge-XE9680")
+	topo, err := LoadPreset("PowerEdge-XE9680", "NVIDIA-H200")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -140,8 +140,8 @@ pfs:
 	if topo.MachineType != "PowerEdge-XE9680" {
 		t.Errorf("expected MachineType=PowerEdge-XE9680, got %q", topo.MachineType)
 	}
-	if topo.ProductType != "NVIDIA-H200" {
-		t.Errorf("expected ProductType=NVIDIA-H200, got %q", topo.ProductType)
+	if topo.GPUType != "NVIDIA-H200" {
+		t.Errorf("expected GPUType=NVIDIA-H200, got %q", topo.GPUType)
 	}
 	if topo.NicModel != "BlueField-3 SuperNIC" {
 		t.Errorf("expected NicModel, got %q", topo.NicModel)
@@ -189,7 +189,7 @@ func TestLoadPreset_NotFound(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 	_ = os.Chdir(tmpDir)
 
-	topo, err := LoadPreset("NonExistent-Machine")
+	topo, err := LoadPreset("NonExistent-Machine", "NVIDIA-H200")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestLoadPreset_NoPresetsDir(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 	_ = os.Chdir(tmpDir)
 
-	topo, err := LoadPreset("PowerEdge-XE9680")
+	topo, err := LoadPreset("PowerEdge-XE9680", "NVIDIA-H200")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -214,6 +214,10 @@ func TestLoadPreset_NoPresetsDir(t *testing.T) {
 }
 
 func TestLoadPreset_InvalidYAML(t *testing.T) {
+	// Invalid YAML is skipped at load time with a warning rather than
+	// surfaced as a hard error — keeps the lookup robust across mixed
+	// preset directories. The lookup just returns nil because no valid
+	// preset matches.
 	tmpDir := t.TempDir()
 	machineDir := filepath.Join(tmpDir, "presets", "BadMachine")
 	if err := os.MkdirAll(machineDir, 0o755); err != nil {
@@ -227,16 +231,19 @@ func TestLoadPreset_InvalidYAML(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 	_ = os.Chdir(tmpDir)
 
-	topo, err := LoadPreset("BadMachine")
-	if err == nil {
-		t.Fatal("expected error for invalid YAML, got nil")
+	topo, err := LoadPreset("BadMachine", "NVIDIA-H200")
+	if err != nil {
+		t.Fatalf("expected nil error (invalid presets are skipped), got: %v", err)
 	}
 	if topo != nil {
-		t.Errorf("expected nil topology on error, got %+v", topo)
+		t.Errorf("expected nil topology for skipped invalid preset, got %+v", topo)
 	}
 }
 
 func TestLoadPreset_EmptyFile(t *testing.T) {
+	// Empty YAML unmarshals to a zero-value Topology, which has empty
+	// machineType and gpuType — both required fields. The preset is
+	// rejected at load time, so LoadPreset returns nil.
 	tmpDir := t.TempDir()
 	machineDir := filepath.Join(tmpDir, "presets", "EmptyMachine")
 	if err := os.MkdirAll(machineDir, 0o755); err != nil {
@@ -250,16 +257,170 @@ func TestLoadPreset_EmptyFile(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 	_ = os.Chdir(tmpDir)
 
-	topo, err := LoadPreset("EmptyMachine")
+	topo, err := LoadPreset("EmptyMachine", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Empty YAML unmarshals to zero-value struct — not nil
-	if topo == nil {
-		t.Fatal("expected non-nil topology for empty YAML")
+	if topo != nil {
+		t.Errorf("expected nil for empty preset (missing required fields), got %+v", topo)
 	}
-	if len(topo.PFs) != 0 {
-		t.Errorf("expected 0 PFs, got %d", len(topo.PFs))
+}
+
+func TestLoadPreset_ExactGPUTypeMatch(t *testing.T) {
+	// Two presets share the same machineType but declare different
+	// gpuTypes — exact-match lookup should return the right one for each
+	// gpuType, and nil when neither matches (no fallback).
+	tmpDir := t.TempDir()
+	presetsDir := filepath.Join(tmpDir, "presets")
+
+	writePreset := func(dir, machine, gpu string) {
+		full := filepath.Join(presetsDir, dir)
+		if err := os.MkdirAll(full, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := "machineType: " + machine + "\ngpuType: " + gpu + "\n"
+		if err := os.WriteFile(filepath.Join(full, "topology.yaml"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writePreset("PowerEdge-XE9680-H200", "PowerEdge-XE9680", "NVIDIA-H200")
+	writePreset("PowerEdge-XE9680-B200", "PowerEdge-XE9680", "NVIDIA-B200")
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	cases := []struct {
+		machine, gpu string
+		expectFound  bool
+	}{
+		{"PowerEdge-XE9680", "NVIDIA-H200", true},
+		{"PowerEdge-XE9680", "NVIDIA-B200", true},
+		{"PowerEdge-XE9680", "NVIDIA-A100", false}, // exact-match only — no fallback
+		{"Other-Machine", "NVIDIA-H200", false},
+	}
+	for _, tc := range cases {
+		topo, err := LoadPreset(tc.machine, tc.gpu)
+		if err != nil {
+			t.Errorf("LoadPreset(%q, %q): unexpected error: %v", tc.machine, tc.gpu, err)
+			continue
+		}
+		if tc.expectFound && topo == nil {
+			t.Errorf("LoadPreset(%q, %q): expected match, got nil", tc.machine, tc.gpu)
+		}
+		if !tc.expectFound && topo != nil {
+			t.Errorf("LoadPreset(%q, %q): expected nil, got %+v", tc.machine, tc.gpu, topo)
+		}
+		if topo != nil && topo.GPUType != tc.gpu {
+			t.Errorf("LoadPreset(%q, %q): wrong gpuType in result: %q", tc.machine, tc.gpu, topo.GPUType)
+		}
+	}
+}
+
+func TestLoadPreset_RejectsMissingGPUType(t *testing.T) {
+	// A preset directory whose topology.yaml has empty gpuType is
+	// silently dropped from the lookup pool — neither LoadPreset nor
+	// ListPresets should surface it.
+	tmpDir := t.TempDir()
+	presetsDir := filepath.Join(tmpDir, "presets")
+
+	mustMkdir := func(name string) string {
+		full := filepath.Join(presetsDir, name)
+		if err := os.MkdirAll(full, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return full
+	}
+	// Valid: machineType + gpuType both set
+	if err := os.WriteFile(filepath.Join(mustMkdir("Valid"), "topology.yaml"),
+		[]byte("machineType: M\ngpuType: NVIDIA-H200\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Invalid: missing gpuType
+	if err := os.WriteFile(filepath.Join(mustMkdir("NoGPU"), "topology.yaml"),
+		[]byte("machineType: M\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Invalid: missing machineType
+	if err := os.WriteFile(filepath.Join(mustMkdir("NoMachine"), "topology.yaml"),
+		[]byte("gpuType: NVIDIA-H200\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	names, err := ListPresets()
+	if err != nil {
+		t.Fatalf("ListPresets failed: %v", err)
+	}
+	if len(names) != 1 || names[0] != "Valid" {
+		t.Errorf("ListPresets: expected [Valid], got %v", names)
+	}
+
+	// Lookup must return nil for the invalid pair (NoGPU declared
+	// machineType=M with empty gpuType, but it was rejected at load).
+	topo, err := LoadPreset("M", "")
+	if err != nil {
+		t.Fatalf("LoadPreset(M, \"\") unexpected error: %v", err)
+	}
+	if topo != nil {
+		t.Errorf("LoadPreset(M, \"\"): expected nil (NoGPU was rejected), got %+v", topo)
+	}
+}
+
+func TestLoadPresetByDir_Found(t *testing.T) {
+	tmpDir := t.TempDir()
+	presetsDir := filepath.Join(tmpDir, "presets", "MyPreset")
+	if err := os.MkdirAll(presetsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(presetsDir, "topology.yaml"),
+		[]byte("machineType: M\ngpuType: NVIDIA-H200\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	topo, err := LoadPresetByDir("MyPreset")
+	if err != nil {
+		t.Fatalf("LoadPresetByDir failed: %v", err)
+	}
+	if topo == nil || topo.MachineType != "M" || topo.GPUType != "NVIDIA-H200" {
+		t.Errorf("LoadPresetByDir returned wrong topology: %+v", topo)
+	}
+}
+
+func TestLoadPresetByDir_Unknown(t *testing.T) {
+	tmpDir := t.TempDir()
+	presetsDir := filepath.Join(tmpDir, "presets", "Foo")
+	if err := os.MkdirAll(presetsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(presetsDir, "topology.yaml"),
+		[]byte("machineType: M\ngpuType: NVIDIA-H200\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+	_ = os.Chdir(tmpDir)
+
+	topo, err := LoadPresetByDir("Bar")
+	if err == nil {
+		t.Fatal("expected error for unknown preset, got nil")
+	}
+	if topo != nil {
+		t.Errorf("expected nil topology on unknown preset, got %+v", topo)
+	}
+	if !containsSubstring(err.Error(), "Bar") {
+		t.Errorf("error should mention requested name 'Bar', got: %v", err)
+	}
+	if !containsSubstring(err.Error(), "Foo") {
+		t.Errorf("error should list available preset 'Foo', got: %v", err)
 	}
 }
 
@@ -275,7 +436,7 @@ func TestLoadPreset_DirectoryWithoutTopologyYAML(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 	_ = os.Chdir(tmpDir)
 
-	topo, err := LoadPreset("NoTopology")
+	topo, err := LoadPreset("NoTopology", "NVIDIA-H200")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -296,7 +457,7 @@ func TestListPresets(t *testing.T) {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(filepath.Join(dir, "topology.yaml"), []byte("machineType: "+name), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "topology.yaml"), []byte("machineType: "+name+"\ngpuType: NVIDIA-H200\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -520,7 +681,7 @@ func TestValidatePreset_MultipleMismatches(t *testing.T) {
 
 func TestApplyPreset_OverridesTopologyFields(t *testing.T) {
 	preset := &Topology{
-		ProductType: "NVIDIA-H200",
+		GPUType: "NVIDIA-H200",
 		PFs: []PresetPF{
 			{
 				DeviceID:     "a2dc",
@@ -547,7 +708,7 @@ func TestApplyPreset_OverridesTopologyFields(t *testing.T) {
 	}
 
 	group := &config.ClusterConfig{
-		ProductType: "", // should be filled from preset
+		GPUType: "", // should be filled from preset
 		PFs: []config.PFConfig{
 			{
 				DeviceID:         "a2dc",
@@ -629,9 +790,13 @@ func TestApplyPreset_OverridesTopologyFields(t *testing.T) {
 		t.Errorf("PF[1] PartNumber: expected discovered-ns-part (preserved), got %q", pf1.PartNumber)
 	}
 
-	// Verify product type was filled from preset
-	if group.ProductType != "NVIDIA-H200" {
-		t.Errorf("ProductType: expected NVIDIA-H200, got %q", group.ProductType)
+	// GPUType is no longer filled in from the preset — it's a matching
+	// key, so by the time ApplyPreset runs, the discovered group's
+	// GPUType already equals the preset's. Here we exercise that the
+	// caller passed an empty GPUType and ApplyPreset does not write
+	// over it (since GPUType fill-in was deliberately removed).
+	if group.GPUType != "" {
+		t.Errorf("GPUType: expected unchanged empty (no fill-in), got %q", group.GPUType)
 	}
 
 	// Verify preset applied flag
@@ -640,20 +805,20 @@ func TestApplyPreset_OverridesTopologyFields(t *testing.T) {
 	}
 }
 
-func TestApplyPreset_PreservesExistingProductType(t *testing.T) {
+func TestApplyPreset_PreservesExistingGPUType(t *testing.T) {
 	preset := &Topology{
-		ProductType: "NVIDIA-H200",
+		GPUType: "NVIDIA-H200",
 		PFs:         []PresetPF{},
 	}
 	group := &config.ClusterConfig{
-		ProductType: "NVIDIA-H100-NVL", // already set — should NOT be overwritten
+		GPUType: "NVIDIA-H100-NVL", // already set — should NOT be overwritten
 		PFs:         []config.PFConfig{},
 	}
 
 	ApplyPreset(preset, group)
 
-	if group.ProductType != "NVIDIA-H100-NVL" {
-		t.Errorf("ProductType: expected NVIDIA-H100-NVL (preserved), got %q", group.ProductType)
+	if group.GPUType != "NVIDIA-H100-NVL" {
+		t.Errorf("GPUType: expected NVIDIA-H100-NVL (preserved), got %q", group.GPUType)
 	}
 }
 
@@ -693,7 +858,7 @@ func TestApplyPreset_LargePreset_PowerEdgeXE9680(t *testing.T) {
 	presetsDir := filepath.Join(tmpDir, "presets")
 
 	// Copy the actual preset file from the repo
-	srcPath := filepath.Join("..", "..", "presets", "PowerEdge-XE9680", "topology.yaml")
+	srcPath := filepath.Join("..", "..", "presets", "PowerEdge-XE9680-H200", "topology.yaml")
 	data, err := os.ReadFile(srcPath)
 	if err != nil {
 		t.Skipf("skipping: cannot read real preset file: %v", err)
@@ -711,7 +876,7 @@ func TestApplyPreset_LargePreset_PowerEdgeXE9680(t *testing.T) {
 	defer func() { _ = os.Chdir(origDir) }()
 	_ = os.Chdir(tmpDir)
 
-	preset, err := LoadPreset("PowerEdge-XE9680")
+	preset, err := LoadPreset("PowerEdge-XE9680", "NVIDIA-H200")
 	if err != nil {
 		t.Fatalf("LoadPreset failed: %v", err)
 	}

--- a/pkg/presets/synthesize.go
+++ b/pkg/presets/synthesize.go
@@ -1,0 +1,79 @@
+// Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package presets
+
+import (
+	"fmt"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+// SynthesizeClusterConfig builds a config.ClusterConfig from a topology preset.
+// This is the entry point used by `l8k generate --for <name>`: instead of
+// discovering hardware against a live cluster, we construct a clusterConfig
+// group entirely from the preset's static description plus a user-provided
+// node selector.
+//
+// presetName is the directory name passed via --for (e.g.
+// "PowerEdge-XE9680-H200"). It is used as the synthesized group's Identifier
+// so that variants of the same machine type produce distinct NicNodePolicy
+// names — `nnpName()` lowercases and truncates to 30 chars, so composite
+// directory names render safely.
+//
+// Returns an error if the preset is missing the capabilities.nodes block —
+// without it, FindApplicableProfile cannot match a profile.
+func SynthesizeClusterConfig(
+	presetName string,
+	preset *Topology,
+	nodeSelector map[string]string,
+) (config.ClusterConfig, error) {
+	if preset == nil {
+		return config.ClusterConfig{}, fmt.Errorf("preset is nil")
+	}
+	if preset.Capabilities == nil || preset.Capabilities.Nodes == nil {
+		return config.ClusterConfig{}, fmt.Errorf(
+			"preset has no capabilities block; add 'capabilities.nodes.{sriov,rdma,ib}' to its topology.yaml to use it with --for")
+	}
+
+	pfs := make([]config.PFConfig, 0, len(preset.PFs))
+	for _, pp := range preset.PFs {
+		pfs = append(pfs, config.PFConfig{
+			DeviceID:         pp.DeviceID,
+			RdmaDevice:       pp.RdmaDevice,
+			PciAddress:       pp.PciAddress,
+			NetworkInterface: pp.NetworkInterface,
+			Traffic:          pp.Traffic,
+			Rail:             pp.Rail,
+			PSID:             pp.PSID,
+			PartNumber:       pp.PartNumber,
+			NumaNode:         pp.NumaNode,
+			ConnectedGPU:     pp.ConnectedGPU,
+			GPUProximity:     pp.GPUProximity,
+		})
+	}
+
+	return config.ClusterConfig{
+		Identifier:    presetName,
+		MachineType:   preset.MachineType,
+		GPUType:       preset.GPUType,
+		PresetApplied: true,
+		Capabilities:  preset.Capabilities,
+		PFs:           pfs,
+		WorkerNodes:   nil,
+		NodeSelector:  nodeSelector,
+	}, nil
+}

--- a/pkg/presets/synthesize_test.go
+++ b/pkg/presets/synthesize_test.go
@@ -1,0 +1,133 @@
+// Copyright 2025 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package presets
+
+import (
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+func TestSynthesizeClusterConfig_FieldMapping(t *testing.T) {
+	rail0 := 0
+	numa0 := 0
+	preset := &Topology{
+		MachineType: "PowerEdge-XE9680",
+		GPUType:     "NVIDIA-H200",
+		Capabilities: &config.ClusterCapabilities{Nodes: &config.NodesCapabilities{
+			Sriov: true, Rdma: true, Ib: false,
+		}},
+		PFs: []PresetPF{
+			{
+				DeviceID: "a2dc", PciAddress: "0000:1a:00.0",
+				RdmaDevice: "rocep26s0f0", NetworkInterface: "eth2",
+				Traffic: "east-west", Rail: &rail0, NumaNode: &numa0,
+				ConnectedGPU: "GPU0", GPUProximity: "PIX",
+				PSID: "mt_0000001069", PartNumber: "0KK4NR",
+			},
+			{
+				DeviceID: "a2dc", PciAddress: "0000:9d:00.0",
+				RdmaDevice: "rocep157s0f0", NetworkInterface: "eth7",
+				Traffic: "north-south", Rail: nil, NumaNode: &numa0,
+				ConnectedGPU: "GPU4", GPUProximity: "PIX",
+				PSID: "mt_0000000884", PartNumber: "0HFWRM",
+			},
+		},
+	}
+	selector := map[string]string{"nvidia.com/gpu.product": "NVIDIA-H200"}
+
+	cc, err := SynthesizeClusterConfig("PowerEdge-XE9680-H200", preset, selector)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Identifier comes from the directory name (so multi-variant presets
+	// produce distinct NicNodePolicy names).
+	if cc.Identifier != "PowerEdge-XE9680-H200" {
+		t.Errorf("Identifier: expected directory name, got %q", cc.Identifier)
+	}
+	if cc.MachineType != "PowerEdge-XE9680" {
+		t.Errorf("MachineType: expected PowerEdge-XE9680, got %q", cc.MachineType)
+	}
+	if cc.GPUType != "NVIDIA-H200" {
+		t.Errorf("GPUType: expected NVIDIA-H200, got %q", cc.GPUType)
+	}
+	if !cc.PresetApplied {
+		t.Error("PresetApplied should be true")
+	}
+	if cc.WorkerNodes != nil {
+		t.Errorf("WorkerNodes should be nil (selector targets nodes at apply time), got %v", cc.WorkerNodes)
+	}
+	if got := cc.NodeSelector["nvidia.com/gpu.product"]; got != "NVIDIA-H200" {
+		t.Errorf("NodeSelector: expected nvidia.com/gpu.product=NVIDIA-H200, got %q", got)
+	}
+
+	// PFs flow through with all fields, including RdmaDevice and
+	// NetworkInterface (preset is authoritative in --for mode since
+	// there is no live discovery to override).
+	if len(cc.PFs) != 2 {
+		t.Fatalf("expected 2 PFs, got %d", len(cc.PFs))
+	}
+	pf0 := cc.PFs[0]
+	if pf0.PciAddress != "0000:1a:00.0" || pf0.RdmaDevice != "rocep26s0f0" ||
+		pf0.NetworkInterface != "eth2" || pf0.Traffic != "east-west" ||
+		pf0.Rail == nil || *pf0.Rail != 0 || pf0.ConnectedGPU != "GPU0" ||
+		pf0.PSID != "mt_0000001069" || pf0.PartNumber != "0KK4NR" {
+		t.Errorf("PF[0] field mapping wrong: %+v", pf0)
+	}
+	pf1 := cc.PFs[1]
+	if pf1.Traffic != "north-south" || pf1.Rail != nil {
+		t.Errorf("PF[1] traffic/rail wrong: %+v", pf1)
+	}
+}
+
+func TestSynthesizeClusterConfig_CapabilitiesPassthrough(t *testing.T) {
+	preset := &Topology{
+		MachineType: "M", GPUType: "G",
+		Capabilities: &config.ClusterCapabilities{Nodes: &config.NodesCapabilities{
+			Sriov: true, Rdma: true, Ib: false,
+		}},
+	}
+	cc, err := SynthesizeClusterConfig("dir", preset, map[string]string{"k": "v"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cc.Capabilities == nil || cc.Capabilities.Nodes == nil {
+		t.Fatal("Capabilities not propagated")
+	}
+	if !cc.Capabilities.Nodes.Sriov || !cc.Capabilities.Nodes.Rdma || cc.Capabilities.Nodes.Ib {
+		t.Errorf("Capabilities mismatch: got %+v", *cc.Capabilities.Nodes)
+	}
+}
+
+func TestSynthesizeClusterConfig_NoCapabilities_ReturnsError(t *testing.T) {
+	preset := &Topology{MachineType: "M", GPUType: "G"}
+	_, err := SynthesizeClusterConfig("dir", preset, map[string]string{"k": "v"})
+	if err == nil {
+		t.Fatal("expected error for preset without capabilities, got nil")
+	}
+	if !containsSubstring(err.Error(), "capabilities") {
+		t.Errorf("error should mention capabilities, got: %v", err)
+	}
+}
+
+func TestSynthesizeClusterConfig_NilPreset(t *testing.T) {
+	_, err := SynthesizeClusterConfig("dir", nil, map[string]string{"k": "v"})
+	if err == nil {
+		t.Fatal("expected error for nil preset, got nil")
+	}
+}

--- a/presets/PowerEdge-R760xa-H100-NVL/topology.yaml
+++ b/presets/PowerEdge-R760xa-H100-NVL/topology.yaml
@@ -1,0 +1,91 @@
+machineType: PowerEdge-R760xa
+manufacturer: Dell Inc.
+gpuType: NVIDIA-H100-NVL
+nicModel: Nvidia BlueField-3 B3140H E-series HHHL SuperNIC 400GbE/NDR (ConnectX-7)
+gpuInterconnect: NV12
+numaNodes: 2
+
+capabilities:
+  nodes:
+    sriov: true
+    rdma: true
+    ib: false
+
+pfs:
+  # --- NUMA 0: GPUs 0-1, CPUs 0-23,48-71 ---
+  # N-S: BF3 dual-port 200G DPU (0d:xx.x)
+  - deviceID: a2dc
+    rdmaDevice: mlx5_0
+    pciAddress: 0000:0d:00.0
+    networkInterface: eth2
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: mt_0000000884
+    partNumber: 0HFWRM
+    model: Bluefield-3 Dual Port 200 GbE QSFP Crypto DPU
+  - deviceID: a2dc
+    rdmaDevice: mlx5_1
+    pciAddress: 0000:0d:00.1
+    networkInterface: eth3
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: mt_0000000884
+    partNumber: 0HFWRM
+    model: Bluefield-3 Dual Port 200 GbE QSFP Crypto DPU
+
+  # N-S: ConnectX-6 Lx dual-port 25GbE (22:xx.x) — OOB / management
+  - deviceID: "101f"
+    rdmaDevice: mlx5_2
+    pciAddress: 0000:22:00.0
+    networkInterface: eth4
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: del0000000030
+    partNumber: 0DN78C
+    model: NVIDIA ConnectX-6 Lx 2x 25G SFP28 OCP3.0 SFF
+  - deviceID: "101f"
+    rdmaDevice: mlx5_3
+    pciAddress: 0000:22:00.1
+    networkInterface: eth5
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: del0000000030
+    partNumber: 0DN78C
+    model: NVIDIA ConnectX-6 Lx 2x 25G SFP28 OCP3.0 SFF
+
+  # East-west: BF3 single-port 400G SuperNIC (37:xx.x) — NODE to GPU0
+  - deviceID: a2dc
+    rdmaDevice: mlx5_4
+    pciAddress: 0000:37:00.0
+    networkInterface: eth6
+    traffic: east-west
+    rail: 0
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: NODE
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL SuperNIC, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled
+
+  # --- NUMA 1: GPUs 2-3, CPUs 24-47,72-95 ---
+  # East-west: BF3 single-port 400G SuperNIC (b5:xx.x) — NODE to GPU2
+  - deviceID: a2dc
+    rdmaDevice: mlx5_5
+    pciAddress: 0000:b5:00.0
+    networkInterface: eth7
+    traffic: east-west
+    rail: 1
+    numaNode: 1
+    connectedGPU: GPU2
+    gpuProximity: NODE
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL SuperNIC, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled

--- a/presets/PowerEdge-XE7745-RTX-PRO-4500/topology.yaml
+++ b/presets/PowerEdge-XE7745-RTX-PRO-4500/topology.yaml
@@ -1,0 +1,117 @@
+machineType: PowerEdge-XE7745
+manufacturer: Dell Inc.
+gpuType: NVIDIA-RTX-PRO-4500-Blackwell
+nicModel: BlueField-3 B3140H E-series HHHL SuperNIC 400GbE/NDR Single-port QSFP112 (ConnectX-7)
+gpuInterconnect: ""
+numaNodes: 2
+
+capabilities:
+  nodes:
+    sriov: true
+    rdma: true
+    ib: false
+
+pfs:
+  # --- NUMA 0: no GPUs, CPUs 0-95 ---
+  # East-west: BF3 single-port 400G SuperNIC (44:00.0) — cross-NUMA to GPU1
+  - deviceID: a2dc
+    rdmaDevice: mlx5_0
+    pciAddress: 0000:44:00.0
+    networkInterface: eth0
+    traffic: east-west
+    rail: 1
+    numaNode: 0
+    connectedGPU: GPU1
+    gpuProximity: SYS
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL DPU, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled
+  # East-west: BF3 single-port 400G SuperNIC (8e:00.0) — cross-NUMA to GPU2
+  - deviceID: a2dc
+    rdmaDevice: mlx5_1
+    pciAddress: 0000:8e:00.0
+    networkInterface: eth1
+    traffic: east-west
+    rail: 2
+    numaNode: 0
+    connectedGPU: GPU2
+    gpuProximity: SYS
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL DPU, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled
+
+  # N-S: ConnectX-6 Lx dual-port 25GbE (c8:xx.x) — OOB / management
+  - deviceID: "101f"
+    rdmaDevice: mlx5_2
+    pciAddress: 0000:c8:00.0
+    networkInterface: eth2
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: mt_0000000547
+    partNumber: 07GGY4
+    model: ConnectX-6 Lx EN adapter card, 25GbE OCP3.0, With Host management, Dual-port SFP28, Crypto and Secure Boot, Thumbscrew (Pull Tab) Brack
+  - deviceID: "101f"
+    rdmaDevice: mlx5_3
+    pciAddress: 0000:c8:00.1
+    networkInterface: eth3
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: mt_0000000547
+    partNumber: 07GGY4
+    model: ConnectX-6 Lx EN adapter card, 25GbE OCP3.0, With Host management, Dual-port SFP28, Crypto and Secure Boot, Thumbscrew (Pull Tab) Brack
+
+  # N-S: BF3 dual-port 200G DPU (ca:xx.x)
+  - deviceID: a2dc
+    rdmaDevice: mlx5_4
+    pciAddress: 0000:ca:00.0
+    networkInterface: eth4
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: mt_0000000884
+    partNumber: 0HFWRM
+    model: Bluefield-3 Dual Port 200 GbE QSFP Crypto DPU
+  - deviceID: a2dc
+    rdmaDevice: mlx5_5
+    pciAddress: 0000:ca:00.1
+    networkInterface: eth5
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: mt_0000000884
+    partNumber: 0HFWRM
+    model: Bluefield-3 Dual Port 200 GbE QSFP Crypto DPU
+
+  # --- NUMA 1: GPUs 0-3 (PCI domain 0001), CPUs 96-191 ---
+  # East-west: BF3 single-port 400G SuperNIC (0001:05:00.0) — PIX to GPU0
+  - deviceID: a2dc
+    rdmaDevice: mlx5_6
+    pciAddress: 0001:05:00.0
+    networkInterface: eth6
+    traffic: east-west
+    rail: 0
+    numaNode: 1
+    connectedGPU: GPU0
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL DPU, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled
+  # East-west: BF3 single-port 400G SuperNIC (0001:c9:00.0) — PIX to GPU3
+  - deviceID: a2dc
+    rdmaDevice: mlx5_7
+    pciAddress: 0001:c9:00.0
+    networkInterface: eth7
+    traffic: east-west
+    rail: 3
+    numaNode: 1
+    connectedGPU: GPU3
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL DPU, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled

--- a/presets/PowerEdge-XE9680-H200/topology.yaml
+++ b/presets/PowerEdge-XE9680-H200/topology.yaml
@@ -1,8 +1,15 @@
 machineType: PowerEdge-XE9680
-productType: NVIDIA-H200
+manufacturer: Dell Inc.
+gpuType: NVIDIA-H200
 nicModel: BlueField-3 B3140H E-series HHHL SuperNIC (ConnectX-7)
 gpuInterconnect: NV18
 numaNodes: 2
+
+capabilities:
+  nodes:
+    sriov: true
+    rdma: true
+    ib: false
 
 pfs:
   # --- NUMA 0: GPUs 0-3, CPUs 0,2,4,6,8,10 ---
@@ -17,6 +24,7 @@ pfs:
     gpuProximity: PIX
     psid: mt_0000001069
     partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL SuperNIC, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled
   - deviceID: a2dc
     rdmaDevice: rocep60s0f0
     pciAddress: 0000:3c:00.0
@@ -28,6 +36,7 @@ pfs:
     gpuProximity: PIX
     psid: mt_0000001069
     partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL SuperNIC, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled
   - deviceID: a2dc
     rdmaDevice: rocep77s0f0
     pciAddress: 0000:4d:00.0
@@ -39,6 +48,7 @@ pfs:
     gpuProximity: PIX
     psid: mt_0000001069
     partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL SuperNIC, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled
   - deviceID: a2dc
     rdmaDevice: rocep94s0f0
     pciAddress: 0000:5e:00.0
@@ -50,6 +60,7 @@ pfs:
     gpuProximity: PIX
     psid: mt_0000001069
     partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL SuperNIC, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled
 
   # --- NUMA 1: GPUs 4-7, CPUs 1,3,5,7,9,11 ---
   - deviceID: a2dc
@@ -63,6 +74,7 @@ pfs:
     gpuProximity: PIX
     psid: mt_0000001069
     partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL SuperNIC, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled
   - deviceID: a2dc
     rdmaDevice: rocep157s0f0
     pciAddress: 0000:9d:00.0
@@ -73,6 +85,7 @@ pfs:
     gpuProximity: PIX
     psid: mt_0000000884
     partNumber: 0HFWRM
+    model: Bluefield-3 Dual Port 200 GbE QSFP Crypto DPU
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:9d:00.1
@@ -83,6 +96,7 @@ pfs:
     gpuProximity: PIX
     psid: mt_0000000884
     partNumber: 0HFWRM
+    model: Bluefield-3 Dual Port 200 GbE QSFP Crypto DPU
   - deviceID: a2dc
     rdmaDevice: rocep188s0f0
     pciAddress: 0000:bc:00.0
@@ -94,6 +108,7 @@ pfs:
     gpuProximity: PIX
     psid: mt_0000001069
     partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL SuperNIC, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled
   - deviceID: a2dc
     rdmaDevice: rocep204s0f0
     pciAddress: 0000:cc:00.0
@@ -105,6 +120,7 @@ pfs:
     gpuProximity: PIX
     psid: mt_0000001069
     partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL SuperNIC, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled
   - deviceID: a2dc
     rdmaDevice: rocep220s0f0
     pciAddress: 0000:dc:00.0
@@ -116,3 +132,4 @@ pfs:
     gpuProximity: PIX
     psid: mt_0000001069
     partNumber: 0KK4NR
+    model: Nvidia BlueField-3 B3140H E-series HHHL SuperNIC, 400GbE(default mode)/NDR IB, Single-port QSFP112, PCIe Gen5.0 x16, 8 Arm cores, 16GB DDR, BMC, Crypto Enabled

--- a/presets/ThinkSystem-SR650-V4-RTX-PRO-6000/topology.yaml
+++ b/presets/ThinkSystem-SR650-V4-RTX-PRO-6000/topology.yaml
@@ -1,0 +1,94 @@
+machineType: ThinkSystem-SR650-V4
+manufacturer: Lenovo
+gpuType: NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition
+nicModel: NVIDIA ConnectX-8 C8240 HHHL SuperNIC, 400GbE / 400Gb/s IB, Dual-port QSFP112 (ConnectX-8)
+gpuInterconnect: ""
+numaNodes: 2
+
+capabilities:
+  nodes:
+    sriov: true
+    rdma: true
+    ib: true
+
+# No PIX NIC<->GPU relationships on this machine (no PCIe switches).
+# - ConnectX-8 (1023): NODE-fallback to lowest-index GPU on the same NUMA.
+# - BF3 dual-port 200G DPU (SN37B36732 / VPI QSFP112 2P 200G): always north-south by SKU.
+# - ConnectX-6 Lx (101f): always north-south by SKU.
+
+pfs:
+  # --- NUMA 0: GPU0 (0000:6c:00.0), CPUs 0-47,96-143 ---
+  # N-S: ConnectX-6 Lx 10/25GbE (0b:xx.x)
+  - deviceID: "101f"
+    rdmaDevice: mlx5_0
+    pciAddress: 0000:0b:00.0
+    networkInterface: ens13f0np0
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: lnv0000000037
+    partNumber: SN37A28493
+    model: Mellanox ConnectX-6 Lx 10/25GbE SFP28 2-port OCP Ethernet Adapter
+  - deviceID: "101f"
+    rdmaDevice: mlx5_1
+    pciAddress: 0000:0b:00.1
+    networkInterface: ens13f1np1
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: lnv0000000037
+    partNumber: SN37A28493
+    model: Mellanox ConnectX-6 Lx 10/25GbE SFP28 2-port OCP Ethernet Adapter
+
+  # East-west (NODE-fallback): ConnectX-8 400G dual-port (46:xx.x)
+  - deviceID: "1023"
+    rdmaDevice: mlx5_2
+    pciAddress: 0000:46:00.0
+    networkInterface: ens3f0np0
+    traffic: east-west
+    rail: 0
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: NODE
+    psid: mt_0000001222
+    partNumber: 900-9X81Q-00CN-ST0
+    model: NVIDIA ConnectX-8 C8240 HHHL SuperNIC, 400GbE / 400Gb/s IB, Dual-port QSFP112, PCIe 6 x16 with x16 PCIe Socket Direct Extension option, Crypto and Secure Boot Enabled
+  - deviceID: "1023"
+    rdmaDevice: mlx5_3
+    pciAddress: 0000:46:00.1
+    networkInterface: ens3f1np1
+    traffic: east-west
+    rail: 1
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: NODE
+    psid: mt_0000001222
+    partNumber: 900-9X81Q-00CN-ST0
+    model: NVIDIA ConnectX-8 C8240 HHHL SuperNIC, 400GbE / 400Gb/s IB, Dual-port QSFP112, PCIe 6 x16 with x16 PCIe Socket Direct Extension option, Crypto and Secure Boot Enabled
+
+  # --- NUMA 1: GPU1 (0000:d8:00.0), CPUs 48-95,144-191 ---
+  # N-S: BF3 dual-port 200G DPU (8b:xx.x) — SKU-classified north-south despite NUMA proximity to GPU1
+  - deviceID: a2dc
+    rdmaDevice: mlx5_4
+    pciAddress: 0000:8b:00.0
+    networkInterface: ""
+    traffic: north-south
+    numaNode: 1
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: ""
+    partNumber: SN37B36732
+    model: Nvidia BlueField-3 VPI QSFP112 2P 200G PCIe Gen5 x16
+  - deviceID: a2dc
+    rdmaDevice: mlx5_5
+    pciAddress: 0000:8b:00.1
+    networkInterface: ""
+    traffic: north-south
+    numaNode: 1
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: ""
+    partNumber: SN37B36732
+    model: Nvidia BlueField-3 VPI QSFP112 2P 200G PCIe Gen5 x16

--- a/presets/ThinkSystem-SR675-V3-H200-NVL/topology.yaml
+++ b/presets/ThinkSystem-SR675-V3-H200-NVL/topology.yaml
@@ -1,0 +1,92 @@
+machineType: ThinkSystem-SR675-V3
+manufacturer: Lenovo
+gpuType: NVIDIA-H200-NVL
+nicModel: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16 (ConnectX-7)
+gpuInterconnect: NV6
+numaNodes: 2
+
+capabilities:
+  nodes:
+    sriov: true
+    rdma: true
+    ib: true
+
+# H200 NVL: GPUs are grouped into 2-GPU NVLink-bridge pairs (NV6).
+# Each rail NIC is PIX to BOTH GPUs of a pair; rail tied to the lowest-index GPU.
+# GPU0/GPU1 pair has no PIX NIC — the only NUMA-0 east-west NIC is tied to the GPU2/GPU3 pair.
+
+pfs:
+  # --- NUMA 0: GPUs 0-3, CPUs 0-63,128-191 ---
+  - deviceID: a2dc
+    rdmaDevice: mlx5_0
+    pciAddress: 0000:21:00.0
+    networkInterface: ens15f0np0
+    traffic: east-west
+    numaNode: 0
+    rail: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: lnv0000000071
+    partNumber: SN37B82788
+    model: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16
+  - deviceID: a2dc
+    rdmaDevice: mlx5_2
+    pciAddress: 0000:65:00.0
+    networkInterface: ens16f0np0
+    traffic: east-west
+    rail: 1
+    numaNode: 0
+    connectedGPU: GPU2
+    gpuProximity: PIX
+    psid: lnv0000000071
+    partNumber: SN37B82788
+    model: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16
+
+  # --- NUMA 1: GPUs 4-7, CPUs 64-127,192-255 ---
+  - deviceID: "1021"
+    rdmaDevice: mlx5_4
+    pciAddress: 0000:85:00.0
+    networkInterface: ens2f0np0
+    traffic: north-south
+    numaNode: 1
+    connectedGPU: GPU4
+    gpuProximity: PIX
+    psid: lnv0000000058
+    partNumber: SN37B06010
+    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
+  - deviceID: "1021"
+    rdmaDevice: mlx5_5
+    pciAddress: 0000:85:00.1
+    networkInterface: ens2f1np1
+    traffic: north-south
+    numaNode: 1
+    connectedGPU: GPU4
+    gpuProximity: PIX
+    psid: lnv0000000058
+    partNumber: SN37B06010
+    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
+
+  - deviceID: a2dc
+    rdmaDevice: mlx5_3
+    pciAddress: 0000:c1:00.0
+    networkInterface: ens20f0np0
+    traffic: east-west
+    rail: 2
+    numaNode: 1
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: lnv0000000071
+    partNumber: SN37B82788
+    model: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16
+  - deviceID: a2dc
+    rdmaDevice: mlx5_1
+    pciAddress: 0000:e5:00.0
+    networkInterface: ens21f0np0
+    traffic: east-west
+    rail: 3
+    numaNode: 1
+    connectedGPU: GPU6
+    gpuProximity: PIX
+    psid: lnv0000000071
+    partNumber: SN37B82788
+    model: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16

--- a/presets/ThinkSystem-SR675-V3-RTX-PRO-6000/topology.yaml
+++ b/presets/ThinkSystem-SR675-V3-RTX-PRO-6000/topology.yaml
@@ -1,0 +1,175 @@
+machineType: ThinkSystem-SR675-V3
+manufacturer: Lenovo
+gpuType: NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition
+nicModel: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter (ConnectX-7)
+gpuInterconnect: ""
+numaNodes: 2
+
+capabilities:
+  nodes:
+    sriov: true
+    rdma: true
+    ib: true
+
+# nvidia-smi was not installed on this host; GPU proximity derived from lspci PCI-tree
+# inspection (shared PCIe root == PIX).
+# CX-7 (1021) is the dominant east-west fabric on this machine: ALL CX-7 PFs are
+# east-west. PIX'd PFs keep their connectedGPU; non-PIX CX-7 PFs are still east-west
+# with connectedGPU="" and gpuProximity=NODE.
+# BF3 dual-port 200G DPU (SN37C16116) is north-south by SKU despite being PIX'd to GPUs.
+# CX-6 Lx (101f) is always north-south.
+
+pfs:
+  # --- NUMA 0 ---
+  # East-west: ConnectX-7 2-port (21:xx.x) — own PCIe root, no GPU under it
+  - deviceID: "1021"
+    rdmaDevice: mlx5_2
+    pciAddress: 0000:21:00.0
+    networkInterface: ens15f0np0
+    traffic: east-west
+    rail: 0
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: lnv0000000058
+    partNumber: SN37B06010
+    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
+  - deviceID: "1021"
+    rdmaDevice: mlx5_3
+    pciAddress: 0000:21:00.1
+    networkInterface: ens15f1np1
+    traffic: east-west
+    rail: 1
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: lnv0000000058
+    partNumber: SN37B06010
+    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
+
+  # N-S: ConnectX-6 Lx OCP 10/25GbE (41:xx.x)
+  - deviceID: "101f"
+    rdmaDevice: mlx5_0
+    pciAddress: 0000:41:00.0
+    networkInterface: ens27f0np0
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: lnv0000000037
+    partNumber: SN37A28493
+    model: Mellanox ConnectX-6 Lx 10/25GbE SFP28 2-port OCP Ethernet Adapter
+  - deviceID: "101f"
+    rdmaDevice: mlx5_1
+    pciAddress: 0000:41:00.1
+    networkInterface: ens27f1np1
+    traffic: north-south
+    numaNode: 0
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: lnv0000000037
+    partNumber: SN37A28493
+    model: Mellanox ConnectX-6 Lx 10/25GbE SFP28 2-port OCP Ethernet Adapter
+
+  # East-west: ConnectX-7 IB (65:xx.x) — PIX to GPU2, GPU3
+  - deviceID: "1021"
+    rdmaDevice: mlx5_6
+    pciAddress: 0000:65:00.0
+    networkInterface: ibs16f0
+    traffic: east-west
+    rail: 2
+    numaNode: 0
+    connectedGPU: GPU2
+    gpuProximity: PIX
+    psid: lnv0000000058
+    partNumber: SN37B06010
+    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
+  - deviceID: "1021"
+    rdmaDevice: mlx5_7
+    pciAddress: 0000:65:00.1
+    networkInterface: ibs16f1
+    traffic: east-west
+    rail: 3
+    numaNode: 0
+    connectedGPU: GPU3
+    gpuProximity: PIX
+    psid: lnv0000000058
+    partNumber: SN37B06010
+    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
+
+  # --- NUMA 1 ---
+  # N-S: BlueField-3 dual-port 200G DPU (85:xx.x) — SKU-classified north-south despite PIX to GPU4/GPU5
+  - deviceID: a2dc
+    rdmaDevice: mlx5_10
+    pciAddress: 0000:85:00.0
+    networkInterface: ens2f0np0
+    traffic: north-south
+    numaNode: 1
+    connectedGPU: GPU4
+    gpuProximity: PIX
+    psid: lnv0000000075
+    partNumber: SN37C16116
+    model: NVIDIA BlueField-3 VPI QSFP112 2P 200G PCIe Gen5 x16 with Tin Plating Connector
+  - deviceID: a2dc
+    rdmaDevice: mlx5_11
+    pciAddress: 0000:85:00.1
+    networkInterface: ens2f1np1
+    traffic: north-south
+    numaNode: 1
+    connectedGPU: GPU5
+    gpuProximity: PIX
+    psid: lnv0000000075
+    partNumber: SN37C16116
+    model: NVIDIA BlueField-3 VPI QSFP112 2P 200G PCIe Gen5 x16 with Tin Plating Connector
+
+  # East-west: ConnectX-7 IB (c1:xx.x) — own PCIe root, no GPU
+  - deviceID: "1021"
+    rdmaDevice: mlx5_8
+    pciAddress: 0000:c1:00.0
+    networkInterface: ibs20f0
+    traffic: east-west
+    rail: 4
+    numaNode: 1
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: lnv0000000058
+    partNumber: SN37B06010
+    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
+  - deviceID: "1021"
+    rdmaDevice: mlx5_9
+    pciAddress: 0000:c1:00.1
+    networkInterface: ibs20f1
+    traffic: east-west
+    rail: 5
+    numaNode: 1
+    connectedGPU: ""
+    gpuProximity: NODE
+    psid: lnv0000000058
+    partNumber: SN37B06010
+    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
+
+  # East-west: ConnectX-7 IB (e5:xx.x) — PIX to GPU6, GPU7
+  - deviceID: "1021"
+    rdmaDevice: mlx5_4
+    pciAddress: 0000:e5:00.0
+    networkInterface: ibs21f0
+    traffic: east-west
+    rail: 6
+    numaNode: 1
+    connectedGPU: GPU6
+    gpuProximity: PIX
+    psid: lnv0000000058
+    partNumber: SN37B06010
+    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
+  - deviceID: "1021"
+    rdmaDevice: mlx5_5
+    pciAddress: 0000:e5:00.1
+    networkInterface: ibs21f1
+    traffic: east-west
+    rail: 7
+    numaNode: 1
+    connectedGPU: GPU7
+    gpuProximity: PIX
+    psid: lnv0000000058
+    partNumber: SN37B06010
+    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter

--- a/presets/ThinkSystem-SR680a-V3-H200/topology.yaml
+++ b/presets/ThinkSystem-SR680a-V3-H200/topology.yaml
@@ -1,9 +1,15 @@
 machineType: ThinkSystem-SR680a-V3
 manufacturer: Lenovo
-productType: NVIDIA-H200
+gpuType: NVIDIA-H200
 nicModel: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16 (ConnectX-7)
 gpuInterconnect: NV18
 numaNodes: 2
+
+capabilities:
+  nodes:
+    sriov: true
+    rdma: true
+    ib: true
 
 pfs:
   # --- NUMA 0: GPUs 0-3, CPUs 0-55,112-167 ---
@@ -18,6 +24,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: SN37B82788
+    model: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16
   - deviceID: a2dc
     rdmaDevice: rocep42s0f0
     pciAddress: 0000:2a:00.0
@@ -29,6 +36,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: SN37B82788
+    model: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16
   - deviceID: a2dc
     rdmaDevice: rocep59s0f0
     pciAddress: 0000:3b:00.0
@@ -40,6 +48,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: SN37B82788
+    model: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16
   - deviceID: a2dc
     rdmaDevice: rocep76s0f0
     pciAddress: 0000:4c:00.0
@@ -51,8 +60,9 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: SN37B82788
+    model: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16
 
-  # --- N-S: ConnectX-6 Lx dual-port 10/25GbE (NUMA 0) ---
+  # --- N-S: ConnectX-6 Lx dual-port 10/25GbE (NUMA 0) --- # Ignored, OOB interface
   - deviceID: "101f"
     rdmaDevice: rocep90s0f0
     pciAddress: 0000:5a:00.0
@@ -63,6 +73,7 @@ pfs:
     gpuProximity: NODE
     psid: ""
     partNumber: SN37A28487
+    model: Mellanox ConnectX-6 Lx 10/25GbE SFP28 2-port PCIe Ethernet Adapter
   - deviceID: "101f"
     rdmaDevice: rocep90s0f1
     pciAddress: 0000:5a:00.1
@@ -73,6 +84,7 @@ pfs:
     gpuProximity: NODE
     psid: ""
     partNumber: SN37A28487
+    model: Mellanox ConnectX-6 Lx 10/25GbE SFP28 2-port PCIe Ethernet Adapter
 
   # --- NUMA 1: GPUs 4-7, CPUs 56-111,168-223 ---
   - deviceID: a2dc
@@ -86,6 +98,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: SN37B82788
+    model: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16
   - deviceID: a2dc
     rdmaDevice: rocep171s0f0
     pciAddress: 0000:ab:00.0
@@ -97,6 +110,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: SN37B82788
+    model: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16
   - deviceID: a2dc
     rdmaDevice: rocep193s0f0
     pciAddress: 0000:c1:00.0
@@ -108,6 +122,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: SN37B82788
+    model: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16
   - deviceID: a2dc
     rdmaDevice: rocep203s0f0
     pciAddress: 0000:cb:00.0
@@ -119,6 +134,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: SN37B82788
+    model: Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16
 
   # --- N-S bond slave: BF3 dual-port (NUMA 1) ---
   - deviceID: a2dc
@@ -131,6 +147,7 @@ pfs:
     gpuProximity: NODE
     psid: ""
     partNumber: SN37B36732
+    model: Nvidia BlueField-3 VPI QSFP112 2P 200G PCIe Gen5 x16
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:d8:00.1
@@ -141,3 +158,4 @@ pfs:
     gpuProximity: NODE
     psid: ""
     partNumber: SN37B36732
+    model: Nvidia BlueField-3 VPI QSFP112 2P 200G PCIe Gen5 x16

--- a/presets/UCSC-885A-M8-H22-H200/topology.yaml
+++ b/presets/UCSC-885A-M8-H22-H200/topology.yaml
@@ -1,9 +1,15 @@
 machineType: UCSC-885A-M8-H22
 manufacturer: Cisco Systems, Inc.
-productType: NVIDIA-H200
+gpuType: NVIDIA-H200
 nicModel: BlueField-3 E-series SuperNIC 400GbE/NDR (ConnectX-7)
 gpuInterconnect: NV18
 numaNodes: 2
+
+capabilities:
+  nodes:
+    sriov: true
+    rdma: true
+    ib: false
 
 pfs:
   # --- NUMA 0: GPUs 0-3, CPUs 0-63,128-191 ---
@@ -18,6 +24,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: 900-9D3D4-00NN-HA0
+    model: "BlueField-3 E-series SuperNIC 400GbE/NDR single port QSFP112, PCIe Gen5.0 x16, 8 Cores, HHHL, Crypto Disabled, 16GB DDR5, BMC, Tall Bracket"
   - deviceID: a2dc
     rdmaDevice: rocep35s0f0
     pciAddress: 0000:23:00.0
@@ -29,6 +36,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: 900-9D3D4-00NN-HA0
+    model: "BlueField-3 E-series SuperNIC 400GbE/NDR single port QSFP112, PCIe Gen5.0 x16, 8 Cores, HHHL, Crypto Disabled, 16GB DDR5, BMC, Tall Bracket"
   - deviceID: a2dc
     rdmaDevice: rocep83s0f0
     pciAddress: 0000:53:00.0
@@ -40,6 +48,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: 900-9D3D4-00NN-HA0
+    model: "BlueField-3 E-series SuperNIC 400GbE/NDR single port QSFP112, PCIe Gen5.0 x16, 8 Cores, HHHL, Crypto Disabled, 16GB DDR5, BMC, Tall Bracket"
   - deviceID: a2dc
     rdmaDevice: rocep105s0f0
     pciAddress: 0000:69:00.0
@@ -51,6 +60,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: 900-9D3D4-00NN-HA0
+    model: "BlueField-3 E-series SuperNIC 400GbE/NDR single port QSFP112, PCIe Gen5.0 x16, 8 Cores, HHHL, Crypto Disabled, 16GB DDR5, BMC, Tall Bracket"
 
   # --- N-S DPU (dual-port, NUMA 0) ---
   - deviceID: a2dc
@@ -63,6 +73,7 @@ pfs:
     gpuProximity: NODE
     psid: ""
     partNumber: 900-9D3B6-00SV-AA0
+    model: "BlueField-3 P-Series DPU 200GbE/NDR200 dual-port QSFP-DD112, PCIe Gen5.0 x16 FHHL, Crypto Disabled, 32GB DDR5, BMC, Tall Bracket"
   - deviceID: a2dc
     rdmaDevice: ""
     pciAddress: 0000:35:00.1
@@ -73,6 +84,7 @@ pfs:
     gpuProximity: NODE
     psid: ""
     partNumber: 900-9D3B6-00SV-AA0
+    model: "BlueField-3 P-Series DPU 200GbE/NDR200 dual-port QSFP-DD112, PCIe Gen5.0 x16 FHHL, Crypto Disabled, 32GB DDR5, BMC, Tall Bracket"
 
   # --- NUMA 1: GPUs 4-7, CPUs 64-127,192-255 ---
   - deviceID: a2dc
@@ -86,6 +98,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: 900-9D3D4-00NN-HA0
+    model: "BlueField-3 E-series SuperNIC 400GbE/NDR single port QSFP112, PCIe Gen5.0 x16, 8 Cores, HHHL, Crypto Disabled, 16GB DDR5, BMC, Tall Bracket"
   - deviceID: a2dc
     rdmaDevice: rocep156s0f0
     pciAddress: 0000:9c:00.0
@@ -97,6 +110,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: 900-9D3D4-00NN-HA0
+    model: "BlueField-3 E-series SuperNIC 400GbE/NDR single port QSFP112, PCIe Gen5.0 x16, 8 Cores, HHHL, Crypto Disabled, 16GB DDR5, BMC, Tall Bracket"
   - deviceID: a2dc
     rdmaDevice: rocep205s0f0
     pciAddress: 0000:cd:00.0
@@ -108,6 +122,7 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: 900-9D3D4-00NN-HA0
+    model: "BlueField-3 E-series SuperNIC 400GbE/NDR single port QSFP112, PCIe Gen5.0 x16, 8 Cores, HHHL, Crypto Disabled, 16GB DDR5, BMC, Tall Bracket"
   - deviceID: a2dc
     rdmaDevice: rocep241s0f0
     pciAddress: 0000:f1:00.0
@@ -119,3 +134,4 @@ pfs:
     gpuProximity: PIX
     psid: ""
     partNumber: 900-9D3D4-00NN-HA0
+    model: "BlueField-3 E-series SuperNIC 400GbE/NDR single port QSFP112, PCIe Gen5.0 x16, 8 Cores, HHHL, Crypto Disabled, 16GB DDR5, BMC, Tall Bracket"

--- a/releases.yaml
+++ b/releases.yaml
@@ -1,0 +1,1 @@
+pkg/networkoperatorplugin/releases.yaml

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -32,7 +32,6 @@ set -euo pipefail
 
 PREFIX="/usr/local"
 DEV_ENV=false
-SKIP_PRESETS_UPDATE=false
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 while [[ $# -gt 0 ]]; do
@@ -45,22 +44,20 @@ while [[ $# -gt 0 ]]; do
             PREFIX="$2"
             shift 2
             ;;
-        --skip-presets-update)
-            SKIP_PRESETS_UPDATE=true
-            shift
-            ;;
         -h|--help)
-            echo "Usage: install-local.sh [--dev-env] [--prefix /path] [--skip-presets-update]"
+            echo "Usage: install-local.sh [--dev-env] [--prefix /path]"
             echo ""
             echo "Options:"
             echo "  --dev-env              Create symlinks instead of copies (for development)"
             echo "  --prefix               Install prefix (default: /usr/local)"
-            echo "  --skip-presets-update   Skip downloading latest presets from GitHub"
+            echo ""
+            echo "Presets are installed from the bundled \`presets/\` tree only."
+            echo "To fetch the latest presets from GitHub, run \`l8k preset update\` after install."
             exit 0
             ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: install-local.sh [--dev-env] [--prefix /path] [--skip-presets-update]"
+            echo "Usage: install-local.sh [--dev-env] [--prefix /path]"
             exit 1
             ;;
     esac
@@ -102,12 +99,6 @@ echo "  Binary:   ${BIN_DIR}/l8k"
 echo "  Profiles: ${SHARE_DIR}/profiles"
 echo "  Presets:  ${SHARE_DIR}/presets"
 echo "  Config:   ${SHARE_DIR}/l8k-config.yaml"
-
-# Try to download latest presets from GitHub (non-fatal on failure)
-if [ "$SKIP_PRESETS_UPDATE" = false ] && [ "$DEV_ENV" = false ]; then
-    echo ""
-    echo "Downloading latest presets from GitHub..."
-    "${BIN_DIR}/l8k" preset update --dir "${SHARE_DIR}/presets" 2>/dev/null \
-        && echo "Presets updated successfully." \
-        || echo "[WARNING] Could not download presets (offline?). Using bundled presets."
-fi
+echo ""
+echo "Presets installed from the bundled \`presets/\` tree."
+echo "Run \`l8k preset update\` to fetch the latest presets from GitHub."

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -51,8 +51,49 @@ l8k discover --user-config my-config.yaml \
 | `profile` | Profile selection criteria (fabric, deployment, multirail) |
 | `clusterConfig[]` | Per-group hardware: NICs, nodes, capabilities, selectors |
 
+Each `clusterConfig[]` entry has these key fields:
+
+- `identifier` — group name (used for `NicNodePolicy` naming).
+- `machineType` — server model (e.g. `PowerEdge-XE9680`); populated from `nvidia.com/gpu.machine` label or DMI fallback.
+- `gpuType` — GPU SKU (e.g. `NVIDIA-H200`); populated from `nvidia.com/gpu.product` label or `nvidia-smi` fallback. **Note:** this field used to be called `productType` — the rename happened to disambiguate it from the server model. Old `productType:` keys in hand-authored configs must be renamed to `gpuType:`.
+- `capabilities.nodes.{sriov,rdma,ib}` — what the underlying hardware supports.
+- `pfs[]` — physical function list with PCI address, device ID, RDMA device, network interface, traffic class, rail, NUMA, GPU affinity.
+- `nodeSelector` — Kubernetes node selector for this group.
+- `workerNodes` — explicit hostnames (populated by discovery).
+
 For the full field-by-field reference with types, defaults, and descriptions,
 read `references/config-schema.md`.
+
+## Topology Presets
+
+The `presets/` directory contains pre-recorded topologies for known hardware combinations. A preset is a `topology.yaml` file with the following shape:
+
+```yaml
+machineType: PowerEdge-XE9680   # required
+gpuType: NVIDIA-H200            # required — both keys are matched as a pair
+nicModel: BlueField-3 SuperNIC (ConnectX-7)
+gpuInterconnect: NV18
+numaNodes: 2
+
+# Required if the preset will be used with `l8k generate --for`.
+# Discovery-time overlay does not need this block.
+capabilities:
+  nodes:
+    sriov: true
+    rdma: true
+    ib: false
+
+pfs:
+  - deviceID: a2dc
+    pciAddress: 0000:1a:00.0
+    traffic: east-west
+    rail: 0
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: PIX
+```
+
+**Lookup is exact-match on `(machineType, gpuType)`.** No any-GPU fallback — a preset that doesn't declare `gpuType:` is rejected at load time. Multi-variant presets for the same machine (different GPU SKUs) live in separate directories with composite names like `PowerEdge-XE9680-H200` / `PowerEdge-XE9680-B200`. The directory name is shown by `l8k preset list` and is what `l8k generate --for <name>` accepts.
 
 ## Common Edits
 

--- a/skills/k8s-launch-kit-discover/SKILL.md
+++ b/skills/k8s-launch-kit-discover/SKILL.md
@@ -96,6 +96,8 @@ clusterConfig:
 
 - If discovery fails with "no pods found for DaemonSet", the error will suggest using `--network-operator-namespace`. Common namespaces are `nvidia-network-operator` and `network-operator`.
 - Discovery uses server-side apply (field owner `l8k-discovery`) — it won't conflict with an existing NicClusterPolicy.
+- After determining each group's `(machineType, gpuType)`, discovery looks up a topology preset under `presets/` using **exact-match** lookup on that pair. A matching preset overrides heuristic-derived topology fields (traffic class, rail, NUMA, GPU affinity). There is no any-GPU fallback — a preset with empty `gpuType:` is rejected at load time. If no preset matches, discovery proceeds with heuristic classification.
+- If you already know the SKU and want to skip cluster discovery entirely, use `l8k generate --for <preset>` (see `k8s-launch-kit-generate`).
 
 ## See Also
 

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -32,6 +32,8 @@ l8k generate --user-config <CONFIG> --fabric <FABRIC> --deployment-type <TYPE> \
 | `--multirail` | — | — | Enable multirail mode |
 | `--save-deployment-files` | Yes | — | Output directory for generated YAMLs |
 | `--group` | — | `group-0` | Filter to a specific hardware group |
+| `--for` | — | preset directory name | Skip discovery: synthesize `clusterConfig` from a topology preset. Requires `--node-selector`. List options with `l8k preset list`. |
+| `--node-selector` | Required with `--for` | `key=val,key2=val2` | Identifies which nodes the synthesized clusterConfig targets at apply time. |
 
 *Not required when `--spectrum-x` is used.
 
@@ -63,7 +65,22 @@ l8k generate --user-config cluster-config.yaml \
   --fabric ethernet --deployment-type sriov \
   --save-deployment-files ./output \
   --output json 2>/dev/null
+
+# Generate from a known server SKU (no cluster discovery required)
+l8k preset list   # see available presets
+l8k generate --user-config cluster-config.yaml \
+  --for ThinkSystem-SR680a-V3 \
+  --node-selector "nvidia.com/gpu.product=NVIDIA-H200" \
+  --fabric ethernet --deployment-type sriov \
+  --save-deployment-files ./output
 ```
+
+## Choosing `l8k discover` vs `--for`
+
+- **`l8k discover` then `l8k generate`** — default flow. Run discovery against a live cluster to learn machine type, GPU type, and NIC topology, then generate from the resulting `cluster-config.yaml`.
+- **`l8k generate --for <preset>`** — skip discovery entirely when the SKU is already known and there is a preset for it. Useful for ahead-of-time generation (CI scaffolding, lab runbooks, demos), or when you don't have `kubectl` access yet. Requires `--node-selector` to identify the target nodes at apply time.
+
+A preset used with `--for` must declare `capabilities.nodes.{sriov,rdma,ib}` in its `topology.yaml`. All bundled presets do.
 
 ## Profile Quick Reference
 

--- a/skills/k8s-launch-kit-pipeline/SKILL.md
+++ b/skills/k8s-launch-kit-pipeline/SKILL.md
@@ -73,6 +73,14 @@ l8k discover --kubeconfig ~/.kube/config \
 l8k generate --user-config ./cluster-config.yaml \
   --fabric ethernet --deployment-type sriov \
   --save-deployment-files ./output --deploy
+
+# Skip discovery entirely with --for (known SKU)
+l8k generate --user-config ./cluster-config.yaml \
+  --for ThinkSystem-SR680a-V3 \
+  --node-selector "nvidia.com/gpu.product=NVIDIA-H200" \
+  --fabric ethernet --deployment-type sriov \
+  --save-deployment-files ./output --deploy \
+  --kubeconfig ~/.kube/config
 ```
 
 ## Common Variations

--- a/skills/k8s-launch-kit-shared/SKILL.md
+++ b/skills/k8s-launch-kit-shared/SKILL.md
@@ -22,6 +22,7 @@ make build && scripts/install.sh --dev-env
 |------|----------|
 | `/usr/local/bin/l8k` | CLI binary (on PATH) |
 | `/usr/local/share/l8k/profiles/` | Go template profiles |
+| `/usr/local/share/l8k/presets/` | Topology presets (per `(machineType, gpuType)` directories) |
 | `/usr/local/share/l8k/l8k-config.yaml` | Default config |
 
 After installation, `l8k` is available system-wide.
@@ -42,7 +43,9 @@ After installation, `l8k` is available system-wide.
 | Command | Description |
 |---------|-------------|
 | `l8k discover` | Discover cluster hardware and produce cluster-config.yaml |
-| `l8k generate` | Generate Kubernetes YAML manifests from config + profile |
+| `l8k generate` | Generate Kubernetes YAML manifests from config + profile (use `--for <preset>` to skip cluster discovery for known SKUs) |
+| `l8k preset list` | List bundled topology presets (directory + machineType + gpuType) |
+| `l8k preset update` | Download latest topology presets from GitHub |
 | `l8k sosreport` | Collect diagnostic dump from cluster |
 | `l8k schema` | List all capabilities as JSON (profiles, flags, exit codes) |
 | `l8k version` | Print version information |

--- a/skills/k8s-launch-kit-troubleshoot/SKILL.md
+++ b/skills/k8s-launch-kit-troubleshoot/SKILL.md
@@ -55,6 +55,11 @@ kubectl get pods -A -o wide | grep -E 'ContainerCreating|Init'
 | RDMA not working | Missing RDMA device plugin or wrong resource name | Check `rdma-shared-dp` pods, verify resource annotations |
 | NIC config daemon not starting | Operator namespace mismatch | Verify `--network-operator-namespace` matches actual namespace |
 | IPPool not allocating | NV-IPAM subnet exhausted or misconfigured | Check `ippools` CR status, verify CIDR ranges |
+| `--for requires --node-selector` | `--for` was passed without `--node-selector` | Add `--node-selector key=val,…`. The synthesized clusterConfig has no live worker-node list; the selector identifies target nodes at apply time. |
+| `--for and --discover-cluster-config are mutually exclusive` | Both flags passed simultaneously | Pick one: `--for` skips discovery, `--discover-cluster-config` runs it. |
+| `unknown preset "X"; available: …` | `--for X` doesn't match any directory under `presets/` | Run `l8k preset list` and re-run with one of those names. |
+| `preset has no capabilities block` | Preset YAML used by `--for` is missing `capabilities.nodes.{sriov,rdma,ib}` | Add the block to the preset's `topology.yaml`. Discovery-time overlay does not require it; only `--for` does. |
+| `unknown field "productType"` in YAML | Hand-authored config still uses the old key name | Rename `productType:` to `gpuType:` (the field was renamed). |
 
 For detailed triage workflow, read `references/troubleshooting-guide.md`.
 

--- a/skills/k8s-network-engineer/SKILL.md
+++ b/skills/k8s-network-engineer/SKILL.md
@@ -26,11 +26,21 @@ Senior NVIDIA Networking Engineer specializing in Kubernetes cloud-native networ
 - Discover cluster hardware: use `l8k discover` (skill: `k8s-launch-kit-discover`)
 - Understand/edit config: use `k8s-launch-kit-config`
 - Choose profile + generate manifests: use `l8k generate` (skill: `k8s-launch-kit-generate`)
+- Skip discovery for known SKUs: use `l8k generate --for <preset>` (skill: `k8s-launch-kit-generate`)
 - Preview before applying: use `l8k generate --dry-run` (skill: `k8s-launch-kit-dryrun`)
 - Deploy to cluster: use `l8k generate --deploy` (skill: `k8s-launch-kit-deploy`)
 - End-to-end automation: use `l8k --discover-cluster-config ... --deploy` (skill: `k8s-launch-kit-pipeline`)
 - Collect diagnostics: use `l8k sosreport` (skill: `k8s-launch-kit-troubleshoot`)
 - Debug failures: use `k8s-launch-kit-troubleshoot`
+
+### Topology Presets
+
+l8k bundles topology presets for known `(machineType, gpuType)` pairs under `presets/`. They serve two flows:
+
+1. **Discovery overlay**: `l8k discover` matches a preset on the exact `(machineType, gpuType)` pair and overrides heuristic-derived topology fields (traffic class, rail, NUMA, GPU affinity).
+2. **Ahead-of-time generation**: `l8k generate --for <preset-name>` skips cluster discovery entirely and synthesizes the `clusterConfig` from a preset. Requires `--node-selector`. Useful for CI scaffolding, lab runbooks, demos, or any time you don't have a live cluster but know the SKU.
+
+Use `l8k preset list` to see available presets. Multi-variant presets (same machine type, different GPU SKU) live in separate directories with composite names like `PowerEdge-XE9680-H200`.
 
 ## Instructions
 


### PR DESCRIPTION
When you have a known server SKU (e.g. ThinkSystem-SR680a-V3) but no kubectl access yet, `--for <preset>` synthesizes the clusterConfig section from a topology preset and skips cluster discovery entirely. Useful for CI scaffolding, lab runbooks, demos, and any other context where running `l8k discover` against a live cluster isn't an option. Requires `--node-selector` since the synthesized clusterConfig has no live worker-node list.

To support multiple variants of the same machine model (e.g. PowerEdge-XE9680 with H200 vs B200), preset lookup is now keyed on `(machineType, gpuType)` instead of `machineType` alone. Both fields are mandatory in every topology.yaml; presets missing either are rejected at load time. There is no any-GPU fallback — exact-match only. Directory names stay free-form (composite naming like PowerEdge-XE9680-H200 is recommended) and serve as the unique identifier for `--for`.

Renames `productType` → `gpuType` everywhere (Go field, YAML key, all sample configs, all test fixtures, all docs). The old name was generic and ambiguous when sitting next to `machineType` and `nicModel`. Hard rename, no backward-compat shim — pre-1.0 cleanup.

Adds an optional `capabilities.nodes.{sriov,rdma,ib}` block to the preset schema. Required when the preset is consumed via `--for` so profile matching can run without live discovery; ignored by the discovery-time overlay path. All three bundled presets gain it.

`l8k preset list` now prints a tabular NAME / MACHINETYPE / GPUTYPE view, and surfaces skipped/invalid presets to stderr with their rejection reason (so a stale install with the old `productType:` key no longer appears as a silent "no presets found").

`scripts/install-local.sh` no longer pulls presets from GitHub during install — installs the bundled `presets/` tree only. Users run `l8k preset update` explicitly when they want the latest from GitHub.

Adds a "Documentation discipline" subsection to CLAUDE.md mandating that any behavioral change must update CLAUDE.md, docs/, README.md, and skills/ in the same PR. Updates the 7 skills that touch preset/config/discover/pipeline flows accordingly.