### PR TITLE
discover: self-contained NIC daemon bootstrap, no Network Operator needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,11 @@ SOSREPORT_URL=https://raw.githubusercontent.com/Mellanox/network-operator/master
 PCI_IDS_URL=https://raw.githubusercontent.com/pciutils/pciids/master/pci.ids
 PCI_IDS_NVIDIA=pkg/networkoperatorplugin/internal/pciids/nvidia.ids
 
-.PHONY: all build clean test coverage deps lint docker-build docker-build-local docker-run update-readme download-sosreport update-pci-ids release release-snapshot help
+# Where the vendored NIC Configuration Operator CRDs live (embedded by pkg/nicconfigdaemon).
+NIC_CONFIG_CRDS_DIR=pkg/nicconfigdaemon/assets/crds
+NIC_CONFIG_OPERATOR_MODULE=github.com/Mellanox/nic-configuration-operator
+
+.PHONY: all build clean test coverage deps lint docker-build docker-build-local docker-run update-readme download-sosreport update-pci-ids sync-nic-config-crds release release-snapshot help
 
 ## Build the binary
 build:
@@ -162,6 +166,19 @@ update-readme: build
 	@mv /tmp/README_new.md README.md
 	@rm -f /tmp/l8k_help.txt
 	@echo "README.md updated successfully"
+
+## Sync vendored NIC Configuration Operator CRDs from go.mod pin into pkg/nicconfigdaemon/assets/crds.
+## Run manually after bumping the nic-configuration-operator version in go.mod.
+sync-nic-config-crds:
+	@mod_dir="$$($(GOCMD) list -m -f '{{.Dir}}' $(NIC_CONFIG_OPERATOR_MODULE))"; \
+	if [ -z "$$mod_dir" ]; then \
+		echo "ERROR: could not locate module $(NIC_CONFIG_OPERATOR_MODULE)"; \
+		exit 1; \
+	fi; \
+	echo "Syncing CRDs from $$mod_dir/config/crd/bases"; \
+	mkdir -p $(NIC_CONFIG_CRDS_DIR); \
+	cp "$$mod_dir"/config/crd/bases/*.yaml $(NIC_CONFIG_CRDS_DIR)/; \
+	chmod u+w $(NIC_CONFIG_CRDS_DIR)/*.yaml
 
 ## Download sosreport script
 download-sosreport:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ K8s Launch Kit (l8k) is a CLI tool for deploying and managing NVIDIA cloud-nativ
 ## Operation Phases
 
 ### Discover Cluster Configuration
-Deploy a minimal Network Operator profile to automatically discover your cluster's network capabilities and hardware configuration. This phase can be skipped if you provide your own configuration file.
+Bootstrap a private NIC Configuration Daemon into the `nvidia-k8s-launch-kit`
+namespace to discover your cluster's network capabilities and hardware
+configuration. Discovery does **not** require a pre-installed Network Operator —
+the daemon and its CRDs are created in a dedicated namespace, used to publish
+`NicDevice` CRs, and torn down when discovery finishes. This phase can be
+skipped if you provide your own configuration file.
 
 ### Select the Deployment Profile
 Specify the desired deployment profile via CLI flags (`--fabric`, `--deployment-type`, `--multirail`, `--spectrum-x`) or via a `profile` section in the user-config file. AI-driven profile selection now lives in the `k8s-launch-kit-*` Claude Code skills, which wrap the deterministic CLI commands.
@@ -129,12 +134,10 @@ Examples:
 
   # Discover + deploy Spectrum-X with JSON output for automation
   l8k --kubeconfig ~/.kube/config --discover-cluster-config \
-    --spectrum-x RA2.2 --multiplane-mode hwplb --number-of-planes 4 \
-    --deploy --output json --yes
+    --spectrum-x RA2.2 --multiplane-mode hwplb --number-of-planes 4 --network-operator-release 26.4 --deploy --output json --yes
 
   # Dry-run: preview what would be deployed
-  l8k --user-config cluster-config.yaml --spectrum-x RA2.2 \
-    --multiplane-mode hwplb --number-of-planes 4 --deploy \
+  l8k --user-config cluster-config.yaml --spectrum-x --deploy \
     --dry-run --output json
 
   # Get tool capabilities as JSON (for AI agents)
@@ -142,18 +145,20 @@ Examples:
 
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
+  deploy      Apply previously generated manifests to a Kubernetes cluster
   discover    Discover cluster network hardware capabilities
   generate    Generate deployment manifests for a network profile
   help        Help about any command
   preset      Manage predefined cluster configuration presets
   schema      Print tool capabilities as JSON (for AI agents and automation)
   sosreport   Collect diagnostic sosreport from a Kubernetes cluster
+  validate    Verify a deployment matches the selected Network Operator release
   version     Print the version number
 
 Common Flags:
       --enabled-plugins string              Comma-separated list of plugins to enable (default "network-operator")
       --image-pull-secrets strings          Image pull secret names for NicClusterPolicy (comma-separated)
-      --kubeconfig string                   Path to kubeconfig file for cluster deployment (required when using --deploy)
+      --kubeconfig string                   Path to kubeconfig file for cluster deployment (required when using --deploy; falls back to $KUBECONFIG, then ~/.kube/config)
       --network-operator-namespace string   Override the network operator namespace from the config file
       --network-operator-release string     Network Operator release line to deploy (MAJOR.MINOR). Selects component image tags + repository from a built-in catalog and drives version-gated template sections. Supported: 25.10, 26.1, 26.4
       --node-selector string                Filter nodes for discovery by label (e.g., key=value,key2=value2) (default "feature.node.kubernetes.io/pci-15b3.present=true")
@@ -166,14 +171,15 @@ Discovery Flags:
 Profile Selection Flags:
       --deployment-type string   Select the deployment type (sriov, rdma_shared, host_device)
       --fabric string            Select the fabric type to deploy (infiniband, ethernet)
-      --for string               Generate for a known server preset (replaces clusterConfig from the preset). Requires --node-selector. Available: PowerEdge-XE9680, ThinkSystem-SR680a-V3, UCSC-885A-M8-H22
-      --group string             Generate templates for a specific group only (e.g., group-0)
+      --for string               Generate for a known server preset (replaces clusterConfig from the preset). Requires --node-selector. Available: PowerEdge-R760xa-H100-NVL, PowerEdge-XE7745-RTX-PRO-4500, PowerEdge-XE9680-H200, ThinkSystem-SR650-V4-RTX-PRO-6000, ThinkSystem-SR675-V3-H200-NVL, ThinkSystem-SR675-V3-RTX-PRO-6000, ThinkSystem-SR680a-V3-H200, UCSC-885A-M8-H22-H200
+      --gpu-type string          Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.
+      --groups strings           Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.
       --multirail                Enable multirail deployment
-      --spectrum-x string        Enable Spectrum-X by passing the SPC-X RA version (e.g. RA2.1, RA2.2). Supported: [RA2.1 RA2.2]
+      --spectrum-x string        Enable Spectrum-X by passing the SPC-X RA version (folds in the legacy --spcx-version). Supported: [RA2.1 RA2.2]
 
 Spectrum-X Flags:
-      --multiplane-mode string   Spectrum-X multiplane mode: swplb, hwplb, uniplane, none (required with --spectrum-x)
-      --number-of-planes int     Number of planes: 1, 2, or 4 (required with --spectrum-x)
+      --multiplane-mode string   Spectrum-X multiplane mode: swplb, hwplb, uniplane (requires --spectrum-x)
+      --number-of-planes int     Number of planes for Spectrum-X (requires --spectrum-x)
 
 Generation Output Flags:
       --enable-doca-driver             Enable DOCA driver deployment (overrides config file docaDriver.enable)
@@ -182,8 +188,9 @@ Generation Output Flags:
       --workload-manifest string       Path to a custom workload manifest YAML (replaces the profile's default example workload)
 
 Deploy Flags:
-      --deploy    Deploy the generated files to the Kubernetes cluster
-      --dry-run   Preview what would be deployed without applying changes to the cluster
+      --deploy                    Deploy the generated files to the Kubernetes cluster
+      --deploy-timeout duration   Maximum end-to-end wall-clock budget for the deploy phase (e.g. 45m, 2h). 0 (the default) means no deadline; the deploy polls until every manifest reaches a terminal state.
+      --dry-run                   Preview what would be deployed without applying changes to the cluster
 
 Output & Logging Flags:
   -h, --help               help for l8k

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.34.6
+	k8s.io/apiextensions-apiserver v0.34.6
 	k8s.io/apimachinery v0.34.6
 	k8s.io/client-go v0.34.6
 	sigs.k8s.io/controller-runtime v0.22.5

--- a/pkg/app/launcher.go
+++ b/pkg/app/launcher.go
@@ -86,9 +86,10 @@ func (l *Launcher) Run() error {
 		switch pluginName {
 		case networkoperatorplugin.PluginName:
 			l.plugins[pluginName] = &networkoperatorplugin.NetworkOperatorPlugin{
-				Groups:       l.options.Groups,
-				GpuType:      l.options.GpuType,
-				NodeSelector: parseNodeSelector(l.options.NodeSelector),
+				Groups:        l.options.Groups,
+				GpuType:       l.options.GpuType,
+				NodeSelector:  parseNodeSelector(l.options.NodeSelector),
+				KeepNamespace: l.options.KeepNamespace,
 			}
 		default:
 			err := fmt.Errorf("unknown plugin: %s", pluginName)

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -32,11 +32,16 @@ import (
 var discoverCmd = &cobra.Command{
 	Use:   "discover",
 	Short: "Discover cluster network hardware capabilities",
-	Long: `Deploy a minimal Network Operator profile to discover cluster network
-hardware capabilities and produce a cluster-config.yaml file.
+	Long: `Bootstrap a private NIC Configuration Daemon into the
+nvidia-k8s-launch-kit namespace and use it to discover cluster network
+hardware capabilities, producing a cluster-config.yaml file.
 
-Discovery inspects NodeFeature CRDs, groups nodes by hardware, detects
-east-west vs north-south NICs, and probes OFED dependent modules.`,
+Discovery does not require a pre-installed Network Operator: the daemon
+and its CRDs are created in a dedicated namespace, used to publish
+NicDevice CRs, and torn down when discovery finishes.
+
+Discovery groups nodes by hardware, detects east-west vs north-south
+NICs, and probes OFED-dependent modules.`,
 	Example: `  # Basic discovery
   l8k discover --kubeconfig ~/.kube/config \
     --save-cluster-config ./cluster-config.yaml
@@ -44,13 +49,13 @@ east-west vs north-south NICs, and probes OFED dependent modules.`,
   # Uses $KUBECONFIG if set
   l8k discover --save-cluster-config ./cluster-config.yaml
 
-  # Non-default operator namespace
-  l8k discover --kubeconfig ~/.kube/config \
-    --network-operator-namespace network-operator \
-    --save-cluster-config ./cluster-config.yaml
-
   # Merge with existing config
   l8k discover --user-config my-config.yaml \
+    --save-cluster-config ./cluster-config.yaml
+
+  # Keep the bootstrap namespace for debugging
+  l8k discover --kubeconfig ~/.kube/config \
+    --keep-namespace \
     --save-cluster-config ./cluster-config.yaml
 
   # Agent mode (JSON output)
@@ -74,6 +79,7 @@ east-west vs north-south NICs, and probes OFED dependent modules.`,
 			SaveClusterConfig:       saveClusterConfig,
 			NetworkOperatorNamespace: networkOperatorNamespace,
 			NetworkOperatorRelease:   networkOperatorRelease,
+			KeepNamespace:            keepNamespace,
 			NodeSelector:            nodeSelector,
 			ImagePullSecrets:        imagePullSecrets,
 			EnabledPlugins:           parseEnabledPlugins(enabledPlugins),
@@ -99,13 +105,14 @@ func init() {
 	discoverCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (falls back to $KUBECONFIG, then ~/.kube/config)")
 	discoverCmd.Flags().StringVar(&userConfig, "user-config", "", "Base config to merge with discovered hardware")
 	discoverCmd.Flags().StringVar(&saveClusterConfig, "save-cluster-config", "", "Output path for cluster-config.yaml")
-	discoverCmd.Flags().StringVar(&networkOperatorNamespace, "network-operator-namespace", "", "Override operator namespace (default: nvidia-network-operator)")
+	discoverCmd.Flags().StringVar(&networkOperatorNamespace, "network-operator-namespace", "", "(deprecated, no-op for discover) Network Operator namespace override")
 	discoverCmd.Flags().StringVar(&networkOperatorRelease, "network-operator-release", "",
 		fmt.Sprintf("Network Operator release line to deploy (MAJOR.MINOR). Supported: %s",
 			strings.Join(networkoperatorplugin.SupportedReleases(), ", ")))
 	discoverCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Filter nodes by label")
 	discoverCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for NicClusterPolicy (comma-separated)")
 	discoverCmd.Flags().StringVar(&enabledPlugins, "enabled-plugins", "network-operator", "Comma-separated list of plugins to enable")
+	discoverCmd.Flags().BoolVar(&keepNamespace, "keep-namespace", false, "Skip teardown of the nvidia-k8s-launch-kit namespace (for debugging)")
 
 	setFlagGroup(discoverCmd, "kubeconfig", GroupCommon)
 	setFlagGroup(discoverCmd, "user-config", GroupCommon)
@@ -115,4 +122,5 @@ func init() {
 	setFlagGroup(discoverCmd, "image-pull-secrets", GroupCommon)
 	setFlagGroup(discoverCmd, "enabled-plugins", GroupCommon)
 	setFlagGroup(discoverCmd, "save-cluster-config", GroupDiscovery)
+	setFlagGroup(discoverCmd, "keep-namespace", GroupDiscovery)
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -76,6 +76,7 @@ var (
 	dryRunFlag                  bool
 	forPreset                   string
 	deployTimeoutRoot           time.Duration
+	keepNamespace               bool
 )
 
 // forFlagHelp builds the help string for `--for`. Computed at init() time so

--- a/pkg/kubeclient/kubeclient.go
+++ b/pkg/kubeclient/kubeclient.go
@@ -17,6 +17,7 @@
 package kubeclient
 
 import (
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,6 +43,7 @@ func New(kubeconfigPath string) (client.Client, *rest.Config, error) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = apiextv1.AddToScheme(scheme)
 	_ = netop.AddToScheme(scheme)
 	_ = nicop.AddToScheme(scheme)
 

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -26,11 +26,11 @@ import (
 	"time"
 
 	"github.com/Mellanox/doca-driver-build/entrypoint/pkg/mofedmodules"
-	netop "github.com/Mellanox/network-operator/api/v1alpha1"
 	nicop "github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/nvidia/k8s-launch-kit/pkg/kubeclient"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/internal/pciids"
+	"github.com/nvidia/k8s-launch-kit/pkg/nicconfigdaemon"
 	"github.com/nvidia/k8s-launch-kit/pkg/presetmatch"
 	"github.com/nvidia/k8s-launch-kit/pkg/presets"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
@@ -93,129 +93,41 @@ func isBlueField3Device(deviceID string) bool {
 func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c client.Client, defaultConfig *config.LaunchKubernetesConfig) error {
 	uiOutput := ui.FromContext(ctx)
 
-	// Ensure a NicClusterPolicy exists (error if any already exists, else create one)
-	policy := &netop.NicClusterPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nic-cluster-policy",
-			Namespace: defaultConfig.NetworkOperator.Namespace,
-		},
-		Spec: netop.NicClusterPolicySpec{
-			NicConfigurationOperator: &netop.NicConfigurationOperatorSpec{
-				Operator: &netop.ImageSpec{
-					Repository:       defaultConfig.NetworkOperator.Repository,
-					Image:            "nic-configuration-operator",
-					Version:          defaultConfig.NetworkOperator.ComponentVersion,
-					ImagePullSecrets: defaultConfig.NetworkOperator.ImagePullSecrets,
-				},
-				ConfigurationDaemon: &netop.ImageSpec{
-					Repository:       defaultConfig.NetworkOperator.Repository,
-					Image:            "nic-configuration-operator-daemon",
-					Version:          defaultConfig.NetworkOperator.ComponentVersion,
-					ImagePullSecrets: defaultConfig.NetworkOperator.ImagePullSecrets,
-				},
-			},
-		},
+	if defaultConfig.NetworkOperator == nil {
+		return fmt.Errorf("networkOperator section is required in config for discovery")
 	}
 
-	log.Log.Info("Deploying a thin NicClusterPolicy for cluster config discovery")
+	bootstrapOpts := nicconfigdaemon.Options{
+		Repository:       defaultConfig.NetworkOperator.Repository,
+		Version:          defaultConfig.NetworkOperator.ComponentVersion,
+		ImagePullSecrets: defaultConfig.NetworkOperator.ImagePullSecrets,
+	}
 
-	// Check if an existing NicClusterPolicy already has NicConfigurationOperator.
-	// If so, we can reuse it without redeploying.
-	existingPolicies, err := EnsureNicClusterPolicy(ctx, c, policy)
+	uiOutput.Info("Bootstrapping NIC configuration daemon in namespace %q", nicconfigdaemon.Namespace)
+	log.Log.Info("Bootstrapping NIC configuration daemon for discovery",
+		"namespace", nicconfigdaemon.Namespace, "image", bootstrapOpts.Image())
+	if err := nicconfigdaemon.Ensure(ctx, c, bootstrapOpts); err != nil {
+		return fmt.Errorf("failed to bootstrap NIC configuration daemon: %w", err)
+	}
+
+	if !p.KeepNamespace {
+		defer func() {
+			uiOutput.Info("Tearing down namespace %q", nicconfigdaemon.Namespace)
+			if cleanupErr := nicconfigdaemon.Cleanup(context.Background(), c); cleanupErr != nil {
+				log.Log.Error(cleanupErr, "failed to tear down discover bootstrap namespace",
+					"namespace", nicconfigdaemon.Namespace)
+				uiOutput.Warning("Failed to delete namespace %q: %v", nicconfigdaemon.Namespace, cleanupErr)
+			}
+		}()
+	} else {
+		uiOutput.Info("--keep-namespace set, leaving namespace %q in place after discovery", nicconfigdaemon.Namespace)
+	}
+
+	// Wait for daemon pods to become Ready in the bootstrap namespace.
+	expectedNodes, dsPods, _, err := waitForDaemonSetPods(ctx, c, uiOutput,
+		nicconfigdaemon.Namespace, nicconfigdaemon.DaemonSetName, 5*time.Minute)
 	if err != nil {
 		return err
-	}
-
-	reuseExisting := false
-	patchedPolicyName := ""
-	if len(existingPolicies) > 0 {
-		// Check if any existing policy already has the nic-configuration daemon with the required version
-		requiredVersion := defaultConfig.NetworkOperator.ComponentVersion
-		for _, ep := range existingPolicies {
-			if ep.Spec.NicConfigurationOperator != nil &&
-				ep.Spec.NicConfigurationOperator.ConfigurationDaemon != nil &&
-				ep.Spec.NicConfigurationOperator.ConfigurationDaemon.Version == requiredVersion {
-				reuseExisting = true
-				uiOutput.Info("Existing NicClusterPolicy already includes nic-configuration-daemon %s, reusing", requiredVersion)
-				log.Log.Info("Reusing existing NicClusterPolicy with NicConfigurationOperator",
-					"name", ep.Name, "version", requiredVersion)
-				break
-			}
-		}
-
-		if !reuseExisting {
-			// Patch existing policy to add NicConfigurationOperator (non-disruptive)
-			targetPolicy := existingPolicies[0]
-			uiOutput.Info("Patching existing NicClusterPolicy %q to add NicConfigurationOperator for discovery", targetPolicy.Name)
-
-			if err := PatchNicConfigOperatorIntoPolicy(ctx, c, targetPolicy.Name, policy.Spec.NicConfigurationOperator); err != nil {
-				return fmt.Errorf("failed to patch NicClusterPolicy with NicConfigurationOperator: %w", err)
-			}
-			if err := WaitNicClusterPolicyReady(ctx, c, targetPolicy.Name); err != nil {
-				return err
-			}
-			patchedPolicyName = targetPolicy.Name
-		}
-	} else {
-		uiOutput.Info("Deploying discovery profile")
-	}
-
-	// Cleanup: remove NicConfigurationOperator we patched in, or delete the thin policy we created
-	if patchedPolicyName != "" {
-		defer func() {
-			uiOutput.Info("Removing discovery NicConfigurationOperator from NicClusterPolicy %q", patchedPolicyName)
-			if err := RemoveNicConfigOperatorFromPolicy(ctx, c, patchedPolicyName); err != nil {
-				log.Log.Error(err, "failed to remove NicConfigurationOperator after discovery")
-				uiOutput.Error("Failed to remove NicConfigurationOperator: %v", err)
-			}
-		}()
-	} else if !reuseExisting {
-		defer func() {
-			if err := DeleteNicClusterPolicy(ctx, c, "nic-cluster-policy"); err != nil {
-				log.Log.Error(err, "failed to delete NicClusterPolicy after discovery")
-			} else {
-				log.Log.Info("NicClusterPolicy deleted after discovery")
-			}
-		}()
-	}
-
-	// After creation/patching, wait for nic-configuration-daemon pods to be Ready.
-	// If we just patched the policy, pods need time to start — poll with timeout.
-	// If we're reusing an existing policy, pods should already be running — try once,
-	// then fall back to the alternate namespace.
-	var expectedNodes []string
-	var dsPods []corev1.Pod
-	if reuseExisting {
-		primaryNS := defaultConfig.NetworkOperator.Namespace
-		uiOutput.Info("Checking for nic-configuration-daemon pods in namespace %q", primaryNS)
-		expectedNodes, dsPods, err = checkDaemonSetPodsReady(ctx, c, primaryNS, "nic-configuration-daemon")
-		if err != nil {
-			primaryErr := err
-			// Try the other common namespace before giving up (legacy chart-rename fallback)
-			alternateNS := alternateNamespace(primaryNS)
-			if alternateNS != "" {
-				uiOutput.Info("Initial probe in namespace %q failed, retrying in fallback namespace %q", primaryNS, alternateNS)
-				expectedNodes, dsPods, err = checkDaemonSetPodsReady(ctx, c, alternateNS, "nic-configuration-daemon")
-				if err == nil {
-					defaultConfig.NetworkOperator.Namespace = alternateNS
-				}
-			}
-			if err != nil {
-				if alternateNS != "" {
-					return fmt.Errorf("no nic-configuration-daemon pods found in namespace %q (also checked fallback namespace %q); use --network-operator-namespace to specify the correct namespace: %w", primaryNS, alternateNS, primaryErr)
-				}
-				return err
-			}
-		}
-	} else {
-		// We just patched/created the policy — pods need time to start.
-		// Poll both the configured namespace and alternate namespace.
-		var foundNS string
-		expectedNodes, dsPods, foundNS, err = waitForDaemonSetPods(ctx, c, uiOutput, defaultConfig.NetworkOperator.Namespace, "nic-configuration-daemon", 10*time.Minute)
-		if err != nil {
-			return err
-		}
-		defaultConfig.NetworkOperator.Namespace = foundNS
 	}
 
 	// Fetch node labels early — needed both for filtering and nodeSelector computation
@@ -236,13 +148,13 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 	}
 
 	// Wait for all expected nodes to report their NicDevice resources
-	if err := waitNicDevicesDiscovered(ctx, c, defaultConfig.NetworkOperator.Namespace, expectedNodes); err != nil {
+	if err := waitNicDevicesDiscovered(ctx, c, nicconfigdaemon.Namespace, expectedNodes); err != nil {
 		return err
 	}
 
 	// Get NicDevice resources and build ClusterConfig from their statuses
 	devices := &nicop.NicDeviceList{}
-	if err := c.List(ctx, devices, client.InNamespace(defaultConfig.NetworkOperator.Namespace)); err != nil {
+	if err := c.List(ctx, devices, client.InNamespace(nicconfigdaemon.Namespace)); err != nil {
 		return err
 	}
 
@@ -267,7 +179,7 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 			needProduct := group.GPUType == ""
 			if needMachine || needProduct {
 				machine, product := discoverHardwareTypes(ctx, p.RESTConfig,
-					defaultConfig.NetworkOperator.Namespace, group.WorkerNodes, dsPods,
+					nicconfigdaemon.Namespace, group.WorkerNodes, dsPods,
 					needMachine, needProduct)
 				if needMachine && machine != "" {
 					group.MachineType = machine
@@ -285,7 +197,7 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 			// Failures are non-fatal; when nvidia-smi is absent, today's
 			// part-number classification continues to govern.
 			discoverGPUTopology(ctx, p.RESTConfig,
-				defaultConfig.NetworkOperator.Namespace, group, dsPods)
+				nicconfigdaemon.Namespace, group, dsPods)
 
 			// Probe per-PF fabric type from active port state + subnet
 			// manager presence (more reliable than firmware link_layer
@@ -293,7 +205,7 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 			// the declarative defaults in `l8k generate` (Unit 8) to fill
 			// `--fabric` from the discovered group.
 			discoverGroupFabric(ctx, p.RESTConfig,
-				defaultConfig.NetworkOperator.Namespace, group, dsPods)
+				nicconfigdaemon.Namespace, group, dsPods)
 
 			// Try to enrich with a predefined topology preset for this
 			// (machine, GPU) pair. presetmatch.MatchGroup runs the
@@ -336,7 +248,7 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 			}
 
 			modules, err := discoverThirdPartyRDMAModules(ctx, p.RESTConfig,
-				defaultConfig.NetworkOperator.Namespace, group.WorkerNodes, dsPods)
+				nicconfigdaemon.Namespace, group.WorkerNodes, dsPods)
 			if err != nil {
 				log.Log.Error(err, "failed to discover OFED-dependent modules", "group", group.Identifier)
 				uiOutput.Warning("Could not discover OFED-dependent modules for group %s: %v", group.Identifier, err)
@@ -520,10 +432,11 @@ func checkDaemonSetPodsReady(ctx context.Context, c client.Client, namespace, da
 	return nodes, dsPods, nil
 }
 
-// waitForDaemonSetPods polls for daemon pods to become ready, checking both the
-// configured namespace and the alternate common namespace. This is needed after
-// patching a NicClusterPolicy to add NicConfigurationOperator, because the
-// network operator needs time to reconcile and create the DaemonSet pods.
+// waitForDaemonSetPods polls until the given DaemonSet has all its pods Ready in
+// the supplied namespace, or the timeout fires. Returns the node names the pods
+// landed on, the pods themselves, the namespace they were found in (always the
+// input namespace — the third return is preserved for callers that previously
+// distinguished between candidate namespaces), and an error.
 func waitForDaemonSetPods(parentCtx context.Context, c client.Client, uiOutput ui.Output, namespace, daemonSetName string, timeout time.Duration) ([]string, []corev1.Pod, string, error) {
 	altNS := alternateNamespace(namespace)
 	progressLabel := fmt.Sprintf("Waiting for %s pods in namespace %q (timeout: %s)", daemonSetName, namespace, timeout.Truncate(time.Second))
@@ -544,7 +457,6 @@ func waitForDaemonSetPods(parentCtx context.Context, c client.Client, uiOutput u
 
 	var lastErr error
 	for {
-		// Try the configured namespace first
 		nodes, pods, err := checkDaemonSetPodsReady(ctx, c, namespace, daemonSetName)
 		if err == nil {
 			progress.Success(fmt.Sprintf("Found %d pod(s) in namespace %q", len(pods), namespace))
@@ -574,8 +486,20 @@ func waitForDaemonSetPods(parentCtx context.Context, c client.Client, uiOutput u
 	}
 }
 
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
 // alternateNamespace returns the other common network operator namespace,
 // or empty string if the current namespace isn't one of the two known defaults.
+// Used by waitForDaemonSetPods as a legacy chart-rename fallback; for the
+// self-contained discover bootstrap (namespace nicconfigdaemon.Namespace),
+// it returns "" and the fallback path is a no-op.
 func alternateNamespace(current string) string {
 	switch current {
 	case "nvidia-network-operator":
@@ -585,15 +509,6 @@ func alternateNamespace(current string) string {
 	default:
 		return ""
 	}
-}
-
-func isPodReady(pod *corev1.Pod) bool {
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-	return false
 }
 
 // waitNicDevicesDiscovered polls until NicDevice objects exist for all expected nodes in the given namespace.

--- a/pkg/networkoperatorplugin/helper.go
+++ b/pkg/networkoperatorplugin/helper.go
@@ -21,11 +21,8 @@ import (
 	"fmt"
 	"time"
 
-	netop "github.com/Mellanox/network-operator/api/v1alpha1"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/crstate"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,56 +34,6 @@ import (
 // Only applies to the helper / discovery path — the deploy state machine
 // in ApplyManifestsFromDir is bounded solely by ctx.Deadline().
 const waitHelperDefaultTimeout = 15 * time.Minute
-
-// EnsureNicClusterPolicy checks for existing NicClusterPolicies and creates the provided one if none exist.
-// If policies already exist, returns them without creating a new one and without error.
-// If no policies exist, creates the provided policy, waits for it to become ready, and returns nil.
-func EnsureNicClusterPolicy(ctx context.Context, c client.Client, policy *netop.NicClusterPolicy) ([]netop.NicClusterPolicy, error) {
-	list := &netop.NicClusterPolicyList{}
-	if err := c.List(ctx, list); err != nil {
-		return nil, err
-	}
-	if len(list.Items) > 0 {
-		return list.Items, nil
-	}
-
-	if err := c.Create(ctx, policy); err != nil {
-		return nil, err
-	}
-
-	return nil, WaitNicClusterPolicyReady(ctx, c, policy.Name)
-}
-
-// DeleteNicClusterPolicies deletes the given NicClusterPolicies from the cluster.
-func DeleteNicClusterPolicies(ctx context.Context, c client.Client, policies []netop.NicClusterPolicy) error {
-	for i := range policies {
-		if err := c.Delete(ctx, &policies[i]); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed to delete existing NicClusterPolicy %q: %w", policies[i].Name, err)
-			}
-		}
-		log.Log.Info("Deleted existing NicClusterPolicy for discovery", "name", policies[i].Name)
-	}
-	return nil
-}
-
-// RestoreNicClusterPolicies re-creates previously saved NicClusterPolicies on the cluster.
-func RestoreNicClusterPolicies(ctx context.Context, c client.Client, policies []netop.NicClusterPolicy) error {
-	for i := range policies {
-		// Clear server-set fields so the object can be recreated
-		policies[i].ResourceVersion = ""
-		policies[i].UID = ""
-		policies[i].Generation = 0
-		policies[i].CreationTimestamp = metav1.Time{}
-		policies[i].ManagedFields = nil
-		policies[i].Status = netop.NicClusterPolicyStatus{}
-		if err := c.Create(ctx, &policies[i]); err != nil {
-			return fmt.Errorf("failed to restore NicClusterPolicy %q: %w", policies[i].Name, err)
-		}
-		log.Log.Info("Restored NicClusterPolicy after discovery", "name", policies[i].Name)
-	}
-	return nil
-}
 
 // WaitNicClusterPolicyReady polls NicClusterPolicy via the crstate
 // registry until it reaches StateSuccess or StateError, with a timeout.
@@ -166,57 +113,4 @@ func waitViaRegistry(parentCtx context.Context, c client.Client, gvk schema.Grou
 		case <-ticker.C:
 		}
 	}
-}
-
-// DeleteNicClusterPolicy deletes the NicClusterPolicy by name, ignoring NotFound errors.
-func DeleteNicClusterPolicy(ctx context.Context, c client.Client, name string) error {
-	obj := &netop.NicClusterPolicy{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	if err := c.Delete(ctx, obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	return nil
-}
-
-// PatchNicConfigOperatorIntoPolicy patches an existing NicClusterPolicy to add
-// the NicConfigurationOperator section via server-side apply, preserving all
-// other fields (ofedDriver, secondaryNetwork, etc.).
-func PatchNicConfigOperatorIntoPolicy(ctx context.Context, c client.Client, policyName string, nicConfigOp *netop.NicConfigurationOperatorSpec) error {
-	// Build a minimal apply-configuration containing only the field we want to own.
-	patch := &netop.NicClusterPolicy{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "mellanox.com/v1alpha1",
-			Kind:       "NicClusterPolicy",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: policyName,
-		},
-		Spec: netop.NicClusterPolicySpec{
-			NicConfigurationOperator: nicConfigOp,
-		},
-	}
-
-	return c.Patch(ctx, patch, client.Apply, client.FieldOwner("l8k-discovery"), client.ForceOwnership)
-}
-
-// RemoveNicConfigOperatorFromPolicy removes the NicConfigurationOperator section
-// that was added during discovery by fetching the policy and updating it.
-func RemoveNicConfigOperatorFromPolicy(ctx context.Context, c client.Client, policyName string) error {
-	policy := &netop.NicClusterPolicy{}
-	if err := c.Get(ctx, client.ObjectKey{Name: policyName}, policy); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to get NicClusterPolicy %q for cleanup: %w", policyName, err)
-	}
-
-	policy.Spec.NicConfigurationOperator = nil
-	if err := c.Update(ctx, policy); err != nil {
-		return fmt.Errorf("failed to remove NicConfigurationOperator from %q: %w", policyName, err)
-	}
-
-	log.Log.Info("Removed NicConfigurationOperator from NicClusterPolicy after discovery", "name", policyName)
-	return nil
 }

--- a/pkg/networkoperatorplugin/networkoperator.go
+++ b/pkg/networkoperatorplugin/networkoperator.go
@@ -44,6 +44,11 @@ type NetworkOperatorPlugin struct {
 	GpuType      string
 	NodeSelector map[string]string
 	RESTConfig   *rest.Config
+
+	// KeepNamespace, when true, suppresses teardown of the
+	// nicconfigdaemon.Namespace at the end of DiscoverClusterConfig — useful
+	// for debugging a failed discovery.
+	KeepNamespace bool
 }
 
 func (p *NetworkOperatorPlugin) GetName() string {

--- a/pkg/nicconfigdaemon/assets/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
+++ b/pkg/nicconfigdaemon/assets/crds/configuration.net.nvidia.com_nicconfigurationtemplates.yaml
@@ -1,0 +1,284 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: nicconfigurationtemplates.configuration.net.nvidia.com
+spec:
+  group: configuration.net.nvidia.com
+  names:
+    kind: NicConfigurationTemplate
+    listKind: NicConfigurationTemplateList
+    plural: nicconfigurationtemplates
+    singular: nicconfigurationtemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NicConfigurationTemplate is the Schema for the nicconfigurationtemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Defines the desired state of NICs
+            properties:
+              nicSelector:
+                description: NIC selector configuration
+                properties:
+                  nicType:
+                    description: Type of the NIC to be selected, e.g. 101d,1015,a2d6
+                      etc.
+                    type: string
+                  pciAddresses:
+                    description: Array of PCI addresses to be selected, e.g. "0000:03:00.0"
+                    items:
+                      pattern: ^0000:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
+                      type: string
+                    type: array
+                  serialNumbers:
+                    description: Serial numbers of the NICs to be selected, e.g. MT2116X09299
+                    items:
+                      type: string
+                    type: array
+                required:
+                - nicType
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector contains labels required on the node. When
+                  empty, the template will be applied to matching devices on all nodes.
+                type: object
+              resetToDefault:
+                default: false
+                description: |-
+                  ResetToDefault specifies whether node agent needs to perform a reset flow
+                  The following operations will be performed:
+                  * Nvconfig reset of all non-volatile configurations
+                    - Mstconfig -d <device> reset for each PF
+                    - Mstconfig -d <device> set ADVANCED_PCI_SETTINGS=1
+                  * Node reboot
+                    - Applies new NIC NV config
+                    - Will undo any runtime configuration previously performed for the device/driver
+                type: boolean
+              template:
+                description: Configuration template to be applied to matching devices
+                properties:
+                  gpuDirectOptimized:
+                    description: GPU Direct optimization settings
+                    properties:
+                      enabled:
+                        description: Optimize GPU Direct
+                        type: boolean
+                      env:
+                        description: GPU direct environment, e.g. Baremetal
+                        type: string
+                    required:
+                    - enabled
+                    - env
+                    type: object
+                  linkType:
+                    description: LinkType to be configured, Ethernet|Infiniband
+                    enum:
+                    - Ethernet
+                    - Infiniband
+                    type: string
+                  numVfs:
+                    description: Number of VFs to be configured
+                    type: integer
+                  pciPerformanceOptimized:
+                    description: PCI performance optimization settings
+                    properties:
+                      enabled:
+                        description: Specifies whether to enable PCI performance optimization
+                        type: boolean
+                      maxAccOutRead:
+                        description: Specifies the PCIe Max Accumulative Outstanding
+                          read bytes
+                        type: integer
+                      maxReadRequest:
+                        description: Specifies the size of a single PCI read request
+                          in bytes
+                        enum:
+                        - 128
+                        - 256
+                        - 512
+                        - 1024
+                        - 2048
+                        - 4096
+                        type: integer
+                    required:
+                    - enabled
+                    type: object
+                  rawNvConfig:
+                    description: List of arbitrary nv config parameters
+                    items:
+                      properties:
+                        name:
+                          description: Name of the arbitrary nvconfig parameter
+                          type: string
+                        value:
+                          description: Value of the arbitrary nvconfig parameter
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  roceOptimized:
+                    description: RoCE optimization settings
+                    properties:
+                      enabled:
+                        description: Optimize RoCE
+                        type: boolean
+                      qos:
+                        description: Quality of Service settings
+                        properties:
+                          pfc:
+                            description: Priority-based Flow Control configuration,
+                              e.g. "0,0,0,1,0,0,0,0"
+                            pattern: ^([01],){7}[01]$
+                            type: string
+                          tos:
+                            description: 8-bit value for type of service
+                            type: integer
+                          trust:
+                            description: Trust mode for QoS settings, e.g. trust-dscp
+                            type: string
+                        required:
+                        - pfc
+                        - trust
+                        type: object
+                    required:
+                    - enabled
+                    type: object
+                  spectrumXOptimized:
+                    description: Spectrum-X optimization settings. Works only with
+                      linkType==Ethernet && numVfs==0. Other optimizations must be
+                      skipped or disabled. RawNvConfig must be empty.
+                    properties:
+                      enabled:
+                        description: Optimize Spectrum X
+                        type: boolean
+                      multiplaneMode:
+                        default: none
+                        description: |-
+                          Multiplane mode to be configured
+                          Can be "none", "swplb", "hwplb", or "uniplane"
+                        enum:
+                        - none
+                        - swplb
+                        - hwplb
+                        - uniplane
+                        type: string
+                      numberOfPlanes:
+                        default: 1
+                        description: Number of planes to be configured
+                        enum:
+                        - 1
+                        - 2
+                        - 4
+                        type: integer
+                      overlay:
+                        default: none
+                        description: |-
+                          Overlay mode to be configured
+                          Can be "l3" or "none"
+                        enum:
+                        - l3
+                        - none
+                        type: string
+                      version:
+                        description: Version of the Spectrum-X architecture to optimize
+                          for
+                        enum:
+                        - RA1.3
+                        - RA2.0
+                        - RA2.1
+                        type: string
+                    required:
+                    - enabled
+                    - version
+                    type: object
+                    x-kubernetes-validations:
+                    - message: when MultiplaneMode is none, numberOfPlanes must be
+                        1
+                      rule: '!has(self.multiplaneMode) || !has(self.numberOfPlanes)
+                        || self.multiplaneMode != ''none'' || self.numberOfPlanes
+                        == 1'
+                    - message: when MultiplaneMode is not none, numberOfPlanes must
+                        not be 1
+                      rule: '!has(self.multiplaneMode) || !has(self.numberOfPlanes)
+                        || self.multiplaneMode == ''none'' || self.numberOfPlanes
+                        != 1'
+                    - message: when Version is RA1.3 or RA2.0, MultiplaneMode must
+                        be none and numberOfPlanes must be 1
+                      rule: '!has(self.version) || !has(self.multiplaneMode) || !has(self.numberOfPlanes)
+                        || !(self.version == ''RA1.3'' || self.version == ''RA2.0'')
+                        || (self.multiplaneMode == ''none'' && self.numberOfPlanes
+                        == 1)'
+                required:
+                - linkType
+                - numVfs
+                type: object
+                x-kubernetes-validations:
+                - message: spectrumXOptimized can be enabled only when linkType=='Ethernet'
+                    and numVfs==1
+                  rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                    || (self.linkType == ''Ethernet'' && self.numVfs == 1)'
+                - message: spectrumXOptimized includes RoCE optimizations, so separate
+                    roceOptimized section must not be enabled
+                  rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                    || !(has(self.roceOptimized) && self.roceOptimized.enabled)'
+                - message: when spectrumXOptimized is enabled, rawNvConfig must be
+                    empty
+                  rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                    || !has(self.rawNvConfig) || size(self.rawNvConfig) == 0'
+            required:
+            - nicSelector
+            - template
+            type: object
+            x-kubernetes-validations:
+            - message: spectrumXOptimized can be enabled only for ConnectX-8 or BlueField-3
+                SuperNICs
+              rule: '!(has(self.template.spectrumXOptimized) && self.template.spectrumXOptimized.enabled)
+                || (self.nicSelector.nicType == ''1023'' || self.nicSelector.nicType
+                == ''a2dc'')'
+            - message: hwplb MultiplaneMode can only be enabled for ConnectX-8 (NicType
+                1023)
+              rule: '!has(self.template.spectrumXOptimized) || !has(self.template.spectrumXOptimized.multiplaneMode)
+                || self.template.spectrumXOptimized.multiplaneMode != ''hwplb'' ||
+                self.nicSelector.nicType == ''1023'''
+          status:
+            description: Defines the observed state of NicConfigurationTemplate
+            properties:
+              nicDevices:
+                description: NicDevice CRs matching this configuration / firmware
+                  template
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/nicconfigdaemon/assets/crds/configuration.net.nvidia.com_nicdevices.yaml
+++ b/pkg/nicconfigdaemon/assets/crds/configuration.net.nvidia.com_nicdevices.yaml
@@ -1,0 +1,409 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: nicdevices.configuration.net.nvidia.com
+spec:
+  group: configuration.net.nvidia.com
+  names:
+    kind: NicDevice
+    listKind: NicDeviceList
+    plural: nicdevices
+    singular: nicdevice
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NicDevice is the Schema for the nicdevices API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NicDeviceSpec defines the desired state of NicDevice
+            properties:
+              configuration:
+                description: Configuration specifies the configuration requested by
+                  NicConfigurationTemplate
+                properties:
+                  resetToDefault:
+                    description: |-
+                      ResetToDefault specifies whether node agent needs to perform a reset flow.
+                      The following operations will be performed:
+                      * Nvconfig reset of all non-volatile configurations
+                        - Mstconfig -d <device> reset for each PF
+                        - Mstconfig -d <device> set ADVANCED_PCI_SETTINGS=1
+                      * Node reboot
+                        - Applies new NIC NV config
+                        - Will undo any runtime configuration previously performed for the device/driver
+                    type: boolean
+                  template:
+                    description: Configuration template applied from the NicConfigurationTemplate
+                      CR
+                    properties:
+                      gpuDirectOptimized:
+                        description: GPU Direct optimization settings
+                        properties:
+                          enabled:
+                            description: Optimize GPU Direct
+                            type: boolean
+                          env:
+                            description: GPU direct environment, e.g. Baremetal
+                            type: string
+                        required:
+                        - enabled
+                        - env
+                        type: object
+                      linkType:
+                        description: LinkType to be configured, Ethernet|Infiniband
+                        enum:
+                        - Ethernet
+                        - Infiniband
+                        type: string
+                      numVfs:
+                        description: Number of VFs to be configured
+                        type: integer
+                      pciPerformanceOptimized:
+                        description: PCI performance optimization settings
+                        properties:
+                          enabled:
+                            description: Specifies whether to enable PCI performance
+                              optimization
+                            type: boolean
+                          maxAccOutRead:
+                            description: Specifies the PCIe Max Accumulative Outstanding
+                              read bytes
+                            type: integer
+                          maxReadRequest:
+                            description: Specifies the size of a single PCI read request
+                              in bytes
+                            enum:
+                            - 128
+                            - 256
+                            - 512
+                            - 1024
+                            - 2048
+                            - 4096
+                            type: integer
+                        required:
+                        - enabled
+                        type: object
+                      rawNvConfig:
+                        description: List of arbitrary nv config parameters
+                        items:
+                          properties:
+                            name:
+                              description: Name of the arbitrary nvconfig parameter
+                              type: string
+                            value:
+                              description: Value of the arbitrary nvconfig parameter
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      roceOptimized:
+                        description: RoCE optimization settings
+                        properties:
+                          enabled:
+                            description: Optimize RoCE
+                            type: boolean
+                          qos:
+                            description: Quality of Service settings
+                            properties:
+                              pfc:
+                                description: Priority-based Flow Control configuration,
+                                  e.g. "0,0,0,1,0,0,0,0"
+                                pattern: ^([01],){7}[01]$
+                                type: string
+                              tos:
+                                description: 8-bit value for type of service
+                                type: integer
+                              trust:
+                                description: Trust mode for QoS settings, e.g. trust-dscp
+                                type: string
+                            required:
+                            - pfc
+                            - trust
+                            type: object
+                        required:
+                        - enabled
+                        type: object
+                      spectrumXOptimized:
+                        description: Spectrum-X optimization settings. Works only
+                          with linkType==Ethernet && numVfs==0. Other optimizations
+                          must be skipped or disabled. RawNvConfig must be empty.
+                        properties:
+                          enabled:
+                            description: Optimize Spectrum X
+                            type: boolean
+                          multiplaneMode:
+                            default: none
+                            description: |-
+                              Multiplane mode to be configured
+                              Can be "none", "swplb", "hwplb", or "uniplane"
+                            enum:
+                            - none
+                            - swplb
+                            - hwplb
+                            - uniplane
+                            type: string
+                          numberOfPlanes:
+                            default: 1
+                            description: Number of planes to be configured
+                            enum:
+                            - 1
+                            - 2
+                            - 4
+                            type: integer
+                          overlay:
+                            default: none
+                            description: |-
+                              Overlay mode to be configured
+                              Can be "l3" or "none"
+                            enum:
+                            - l3
+                            - none
+                            type: string
+                          version:
+                            description: Version of the Spectrum-X architecture to
+                              optimize for
+                            enum:
+                            - RA1.3
+                            - RA2.0
+                            - RA2.1
+                            type: string
+                        required:
+                        - enabled
+                        - version
+                        type: object
+                        x-kubernetes-validations:
+                        - message: when MultiplaneMode is none, numberOfPlanes must
+                            be 1
+                          rule: '!has(self.multiplaneMode) || !has(self.numberOfPlanes)
+                            || self.multiplaneMode != ''none'' || self.numberOfPlanes
+                            == 1'
+                        - message: when MultiplaneMode is not none, numberOfPlanes
+                            must not be 1
+                          rule: '!has(self.multiplaneMode) || !has(self.numberOfPlanes)
+                            || self.multiplaneMode == ''none'' || self.numberOfPlanes
+                            != 1'
+                        - message: when Version is RA1.3 or RA2.0, MultiplaneMode
+                            must be none and numberOfPlanes must be 1
+                          rule: '!has(self.version) || !has(self.multiplaneMode) ||
+                            !has(self.numberOfPlanes) || !(self.version == ''RA1.3''
+                            || self.version == ''RA2.0'') || (self.multiplaneMode
+                            == ''none'' && self.numberOfPlanes == 1)'
+                    required:
+                    - linkType
+                    - numVfs
+                    type: object
+                    x-kubernetes-validations:
+                    - message: spectrumXOptimized can be enabled only when linkType=='Ethernet'
+                        and numVfs==1
+                      rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                        || (self.linkType == ''Ethernet'' && self.numVfs == 1)'
+                    - message: spectrumXOptimized includes RoCE optimizations, so
+                        separate roceOptimized section must not be enabled
+                      rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                        || !(has(self.roceOptimized) && self.roceOptimized.enabled)'
+                    - message: when spectrumXOptimized is enabled, rawNvConfig must
+                        be empty
+                      rule: '!(has(self.spectrumXOptimized) && self.spectrumXOptimized.enabled)
+                        || !has(self.rawNvConfig) || size(self.rawNvConfig) == 0'
+                type: object
+              firmware:
+                description: Firmware specifies the fw upgrade policy requested by
+                  NicFirmwareTemplate
+                properties:
+                  nicFirmwareSourceRef:
+                    description: NicFirmwareSourceRef refers to existing NicFirmwareSource
+                      CR on where to get the FW from
+                    type: string
+                  updatePolicy:
+                    description: UpdatePolicy indicates whether the operator needs
+                      to validate installed FW or upgrade it
+                    enum:
+                    - Validate
+                    - Update
+                    type: string
+                required:
+                - nicFirmwareSourceRef
+                - updatePolicy
+                type: object
+              interfaceNameTemplate:
+                description: InterfaceNameTemplate specifies the interface name template
+                  to be applied to the NIC
+                properties:
+                  netDevicePrefix:
+                    description: NetDevicePrefix specifies the prefix for the net
+                      device name
+                    type: string
+                  nicIndex:
+                    description: NicIndex is the index of the NIC in the flattened
+                      list of NICs based on the Template
+                    type: integer
+                  planeIndices:
+                    description: PlaneIndices is the indices of the planes for the
+                      given NIC based on the Template
+                    items:
+                      type: integer
+                    type: array
+                  railIndex:
+                    description: RailIndex is the index of the rail where the given
+                      NIC belongs to based on the Template
+                    type: integer
+                  rdmaDevicePrefix:
+                    type: string
+                required:
+                - netDevicePrefix
+                - nicIndex
+                - planeIndices
+                - railIndex
+                - rdmaDevicePrefix
+                type: object
+            type: object
+          status:
+            description: NicDeviceStatus defines the observed state of NicDevice
+            properties:
+              conditions:
+                description: List of conditions observed for the device
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              dpu:
+                description: DPU indicates if the device is a BlueField in DPU mode
+                type: boolean
+              firmwareVersion:
+                description: Firmware version currently installed on the device, e.g.
+                  22.31.1014
+                type: string
+              modelName:
+                description: ModelName is the model name of the device, e.g. ConnectX-6
+                  or BlueField-3
+                type: string
+              node:
+                description: Node where the device is located
+                type: string
+              partNumber:
+                description: Part number of the device, e.g. MCX713106AEHEA_QP1
+                type: string
+              ports:
+                description: List of ports for the device
+                items:
+                  description: NicDevicePortSpec describes the ports of the NIC
+                  properties:
+                    networkInterface:
+                      description: NetworkInterface is the name of the network interface
+                        for this port, e.g. eth1
+                      type: string
+                    pci:
+                      description: PCI is a PCI address of the port, e.g. 0000:3b:00.0
+                      type: string
+                    rdmaInterface:
+                      description: RdmaInterface is the name of the rdma interface
+                        for this port, e.g. mlx5_1
+                      type: string
+                  required:
+                  - pci
+                  type: object
+                type: array
+              psid:
+                description: Product Serial ID of the device, e.g. MT_0000000221
+                type: string
+              serialNumber:
+                description: Serial number of the device, e.g. MT2116X09299
+                type: string
+              superNIC:
+                description: SuperNIC indicates if the device is a SuperNIC
+                type: boolean
+              type:
+                description: Type of device, e.g. ConnectX7
+                type: string
+            required:
+            - dpu
+            - firmwareVersion
+            - modelName
+            - node
+            - partNumber
+            - ports
+            - psid
+            - serialNumber
+            - superNIC
+            - type
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/nicconfigdaemon/assets/crds/configuration.net.nvidia.com_nicfirmwaresources.yaml
+++ b/pkg/nicconfigdaemon/assets/crds/configuration.net.nvidia.com_nicfirmwaresources.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: nicfirmwaresources.configuration.net.nvidia.com
+spec:
+  group: configuration.net.nvidia.com
+  names:
+    kind: NicFirmwareSource
+    listKind: NicFirmwareSourceList
+    plural: nicfirmwaresources
+    singular: nicfirmwaresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NicFirmwareSource is the Schema for the nicfirmwaresources API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NicFirmwareSourceSpec represents a list of url sources for
+              FW
+            properties:
+              bfbUrlSource:
+                description: BFBUrlSource represents a url source for BlueField Bundle
+                type: string
+              binUrlSources:
+                description: BinUrlSources represents a list of url sources for ConnectX
+                  Firmware
+                items:
+                  type: string
+                minItems: 1
+                type: array
+              docaSpcXCCUrlSource:
+                description: |-
+                  DocaSpcXCCUrlSource represents a url source for DOCA SPC-X CC .deb package for ubuntu 22.04
+                  Will be removed in the future, once Doca SPC-X CC algorithm will be publicly available
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: At least one of binUrlSources, bfbUrlSource, or docaSpcXCCUrlSource
+                must be specified
+              rule: size(self.binUrlSources) > 0 || size(self.bfbUrlSource) > 0 ||
+                size(self.docaSpcXCCUrlSource) > 0
+          status:
+            description: NicFirmwareSourceStatus represents the status of the FW from
+              given sources, e.g. version available for PSIDs
+            properties:
+              bfbVersions:
+                additionalProperties:
+                  type: string
+                description: BFBVersions represents the FW versions available in the
+                  provided BFB bundle
+                type: object
+              binaryVersions:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: |-
+                  Versions is a map of available FW binaries versions to PSIDs
+                  a PSID should have only a single FW version available for it
+                type: object
+              docaSpcXCCVersion:
+                description: DocaSpcXCCVersion represents the FW versions available
+                  in the provided DOCA SPC-X CC .deb package for ubuntu 22.04
+                type: string
+              reason:
+                description: Reason shows an error message if occurred
+                type: string
+              state:
+                description: State represents the firmware processing state
+                enum:
+                - Downloading
+                - Processing
+                - Success
+                - ProcessingFailed
+                - DownloadFailed
+                - CacheVerificationFailed
+                type: string
+            required:
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/nicconfigdaemon/assets/crds/configuration.net.nvidia.com_nicfirmwaretemplates.yaml
+++ b/pkg/nicconfigdaemon/assets/crds/configuration.net.nvidia.com_nicfirmwaretemplates.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: nicfirmwaretemplates.configuration.net.nvidia.com
+spec:
+  group: configuration.net.nvidia.com
+  names:
+    kind: NicFirmwareTemplate
+    listKind: NicFirmwareTemplateList
+    plural: nicfirmwaretemplates
+    singular: nicfirmwaretemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NicFirmwareTemplate is the Schema for the nicfirmwaretemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NicFirmwareTemplateSpec defines the FW templates and node/nic
+              selectors for it
+            properties:
+              nicSelector:
+                description: NIC selector configuration
+                properties:
+                  nicType:
+                    description: Type of the NIC to be selected, e.g. 101d,1015,a2d6
+                      etc.
+                    type: string
+                  pciAddresses:
+                    description: Array of PCI addresses to be selected, e.g. "0000:03:00.0"
+                    items:
+                      pattern: ^0000:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$
+                      type: string
+                    type: array
+                  serialNumbers:
+                    description: Serial numbers of the NICs to be selected, e.g. MT2116X09299
+                    items:
+                      type: string
+                    type: array
+                required:
+                - nicType
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector contains labels required on the node. When
+                  empty, the template will be applied to matching devices on all nodes.
+                type: object
+              template:
+                description: Firmware update template
+                properties:
+                  nicFirmwareSourceRef:
+                    description: NicFirmwareSourceRef refers to existing NicFirmwareSource
+                      CR on where to get the FW from
+                    type: string
+                  updatePolicy:
+                    description: UpdatePolicy indicates whether the operator needs
+                      to validate installed FW or upgrade it
+                    enum:
+                    - Validate
+                    - Update
+                    type: string
+                required:
+                - nicFirmwareSourceRef
+                - updatePolicy
+                type: object
+            required:
+            - nicSelector
+            - template
+            type: object
+          status:
+            description: NicTemplateStatus defines the observed state of NicConfigurationTemplate
+              and NicFirmwareTemplate
+            properties:
+              nicDevices:
+                description: NicDevice CRs matching this configuration / firmware
+                  template
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/nicconfigdaemon/assets/crds/configuration.net.nvidia.com_nicinterfacenametemplates.yaml
+++ b/pkg/nicconfigdaemon/assets/crds/configuration.net.nvidia.com_nicinterfacenametemplates.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: nicinterfacenametemplates.configuration.net.nvidia.com
+spec:
+  group: configuration.net.nvidia.com
+  names:
+    kind: NicInterfaceNameTemplate
+    listKind: NicInterfaceNameTemplateList
+    plural: nicinterfacenametemplates
+    singular: nicinterfacenametemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NicInterfaceNameTemplate is the Schema for the nicinterfacenametemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NicInterfaceNameTemplateSpec defines the desired state of
+              NicInterfaceNameTemplate
+            properties:
+              netDevicePrefix:
+                description: |-
+                  NetDevicePrefix specifies the prefix for the net device name
+                  %nic_id%, %plane_id% and %rail_id% placeholders can be used to construct the device name
+                  %nic_id% is the index of the NIC in the flattened list of NICs
+                  %plane_id% is the index of the plane of the specific NIC
+                  %rail_id% is the index of the rail where the given NIC belongs to
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector contains labels required on the node. When
+                  empty, the template will be applied to matching devices on all nodes.
+                type: object
+              pfsPerNic:
+                description: |-
+                  PfsPerNic specifies the number of PFs per NIC
+                  Used to calculate the number of planes per NIC
+                type: integer
+              railPciAddresses:
+                description: |-
+                  RailPciAddresses defines the PCI address to rail mapping and order
+                  The first dimension is the rail index, the second dimension is the PCI addresses of the NICs in the rail.
+                  The PCI addresses must be sorted in the order of the rails.
+                  Example: [["0000:1a:00.0", "0000:2a:00.0"], ["0000:3a:00.0", "0000:4a:00.0"]] specifies 2 rails with 2 NICs each.
+                items:
+                  items:
+                    type: string
+                  type: array
+                type: array
+              rdmaDevicePrefix:
+                description: |-
+                  RdmaDevicePrefix specifies the prefix for the rdma device name
+                  %nic_id%, %plane_id% and %rail_id% placeholders can be used to construct the device name
+                  %nic_id% is the index of the NIC in the flattened list of NICs
+                  %plane_id% is the index of the plane of the specific NIC
+                  %rail_id% is the index of the rail where the given NIC belongs to
+                type: string
+            required:
+            - netDevicePrefix
+            - pfsPerNic
+            - railPciAddresses
+            - rdmaDevicePrefix
+            type: object
+          status:
+            description: NicInterfaceNameTemplateStatus defines the observed state
+              of NicInterfaceNameTemplate
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/nicconfigdaemon/assets/daemon.yaml.tmpl
+++ b/pkg/nicconfigdaemon/assets/daemon.yaml.tmpl
@@ -1,0 +1,183 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: k8s-launch-kit
+    app.kubernetes.io/component: discover
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .SAName }}
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: k8s-launch-kit
+---
+# Empty stand-in for the ConfigMap normally shipped by the
+# nic-configuration-operator Helm chart. The daemon's
+# helper.InitNicFwMapFromConfigMap performs a Get on this name at startup
+# and exits if it errors; an empty Data map is enough to let init succeed
+# (NicFirmwareMap stays empty, which is fine — discovery doesn't drive
+# firmware upgrades).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nic-configuration-operator-supported-nic-firmware
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: k8s-launch-kit
+data: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .ClusterRoleName }}
+  labels:
+    app.kubernetes.io/managed-by: k8s-launch-kit
+rules:
+- apiGroups:
+  - configuration.net.nvidia.com
+  resources:
+  - nicdevices
+  - nicdevices/status
+  - nicconfigurationtemplates
+  - nicfirmwaretemplates
+  - nicfirmwaresources
+  - nicinterfacenametemplates
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - maintenance.nvidia.com
+  resources:
+  - nodemaintenances
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .ClusterRoleBindingName }}
+  labels:
+    app.kubernetes.io/managed-by: k8s-launch-kit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .ClusterRoleName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .SAName }}
+  namespace: {{ .Namespace }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .DaemonSetName }}
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/name: nic-configuration-daemon
+    app.kubernetes.io/managed-by: k8s-launch-kit
+spec:
+  selector:
+    matchLabels:
+      control-plane: nic-configuration-daemon
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: nic-configuration-daemon
+      labels:
+        control-plane: nic-configuration-daemon
+        app.kubernetes.io/name: nic-configuration-daemon
+        app.kubernetes.io/managed-by: k8s-launch-kit
+    spec:
+      hostPID: true
+      priorityClassName: system-node-critical
+      serviceAccountName: {{ .SAName }}
+      terminationGracePeriodSeconds: 10
+      nodeSelector:
+        feature.node.kubernetes.io/pci-15b3.present: "true"
+{{- if .ImagePullSecrets }}
+      imagePullSecrets:
+{{- range .ImagePullSecrets }}
+        - name: {{ . }}
+{{- end }}
+{{- end }}
+      containers:
+        - name: nic-configuration-daemon
+          image: {{ .Image }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LOG_LEVEL
+              value: {{ .LogLevel }}
+          volumeMounts:
+            - name: sys
+              mountPath: /sys
+              readOnly: false
+      volumes:
+        - name: sys
+          hostPath:
+            path: /sys

--- a/pkg/nicconfigdaemon/assets/embed.go
+++ b/pkg/nicconfigdaemon/assets/embed.go
@@ -1,0 +1,27 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package assets embeds the NIC Configuration Operator CRD YAMLs and the daemon
+// manifest template used by l8k discover's self-contained bootstrap.
+package assets
+
+import "embed"
+
+//go:embed crds/*.yaml
+var CRDs embed.FS
+
+//go:embed daemon.yaml.tmpl
+var DaemonTemplate string

--- a/pkg/nicconfigdaemon/bootstrap.go
+++ b/pkg/nicconfigdaemon/bootstrap.go
@@ -1,0 +1,292 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package nicconfigdaemon bootstraps a self-contained NIC Configuration Daemon
+// into a private namespace so that `l8k discover` can collect NicDevice CRs
+// without requiring a pre-installed Network Operator Helm release.
+package nicconfigdaemon
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"strings"
+	"text/template"
+
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	yaml "sigs.k8s.io/yaml"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/nicconfigdaemon/assets"
+)
+
+const (
+	// Namespace is the private namespace into which `l8k discover` deploys
+	// the NIC Configuration Daemon and its companion RBAC.
+	Namespace = "nvidia-k8s-launch-kit"
+
+	// DaemonImageName is the container image short name; the caller composes
+	// the full image reference as "<repository>/<DaemonImageName>:<version>".
+	DaemonImageName = "nic-configuration-operator-daemon"
+
+	// SAName is the ServiceAccount used by the bootstrapped daemon. Renamed
+	// from upstream "controller-manager" to avoid colliding with a coexisting
+	// Network Operator install in the same cluster.
+	SAName = "k8s-launch-kit-nic-config-daemon"
+
+	// ClusterRoleName / ClusterRoleBindingName are cluster-scoped so they must
+	// not collide with upstream "manager-role" / "manager-rolebinding".
+	ClusterRoleName        = "k8s-launch-kit-nic-config-daemon"
+	ClusterRoleBindingName = "k8s-launch-kit-nic-config-daemon"
+
+	// DaemonSetName matches the upstream name. The discovery code looks for
+	// pods owned by a DaemonSet with this name in the Namespace above.
+	DaemonSetName = "nic-configuration-daemon"
+
+	// DefaultLogLevel is used when Options.LogLevel is empty.
+	DefaultLogLevel = "info"
+)
+
+// Options configures a bootstrap of the self-contained NIC Configuration
+// Daemon.
+type Options struct {
+	// Repository is the container image repository (e.g. "nvcr.io/nvidia/mellanox").
+	Repository string
+
+	// Version is the image tag corresponding to the chosen Network Operator
+	// release line (e.g. "v1.3.1").
+	Version string
+
+	// ImagePullSecrets is forwarded onto the DaemonSet pod spec.
+	ImagePullSecrets []string
+
+	// LogLevel sets the LOG_LEVEL env var on the daemon container. Defaults
+	// to DefaultLogLevel when empty.
+	LogLevel string
+}
+
+// Image returns the fully qualified image reference for the daemon.
+func (o Options) Image() string {
+	return fmt.Sprintf("%s/%s:%s", strings.TrimRight(o.Repository, "/"), DaemonImageName, o.Version)
+}
+
+// Ensure creates the private namespace, applies the NIC Configuration Operator
+// CRDs if they are missing, and applies the daemon SA/RBAC/DaemonSet via
+// server-side apply. It is idempotent: re-running over a partially-bootstrapped
+// state is safe.
+//
+// CRDs are intentionally only created when absent — a coexisting Network
+// Operator install may own the CRDs at a different version and we must not
+// fight it.
+func Ensure(ctx context.Context, c client.Client, opts Options) error {
+	if opts.Repository == "" {
+		return fmt.Errorf("nicconfigdaemon: Options.Repository is required")
+	}
+	if opts.Version == "" {
+		return fmt.Errorf("nicconfigdaemon: Options.Version is required")
+	}
+	if opts.LogLevel == "" {
+		opts.LogLevel = DefaultLogLevel
+	}
+
+	if err := ensureCRDs(ctx, c); err != nil {
+		return fmt.Errorf("failed to ensure CRDs: %w", err)
+	}
+
+	manifests, err := renderDaemonManifests(opts)
+	if err != nil {
+		return fmt.Errorf("failed to render daemon manifests: %w", err)
+	}
+
+	for _, obj := range manifests {
+		if err := applyUnstructured(ctx, c, obj); err != nil {
+			return fmt.Errorf("failed to apply %s/%s: %w", obj.GetKind(), obj.GetName(), err)
+		}
+		log.Log.V(1).Info("Applied bootstrap manifest",
+			"kind", obj.GetKind(), "name", obj.GetName(), "namespace", obj.GetNamespace())
+	}
+	return nil
+}
+
+// ensureCRDs reads every YAML under the embedded crds/ dir and creates it on
+// the cluster if no CRD with the same name exists yet.
+func ensureCRDs(ctx context.Context, c client.Client) error {
+	entries, err := fs.ReadDir(assets.CRDs, "crds")
+	if err != nil {
+		return fmt.Errorf("read embedded CRDs: %w", err)
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf("no CRDs embedded under crds/")
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		data, rErr := fs.ReadFile(assets.CRDs, "crds/"+entry.Name())
+		if rErr != nil {
+			return fmt.Errorf("read embedded CRD %s: %w", entry.Name(), rErr)
+		}
+		desired := &apiextv1.CustomResourceDefinition{}
+		if uErr := yaml.Unmarshal(data, desired); uErr != nil {
+			return fmt.Errorf("decode embedded CRD %s: %w", entry.Name(), uErr)
+		}
+
+		existing := &apiextv1.CustomResourceDefinition{}
+		getErr := c.Get(ctx, types.NamespacedName{Name: desired.Name}, existing)
+		switch {
+		case getErr == nil:
+			log.Log.V(1).Info("CRD already present; leaving untouched",
+				"name", desired.Name)
+		case apierrors.IsNotFound(getErr):
+			// Strip the resourceVersion just in case the YAML carried one.
+			desired.ResourceVersion = ""
+			if cErr := c.Create(ctx, desired); cErr != nil && !apierrors.IsAlreadyExists(cErr) {
+				return fmt.Errorf("create CRD %s: %w", desired.Name, cErr)
+			}
+			log.Log.Info("Installed NIC Configuration Operator CRD",
+				"name", desired.Name)
+		default:
+			return fmt.Errorf("get CRD %s: %w", desired.Name, getErr)
+		}
+	}
+	return nil
+}
+
+// renderDaemonManifests executes the embedded daemon.yaml.tmpl against opts
+// and decodes each YAML document into an *unstructured.Unstructured ready for
+// server-side apply.
+func renderDaemonManifests(opts Options) ([]*unstructured.Unstructured, error) {
+	tmpl, err := template.New("daemon").Parse(assets.DaemonTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("parse daemon template: %w", err)
+	}
+
+	data := map[string]interface{}{
+		"Namespace":              Namespace,
+		"SAName":                 SAName,
+		"ClusterRoleName":        ClusterRoleName,
+		"ClusterRoleBindingName": ClusterRoleBindingName,
+		"DaemonSetName":          DaemonSetName,
+		"Image":                  opts.Image(),
+		"ImagePullSecrets":       opts.ImagePullSecrets,
+		"LogLevel":               opts.LogLevel,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("execute daemon template: %w", err)
+	}
+
+	return decodeMultiDocYAML(buf.Bytes())
+}
+
+// decodeMultiDocYAML splits a multi-document YAML stream on `---` separators
+// and decodes each document into *unstructured.Unstructured with GVK set.
+func decodeMultiDocYAML(raw []byte) ([]*unstructured.Unstructured, error) {
+	var out []*unstructured.Unstructured
+	for _, doc := range splitYAMLDocuments(string(raw)) {
+		trimmed := strings.TrimSpace(doc)
+		if trimmed == "" {
+			continue
+		}
+		// Skip pure-comment documents.
+		nonComment := false
+		for _, line := range strings.Split(trimmed, "\n") {
+			if l := strings.TrimSpace(line); l != "" && !strings.HasPrefix(l, "#") {
+				nonComment = true
+				break
+			}
+		}
+		if !nonComment {
+			continue
+		}
+
+		obj := &unstructured.Unstructured{}
+		if err := yaml.Unmarshal([]byte(doc), obj); err != nil {
+			return nil, fmt.Errorf("decode manifest: %w", err)
+		}
+		if obj.GetKind() == "" {
+			return nil, fmt.Errorf("manifest is missing kind: %s", trimmed)
+		}
+		if apiv := obj.GetAPIVersion(); apiv != "" {
+			gv, gErr := schema.ParseGroupVersion(apiv)
+			if gErr != nil {
+				return nil, fmt.Errorf("parse apiVersion %q: %w", apiv, gErr)
+			}
+			obj.SetGroupVersionKind(gv.WithKind(obj.GetKind()))
+		}
+		out = append(out, obj)
+	}
+	return out, nil
+}
+
+// splitYAMLDocuments splits a YAML stream on lines that start with '---'.
+// (Mirrors the helper in pkg/networkoperatorplugin/deploy.go but kept local
+// so this package has no dependency on its caller.)
+func splitYAMLDocuments(s string) []string {
+	var docs []string
+	var cur []string
+	for _, ln := range strings.Split(s, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(ln), "---") {
+			if len(cur) > 0 {
+				docs = append(docs, strings.Join(cur, "\n"))
+				cur = nil
+			}
+			continue
+		}
+		cur = append(cur, ln)
+	}
+	if len(cur) > 0 {
+		docs = append(docs, strings.Join(cur, "\n"))
+	}
+	return docs
+}
+
+// applyUnstructured creates the object if it does not exist, otherwise
+// overwrites it via Update with the existing resourceVersion. This Get →
+// Create-or-Update pattern is functionally equivalent to a single-owner SSA
+// for the kinds we render (Namespace, SA, ClusterRole, ClusterRoleBinding,
+// DaemonSet) and works against both real clusters and the controller-runtime
+// fake client (which does not implement server-side apply).
+func applyUnstructured(ctx context.Context, c client.Client, obj *unstructured.Unstructured) error {
+	key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(obj.GroupVersionKind())
+	getErr := c.Get(ctx, key, existing)
+	switch {
+	case apierrors.IsNotFound(getErr):
+		create := obj.DeepCopy()
+		create.SetResourceVersion("")
+		if err := c.Create(ctx, create); err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		return nil
+	case getErr != nil:
+		return getErr
+	default:
+		update := obj.DeepCopy()
+		update.SetResourceVersion(existing.GetResourceVersion())
+		return c.Update(ctx, update)
+	}
+}

--- a/pkg/nicconfigdaemon/bootstrap_test.go
+++ b/pkg/nicconfigdaemon/bootstrap_test.go
@@ -1,0 +1,290 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nicconfigdaemon
+
+import (
+	"context"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	yaml "sigs.k8s.io/yaml"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/nicconfigdaemon/assets"
+)
+
+const (
+	testRepo    = "nvcr.io/nvidia/mellanox"
+	testVersion = "v1.3.1"
+)
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, apiextv1.AddToScheme(scheme))
+	return scheme
+}
+
+func newFakeClient(t *testing.T, initObjs ...client.Object) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(initObjs...).
+		Build()
+}
+
+// embeddedCRDNames returns the metadata.name of every CRD shipped under
+// pkg/nicconfigdaemon/assets/crds. Used so tests stay in sync with the
+// vendored set without hard-coding the count.
+func embeddedCRDNames(t *testing.T) []string {
+	t.Helper()
+	entries, err := fs.ReadDir(assets.CRDs, "crds")
+	require.NoError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		data, rErr := fs.ReadFile(assets.CRDs, "crds/"+entry.Name())
+		require.NoError(t, rErr)
+		crd := &apiextv1.CustomResourceDefinition{}
+		require.NoError(t, yaml.Unmarshal(data, crd))
+		require.NotEmpty(t, crd.Name, "embedded CRD %s is missing metadata.name", entry.Name())
+		names = append(names, crd.Name)
+	}
+	return names
+}
+
+func TestEnsure_CreatesNamespaceAndCRDsWhenMissing(t *testing.T) {
+	c := newFakeClient(t)
+
+	require.NoError(t, Ensure(context.Background(), c, Options{
+		Repository: testRepo,
+		Version:    testVersion,
+	}))
+
+	// Namespace
+	ns := &corev1.Namespace{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: Namespace}, ns))
+
+	// SA
+	sa := &corev1.ServiceAccount{}
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Namespace: Namespace, Name: SAName}, sa))
+
+	// ClusterRole + ClusterRoleBinding
+	cr := &rbacv1.ClusterRole{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: ClusterRoleName}, cr))
+	crb := &rbacv1.ClusterRoleBinding{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: ClusterRoleBindingName}, crb))
+
+	// DaemonSet
+	ds := &appsv1.DaemonSet{}
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Namespace: Namespace, Name: DaemonSetName}, ds))
+
+	// CRDs: every embedded YAML was created
+	for _, name := range embeddedCRDNames(t) {
+		crd := &apiextv1.CustomResourceDefinition{}
+		require.NoErrorf(t, c.Get(context.Background(), types.NamespacedName{Name: name}, crd),
+			"CRD %q missing after Ensure", name)
+	}
+}
+
+func TestEnsure_SkipsCRDsWhenPresent(t *testing.T) {
+	// Pre-create every embedded CRD with a non-default annotation so we can
+	// confirm Ensure left them untouched.
+	prePopulated := make([]client.Object, 0)
+	for _, name := range embeddedCRDNames(t) {
+		prePopulated = append(prePopulated, &apiextv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Annotations: map[string]string{"pre-existing": "true"},
+			},
+			Spec: apiextv1.CustomResourceDefinitionSpec{
+				Group: "configuration.net.nvidia.com",
+				Names: apiextv1.CustomResourceDefinitionNames{
+					Kind:     "Placeholder",
+					ListKind: "PlaceholderList",
+					Plural:   "placeholders",
+					Singular: "placeholder",
+				},
+				Scope: apiextv1.NamespaceScoped,
+				Versions: []apiextv1.CustomResourceDefinitionVersion{
+					{Name: "v1alpha1", Served: true, Storage: true,
+						Schema: &apiextv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextv1.JSONSchemaProps{Type: "object"},
+						}},
+				},
+			},
+		})
+	}
+	c := newFakeClient(t, prePopulated...)
+
+	require.NoError(t, Ensure(context.Background(), c, Options{
+		Repository: testRepo,
+		Version:    testVersion,
+	}))
+
+	for _, name := range embeddedCRDNames(t) {
+		crd := &apiextv1.CustomResourceDefinition{}
+		require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: name}, crd))
+		// Annotation survives → Ensure did not overwrite.
+		assert.Equal(t, "true", crd.Annotations["pre-existing"], "Ensure must not touch pre-existing CRD %q", name)
+		// The placeholder Kind survives → CRD spec was not replaced.
+		assert.Equal(t, "Placeholder", crd.Spec.Names.Kind)
+	}
+}
+
+func TestEnsure_AppliesDaemonSetWithExpectedImage(t *testing.T) {
+	c := newFakeClient(t)
+
+	pullSecrets := []string{"my-registry-creds"}
+	require.NoError(t, Ensure(context.Background(), c, Options{
+		Repository:       testRepo,
+		Version:          testVersion,
+		ImagePullSecrets: pullSecrets,
+		LogLevel:         "debug",
+	}))
+
+	ds := &appsv1.DaemonSet{}
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Namespace: Namespace, Name: DaemonSetName}, ds))
+
+	require.Len(t, ds.Spec.Template.Spec.Containers, 1)
+	container := ds.Spec.Template.Spec.Containers[0]
+
+	expectedImage := testRepo + "/" + DaemonImageName + ":" + testVersion
+	assert.Equal(t, expectedImage, container.Image, "daemon image mismatch")
+
+	// LOG_LEVEL flowed through from Options
+	var logLevelEnv string
+	for _, e := range container.Env {
+		if e.Name == "LOG_LEVEL" {
+			logLevelEnv = e.Value
+		}
+	}
+	assert.Equal(t, "debug", logLevelEnv)
+
+	// ImagePullSecrets surfaced on the pod spec
+	require.Len(t, ds.Spec.Template.Spec.ImagePullSecrets, 1)
+	assert.Equal(t, "my-registry-creds", ds.Spec.Template.Spec.ImagePullSecrets[0].Name)
+
+	// nodeSelector pins to Mellanox-NIC nodes
+	assert.Equal(t, "true",
+		ds.Spec.Template.Spec.NodeSelector["feature.node.kubernetes.io/pci-15b3.present"])
+
+	// Privileged + hostPID required for the daemon to read /sys
+	assert.True(t, ds.Spec.Template.Spec.HostPID)
+	require.NotNil(t, container.SecurityContext)
+	require.NotNil(t, container.SecurityContext.Privileged)
+	assert.True(t, *container.SecurityContext.Privileged)
+}
+
+func TestEnsure_Idempotent(t *testing.T) {
+	c := newFakeClient(t)
+	opts := Options{Repository: testRepo, Version: testVersion}
+
+	require.NoError(t, Ensure(context.Background(), c, opts))
+	// Second call must not error or leave duplicates behind.
+	require.NoError(t, Ensure(context.Background(), c, opts))
+
+	// Single namespace exists.
+	ns := &corev1.Namespace{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: Namespace}, ns))
+}
+
+func TestEnsure_RejectsEmptyRepositoryOrVersion(t *testing.T) {
+	c := newFakeClient(t)
+
+	err := Ensure(context.Background(), c, Options{Version: testVersion})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Repository")
+
+	err = Ensure(context.Background(), c, Options{Repository: testRepo})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Version")
+}
+
+func TestOptions_Image_TrimsTrailingSlashOnRepository(t *testing.T) {
+	opts := Options{Repository: "nvcr.io/nvidia/mellanox/", Version: "v1.3.1"}
+	assert.Equal(t, "nvcr.io/nvidia/mellanox/nic-configuration-operator-daemon:v1.3.1", opts.Image())
+}
+
+func TestCleanup_DeletesNamespaceAndClusterRBAC(t *testing.T) {
+	c := newFakeClient(t)
+	require.NoError(t, Ensure(context.Background(), c, Options{
+		Repository: testRepo,
+		Version:    testVersion,
+	}))
+
+	require.NoError(t, Cleanup(context.Background(), c))
+
+	// Namespace removed
+	err := c.Get(context.Background(), types.NamespacedName{Name: Namespace}, &corev1.Namespace{})
+	assert.True(t, apierrors.IsNotFound(err), "namespace should be gone, got: %v", err)
+
+	// ClusterRole/ClusterRoleBinding removed
+	err = c.Get(context.Background(), types.NamespacedName{Name: ClusterRoleName}, &rbacv1.ClusterRole{})
+	assert.True(t, apierrors.IsNotFound(err))
+	err = c.Get(context.Background(), types.NamespacedName{Name: ClusterRoleBindingName}, &rbacv1.ClusterRoleBinding{})
+	assert.True(t, apierrors.IsNotFound(err))
+
+	// CRDs intentionally remain in place (so external NicDevice CRs survive).
+	for _, name := range embeddedCRDNames(t) {
+		err := c.Get(context.Background(), types.NamespacedName{Name: name}, &apiextv1.CustomResourceDefinition{})
+		assert.NoErrorf(t, err, "CRD %q should remain after Cleanup", name)
+	}
+}
+
+func TestCleanup_NamespaceMissingIsNoOp(t *testing.T) {
+	c := newFakeClient(t)
+
+	// Nothing was ever created; Cleanup must succeed.
+	require.NoError(t, Cleanup(context.Background(), c))
+}
+
+func TestRenderDaemonManifests_AllExpectedKindsPresent(t *testing.T) {
+	objs, err := renderDaemonManifests(Options{
+		Repository: testRepo,
+		Version:    testVersion,
+		LogLevel:   "info",
+	})
+	require.NoError(t, err)
+
+	kinds := map[string]bool{}
+	for _, o := range objs {
+		kinds[strings.ToLower(o.GetKind())] = true
+	}
+	for _, expected := range []string{"namespace", "serviceaccount", "clusterrole", "clusterrolebinding", "daemonset"} {
+		assert.True(t, kinds[expected], "expected manifest kind %q to be rendered", expected)
+	}
+}

--- a/pkg/nicconfigdaemon/teardown.go
+++ b/pkg/nicconfigdaemon/teardown.go
@@ -1,0 +1,88 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nicconfigdaemon
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Cleanup removes everything Ensure created, except the CRDs. CRDs are left in
+// place so any NicDevice CRs that other tools or future runs may rely on are
+// not silently destroyed.
+//
+// Best effort: errors on individual deletes are logged but do not abort the
+// remaining deletes — the caller typically runs Cleanup from a defer in the
+// discovery path.
+func Cleanup(ctx context.Context, c client.Client) error {
+	if err := deleteNamespace(ctx, c); err != nil {
+		log.Log.Error(err, "failed to delete bootstrap namespace", "namespace", Namespace)
+	}
+
+	// ClusterRoleBinding and ClusterRole are cluster-scoped, so cascade deletion
+	// of the namespace does NOT remove them — delete them explicitly.
+	if err := deleteClusterRoleBinding(ctx, c); err != nil {
+		log.Log.Error(err, "failed to delete cluster role binding", "name", ClusterRoleBindingName)
+	}
+	if err := deleteClusterRole(ctx, c); err != nil {
+		log.Log.Error(err, "failed to delete cluster role", "name", ClusterRoleName)
+	}
+	return nil
+}
+
+func deleteNamespace(ctx context.Context, c client.Client) error {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: Namespace}}
+	if err := c.Delete(ctx, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("delete namespace %s: %w", Namespace, err)
+	}
+	log.Log.Info("Deleted bootstrap namespace", "namespace", Namespace)
+	return nil
+}
+
+func deleteClusterRole(ctx context.Context, c client.Client) error {
+	cr := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: ClusterRoleName}}
+	if err := c.Delete(ctx, cr); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("delete ClusterRole %s: %w", ClusterRoleName, err)
+	}
+	log.Log.V(1).Info("Deleted ClusterRole", "name", ClusterRoleName)
+	return nil
+}
+
+func deleteClusterRoleBinding(ctx context.Context, c client.Client) error {
+	crb := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: ClusterRoleBindingName}}
+	if err := c.Delete(ctx, crb); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("delete ClusterRoleBinding %s: %w", ClusterRoleBindingName, err)
+	}
+	log.Log.V(1).Info("Deleted ClusterRoleBinding", "name", ClusterRoleBindingName)
+	return nil
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -32,7 +32,11 @@ type Options struct {
 	// cluster-config.yaml and never errors on "no profile selected".
 	DiscoverOnly      bool
 	SaveClusterConfig string // Path to save discovered config
-	NetworkOperatorNamespace string   // Override namespace for Network Operator (optional)
+	NetworkOperatorNamespace string // Override namespace for Network Operator (optional; ignored by `discover`)
+	// KeepNamespace, when true, suppresses teardown of the
+	// nvidia-k8s-launch-kit bootstrap namespace at the end of `discover` —
+	// useful for debugging a failed run.
+	KeepNamespace bool
 	// NetworkOperatorRelease is a MAJOR.MINOR catalog key (e.g. "26.4"), not
 	// a full semver. Selects component image tags + repository from the
 	// embedded releases catalog and drives version-gated template sections.

--- a/skills/k8s-launch-kit-discover/SKILL.md
+++ b/skills/k8s-launch-kit-discover/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-discover
-version: 1.1.0
+version: 1.2.0
 description: "Use this skill when the user wants to discover their Kubernetes cluster's network hardware capabilities using k8s-launch-kit (l8k). Activate for: cluster discovery, hardware detection, NIC detection, finding what GPUs or NICs are in a cluster, creating a cluster config file, or when the user says 'discover' in the context of l8k or NVIDIA networking."
 metadata:
   requires:
@@ -12,6 +12,15 @@ metadata:
 > **PREREQUISITE:** Read `../k8s-launch-kit-shared/SKILL.md` for install paths, global flags, and output modes.
 
 Discover cluster hardware and produce a `cluster-config.yaml` describing NICs, GPUs, rails, and node groups.
+
+**l8k discover is self-contained.** It does NOT require a pre-installed
+Network Operator. On every run it bootstraps the NIC Configuration Daemon
+(and the 5 nic-configuration-operator CRDs, only if missing) into a private
+namespace `nvidia-k8s-launch-kit`, reads `NicDevice` CRs published by the
+daemon, then tears the namespace down on exit (unless `--keep-namespace`
+is set). The daemon image is pulled from `<networkOperator.repository>/
+nic-configuration-operator-daemon:<networkOperator.componentVersion>` (both
+fields come from `l8k-config.yaml`).
 
 ## Usage (from AI agent)
 
@@ -34,10 +43,11 @@ l8k discover --save-cluster-config <OUTPUT> [--kubeconfig <PATH>]
 |------|----------|---------|-------------|
 | `--kubeconfig` | — | `$KUBECONFIG` env var | Path to kubeconfig (optional — falls back to env var) |
 | `--save-cluster-config` | Yes | — | Output path for cluster-config.yaml |
-| `--network-operator-namespace` | — | `nvidia-network-operator` | Override operator namespace |
+| `--keep-namespace` | — | `false` | Skip teardown of the `nvidia-k8s-launch-kit` bootstrap namespace (for debugging) |
+| `--network-operator-namespace` | — | — | **Deprecated for `discover`**: accepted but ignored. The daemon always runs in `nvidia-k8s-launch-kit`. Still used by `l8k generate` / `l8k deploy`. |
 | `--user-config` | — | — | Base config to merge with discovered hardware |
-| `--node-selector` | — | — | Restrict to matching nodes |
-| `--image-pull-secrets` | — | — | Image pull secret names for NicClusterPolicy (comma-separated) |
+| `--node-selector` | — | `feature.node.kubernetes.io/pci-15b3.present=true` | Restrict daemon scheduling + NicDevice wait to matching nodes |
+| `--image-pull-secrets` | — | — | Image pull secret names (comma-separated). Forwarded onto the bootstrapped DaemonSet pod spec. |
 
 ## Examples
 
@@ -50,10 +60,10 @@ l8k discover \
 # Using $KUBECONFIG env var (no --kubeconfig needed)
 l8k discover --save-cluster-config ./cluster-config.yaml
 
-# Non-default operator namespace
+# Keep the bootstrap namespace for debugging
 l8k discover \
   --kubeconfig ~/.kube/config \
-  --network-operator-namespace network-operator \
+  --keep-namespace \
   --save-cluster-config ./cluster-config.yaml
 
 # Merge with existing config
@@ -110,14 +120,34 @@ resolved.
 
 ## Prerequisites
 
-- NVIDIA Network Operator Helm chart installed in the cluster
-- Node Feature Discovery (NFD) active with `NodeFeature` CRDs populated
-- Worker nodes with label `feature.node.kubernetes.io/pci-15b3.present=true`
+- Node Feature Discovery (NFD) active on the cluster so worker nodes
+  carry `feature.node.kubernetes.io/pci-15b3.present=true` (the daemon's
+  nodeSelector — without it, no daemon pods schedule and discovery times
+  out)
+- Image-pull access from every worker node to
+  `<networkOperator.repository>/nic-configuration-operator-daemon:<networkOperator.componentVersion>`.
+  Use `--image-pull-secrets <name>` (or `networkOperator.imagePullSecrets`
+  in the config file) for private registries.
+- Network Operator does **NOT** need to be pre-installed.
 
 ## Tips
 
-- If discovery fails with "no pods found for DaemonSet", the error will suggest using `--network-operator-namespace`. Common namespaces are `nvidia-network-operator` and `network-operator`.
-- Discovery uses server-side apply (field owner `l8k-discovery`) — it won't conflict with an existing NicClusterPolicy.
+- The bootstrap namespace is **always** `nvidia-k8s-launch-kit` — not configurable. The
+  daemon's SA / ClusterRole / ClusterRoleBinding are renamed to
+  `k8s-launch-kit-nic-config-daemon` so they don't collide with the cluster-scoped
+  names a coexisting Network Operator install would create.
+- CRDs (`nicdevices`, `nicconfigurationtemplates`, etc.) are applied **only when missing**.
+  If they already exist (because Network Operator or a prior l8k discover run created
+  them), they're left alone — discovery never overwrites a different version.
+- After discovery finishes the namespace is torn down (cascade-delete handles SA /
+  RoleBinding / DaemonSet / pods / NicDevice CRs); the CRDs intentionally persist so
+  any external NicDevice consumers survive. Cluster-scoped ClusterRole /
+  ClusterRoleBinding are deleted explicitly.
+- Pass `--keep-namespace` to leave the namespace in place — useful when debugging
+  daemon pod start-up failures (`kubectl describe pod -n nvidia-k8s-launch-kit`).
+- If daemon pods don't go Ready within 5 minutes, discovery aborts. Common causes:
+  ImagePullBackOff (check the image tag exists in your registry), no nodes match
+  `pci-15b3.present=true` (NFD not running or no Mellanox NICs), pull-secret missing.
 - After determining each group's `(machineType, gpuType)`, discovery looks up a topology preset under `presets/` using **exact-match** lookup on that pair. A matching preset overrides heuristic-derived topology fields (traffic class, rail, NUMA, GPU affinity). There is no any-GPU fallback — a preset with empty `gpuType:` is rejected at load time. If no preset matches, discovery proceeds with heuristic classification.
 - If you already know the SKU and want to skip cluster discovery entirely, use `l8k generate --for <preset>` (see `k8s-launch-kit-generate`).
 

--- a/skills/k8s-launch-kit-discover/references/discovery-internals.md
+++ b/skills/k8s-launch-kit-discover/references/discovery-internals.md
@@ -6,21 +6,46 @@ are made.
 
 ---
 
-## Non-Disruptive Discovery
+## Self-Contained Bootstrap (no Network Operator required)
 
-Discovery must be safe to run on production clusters. To achieve this, l8k never
-deletes or recreates the NicClusterPolicy. Instead it uses **server-side apply** with
-field owner `l8k-discovery`.
+Discovery does not depend on a pre-installed Network Operator. On every `l8k discover`
+run, the CLI bootstraps just the NIC Configuration Daemon (and its CRDs, if missing)
+into a private namespace, reads the resulting `NicDevice` CRs, then tears the
+namespace down.
 
-- If no NicClusterPolicy exists, discovery creates a minimal one that enables only the
-  NIC configuration daemon.
-- If a NicClusterPolicy already exists (e.g., managed by Helm or another controller),
-  discovery patches only the fields it owns (`l8k-discovery`). Fields owned by other
-  managers are left untouched.
-- On conflict (another manager owns a field discovery needs to set), discovery reports
-  the conflict and exits with code 3 rather than forcing an overwrite.
+The objects created by `Ensure(ctx, c, opts)` (`pkg/nicconfigdaemon/`) on every run:
 
-This approach ensures discovery never disrupts an existing Network Operator deployment.
+| Kind | Name | Scope | Lifecycle |
+|------|------|-------|-----------|
+| `Namespace` | `nvidia-k8s-launch-kit` | cluster | created on `Ensure`, deleted on `Cleanup` (cascade) |
+| `CustomResourceDefinition` | `nicdevices.configuration.net.nvidia.com` and 4 others | cluster | applied **only when absent** — never overwritten; persist after cleanup |
+| `ServiceAccount` | `k8s-launch-kit-nic-config-daemon` | namespaced | created on `Ensure`, deleted by namespace cascade |
+| `ClusterRole` | `k8s-launch-kit-nic-config-daemon` | cluster | created on `Ensure`, deleted explicitly on `Cleanup` |
+| `ClusterRoleBinding` | `k8s-launch-kit-nic-config-daemon` | cluster | created on `Ensure`, deleted explicitly on `Cleanup` |
+| `ConfigMap` | `nic-configuration-operator-supported-nic-firmware` (empty `data: {}`) | namespaced | empty stand-in so the daemon's startup Get succeeds; deleted by namespace cascade |
+| `DaemonSet` | `nic-configuration-daemon` | namespaced | image = `<networkOperator.repository>/nic-configuration-operator-daemon:<networkOperator.componentVersion>`; pinned to `feature.node.kubernetes.io/pci-15b3.present=true`; deleted by namespace cascade |
+
+### Why renamed RBAC
+
+The upstream nic-configuration-operator Helm chart uses cluster-scoped names
+`controller-manager`, `manager-role`, `manager-rolebinding`. Discovery uses
+`k8s-launch-kit-nic-config-daemon` for all three so it can coexist with a Network
+Operator install without collision.
+
+### Why CRDs persist
+
+Cleanup deletes the namespace and the cluster RBAC but **not** the CRDs. If the
+discover run was the thing that installed them, removing them would orphan any
+`NicDevice` CRs other tools or future runs may rely on — and CRD deletion would
+require also removing every CR. The cost of leaving them: 5 schema definitions in
+the API server, no controllers, no consumed resources.
+
+### `--keep-namespace`
+
+Adds a single skip to the `defer Cleanup(...)` call so the bootstrap survives the
+exit. Use for `kubectl describe pod -n nvidia-k8s-launch-kit` post-mortems when
+daemon pods don't go Ready (ImagePullBackOff, missing pull secret, no
+`pci-15b3.present` nodes).
 
 ---
 

--- a/skills/k8s-launch-kit-pipeline/SKILL.md
+++ b/skills/k8s-launch-kit-pipeline/SKILL.md
@@ -47,7 +47,8 @@ l8k --discover-cluster-config \
   --spectrum-x RA2.2 --multiplane-mode hwplb --number-of-planes 4 \
   --save-deployment-files ./output --deploy
 
-# Non-default operator namespace
+# Non-default operator namespace (applies to generate/deploy only — discover
+# always uses its own nvidia-k8s-launch-kit namespace)
 l8k --discover-cluster-config \
   --kubeconfig ~/.kube/config \
   --network-operator-namespace network-operator \

--- a/skills/k8s-launch-kit-shared/SKILL.md
+++ b/skills/k8s-launch-kit-shared/SKILL.md
@@ -61,7 +61,7 @@ The root command `l8k --discover-cluster-config ...` still works for backward-co
 | `--output <FORMAT>` | Output format: `text` (default), `json` |
 | `--yes` / `-y` | Auto-confirm all prompts (root command only — **not available on subcommands**; `--output json` auto-confirms) |
 | `--quiet` / `-q` | Suppress informational output (errors still shown) |
-| `--network-operator-namespace <NS>` | Override network operator namespace (default: `nvidia-network-operator`) |
+| `--network-operator-namespace <NS>` | Override network operator namespace (default: `nvidia-network-operator`). **No-op for `l8k discover`** — discover always bootstraps into `nvidia-k8s-launch-kit`; the flag still applies to `l8k generate` / `l8k deploy` / `l8k validate`. |
 | `--pod-namespace <NS>` | Namespace for pods and network resources (default: `default`) |
 | `--node-selector <LABELS>` | Restrict to nodes matching labels (comma-separated, ANDed) |
 | `--image-pull-secrets <NAMES>` | Image pull secret names for NicClusterPolicy (comma-separated) |
@@ -135,8 +135,10 @@ deployment types, flags, exit codes, and output formats.
 
 ## Network Operator Namespace Resolution
 
-Both `nvidia-network-operator` and `network-operator` are common default namespaces. If l8k fails with "no pods found", the error message will suggest using `--network-operator-namespace` to specify the correct namespace.
+Applies to `l8k generate` / `l8k deploy` / `l8k validate` only. `l8k discover`
+manages its own private namespace (`nvidia-k8s-launch-kit`) and ignores this flag.
 
-When the user does not specify a namespace and discovery fails:
-1. Check the error message for the namespace hint
-2. Retry with `--network-operator-namespace <correct-namespace>`
+Both `nvidia-network-operator` and `network-operator` are common default namespaces
+for an existing Network Operator install. If `l8k generate` / `l8k deploy` /
+`l8k validate` can't find Network Operator resources, retry with
+`--network-operator-namespace <correct-namespace>`.

--- a/skills/k8s-launch-kit-troubleshoot/SKILL.md
+++ b/skills/k8s-launch-kit-troubleshoot/SKILL.md
@@ -53,7 +53,8 @@ kubectl get pods -A -o wide | grep -E 'ContainerCreating|Init'
 | `CrashLoopBackOff` on mofed pods | Kernel module conflict | Check `thirdPartyRDMAModules`, enable `unloadThirdPartyRDMAModules` |
 | No VFs on node | SriovNetworkNodePolicy not matching | Verify `nodeSelector` labels match worker nodes |
 | RDMA not working | Missing RDMA device plugin or wrong resource name | Check `rdma-shared-dp` pods, verify resource annotations |
-| NIC config daemon not starting | Operator namespace mismatch | Verify `--network-operator-namespace` matches actual namespace |
+| `l8k discover` daemon pods stuck (ImagePullBackOff / Pending) | Bad image tag, missing pull secret, or no `feature.node.kubernetes.io/pci-15b3.present=true` nodes | Re-run with `--keep-namespace` then `kubectl describe pod -n nvidia-k8s-launch-kit`. Fix `networkOperator.componentVersion` / pass `--image-pull-secrets` / verify NFD is running. |
+| `l8k validate` / `deploy` can't find Network Operator pods | Operator namespace mismatch | Verify `--network-operator-namespace` matches actual namespace (does NOT apply to `l8k discover` — it ignores the flag and uses its own `nvidia-k8s-launch-kit` namespace) |
 | IPPool not allocating | NV-IPAM subnet exhausted or misconfigured | Check `ippools` CR status, verify CIDR ranges |
 | `--for requires --node-selector` | `--for` was passed without `--node-selector` | Add `--node-selector key=val,…`. The synthesized clusterConfig has no live worker-node list; the selector identifies target nodes at apply time. |
 | `--for and --discover-cluster-config are mutually exclusive` | Both flags passed simultaneously | Pick one: `--for` skips discovery, `--discover-cluster-config` runs it. |


### PR DESCRIPTION
l8k discover used to require a pre-installed Network Operator: it deployed a thin NicClusterPolicy with a NicConfigurationOperator section to spin up nic-configuration-daemon pods, then read NicDevice CRs from the NO namespace. That made discovery downstream of the full NO Helm install even though discovery itself needs nothing from OFED, device plugins, networks, or IPAM.

Discover now bootstraps just the NIC configuration daemon (and the 5 nic-configuration-operator CRDs, only if missing) into a private namespace nvidia-k8s-launch-kit, lets the daemon publish NicDevice CRs there, runs the existing build/probe pipeline against that namespace, and tears the namespace down at exit. l8k generate and l8k deploy are unchanged.

New package pkg/nicconfigdaemon (Ensure + Cleanup + vendored CRDs + daemon template) drives the bootstrap. The renamed SA / ClusterRole / ClusterRoleBinding (k8s-launch-kit-nic-config-daemon) avoid cluster-scoped name collisions with a coexisting NO install. An empty nic-configuration-operator-supported-nic-firmware ConfigMap is seeded so the daemon's startup Get on it succeeds without the upstream Helm chart; discovery doesn't drive firmware upgrades so the data map can stay empty.

New flag --keep-namespace skips the teardown defer for debugging. The legacy --network-operator-namespace flag is now a no-op for discover (accepted to avoid breaking scripts).

CRDs are vendored under pkg/nicconfigdaemon/assets/crds and sync'd from the go.mod-pinned nic-configuration-operator module via a new manual `make sync-nic-config-crds` target; never wired into the default build so library consumers can compile without code-gen prerequisites.