### PR TITLE
validate: gate PF section-header tint on actual conflict

### DIFF
--- a/pkg/networkoperatorplugin/connectivity/report.go
+++ b/pkg/networkoperatorplugin/connectivity/report.go
@@ -257,6 +257,19 @@ func reportFuncMap() template.FuncMap {
 			}
 			return "state-unknown"
 		},
+		// pfsHaveMismatch reports whether any row in the given PF
+		// list has Mismatched=true. Used in the template to gate
+		// the red/orange section-header tint on whether there's
+		// actually a conflict to surface — groups whose Actual and
+		// Expected line up render with a plain muted header.
+		"pfsHaveMismatch": func(pfs []PFInfo) bool {
+			for _, pf := range pfs {
+				if pf.Mismatched {
+					return true
+				}
+			}
+			return false
+		},
 		// presetStatusLabel renders the human-facing label for the
 		// per-group platform-topology row's status badge.
 		"presetStatusLabel": func(s presetmatch.Status) string {

--- a/pkg/networkoperatorplugin/connectivity/report.html.tmpl
+++ b/pkg/networkoperatorplugin/connectivity/report.html.tmpl
@@ -600,7 +600,7 @@ footer strong { color: var(--text-muted); }
       </dl>
 
       {{- if .EastWestPFs}}
-      <div class="matrix-rail pf-section-actual">East-west PFs — Actual ({{if .PFCountMismatch}}{{.PFCountMismatch.Got}} <span class="mismatch-inline">certified topology expects {{.PFCountMismatch.Expected}}</span>{{else}}{{len .EastWestPFs}}{{end}})</div>
+      <div class="matrix-rail{{if or .PFCountMismatch (pfsHaveMismatch .EastWestPFs)}} pf-section-actual{{end}}">East-west PFs — Actual ({{if .PFCountMismatch}}{{.PFCountMismatch.Got}} <span class="mismatch-inline">certified topology expects {{.PFCountMismatch.Expected}}</span>{{else}}{{len .EastWestPFs}}{{end}})</div>
       <table>
         <thead><tr><th>PCI</th><th>Device ID</th><th>Rail</th><th>Netdev</th><th>RDMA</th><th>PSID</th><th>Part #</th><th>NUMA</th><th>GPU</th></tr></thead>
         <tbody>
@@ -622,7 +622,7 @@ footer strong { color: var(--text-muted); }
       {{- end}}
 
       {{- if .ExpectedEastWestPFs}}
-      <div class="matrix-rail pf-section-expected">East-west PFs — Expected by certified topology ({{len .ExpectedEastWestPFs}})</div>
+      <div class="matrix-rail{{if pfsHaveMismatch .ExpectedEastWestPFs}} pf-section-expected{{end}}">East-west PFs — Expected by certified topology ({{len .ExpectedEastWestPFs}})</div>
       <table>
         <thead><tr><th>PCI</th><th>Device ID</th><th>Rail</th><th>Netdev</th><th>RDMA</th><th>PSID</th><th>Part #</th><th>NUMA</th><th>GPU</th></tr></thead>
         <tbody>
@@ -644,7 +644,7 @@ footer strong { color: var(--text-muted); }
       {{- end}}
 
       {{- if .NorthSouthPFs}}
-      <div class="matrix-rail pf-section-actual">North-south PFs — Actual ({{len .NorthSouthPFs}})</div>
+      <div class="matrix-rail{{if pfsHaveMismatch .NorthSouthPFs}} pf-section-actual{{end}}">North-south PFs — Actual ({{len .NorthSouthPFs}})</div>
       <table>
         <thead><tr><th>PCI</th><th>Device ID</th><th>Netdev</th><th>RDMA</th><th>PSID</th><th>Part #</th></tr></thead>
         <tbody>
@@ -663,7 +663,7 @@ footer strong { color: var(--text-muted); }
       {{- end}}
 
       {{- if .ExpectedNorthSouthPFs}}
-      <div class="matrix-rail pf-section-expected">North-south PFs — Expected by certified topology ({{len .ExpectedNorthSouthPFs}})</div>
+      <div class="matrix-rail{{if pfsHaveMismatch .ExpectedNorthSouthPFs}} pf-section-expected{{end}}">North-south PFs — Expected by certified topology ({{len .ExpectedNorthSouthPFs}})</div>
       <table>
         <thead><tr><th>PCI</th><th>Device ID</th><th>Netdev</th><th>RDMA</th><th>PSID</th><th>Part #</th></tr></thead>
         <tbody>


### PR DESCRIPTION
The Actual / Expected PF sub-tables in the Node groups section previously got their red / orange header tint unconditionally. On clusters where the discovered hardware matches the certified topology cleanly, that surfaced a red "East-west PFs — Actual" banner even though nothing was wrong — misleading at a glance.

This commit gates the header tint classes on whether any row in that specific table is Mismatched (or, for the Actual east-west header, whether the discovered PF count differs from the certified topology's count). Groups whose Actual and Expected line up render with a plain muted header now; only the tables that actually drift get the red / orange band.

Added one tiny template helper, pfsHaveMismatch, that returns true if any PFInfo in the list has Mismatched=true. The four section headers compose it with the existing PFCountMismatch check via {{or}}.

The golden file is unchanged because the existing fixture already populates Mismatched rows in both tables — the tinted path is what's exercised by the golden. The no-conflict branch is exercised at runtime when validate runs against a cluster that matches its preset cleanly.