### PR TITLE
Fix discover's kubeconfig fallback and namespace-probe logging

### DIFF
--- a/pkg/cmd/deploy.go
+++ b/pkg/cmd/deploy.go
@@ -141,7 +141,7 @@ func resolveDeploymentDir(dir string) (string, error) {
 func init() {
 	rootCmd.AddCommand(deployCmd)
 
-	deployCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (falls back to $KUBECONFIG)")
+	deployCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (falls back to $KUBECONFIG, then ~/.kube/config)")
 	deployCmd.Flags().StringVar(&deploymentFiles, "deployment-files", DefaultDeploymentDir, "Directory containing the manifests to apply")
 	deployCmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "Preview the deployment via server-side dry-run without persisting changes")
 

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -96,7 +96,7 @@ east-west vs north-south NICs, and probes OFED dependent modules.`,
 func init() {
 	rootCmd.AddCommand(discoverCmd)
 
-	discoverCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (falls back to $KUBECONFIG)")
+	discoverCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (falls back to $KUBECONFIG, then ~/.kube/config)")
 	discoverCmd.Flags().StringVar(&userConfig, "user-config", "", "Base config to merge with discovered hardware")
 	discoverCmd.Flags().StringVar(&saveClusterConfig, "save-cluster-config", "", "Output path for cluster-config.yaml")
 	discoverCmd.Flags().StringVar(&networkOperatorNamespace, "network-operator-namespace", "", "Override operator namespace (default: nvidia-network-operator)")

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -205,7 +205,7 @@ func init() {
 
 	// Deploy (optional)
 	generateCmd.Flags().BoolVar(&deploy, "deploy", false, "Also deploy after generating")
-	generateCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Kubeconfig (required with --deploy, falls back to $KUBECONFIG)")
+	generateCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Kubeconfig (required with --deploy, falls back to $KUBECONFIG, then ~/.kube/config)")
 	generateCmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "Preview what would be deployed")
 
 	setFlagGroup(generateCmd, "user-config", GroupCommon)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/app"
@@ -249,7 +250,7 @@ func init() {
 
 	// Phase 3: Cluster deployment flags
 	rootCmd.Flags().BoolVar(&deploy, "deploy", false, "Deploy the generated files to the Kubernetes cluster")
-	rootCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file for cluster deployment (required when using --deploy)")
+	rootCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file for cluster deployment (required when using --deploy; falls back to $KUBECONFIG, then ~/.kube/config)")
 
 	// Output control flags
 	rootCmd.PersistentFlags().StringVar(&outputFormat, "output", "text", "Output format: text (default, human-readable) or json (structured, for automation and AI agents)")
@@ -482,8 +483,13 @@ func parseEnabledPlugins(enabledPlugins string) []string {
 	return strings.Split(enabledPlugins, ",")
 }
 
+// defaultKubeconfigHomeFile is the kubectl-style default kubeconfig location
+// ($HOME/.kube/config). Overridable in tests.
+var defaultKubeconfigHomeFile = clientcmd.RecommendedHomeFile
+
 // resolveKubeconfig resolves the kubeconfig path from flag or environment.
-// Priority: 1) --kubeconfig flag, 2) $KUBECONFIG env var
+// Priority: 1) --kubeconfig flag, 2) $KUBECONFIG env var, 3) $HOME/.kube/config
+// (the kubectl default — only returned when the file exists).
 func resolveKubeconfig(flagValue string) (string, error) {
 	if flagValue != "" {
 		return flagValue, nil
@@ -491,7 +497,12 @@ func resolveKubeconfig(flagValue string) (string, error) {
 	if envVal := os.Getenv("KUBECONFIG"); envVal != "" {
 		return envVal, nil
 	}
-	return "", fmt.Errorf("no kubeconfig found: set $KUBECONFIG or pass --kubeconfig <path>")
+	if defaultKubeconfigHomeFile != "" {
+		if _, err := os.Stat(defaultKubeconfigHomeFile); err == nil {
+			return defaultKubeconfigHomeFile, nil
+		}
+	}
+	return "", fmt.Errorf("no kubeconfig found: set $KUBECONFIG, pass --kubeconfig <path>, or create %s", defaultKubeconfigHomeFile)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -17,6 +17,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
@@ -376,4 +378,54 @@ func TestValidateConfig_ForWithNodeSelectorPasses(t *testing.T) {
 	}
 	err := validateConfig(&opts)
 	assert.NoError(t, err)
+}
+
+func TestResolveKubeconfig(t *testing.T) {
+	// Snapshot and restore the package-level defaults so tests don't leak.
+	origHome := defaultKubeconfigHomeFile
+	origEnv, envSet := os.LookupEnv("KUBECONFIG")
+	t.Cleanup(func() {
+		defaultKubeconfigHomeFile = origHome
+		if envSet {
+			_ = os.Setenv("KUBECONFIG", origEnv)
+		} else {
+			_ = os.Unsetenv("KUBECONFIG")
+		}
+	})
+
+	t.Run("flag wins over env and home", func(t *testing.T) {
+		_ = os.Setenv("KUBECONFIG", "/from/env")
+		defaultKubeconfigHomeFile = "/does/not/exist"
+		got, err := resolveKubeconfig("/from/flag")
+		require.NoError(t, err)
+		assert.Equal(t, "/from/flag", got)
+	})
+
+	t.Run("env wins over home", func(t *testing.T) {
+		_ = os.Setenv("KUBECONFIG", "/from/env")
+		defaultKubeconfigHomeFile = "/does/not/exist"
+		got, err := resolveKubeconfig("")
+		require.NoError(t, err)
+		assert.Equal(t, "/from/env", got)
+	})
+
+	t.Run("home file used when it exists and nothing else set", func(t *testing.T) {
+		_ = os.Unsetenv("KUBECONFIG")
+		tmpDir := t.TempDir()
+		homeFile := filepath.Join(tmpDir, "config")
+		require.NoError(t, os.WriteFile(homeFile, []byte("placeholder"), 0o600))
+		defaultKubeconfigHomeFile = homeFile
+		got, err := resolveKubeconfig("")
+		require.NoError(t, err)
+		assert.Equal(t, homeFile, got)
+	})
+
+	t.Run("error when home file missing and nothing else set", func(t *testing.T) {
+		_ = os.Unsetenv("KUBECONFIG")
+		defaultKubeconfigHomeFile = filepath.Join(t.TempDir(), "missing-config")
+		got, err := resolveKubeconfig("")
+		require.Error(t, err)
+		assert.Empty(t, got)
+		assert.Contains(t, err.Error(), "no kubeconfig found")
+	})
 }

--- a/pkg/cmd/sosreport.go
+++ b/pkg/cmd/sosreport.go
@@ -109,7 +109,7 @@ func findSosreportScript() (string, error) {
 func init() {
 	rootCmd.AddCommand(sosreportCmd)
 
-	sosreportCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (falls back to $KUBECONFIG)")
+	sosreportCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (falls back to $KUBECONFIG, then ~/.kube/config)")
 	sosreportCmd.Flags().StringVar(&sosreportOutputDir, "output-dir", "./sosreport", "Directory to save the sosreport")
 
 	setFlagGroup(sosreportCmd, "kubeconfig", GroupCommon)

--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -305,7 +305,7 @@ func versionStatusText(vc *networkoperatorplugin.VersionCheck) string {
 func init() {
 	rootCmd.AddCommand(validateCmd)
 
-	validateCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (falls back to $KUBECONFIG)")
+	validateCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (falls back to $KUBECONFIG, then ~/.kube/config)")
 	validateCmd.Flags().StringVar(&deploymentFiles, "deployment-files", DefaultDeploymentDir, "Directory containing the manifests to verify")
 	validateCmd.Flags().StringVar(&userConfig, "user-config", "", "Cluster config file (auto-detected from ./cluster-config.yaml). Used to read networkOperator.selectedRelease and operator namespace.")
 

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -189,18 +189,24 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 	var expectedNodes []string
 	var dsPods []corev1.Pod
 	if reuseExisting {
-		expectedNodes, dsPods, err = checkDaemonSetPodsReady(ctx, c, defaultConfig.NetworkOperator.Namespace, "nic-configuration-daemon")
+		primaryNS := defaultConfig.NetworkOperator.Namespace
+		uiOutput.Info("Checking for nic-configuration-daemon pods in namespace %q", primaryNS)
+		expectedNodes, dsPods, err = checkDaemonSetPodsReady(ctx, c, primaryNS, "nic-configuration-daemon")
 		if err != nil {
-			// Try the other common namespace before giving up
-			alternateNS := alternateNamespace(defaultConfig.NetworkOperator.Namespace)
+			primaryErr := err
+			// Try the other common namespace before giving up (legacy chart-rename fallback)
+			alternateNS := alternateNamespace(primaryNS)
 			if alternateNS != "" {
-				uiOutput.Info("Retrying in namespace %q", alternateNS)
+				uiOutput.Info("Initial probe in namespace %q failed, retrying in fallback namespace %q", primaryNS, alternateNS)
 				expectedNodes, dsPods, err = checkDaemonSetPodsReady(ctx, c, alternateNS, "nic-configuration-daemon")
 				if err == nil {
 					defaultConfig.NetworkOperator.Namespace = alternateNS
 				}
 			}
 			if err != nil {
+				if alternateNS != "" {
+					return fmt.Errorf("no nic-configuration-daemon pods found in namespace %q (also checked fallback namespace %q); use --network-operator-namespace to specify the correct namespace: %w", primaryNS, alternateNS, primaryErr)
+				}
 				return err
 			}
 		}
@@ -533,7 +539,12 @@ func checkDaemonSetPodsReady(ctx context.Context, c client.Client, namespace, da
 // patching a NicClusterPolicy to add NicConfigurationOperator, because the
 // network operator needs time to reconcile and create the DaemonSet pods.
 func waitForDaemonSetPods(parentCtx context.Context, c client.Client, uiOutput ui.Output, namespace, daemonSetName string, timeout time.Duration) ([]string, []corev1.Pod, string, error) {
-	progress := uiOutput.StartProgress(fmt.Sprintf("Waiting for %s pods (timeout: %s)", daemonSetName, timeout.Truncate(time.Second)))
+	altNS := alternateNamespace(namespace)
+	progressLabel := fmt.Sprintf("Waiting for %s pods in namespace %q (timeout: %s)", daemonSetName, namespace, timeout.Truncate(time.Second))
+	if altNS != "" {
+		progressLabel = fmt.Sprintf("Waiting for %s pods in namespace %q (also polling fallback %q; timeout: %s)", daemonSetName, namespace, altNS, timeout.Truncate(time.Second))
+	}
+	progress := uiOutput.StartProgress(progressLabel)
 
 	ctx := parentCtx
 	if _, hasDeadline := parentCtx.Deadline(); !hasDeadline {
@@ -542,7 +553,6 @@ func waitForDaemonSetPods(parentCtx context.Context, c client.Client, uiOutput u
 		defer cancel()
 	}
 
-	altNS := alternateNamespace(namespace)
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
@@ -560,7 +570,7 @@ func waitForDaemonSetPods(parentCtx context.Context, c client.Client, uiOutput u
 		if altNS != "" {
 			nodes, pods, err = checkDaemonSetPodsReady(ctx, c, altNS, daemonSetName)
 			if err == nil {
-				progress.Success(fmt.Sprintf("Found %d pod(s) in namespace %q", len(pods), altNS))
+				progress.Success(fmt.Sprintf("Found %d pod(s) in fallback namespace %q", len(pods), altNS))
 				return nodes, pods, altNS, nil
 			}
 		}
@@ -568,7 +578,10 @@ func waitForDaemonSetPods(parentCtx context.Context, c client.Client, uiOutput u
 		select {
 		case <-ctx.Done():
 			progress.Fail("Timeout waiting for daemon pods")
-			return nil, nil, "", fmt.Errorf("timeout waiting for %s pods to start: %w", daemonSetName, lastErr)
+			if altNS != "" {
+				return nil, nil, "", fmt.Errorf("timeout waiting for %s pods to start in namespace %q (also checked fallback namespace %q); use --network-operator-namespace to specify the correct namespace: %w", daemonSetName, namespace, altNS, lastErr)
+			}
+			return nil, nil, "", fmt.Errorf("timeout waiting for %s pods to start in namespace %q: %w", daemonSetName, namespace, lastErr)
 		case <-ticker.C:
 			progress.Update(fmt.Sprintf("Waiting for %s pods...", daemonSetName))
 		}


### PR DESCRIPTION
resolveKubeconfig now falls back to ~/.kube/config (the kubectl default) after --kubeconfig and $KUBECONFIG. Help text updated on all six commands that register the flag.

Discovery's alternate-namespace heuristic stays in place but now logs the primary namespace before probing it, names both namespaces on retry, and wraps the terminal error with both names — so --network-operator-namespace no longer looks ignored when the heuristic runs.