### PR TITLE
profiles: drop identifier suffix from resource names; bound DS app labels

### DIFF
--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -19,6 +19,7 @@ package networkoperatorplugin
 import (
 	"bytes"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"slices"
@@ -64,15 +65,15 @@ var templateFuncs = template.FuncMap{
 		}
 		return "-" + s
 	},
-	// resourceSuffix prepends a "_" and replaces all "-" with "_", producing a
-	// suffix suitable for K8s extended resource names (which use underscores).
-	// e.g., resourceSuffix("group-0") → "_group_0", resourceSuffix("") → ""
-	"resourceSuffix": func(s string) string {
-		if s == "" {
-			return ""
-		}
-		return "_" + strings.ReplaceAll(s, "-", "_")
-	},
+	// boundedSuffix returns "-<value>" suitable for appending to a name or label
+	// value such that the combined string never exceeds the k8s 63-char label-value
+	// limit. Callers pass the maximum allowed length of the returned suffix —
+	// typically 63 minus the length of the prefix the suffix is appended to.
+	// Empty input returns "". Inputs whose natural "-<s>" form fits within maxLen
+	// are used verbatim. Longer inputs are truncated and combined with an FNV-32a
+	// hash of the original (same algorithm as MachineLabelValue), so the result
+	// is deterministic across calls but never breaches maxLen.
+	"boundedSuffix": boundedSuffix,
 	// pfsPerNic computes how many PFs share the same physical NIC by grouping
 	// east-west PFs by PCI bus:device prefix (everything before the last ".").
 	// E.g., 8 PFs across 8 NICs → 1; 8 PFs across 4 NICs → 2.
@@ -136,16 +137,9 @@ func legacyRdmaSharedConfigList(groups []config.ClusterConfig, rdmaShared *confi
 	if rdmaShared == nil {
 		return ""
 	}
-	resourceSuffixForGroup := func(id string) string {
-		if id == "" {
-			return ""
-		}
-		return "_" + strings.ReplaceAll(id, "-", "_")
-	}
 	var entries []string
 	for _, g := range groups {
 		ew := filterEastWestPFs(g.PFs)
-		suf := resourceSuffixForGroup(g.Identifier)
 		if multirail {
 			for _, pf := range ew {
 				rail := 0
@@ -153,12 +147,12 @@ func legacyRdmaSharedConfigList(groups []config.ClusterConfig, rdmaShared *confi
 					rail = *pf.Rail
 				}
 				entries = append(entries, fmt.Sprintf(`          {
-            "resourceName": "%s_rail_%d%s",
+            "resourceName": "%s_rail_%d",
             "rdmaHcaMax": %d,
             "selectors": {
               "ifNames": [%q]
             }
-          }`, rdmaShared.ResourceName, rail, suf, rdmaShared.HcaMax, pf.NetworkInterface))
+          }`, rdmaShared.ResourceName, rail, rdmaShared.HcaMax, pf.NetworkInterface))
 			}
 		} else {
 			names := make([]string, 0, len(ew))
@@ -166,12 +160,12 @@ func legacyRdmaSharedConfigList(groups []config.ClusterConfig, rdmaShared *confi
 				names = append(names, fmt.Sprintf("%q", pf.NetworkInterface))
 			}
 			entries = append(entries, fmt.Sprintf(`          {
-            "resourceName": "%s%s",
+            "resourceName": "%s",
             "rdmaHcaMax": %d,
             "selectors": {
               "ifNames": [%s]
             }
-          }`, rdmaShared.ResourceName, suf, rdmaShared.HcaMax, strings.Join(names, ", ")))
+          }`, rdmaShared.ResourceName, rdmaShared.HcaMax, strings.Join(names, ", ")))
 		}
 	}
 	if len(entries) == 0 {
@@ -187,16 +181,9 @@ func legacySriovDevicePluginConfigList(groups []config.ClusterConfig, hostdev *c
 	if hostdev == nil {
 		return ""
 	}
-	resourceSuffixForGroup := func(id string) string {
-		if id == "" {
-			return ""
-		}
-		return "_" + strings.ReplaceAll(id, "-", "_")
-	}
 	var entries []string
 	for _, g := range groups {
 		ew := filterEastWestPFs(g.PFs)
-		suf := resourceSuffixForGroup(g.Identifier)
 		if multirail {
 			for _, pf := range ew {
 				rail := 0
@@ -212,23 +199,23 @@ func legacySriovDevicePluginConfigList(groups []config.ClusterConfig, hostdev *c
 				}
 				entries = append(entries, fmt.Sprintf(`          {
             "resourcePrefix": "nvidia.com",
-            "resourceName": "%s_rail_%d%s",
+            "resourceName": "%s_rail_%d",
             "selectors": {
               "vendors": ["15b3"],
 %s
               "isRdma": true
             }
-          }`, hostdev.ResourceName, rail, suf, selector))
+          }`, hostdev.ResourceName, rail, selector))
 			}
 		} else {
 			entries = append(entries, fmt.Sprintf(`          {
             "resourcePrefix": "nvidia.com",
-            "resourceName": "%s%s",
+            "resourceName": "%s",
             "selectors": {
               "vendors": ["15b3"],
               "isRdma": true
             }
-          }`, hostdev.ResourceName, suf))
+          }`, hostdev.ResourceName))
 		}
 	}
 	if len(entries) == 0 {
@@ -823,6 +810,35 @@ func sanitizeIdentifier(s string) string {
 	s = strings.ToLower(s)
 	s = strings.ReplaceAll(s, " ", "-")
 	return s
+}
+
+// boundedSuffix returns "-<value>" bounded to at most maxLen chars (including
+// the leading "-"). When the natural "-<s>" form fits, it is returned as-is;
+// otherwise the prefix is truncated and an 8-hex FNV-32a hash of the original
+// is appended, matching MachineLabelValue's algorithm. Empty input returns "".
+//
+// Used by templates that compose label values from ClusterConfig.Identifier:
+// the rendered "<prefix><boundedSuffix>" combination must respect k8s'
+// 63-char label-value limit. Callers pass `63 - len(prefix)` as maxLen.
+func boundedSuffix(maxLen int, s string) string {
+	if s == "" {
+		return ""
+	}
+	natural := "-" + s
+	if len(natural) <= maxLen {
+		return natural
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(s))
+	hashTail := fmt.Sprintf("-%08x", h.Sum32())
+	// 1 (leading "-") + prefixBudget + len(hashTail) == maxLen
+	prefixBudget := maxLen - 1 - len(hashTail)
+	if prefixBudget < 1 {
+		// Degenerate budget — return the hash alone with its leading "-".
+		return hashTail
+	}
+	prefix := strings.TrimRight(s[:prefixBudget], "-_.")
+	return "-" + prefix + hashTail
 }
 
 // mergeCompatibleGroups merges ClusterConfig groups that share the same gpuType

--- a/pkg/networkoperatorplugin/templates_test.go
+++ b/pkg/networkoperatorplugin/templates_test.go
@@ -450,6 +450,31 @@ func ewPF(pciAddr string, rail int) config.PFConfig {
 	}
 }
 
+func TestBoundedSuffix(t *testing.T) {
+	tests := []struct {
+		name   string
+		maxLen int
+		input  string
+		want   string
+	}{
+		{"empty input returns empty", 48, "", ""},
+		{"short input fits verbatim", 48, "nvidia-h200", "-nvidia-h200"},
+		{"input exactly at limit fits", 12, "nvidia-h200", "-nvidia-h200"},
+		{"long input truncates with hash", 20,
+			"thinksystem-sr675-v3-system-board-nvidia-rtx-pro-6000-ef08f5e8",
+			// 20-char total: "-" + prefixBudget(10) + "-" + 8 hex = 20
+			"-thinksyste-13f4b849"},
+		{"deterministic across calls", 16, "deterministic-test-input", "-determ-432b6939"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := boundedSuffix(tc.maxLen, tc.input)
+			assert.Equal(t, tc.want, got)
+			assert.LessOrEqual(t, len(got), tc.maxLen, "result exceeds maxLen")
+		})
+	}
+}
+
 func TestSanitizeIdentifier(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/networkoperatorplugin/workload.go
+++ b/pkg/networkoperatorplugin/workload.go
@@ -180,10 +180,6 @@ func buildNetworkResources(cfg *config.LaunchKubernetesConfig, group *config.Clu
 
 	ewPFs := filterEastWestPFs(group.PFs)
 	isMultirail := cfg.Profile.Multirail
-	resSuffix := ""
-	if group.Identifier != "" {
-		resSuffix = "_" + strings.ReplaceAll(group.Identifier, "-", "_")
-	}
 
 	resources := map[string]string{}
 
@@ -230,12 +226,12 @@ func buildNetworkResources(cfg *config.LaunchKubernetesConfig, group *config.Clu
 	if isMultirail {
 		for _, pf := range ewPFs {
 			if pf.Rail != nil {
-				key := fmt.Sprintf("%s/%s_rail_%d%s", resourcePrefix, resourceName, *pf.Rail, resSuffix)
+				key := fmt.Sprintf("%s/%s_rail_%d", resourcePrefix, resourceName, *pf.Rail)
 				resources[key] = "1"
 			}
 		}
 	} else {
-		key := fmt.Sprintf("%s/%s%s", resourcePrefix, resourceName, resSuffix)
+		key := fmt.Sprintf("%s/%s", resourcePrefix, resourceName)
 		resources[key] = "1"
 	}
 

--- a/pkg/networkoperatorplugin/workload_test.go
+++ b/pkg/networkoperatorplugin/workload_test.go
@@ -95,8 +95,8 @@ spec:
 	c0 := containers[0].(map[string]interface{})
 	res := c0["resources"].(map[string]interface{})
 	requests := res["requests"].(map[string]interface{})
-	assert.Equal(t, "1", requests["nvidia.com/sriov_net_rail_0_a100"])
-	assert.Equal(t, "1", requests["nvidia.com/sriov_net_rail_1_a100"])
+	assert.Equal(t, "1", requests["nvidia.com/sriov_net_rail_0"])
+	assert.Equal(t, "1", requests["nvidia.com/sriov_net_rail_1"])
 
 	// Node affinity injected
 	affinity := spec["affinity"].(map[string]interface{})
@@ -144,8 +144,8 @@ spec:
 	c0 := containers[0].(map[string]interface{})
 	res := c0["resources"].(map[string]interface{})
 	limits := res["limits"].(map[string]interface{})
-	assert.Equal(t, "1", limits["nvidia.com/sriov_net_rail_0_a100"])
-	assert.Equal(t, "1", limits["nvidia.com/sriov_net_rail_1_a100"])
+	assert.Equal(t, "1", limits["nvidia.com/sriov_net_rail_0"])
+	assert.Equal(t, "1", limits["nvidia.com/sriov_net_rail_1"])
 }
 
 func TestPatchWorkloadManifest_DaemonSet(t *testing.T) {
@@ -299,8 +299,8 @@ func TestBuildNetworkResources(t *testing.T) {
 		cfg, group := multirailSriovConfig()
 		got := buildNetworkResources(cfg, group)
 		assert.Equal(t, map[string]string{
-			"nvidia.com/sriov_net_rail_0_a100": "1",
-			"nvidia.com/sriov_net_rail_1_a100": "1",
+			"nvidia.com/sriov_net_rail_0": "1",
+			"nvidia.com/sriov_net_rail_1": "1",
 		}, got)
 	})
 

--- a/profiles/host-device-rdma/11-nicnodepolicy.yaml
+++ b/profiles/host-device-rdma/11-nicnodepolicy.yaml
@@ -69,7 +69,7 @@ spec:
         {{- if eq $pf.Traffic "east-west"}}
           {
             "resourcePrefix": "nvidia.com",
-            "resourceName": "{{$.Hostdev.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}",
+            "resourceName": "{{$.Hostdev.ResourceName}}_rail_{{$pf.Rail}}",
             "selectors": {
               "vendors": ["15b3"],
               {{- if and $.NicConfigurationOperator $.NicConfigurationOperator.DeployNicInterfaceNameTemplate }}
@@ -87,7 +87,7 @@ spec:
         {{- else}}
           {
             "resourcePrefix": "nvidia.com",
-            "resourceName": "{{.Hostdev.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}",
+            "resourceName": "{{.Hostdev.ResourceName}}",
             "selectors": {
               "vendors": ["15b3"],
               "isRdma": true

--- a/profiles/host-device-rdma/30-hostdevicenetwork.yaml
+++ b/profiles/host-device-rdma/30-hostdevicenetwork.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{$.Hostdev.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}
 spec:
   networkNamespace: "{{$.PodNamespace}}"
-  resourceName: "{{$.Hostdev.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}"
+  resourceName: "{{$.Hostdev.ResourceName}}_rail_{{$pf.Rail}}"
   ipam: |
     {
       "type": "nv-ipam",
@@ -24,7 +24,7 @@ metadata:
   name: {{.Hostdev.NetworkName}}{{suffix $.ClusterConfig.Identifier}}
 spec:
   networkNamespace: "{{$.PodNamespace}}"
-  resourceName: "{{.Hostdev.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}"
+  resourceName: "{{.Hostdev.ResourceName}}"
   ipam: |
     {
       "type": "nv-ipam",

--- a/profiles/host-device-rdma/40-example-daemonset.yaml
+++ b/profiles/host-device-rdma/40-example-daemonset.yaml
@@ -3,16 +3,16 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: hostdev-test{{suffix .ClusterConfig.Identifier}}
+  name: hostdev-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
-      app: hostdev-test{{suffix .ClusterConfig.Identifier}}
+      app: hostdev-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   template:
     metadata:
       labels:
-        app: hostdev-test{{suffix .ClusterConfig.Identifier}}
+        app: hostdev-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Hostdev.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{- end}}{{- end}}
     spec:
@@ -53,29 +53,29 @@ spec:
           requests:
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
-            nvidia.com/{{$.Hostdev.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: '1'
+            nvidia.com/{{$.Hostdev.ResourceName}}_rail_{{$pf.Rail}}: '1'
             {{- end}}
             {{- end}}
           limits:
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
-            nvidia.com/{{$.Hostdev.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: '1'
+            nvidia.com/{{$.Hostdev.ResourceName}}_rail_{{$pf.Rail}}: '1'
             {{- end}}
             {{- end}}
 {{- else}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: hostdev-test{{suffix .ClusterConfig.Identifier}}
+  name: hostdev-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
-      app: hostdev-test{{suffix .ClusterConfig.Identifier}}
+      app: hostdev-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   template:
     metadata:
       labels:
-        app: hostdev-test{{suffix .ClusterConfig.Identifier}}
+        app: hostdev-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
         k8s.v1.cni.cncf.io/networks: {{.Hostdev.NetworkName}}{{suffix $.ClusterConfig.Identifier}}
     spec:
@@ -114,7 +114,7 @@ spec:
             add: ["IPC_LOCK"]
         resources:
           requests:
-            nvidia.com/{{.Hostdev.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: '1'
+            nvidia.com/{{.Hostdev.ResourceName}}: '1'
           limits:
-            nvidia.com/{{.Hostdev.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: '1'
+            nvidia.com/{{.Hostdev.ResourceName}}: '1'
 {{- end}}

--- a/profiles/ipoib-rdma-shared/11-nicnodepolicy.yaml
+++ b/profiles/ipoib-rdma-shared/11-nicnodepolicy.yaml
@@ -70,7 +70,7 @@ spec:
           {{- range $i, $pf := .ClusterConfig.PFs}}
           {{- if eq $pf.Traffic "east-west"}}
           {
-            "resourceName": "{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}",
+            "resourceName": "{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}",
             "rdmaHcaMax": {{$.RdmaShared.HcaMax}},
             "selectors": {
               "ifNames": ["{{$pf.NetworkInterface}}"]
@@ -82,7 +82,7 @@ spec:
         {{- else}}
           {{- /* Create single RDMA resource with all interfaces */ -}}
           {
-            "resourceName": "{{.RdmaShared.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}",
+            "resourceName": "{{.RdmaShared.ResourceName}}",
             "rdmaHcaMax": {{.RdmaShared.HcaMax}},
             "selectors": {
               "ifNames": [{{range $i, $pf := .ClusterConfig.PFs}}{{if gt $i 0}}, {{end}}"{{$pf.NetworkInterface}}"{{end}}]

--- a/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
@@ -3,16 +3,16 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: ipoib-test{{suffix .ClusterConfig.Identifier}}
+  name: ipoib-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
-      app: ipoib-test{{suffix .ClusterConfig.Identifier}}
+      app: ipoib-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   template:
     metadata:
       labels:
-        app: ipoib-test{{suffix .ClusterConfig.Identifier}}
+        app: ipoib-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Ipoib.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{- end}}{{- end}}
     spec:
@@ -53,13 +53,13 @@ spec:
           requests:
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
-            rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: 1
+            rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
             {{- end}}
             {{- end}}
           limits:
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
-            rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: 1
+            rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
             {{- end}}
             {{- end}}
 {{- else}}
@@ -67,16 +67,16 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: ipoib-test{{suffix $.ClusterConfig.Identifier}}
+  name: ipoib-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
   namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
-      app: ipoib-test{{suffix $.ClusterConfig.Identifier}}
+      app: ipoib-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
   template:
     metadata:
       labels:
-        app: ipoib-test{{suffix $.ClusterConfig.Identifier}}
+        app: ipoib-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
       annotations:
         k8s.v1.cni.cncf.io/networks: {{.Ipoib.NetworkName}}{{suffix $.ClusterConfig.Identifier}}
     spec:
@@ -115,7 +115,7 @@ spec:
             add: ["IPC_LOCK"]
         resources:
           requests:
-            rdma/{{.RdmaShared.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: 1
+            rdma/{{.RdmaShared.ResourceName}}: 1
           limits:
-            rdma/{{.RdmaShared.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: 1
+            rdma/{{.RdmaShared.ResourceName}}: 1
 {{end}}

--- a/profiles/macvlan-rdma-shared/11-nicnodepolicy.yaml
+++ b/profiles/macvlan-rdma-shared/11-nicnodepolicy.yaml
@@ -69,7 +69,7 @@ spec:
           {{- range $i, $pf := .ClusterConfig.PFs}}
           {{- if eq $pf.Traffic "east-west"}}
           {
-            "resourceName": "{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}",
+            "resourceName": "{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}",
             "rdmaHcaMax": {{$.RdmaShared.HcaMax}},
             "selectors": {
               "ifNames": ["{{$pf.NetworkInterface}}"]
@@ -80,7 +80,7 @@ spec:
         {{- else}}
           {{- /* Create single RDMA resource with all interfaces */ -}}
           {
-            "resourceName": "{{.RdmaShared.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}",
+            "resourceName": "{{.RdmaShared.ResourceName}}",
             "rdmaHcaMax": {{.RdmaShared.HcaMax}},
             "selectors": {
               "ifNames": [{{range $i, $pf := .ClusterConfig.PFs}}{{if gt $i 0}}, {{end}}"{{$pf.NetworkInterface}}"{{end}}]

--- a/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
@@ -3,16 +3,16 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: macvlan-test{{suffix .ClusterConfig.Identifier}}
+  name: macvlan-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
-      app: macvlan-test{{suffix .ClusterConfig.Identifier}}
+      app: macvlan-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   template:
     metadata:
       labels:
-        app: macvlan-test{{suffix .ClusterConfig.Identifier}}
+        app: macvlan-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Macvlan.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{- end}}{{- end}}
     spec:
@@ -53,13 +53,13 @@ spec:
           requests:
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
-            rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: 1
+            rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
             {{- end}}
             {{- end}}
           limits:
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
-            rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: 1
+            rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
             {{- end}}
             {{- end}}
 {{- else}}
@@ -67,16 +67,16 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: macvlan-test{{suffix $.ClusterConfig.Identifier}}
+  name: macvlan-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
   namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
-      app: macvlan-test{{suffix $.ClusterConfig.Identifier}}
+      app: macvlan-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
   template:
     metadata:
       labels:
-        app: macvlan-test{{suffix $.ClusterConfig.Identifier}}
+        app: macvlan-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
       annotations:
         k8s.v1.cni.cncf.io/networks: {{.Macvlan.NetworkName}}{{suffix $.ClusterConfig.Identifier}}
     spec:
@@ -115,7 +115,7 @@ spec:
             add: ["IPC_LOCK"]
         resources:
           requests:
-            rdma/{{.RdmaShared.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: 1
+            rdma/{{.RdmaShared.ResourceName}}: 1
           limits:
-            rdma/{{.RdmaShared.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: 1
+            rdma/{{.RdmaShared.ResourceName}}: 1
 {{end}}

--- a/profiles/spectrum-x-ra2.1/50-sriovnetworknodepolicy.yaml
+++ b/profiles/spectrum-x-ra2.1/50-sriovnetworknodepolicy.yaml
@@ -36,8 +36,7 @@ spec:
   nicSelector:
     pfNames:
       - "{{ replaceVars $.SpectrumX.NetdevPrefix $railIdx $planeIdx $railIdx }}"
-  resourceName: rail_{{$railIdx}}_plane_{{$planeIdx}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}
-  {{- if $.ClusterConfig.NodeSelector }}
+  resourceName: rail_{{$railIdx}}_plane_{{$planeIdx}}  {{- if $.ClusterConfig.NodeSelector }}
   nodeSelector:
     {{- range $key, $value := $.ClusterConfig.NodeSelector }}
     {{ $key }}: "{{ $value }}"
@@ -77,8 +76,7 @@ spec:
   numVfs: 1
   nicSelector:
     pfNames: [{{- $firstPF := true }}{{- range $planeIdx := untilStep 0 $planes 1 }}{{- if not $firstPF }}, {{ end }}{{- $firstPF = false }}"{{ replaceVars $.SpectrumX.NetdevPrefix $railIdx $planeIdx $railIdx }}"{{- end }}]
-  resourceName: rail_{{$railIdx}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}
-  {{- if $.ClusterConfig.NodeSelector }}
+  resourceName: rail_{{$railIdx}}  {{- if $.ClusterConfig.NodeSelector }}
   nodeSelector:
     {{- range $key, $value := $.ClusterConfig.NodeSelector }}
     {{ $key }}: "{{ $value }}"

--- a/profiles/spectrum-x-ra2.1/90-example-daemonset.yaml
+++ b/profiles/spectrum-x-ra2.1/90-example-daemonset.yaml
@@ -2,16 +2,16 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: spectrum-x-test{{suffix .ClusterConfig.Identifier}}
+  name: spectrum-x-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
-      app: spectrum-x-test{{suffix .ClusterConfig.Identifier}}
+      app: spectrum-x-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   template:
     metadata:
       labels:
-        app: spectrum-x-test{{suffix .ClusterConfig.Identifier}}
+        app: spectrum-x-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
         {{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
         {{- $railCount := railCount .ClusterConfig.PFs $planes }}

--- a/profiles/spectrum-x/90-example-daemonset.yaml
+++ b/profiles/spectrum-x/90-example-daemonset.yaml
@@ -2,16 +2,16 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: spectrum-x-test{{suffix .ClusterConfig.Identifier}}
+  name: spectrum-x-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
-      app: spectrum-x-test{{suffix .ClusterConfig.Identifier}}
+      app: spectrum-x-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   template:
     metadata:
       labels:
-        app: spectrum-x-test{{suffix .ClusterConfig.Identifier}}
+        app: spectrum-x-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
         {{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
         {{- $railCount := railCount .ClusterConfig.PFs $planes }}

--- a/profiles/sriov-ethernet-rdma/40-sriovnetworknodepolicy.yaml
+++ b/profiles/sriov-ethernet-rdma/40-sriovnetworknodepolicy.yaml
@@ -35,8 +35,7 @@ spec:
   linkType: ETH
   numVfs: {{$.Sriov.NumVfs}}
   priority: {{$.Sriov.Priority}}
-  resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}
-{{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
+  resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
 {{- end -}}
 {{- else -}}
@@ -60,5 +59,4 @@ spec:
   linkType: ETH
   numVfs: {{.Sriov.NumVfs}}
   priority: {{.Sriov.Priority}}
-  resourceName: {{.Sriov.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}
-{{- end}}
+  resourceName: {{.Sriov.ResourceName}}{{- end}}

--- a/profiles/sriov-ethernet-rdma/50-sriovnetwork.yaml
+++ b/profiles/sriov-ethernet-rdma/50-sriovnetwork.yaml
@@ -14,8 +14,7 @@ spec:
       "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}"
     }
   networkNamespace: "{{$.PodNamespace}}"
-  resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}
-{{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
+  resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
 {{- end -}}
 {{- else -}}
@@ -31,5 +30,4 @@ spec:
       "poolName": "{{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}"
     }
   networkNamespace: "{{$.PodNamespace}}"
-  resourceName: {{.Sriov.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}
-{{- end}}
+  resourceName: {{.Sriov.ResourceName}}{{- end}}

--- a/profiles/sriov-ethernet-rdma/60-example-daemonset.yaml
+++ b/profiles/sriov-ethernet-rdma/60-example-daemonset.yaml
@@ -3,16 +3,16 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: sriov-test{{suffix .ClusterConfig.Identifier}}
+  name: sriov-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
-      app: sriov-test{{suffix .ClusterConfig.Identifier}}
+      app: sriov-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   template:
     metadata:
       labels:
-        app: sriov-test{{suffix .ClusterConfig.Identifier}}
+        app: sriov-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{- end}}{{- end}}
     spec:
@@ -53,29 +53,29 @@ spec:
           requests:
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
-            nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: '1'
+            nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
             {{- end}}
             {{- end}}
           limits:
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
-            nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: '1'
+            nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
             {{- end}}
             {{- end}}
 {{- else}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: sriov-test{{suffix $.ClusterConfig.Identifier}}
+  name: sriov-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
   namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
-      app: sriov-test{{suffix $.ClusterConfig.Identifier}}
+      app: sriov-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
   template:
     metadata:
       labels:
-        app: sriov-test{{suffix $.ClusterConfig.Identifier}}
+        app: sriov-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
       annotations:
         k8s.v1.cni.cncf.io/networks: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}
     spec:
@@ -114,7 +114,7 @@ spec:
             add: ["IPC_LOCK"]
         resources:
           requests:
-            nvidia.com/{{.Sriov.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: '1'
+            nvidia.com/{{.Sriov.ResourceName}}: '1'
           limits:
-            nvidia.com/{{.Sriov.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: '1'
+            nvidia.com/{{.Sriov.ResourceName}}: '1'
 {{- end}}

--- a/profiles/sriov-ib-rdma/40-sriovnetworknodepolicy.yaml
+++ b/profiles/sriov-ib-rdma/40-sriovnetworknodepolicy.yaml
@@ -35,8 +35,7 @@ spec:
   isRdma: true
   numVfs: {{$.Sriov.NumVfs}}
   priority: {{$.Sriov.Priority}}
-  resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}
-{{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
+  resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
 {{- end -}}
 {{- else -}}
@@ -60,5 +59,4 @@ spec:
   isRdma: true
   numVfs: {{.Sriov.NumVfs}}
   priority: {{.Sriov.Priority}}
-  resourceName: {{.Sriov.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}
-{{- end}}
+  resourceName: {{.Sriov.ResourceName}}{{- end}}

--- a/profiles/sriov-ib-rdma/50-sriovibnetwork.yaml
+++ b/profiles/sriov-ib-rdma/50-sriovibnetwork.yaml
@@ -13,8 +13,7 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}"
     }
-  resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}
-  linkState: enable
+  resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}  linkState: enable
   networkNamespace: "{{$.PodNamespace}}"
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
@@ -31,7 +30,6 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}"
     }
-  resourceName: {{.Sriov.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}
-  linkState: enable
+  resourceName: {{.Sriov.ResourceName}}  linkState: enable
   networkNamespace: "{{$.PodNamespace}}"
 {{- end}}

--- a/profiles/sriov-ib-rdma/60-example-daemonset.yaml
+++ b/profiles/sriov-ib-rdma/60-example-daemonset.yaml
@@ -3,16 +3,16 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: sriov-ib-test{{suffix .ClusterConfig.Identifier}}
+  name: sriov-ib-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
-      app: sriov-ib-test{{suffix .ClusterConfig.Identifier}}
+      app: sriov-ib-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
   template:
     metadata:
       labels:
-        app: sriov-ib-test{{suffix .ClusterConfig.Identifier}}
+        app: sriov-ib-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{- end}}{{- end}}
     spec:
@@ -53,29 +53,29 @@ spec:
           requests:
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
-            nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: '1'
+            nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
             {{- end}}
             {{- end}}
           limits:
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
-            nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: '1'
+            nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
             {{- end}}
             {{- end}}
 {{- else}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: sriov-ib-test{{suffix $.ClusterConfig.Identifier}}
+  name: sriov-ib-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
   namespace: "{{$.PodNamespace}}"
 spec:
   selector:
     matchLabels:
-      app: sriov-ib-test{{suffix $.ClusterConfig.Identifier}}
+      app: sriov-ib-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
   template:
     metadata:
       labels:
-        app: sriov-ib-test{{suffix $.ClusterConfig.Identifier}}
+        app: sriov-ib-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
       annotations:
         k8s.v1.cni.cncf.io/networks: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}
     spec:
@@ -114,7 +114,7 @@ spec:
             add: ["IPC_LOCK"]
         resources:
           requests:
-            nvidia.com/{{.Sriov.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: '1'
+            nvidia.com/{{.Sriov.ResourceName}}: '1'
           limits:
-            nvidia.com/{{.Sriov.ResourceName}}{{resourceSuffix $.ClusterConfig.MergedIdentifier}}: '1'
+            nvidia.com/{{.Sriov.ResourceName}}: '1'
 {{- end}}


### PR DESCRIPTION
Extended resource names (`nvidia.com/sriov_resource_rail_N_<id>` etc.) breached k8s' 63-char limit when the composed `<machineType>-<gpuType>` identifier was long (e.g. ThinkSystem-SR675-V3-System-Board paired with NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition). `l8k validate` would fail to apply the example DaemonSet with "name part must be no more than 63 characters" errors on every rail-keyed resource.

Resource names don't structurally need a per-source suffix: each node's SR-IOV device plugin only registers VFs matching its own nicSelector, so sources in the same merged bucket can — and should — share the same extended resource name. Drop the suffix from every profile template and from the 26.1 legacy NCP rendering. `buildNetworkResources` (user-workload patcher) follows suit so injected resource keys still match what the device plugin registered.

DaemonSet labels (`spec.selector.matchLabels.app`, `spec.template.labels`) also breach 63 chars when the identifier is long. Add a `boundedSuffix maxLen identifier` template helper that uses the same FNV-32a truncate-with-hash algorithm as `MachineLabelValue`, and apply it with maxLen=48 to every example DS (the widest test-prefix is `spectrum-x-test` at 15 chars, leaving the suffix budget at 48 to stay under 63 total).

Node labels, nodeSelectors, and CR metadata.name retain their current shape — they either fit by construction (the 253-char DNS subdomain limit absorbs ~84-char names easily) or are already protected by MachineLabelValue's truncate-with-hash.