### PR TITLE
Always deploy NicInterfaceNameTemplate when the flag is set

### DIFF
--- a/l8k-config.yaml
+++ b/l8k-config.yaml
@@ -5,9 +5,9 @@ networkOperator:
   # populated from the embedded catalog; explicit values here are overridden.
   # Supported: 26.1, 26.4. Leave empty to use the explicit values below as-is.
   # selectedRelease: "26.4"
-  version: v26.4.0-beta.6
-  componentVersion: network-operator-v26.4.0-beta.6
-  repository: nvcr.io/nvstaging/mellanox
+  version: v26.4.0
+  componentVersion: network-operator-v26.4.0
+  repository: nvcr.io/nvidia/mellanox
   namespace: nvidia-network-operator
   # imagePullSecrets:
   #   - my-registry-secret
@@ -19,7 +19,7 @@ podNamespace: default
 
 docaDriver:
   enable: true
-  version: doca3.4.0-26.04-0.4.2.0-0
+  version: doca3.4.0-26.04-1.0.0.0-0
   unloadStorageModules: true
   enableNFSRDMA: false
   unloadThirdPartyRDMAModules: true

--- a/pkg/networkoperatorplugin/releases.yaml
+++ b/pkg/networkoperatorplugin/releases.yaml
@@ -18,8 +18,8 @@ releases:
       version: doca3.3.0-26.01-1.0.0.0-4
   "26.4":
     networkOperator:
-      version: v26.4.0-beta.6
-      componentVersion: network-operator-v26.4.0-beta.6
-      repository: nvcr.io/nvstaging/mellanox
+      version: v26.4.0
+      componentVersion: network-operator-v26.4.0
+      repository: nvcr.io/nvidia/mellanox
     docaDriver:
-      version: doca3.4.0-26.04-0.4.2.0-0
+      version: doca3.4.0-26.04-1.0.0.0-0

--- a/pkg/networkoperatorplugin/render_plan.go
+++ b/pkg/networkoperatorplugin/render_plan.go
@@ -48,8 +48,9 @@ type RenderBucket struct {
 // same input order as `filteredGroups` for deterministic output.
 //
 // The second return value is the OR of `HadPciConflict` across all
-// buckets — used by the legacy NicInterfaceNameTemplate gating.
-func planRender(originalGroups, filteredGroups []config.ClusterConfig, useNameTemplates bool) ([]RenderBucket, bool) {
+// buckets — preserved for diagnostics; the renderer always emits
+// NicInterfaceNameTemplate, so this is informational only.
+func planRender(originalGroups, filteredGroups []config.ClusterConfig) ([]RenderBucket, bool) {
 	originalByKey := bucketize(originalGroups)
 	filteredOrder, filteredByKey := bucketizeOrdered(filteredGroups)
 
@@ -498,20 +499,3 @@ func subnetsAt(planSubnets [][]config.NvIpamSubnetConfig, i int) []config.NvIpam
 	return planSubnets[i]
 }
 
-// plansHaveEmptyNetworkInterfaceNames is the per-plan equivalent of
-// `hasEmptyNetworkInterfaceNames`: returns true when any east-west PF
-// across any plan's source groups has an empty NetworkInterface field.
-// Drives the NicInterfaceNameTemplate-required gating in the
-// rdma_shared deployment path.
-func plansHaveEmptyNetworkInterfaceNames(plans []RenderBucket) bool {
-	for _, plan := range plans {
-		for _, src := range plan.Sources {
-			for _, pf := range filterEastWestPFs(src.PFs) {
-				if pf.NetworkInterface == "" {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -682,29 +682,7 @@ func (p *NetworkOperatorPlugin) GenerateProfileDeploymentFiles(profile *profiles
 	// ClusterConfig per bucket, and decide Mode A vs B per bucket by
 	// comparing to the original (pre-filter) bucket. The plans drive
 	// the per-template scope dispatch below.
-	useNameTemplates := cfg.NicConfigurationOperator != nil &&
-		cfg.NicConfigurationOperator.DeployNicInterfaceNameTemplate
-
-	plans, hadPciConflicts := planRender(cfg.ClusterConfig, filtered, useNameTemplates)
-
-	// NicInterfaceNameTemplate is only needed when:
-	// 1. Merged groups have cross-rail PCI conflicts, OR
-	// 2. Deployment is rdma_shared AND PFs have empty NetworkInterface
-	//    names (rdmaSharedDevicePlugin uses ifNames selectors that
-	//    require them).
-	// When neither condition holds, disable name templates so the
-	// device plugin uses PCI addresses directly.
-	if useNameTemplates && !isSpectrumX(cfg) {
-		needsNameTemplates := hadPciConflicts ||
-			(isRdmaShared(cfg) && plansHaveEmptyNetworkInterfaceNames(plans))
-		if !needsNameTemplates {
-			overrideNicCfg := *cfg.NicConfigurationOperator
-			overrideNicCfg.DeployNicInterfaceNameTemplate = false
-			overrideCfg := *cfg
-			overrideCfg.NicConfigurationOperator = &overrideNicCfg
-			cfg = &overrideCfg
-		}
-	}
+	plans, _ := planRender(cfg.ClusterConfig, filtered)
 
 	// Pre-allocate subnets across all plans' merged groups so per-plan
 	// `ProcessTemplate` calls don't independently re-allocate from


### PR DESCRIPTION
Remove the auto-disable heuristic that flipped
deployNicInterfaceNameTemplate back to false when selectors could be resolved without it (no cross-rail PCI conflicts AND not rdma_shared with empty NetworkInterface). The renderer now emits the CR for every profile and cluster shape whenever the flag is true.

Rationale: deploying the template even when not strictly required gives operators stable, rail-based netdev names (rdma_r0, eth_r1, ...) regardless of the underlying PCI layout. Pod manifests and NetworkAttachmentDefinitions become portable across server SKUs, and reboots that re-enumerate PCI no longer break selectors. The cost is one extra CR per group; the win is uniform interface names everywhere.

Users can still opt out by setting
`nicConfigurationOperator.deployNicInterfaceNameTemplate: false` in their config -- only the auto-flip-to-false override is gone.

Drops the now-dead `useNameTemplates` parameter from `planRender` and removes the `plansHaveEmptyNetworkInterfaceNames` helper that only the auto-disable path called.