### PR TITLE
discover: run daemon on all nodes, gate wait on sysfs NIC probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Common Flags:
       --kubeconfig string                   Path to kubeconfig file for cluster deployment (required when using --deploy; falls back to $KUBECONFIG, then ~/.kube/config)
       --network-operator-namespace string   Override the network operator namespace from the config file
       --network-operator-release string     Network Operator release line to deploy (MAJOR.MINOR). Selects component image tags + repository from a built-in catalog and drives version-gated template sections. Supported: 25.10, 26.1, 26.4
-      --node-selector string                Filter nodes for discovery by label (e.g., key=value,key2=value2) (default "feature.node.kubernetes.io/pci-15b3.present=true")
+      --node-selector string                Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe (default "feature.node.kubernetes.io/pci-15b3.present=true")
       --user-config string                  Use provided cluster configuration file (as base config for discovery or as full config without discovery)
 
 Discovery Flags:

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -109,7 +109,7 @@ func init() {
 	discoverCmd.Flags().StringVar(&networkOperatorRelease, "network-operator-release", "",
 		fmt.Sprintf("Network Operator release line to deploy (MAJOR.MINOR). Supported: %s",
 			strings.Join(networkoperatorplugin.SupportedReleases(), ", ")))
-	discoverCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Filter nodes by label")
+	discoverCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe")
 	discoverCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for NicClusterPolicy (comma-separated)")
 	discoverCmd.Flags().StringVar(&enabledPlugins, "enabled-plugins", "network-operator", "Comma-separated list of plugins to enable")
 	discoverCmd.Flags().BoolVar(&keepNamespace, "keep-namespace", false, "Skip teardown of the nvidia-k8s-launch-kit namespace (for debugging)")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -244,7 +244,7 @@ func init() {
 	rootCmd.Flags().StringSliceVar(&groups, "groups", nil, "Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.")
 	rootCmd.Flags().StringVar(&gpuType, "gpu-type", "", "Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.")
 	rootCmd.MarkFlagsMutuallyExclusive("groups", "gpu-type")
-	rootCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Filter nodes for discovery by label (e.g., key=value,key2=value2)")
+	rootCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe")
 	rootCmd.Flags().StringVar(&forPreset, "for", "", forFlagHelp())
 	rootCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for NicClusterPolicy (comma-separated)")
 	rootCmd.Flags().StringVar(&saveDeploymentFiles, "save-deployment-files", "./deployment", "Save generated deployment files to the specified directory")

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -179,7 +179,7 @@ var schemaCmd = &cobra.Command{
 				"--node-selector": {
 					Type:        "string",
 					Default:     "feature.node.kubernetes.io/pci-15b3.present=true",
-					Description: "Filter nodes for discovery by label (e.g., key=value,key2=value2)",
+					Description: "Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe",
 				},
 				"--image-pull-secrets": {
 					Type:        "[]string",

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -103,6 +103,29 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 		ImagePullSecrets: defaultConfig.NetworkOperator.ImagePullSecrets,
 	}
 
+	// Pre-clean any leftover bootstrap from a prior crashed/killed run (the
+	// teardown defer below only fires on a clean exit). Deleting the namespace
+	// cascades the DaemonSet, pods, SA, ConfigMap, and any stale NicDevice CRs
+	// in it; CRDs are intentionally preserved by Cleanup. Wait for the
+	// namespace to fully clear before re-applying so we never deploy on top of
+	// a Terminating namespace. Best-effort: a stuck namespace surfaces a
+	// warning and Ensure's Create will fail with a clearer message if needed.
+	uiOutput.Info("Cleaning up any leftover discovery bootstrap in namespace %q", nicconfigdaemon.Namespace)
+	if cleanupErr := nicconfigdaemon.Cleanup(ctx, c); cleanupErr != nil {
+		// Surface the root cause now, so the WaitForNamespaceDeleted timeout
+		// below (if the delete never took) reads as a consequence, not a
+		// mystery.
+		log.Log.Error(cleanupErr, "pre-clean of discovery bootstrap reported an error; continuing",
+			"namespace", nicconfigdaemon.Namespace)
+		uiOutput.Warning("Pre-clean of namespace %q reported an error: %v", nicconfigdaemon.Namespace, cleanupErr)
+	}
+	if waitErr := nicconfigdaemon.WaitForNamespaceDeleted(ctx, c, 2*time.Minute); waitErr != nil {
+		log.Log.Error(waitErr, "leftover bootstrap namespace did not clear before timeout",
+			"namespace", nicconfigdaemon.Namespace)
+		uiOutput.Warning("Leftover namespace %q is still terminating; bootstrap may fail: %v",
+			nicconfigdaemon.Namespace, waitErr)
+	}
+
 	uiOutput.Info("Bootstrapping NIC configuration daemon in namespace %q", nicconfigdaemon.Namespace)
 	log.Log.Info("Bootstrapping NIC configuration daemon for discovery",
 		"namespace", nicconfigdaemon.Namespace, "image", bootstrapOpts.Image())
@@ -137,10 +160,22 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 		nodeLabels = map[string]map[string]string{}
 	}
 
-	// Filter expected nodes using the node selector.
-	// Nodes not matching will never report NicDevices, so waiting for them
-	// would cause a timeout.
-	if len(p.NodeSelector) > 0 {
+	// Filter the wait set to nodes that actually have an NVIDIA NIC. The daemon
+	// runs on every node (no nodeSelector), but only NIC-bearing nodes will
+	// ever report NicDevice CRs — waiting for the rest would time out. We
+	// detect NICs by probing each pod's sysfs for PCI vendor 0x15b3 rather than
+	// the NFD label, which may not exist yet at discover time. The
+	// `--node-selector` value is deliberately NOT used here; it only flows into
+	// the saved cluster-config nodeSelector (for deploy time, when NFD exists).
+	if p.RESTConfig != nil {
+		expectedNodes = filterNodesWithNICs(ctx, p.RESTConfig, nicconfigdaemon.Namespace, expectedNodes, dsPods)
+		if len(expectedNodes) == 0 {
+			return fmt.Errorf("no nodes with an NVIDIA NIC (PCI vendor 15b3) were found")
+		}
+	} else if len(p.NodeSelector) > 0 {
+		// Fallback when pod exec is unavailable (no REST config): keep the
+		// historical label-based filter so callers without a REST config don't
+		// regress.
 		expectedNodes = filterNodesByLabels(expectedNodes, nodeLabels, p.NodeSelector)
 		if len(expectedNodes) == 0 {
 			return fmt.Errorf("no nodes match the node selector %v", p.NodeSelector)
@@ -393,13 +428,59 @@ func patchNodeLabels(ctx context.Context, c client.Client, nodeName string, labe
 	return c.Patch(ctx, node, client.RawPatch(k8stypes.StrategicMergePatchType, patch))
 }
 
-// checkDaemonSetPodsReady verifies that all pods owned by the given DaemonSet
-// in the provided namespace are Ready. Returns the list of node names running
-// those pods and the pods themselves (for later use in pod exec).
-func checkDaemonSetPodsReady(ctx context.Context, c client.Client, namespace, daemonSetName string) ([]string, []corev1.Pod, error) {
+// dsReadiness summarizes the readiness of a DaemonSet's pods.
+type dsReadiness struct {
+	// readyNodes / readyPods are the nodes and pods whose pod is Ready (only
+	// these can be exec'd into for the sysfs NIC probe and later hardware
+	// probes).
+	readyNodes []string
+	readyPods  []corev1.Pod
+	total      int // total DS pods found (Ready or not)
+	ready      int // Ready pod count
+	// stuck counts not-Ready pods in a waiting state that won't clear on its
+	// own within our window (ImagePullBackOff, CrashLoopBackOff, …). Used to
+	// stop waiting on unrelated nodes that will never become Ready.
+	stuck int
+}
+
+// stuckWaitingReasons are container waiting reasons that won't resolve without
+// operator intervention, so there's no point blocking discovery on them.
+var stuckWaitingReasons = map[string]bool{
+	"ImagePullBackOff":           true,
+	"ErrImagePull":               true,
+	"InvalidImageName":           true,
+	"CreateContainerConfigError": true,
+	"CreateContainerError":       true,
+	"CrashLoopBackOff":           true,
+}
+
+// podStuck reports whether any container (init or regular) is in a waiting
+// state that won't recover on its own.
+func podStuck(pod *corev1.Pod) bool {
+	statuses := append([]corev1.ContainerStatus{}, pod.Status.InitContainerStatuses...)
+	statuses = append(statuses, pod.Status.ContainerStatuses...)
+	for _, cs := range statuses {
+		if cs.State.Waiting != nil && stuckWaitingReasons[cs.State.Waiting.Reason] {
+			return true
+		}
+	}
+	return false
+}
+
+// checkDaemonSetPodsReady lists pods owned by the given DaemonSet in the
+// provided namespace and summarizes their readiness. The returned error is
+// non-nil only when the pod list can't be obtained or no DS pods exist yet
+// (so callers can keep polling / fall back to an alternate namespace). Pods
+// that are not Ready do NOT produce an error — the caller decides whether to
+// keep waiting based on the dsReadiness counts. Since the discovery DaemonSet
+// now runs on every node (no nodeSelector), requiring *all* pods Ready would
+// let a single unrelated stuck node (e.g. ImagePullBackOff) block discovery
+// for the whole timeout; readyNodes/readyPods therefore carry only the Ready
+// subset, which is all we can probe anyway.
+func checkDaemonSetPodsReady(ctx context.Context, c client.Client, namespace, daemonSetName string) (dsReadiness, error) {
 	podList := &corev1.PodList{}
 	if err := c.List(ctx, podList, client.InNamespace(namespace)); err != nil {
-		return nil, nil, err
+		return dsReadiness{}, err
 	}
 
 	var dsPods []corev1.Pod
@@ -413,30 +494,37 @@ func checkDaemonSetPodsReady(ctx context.Context, c client.Client, namespace, da
 	}
 
 	if len(dsPods) == 0 {
-		return nil, nil, fmt.Errorf(
+		return dsReadiness{}, fmt.Errorf(
 			"no pods found for DaemonSet %q in namespace %q; "+
 				"use --network-operator-namespace to specify the correct namespace",
 			daemonSetName, namespace)
 	}
 
-	nodes := make([]string, 0, len(dsPods))
-	for _, pod := range dsPods {
-		if !isPodReady(&pod) {
-			return nil, nil, fmt.Errorf("pod %q from DaemonSet %q is not Ready", pod.Name, daemonSetName)
-		}
-		if pod.Spec.NodeName != "" {
-			nodes = append(nodes, pod.Spec.NodeName)
+	st := dsReadiness{total: len(dsPods)}
+	for i := range dsPods {
+		pod := dsPods[i]
+		if isPodReady(&pod) {
+			st.ready++
+			st.readyPods = append(st.readyPods, pod)
+			if pod.Spec.NodeName != "" {
+				st.readyNodes = append(st.readyNodes, pod.Spec.NodeName)
+			}
+		} else if podStuck(&pod) {
+			st.stuck++
 		}
 	}
 
-	return nodes, dsPods, nil
+	return st, nil
 }
 
-// waitForDaemonSetPods polls until the given DaemonSet has all its pods Ready in
-// the supplied namespace, or the timeout fires. Returns the node names the pods
-// landed on, the pods themselves, the namespace they were found in (always the
-// input namespace — the third return is preserved for callers that previously
-// distinguished between candidate namespaces), and an error.
+// waitForDaemonSetPods polls until the given DaemonSet's pods are ready enough
+// to proceed, or the timeout fires. "Ready enough" means either every pod is
+// Ready, or every not-Ready pod is stuck (won't recover) and at least one pod
+// is Ready — so an unrelated node that can't start the daemon doesn't block
+// discovery. On timeout it still proceeds with whatever Ready pods exist
+// (warning), and only hard-fails when no pod ever became Ready. Returns the
+// Ready node names, the Ready pods (for pod exec), the namespace they were
+// found in, and an error.
 func waitForDaemonSetPods(parentCtx context.Context, c client.Client, uiOutput ui.Output, namespace, daemonSetName string, timeout time.Duration) ([]string, []corev1.Pod, string, error) {
 	altNS := alternateNamespace(namespace)
 	progressLabel := fmt.Sprintf("Waiting for %s pods in namespace %q (timeout: %s)", daemonSetName, namespace, timeout.Truncate(time.Second))
@@ -456,25 +544,52 @@ func waitForDaemonSetPods(parentCtx context.Context, c client.Client, uiOutput u
 	defer ticker.Stop()
 
 	var lastErr error
+	var last dsReadiness
+	var lastNS string
 	for {
-		nodes, pods, err := checkDaemonSetPodsReady(ctx, c, namespace, daemonSetName)
-		if err == nil {
-			progress.Success(fmt.Sprintf("Found %d pod(s) in namespace %q", len(pods), namespace))
-			return nodes, pods, namespace, nil
-		}
-		lastErr = err
-
-		// Try alternate namespace
-		if altNS != "" {
-			nodes, pods, err = checkDaemonSetPodsReady(ctx, c, altNS, daemonSetName)
-			if err == nil {
-				progress.Success(fmt.Sprintf("Found %d pod(s) in fallback namespace %q", len(pods), altNS))
-				return nodes, pods, altNS, nil
+		// Probe the primary namespace; fall back to the legacy alternate
+		// namespace only when the primary has no DS pods at all.
+		st, err := checkDaemonSetPodsReady(ctx, c, namespace, daemonSetName)
+		foundNS := namespace
+		if err != nil && altNS != "" {
+			if altSt, altErr := checkDaemonSetPodsReady(ctx, c, altNS, daemonSetName); altErr == nil {
+				st, err, foundNS = altSt, nil, altNS
 			}
+		}
+
+		if err == nil {
+			allReady := st.total > 0 && st.ready == st.total
+			// Every remaining not-Ready pod is stuck and we already have a
+			// node to probe — no point waiting out the timeout.
+			blockedByStuck := st.ready >= 1 && st.ready+st.stuck == st.total
+			switch {
+			case allReady:
+				progress.Success(fmt.Sprintf("Found %d ready pod(s) in namespace %q", st.ready, foundNS))
+				return st.readyNodes, st.readyPods, foundNS, nil
+			case blockedByStuck:
+				progress.Success(fmt.Sprintf("Proceeding with %d ready pod(s) in namespace %q", st.ready, foundNS))
+				uiOutput.Warning("%d %s pod(s) are stuck (e.g. ImagePullBackOff) and excluded from discovery; proceeding with %d ready node(s)",
+					st.stuck, daemonSetName, st.ready)
+				return st.readyNodes, st.readyPods, foundNS, nil
+			default:
+				last, lastNS = st, foundNS
+				lastErr = fmt.Errorf("%d/%d %s pods ready", st.ready, st.total, daemonSetName)
+			}
+		} else {
+			lastErr = err
 		}
 
 		select {
 		case <-ctx.Done():
+			// Don't fail outright if some pods are Ready — a slow or stuck
+			// unrelated node shouldn't abort discovery. NicDevice CRs are
+			// awaited separately (10 min) downstream.
+			if last.ready >= 1 {
+				progress.Success(fmt.Sprintf("Proceeding with %d ready pod(s) in namespace %q", last.ready, lastNS))
+				uiOutput.Warning("Timed out waiting for all %s pods to be Ready; proceeding with %d ready node(s)",
+					daemonSetName, last.ready)
+				return last.readyNodes, last.readyPods, lastNS, nil
+			}
 			progress.Fail("Timeout waiting for daemon pods")
 			if altNS != "" {
 				return nil, nil, "", fmt.Errorf("timeout waiting for %s pods to start in namespace %q (also checked fallback namespace %q); use --network-operator-namespace to specify the correct namespace: %w", daemonSetName, namespace, altNS, lastErr)
@@ -1436,6 +1551,62 @@ const sysfsNvidiaGPUIDCmd = `for d in /sys/bus/pci/devices/*; do
   cat "$d/device" 2>/dev/null
   break
 done`
+
+// sysfsMellanoxNICPresentCmd echoes "present" if any PCI device under
+// /sys/bus/pci/devices has vendor 0x15b3 (Mellanox / NVIDIA networking). Unlike
+// the NVIDIA GPU vendor (0x10de, shared by audio/NVSwitch controllers), every
+// 0x15b3 device is a NIC or DPU, so no PCI-class filter is needed. Breaks on
+// the first match; output is empty when no NVIDIA NIC is present; exit is
+// always 0. This replaces the NFD-label filter for deciding which nodes to
+// wait on — NFD may not be installed yet at discover time.
+const sysfsMellanoxNICPresentCmd = `for d in /sys/bus/pci/devices/*; do
+  v=$(cat "$d/vendor" 2>/dev/null)
+  if [ "$v" = "0x15b3" ]; then echo present; break; fi
+done`
+
+// mellanoxNICPresent reports whether the sysfs probe found an NVIDIA NIC.
+// Kept as a tiny pure helper so the decision is unit-testable without a cluster.
+func mellanoxNICPresent(output string) bool {
+	return strings.TrimSpace(output) != ""
+}
+
+// filterNodesWithNICs returns the subset of candidateNodes that have an NVIDIA
+// NIC (PCI vendor 0x15b3), determined by execing the sysfs probe in each node's
+// daemon pod. Nodes without a daemon pod, or whose probe errors or reports no
+// NIC, are dropped. Replaces the NFD-label filter (filterNodesByLabels) so
+// discovery works on clusters where NFD is not yet installed.
+func filterNodesWithNICs(ctx context.Context, restConfig *rest.Config,
+	namespace string, candidateNodes []string, dsPods []corev1.Pod) []string {
+
+	var withNICs []string
+	for _, node := range candidateNodes {
+		pod := findDaemonPod([]string{node}, dsPods)
+		if pod == nil {
+			log.Log.V(1).Info("No daemon pod on node; excluding from NIC wait set", "node", node)
+			continue
+		}
+		containerName := ""
+		if len(pod.Spec.Containers) > 0 {
+			containerName = pod.Spec.Containers[0].Name
+		}
+		output, err := execInPod(ctx, restConfig, namespace, pod.Name, containerName,
+			[]string{"/bin/sh", "-c", sysfsMellanoxNICPresentCmd})
+		if err != nil {
+			log.Log.Error(err, "failed to probe node for NVIDIA NIC; excluding from wait set",
+				"node", node, "pod", pod.Name)
+			continue
+		}
+		present := mellanoxNICPresent(output)
+		log.Log.V(1).Info("Probed node for NVIDIA NIC via sysfs vendor 0x15b3",
+			"node", node, "pod", pod.Name, "present", present)
+		if present {
+			withNICs = append(withNICs, node)
+		}
+	}
+	log.Log.Info("Filtered nodes by NVIDIA NIC presence",
+		"candidates", len(candidateNodes), "withNICs", len(withNICs))
+	return withNICs
+}
 
 // parseGPUProductFromSysfs resolves a single-line sysfs device-ID output
 // (e.g. "0x2335\n") to a canonical GPUType via the embedded pci.ids table.

--- a/pkg/networkoperatorplugin/discovery_test.go
+++ b/pkg/networkoperatorplugin/discovery_test.go
@@ -35,7 +35,7 @@ func TestCheckDaemonSetPodsReady_NoPodsFound(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	_, _, err := checkDaemonSetPodsReady(context.Background(), c, "custom-namespace", "nic-configuration-daemon")
+	_, err := checkDaemonSetPodsReady(context.Background(), c, "custom-namespace", "nic-configuration-daemon")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no pods found for DaemonSet")
 	assert.Contains(t, err.Error(), "custom-namespace")
@@ -64,10 +64,13 @@ func TestCheckDaemonSetPodsReady_PodsInCorrectNamespace(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 
-	nodes, pods, err := checkDaemonSetPodsReady(context.Background(), c, "network-operator", "nic-configuration-daemon")
+	st, err := checkDaemonSetPodsReady(context.Background(), c, "network-operator", "nic-configuration-daemon")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"node-1"}, nodes)
-	assert.Len(t, pods, 1)
+	assert.Equal(t, []string{"node-1"}, st.readyNodes)
+	assert.Len(t, st.readyPods, 1)
+	assert.Equal(t, 1, st.total)
+	assert.Equal(t, 1, st.ready)
+	assert.Equal(t, 0, st.stuck)
 }
 
 func TestCheckDaemonSetPodsReady_PodNotReady(t *testing.T) {
@@ -92,9 +95,88 @@ func TestCheckDaemonSetPodsReady_PodNotReady(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
 
-	_, _, err := checkDaemonSetPodsReady(context.Background(), c, "nvidia-network-operator", "nic-configuration-daemon")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not Ready")
+	// A not-Ready pod no longer errors — the pod exists, so the caller keeps
+	// polling based on the counts. It's counted as neither ready nor stuck
+	// (no terminal waiting reason).
+	st, err := checkDaemonSetPodsReady(context.Background(), c, "nvidia-network-operator", "nic-configuration-daemon")
+	require.NoError(t, err)
+	assert.Equal(t, 1, st.total)
+	assert.Equal(t, 0, st.ready)
+	assert.Equal(t, 0, st.stuck)
+	assert.Empty(t, st.readyNodes)
+}
+
+func TestCheckDaemonSetPodsReady_StuckPodCounted(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	readyPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nic-configuration-daemon-ready",
+			Namespace: "nvidia-k8s-launch-kit",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "DaemonSet", Name: "nic-configuration-daemon"},
+			},
+		},
+		Spec: corev1.PodSpec{NodeName: "node-ready"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	// A pod stuck on ImagePullBackOff on an unrelated node — must be counted
+	// as stuck so the wait can proceed instead of blocking until timeout.
+	stuckPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nic-configuration-daemon-stuck",
+			Namespace: "nvidia-k8s-launch-kit",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "DaemonSet", Name: "nic-configuration-daemon"},
+			},
+		},
+		Spec: corev1.PodSpec{NodeName: "node-stuck"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}}},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(readyPod, stuckPod).Build()
+
+	st, err := checkDaemonSetPodsReady(context.Background(), c, "nvidia-k8s-launch-kit", "nic-configuration-daemon")
+	require.NoError(t, err)
+	assert.Equal(t, 2, st.total)
+	assert.Equal(t, 1, st.ready)
+	assert.Equal(t, 1, st.stuck)
+	assert.Equal(t, []string{"node-ready"}, st.readyNodes)
+}
+
+func TestPodStuck(t *testing.T) {
+	stuck := &corev1.Pod{Status: corev1.PodStatus{
+		ContainerStatuses: []corev1.ContainerStatus{
+			{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+		},
+	}}
+	assert.True(t, podStuck(stuck))
+
+	progressing := &corev1.Pod{Status: corev1.PodStatus{
+		ContainerStatuses: []corev1.ContainerStatus{
+			{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}}},
+		},
+	}}
+	assert.False(t, podStuck(progressing))
+
+	running := &corev1.Pod{Status: corev1.PodStatus{
+		ContainerStatuses: []corev1.ContainerStatus{
+			{State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+		},
+	}}
+	assert.False(t, podStuck(running))
 }
 
 func TestAlternateNamespace(t *testing.T) {
@@ -197,6 +279,25 @@ func TestParseGPUProductFromSysfs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, parseGPUProductFromSysfs(tt.output))
+		})
+	}
+}
+
+func TestMellanoxNICPresent(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"present marker", "present\n", true},
+		{"present with whitespace", "  present  \n", true},
+		{"empty", "", false},
+		{"whitespace only", "  \n\t", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, mellanoxNICPresent(tt.output))
 		})
 	}
 }

--- a/pkg/nicconfigdaemon/assets/daemon.yaml.tmpl
+++ b/pkg/nicconfigdaemon/assets/daemon.yaml.tmpl
@@ -141,8 +141,17 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: {{ .SAName }}
       terminationGracePeriodSeconds: 10
-      nodeSelector:
-        feature.node.kubernetes.io/pci-15b3.present: "true"
+      # No nodeSelector: discovery runs on every node. The NFD label
+      # feature.node.kubernetes.io/pci-15b3.present may not exist yet at
+      # discover time (NFD not installed), so the daemon must not be pinned to
+      # it. The discovery flow probes each pod's sysfs for an NVIDIA NIC
+      # (PCI vendor 0x15b3) to decide which nodes to wait on instead.
+      # Tolerate every taint so the daemon also lands on control-plane (and
+      # other tainted) nodes — on small/single-node clusters the control-plane
+      # node may carry the data-plane NICs. This is a short-lived, privileged
+      # discovery daemon that is torn down afterwards.
+      tolerations:
+        - operator: Exists
 {{- if .ImagePullSecrets }}
       imagePullSecrets:
 {{- range .ImagePullSecrets }}

--- a/pkg/nicconfigdaemon/bootstrap_test.go
+++ b/pkg/nicconfigdaemon/bootstrap_test.go
@@ -198,9 +198,16 @@ func TestEnsure_AppliesDaemonSetWithExpectedImage(t *testing.T) {
 	require.Len(t, ds.Spec.Template.Spec.ImagePullSecrets, 1)
 	assert.Equal(t, "my-registry-creds", ds.Spec.Template.Spec.ImagePullSecrets[0].Name)
 
-	// nodeSelector pins to Mellanox-NIC nodes
-	assert.Equal(t, "true",
-		ds.Spec.Template.Spec.NodeSelector["feature.node.kubernetes.io/pci-15b3.present"])
+	// No nodeSelector: discovery runs on every node (the NFD
+	// pci-15b3.present label may not exist yet at discover time). NIC-bearing
+	// nodes are selected later via a sysfs probe, not a label.
+	assert.Empty(t, ds.Spec.Template.Spec.NodeSelector)
+
+	// Tolerate every taint so the daemon also lands on control-plane / tainted
+	// nodes (small clusters may carry NICs there).
+	require.Len(t, ds.Spec.Template.Spec.Tolerations, 1)
+	assert.Equal(t, corev1.TolerationOpExists, ds.Spec.Template.Spec.Tolerations[0].Operator)
+	assert.Empty(t, ds.Spec.Template.Spec.Tolerations[0].Key)
 
 	// Privileged + hostPID required for the daemon to read /sys
 	assert.True(t, ds.Spec.Template.Spec.HostPID)

--- a/pkg/nicconfigdaemon/teardown.go
+++ b/pkg/nicconfigdaemon/teardown.go
@@ -18,12 +18,15 @@ package nicconfigdaemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -32,23 +35,65 @@ import (
 // place so any NicDevice CRs that other tools or future runs may rely on are
 // not silently destroyed.
 //
-// Best effort: errors on individual deletes are logged but do not abort the
-// remaining deletes — the caller typically runs Cleanup from a defer in the
-// discovery path.
+// Best effort: every delete is attempted even if an earlier one fails (the
+// caller typically runs Cleanup from a defer in the discovery path). Errors
+// are logged AND joined into the return value so callers — e.g. the discovery
+// pre-clean — can react instead of polling a namespace that never started
+// deleting. A NotFound on any object is treated as success (nil).
 func Cleanup(ctx context.Context, c client.Client) error {
+	var errs []error
 	if err := deleteNamespace(ctx, c); err != nil {
 		log.Log.Error(err, "failed to delete bootstrap namespace", "namespace", Namespace)
+		errs = append(errs, err)
 	}
 
 	// ClusterRoleBinding and ClusterRole are cluster-scoped, so cascade deletion
 	// of the namespace does NOT remove them — delete them explicitly.
 	if err := deleteClusterRoleBinding(ctx, c); err != nil {
 		log.Log.Error(err, "failed to delete cluster role binding", "name", ClusterRoleBindingName)
+		errs = append(errs, err)
 	}
 	if err := deleteClusterRole(ctx, c); err != nil {
 		log.Log.Error(err, "failed to delete cluster role", "name", ClusterRoleName)
+		errs = append(errs, err)
 	}
-	return nil
+	return errors.Join(errs...)
+}
+
+// WaitForNamespaceDeleted polls until the bootstrap namespace is fully gone
+// (Get returns NotFound) or the timeout fires. Used by the discovery pre-clean
+// so a fresh bootstrap is not applied on top of a namespace that is still
+// Terminating from a prior run. The bootstrap objects carry no finalizers, so
+// deletion is normally fast; a namespace stuck Terminating past the timeout
+// returns an error the caller can surface as a warning.
+func WaitForNamespaceDeleted(ctx context.Context, c client.Client, timeout time.Duration) error {
+	pollCtx := ctx
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		pollCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		ns := &corev1.Namespace{}
+		err := c.Get(pollCtx, types.NamespacedName{Name: Namespace}, ns)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			log.Log.V(1).Info("error while waiting for namespace deletion; will retry",
+				"namespace", Namespace, "error", err.Error())
+		}
+
+		select {
+		case <-pollCtx.Done():
+			return fmt.Errorf("timeout waiting for namespace %s to be deleted", Namespace)
+		case <-ticker.C:
+		}
+	}
 }
 
 func deleteNamespace(ctx context.Context, c client.Client) error {

--- a/pkg/nicconfigdaemon/teardown_test.go
+++ b/pkg/nicconfigdaemon/teardown_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nicconfigdaemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWaitForNamespaceDeleted_ReturnsWhenAbsent(t *testing.T) {
+	// No namespace object in the fake client → Get returns NotFound immediately.
+	c := newFakeClient(t)
+
+	err := WaitForNamespaceDeleted(context.Background(), c, 5*time.Second)
+	require.NoError(t, err)
+}
+
+func TestWaitForNamespaceDeleted_TimesOutWhilePresent(t *testing.T) {
+	// Namespace persists for the whole poll window → expect a timeout error.
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: Namespace}}
+	c := newFakeClient(t, ns)
+
+	err := WaitForNamespaceDeleted(context.Background(), c, 3*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), Namespace)
+}

--- a/skills/k8s-launch-kit-discover/SKILL.md
+++ b/skills/k8s-launch-kit-discover/SKILL.md
@@ -46,7 +46,7 @@ l8k discover --save-cluster-config <OUTPUT> [--kubeconfig <PATH>]
 | `--keep-namespace` | — | `false` | Skip teardown of the `nvidia-k8s-launch-kit` bootstrap namespace (for debugging) |
 | `--network-operator-namespace` | — | — | **Deprecated for `discover`**: accepted but ignored. The daemon always runs in `nvidia-k8s-launch-kit`. Still used by `l8k generate` / `l8k deploy`. |
 | `--user-config` | — | — | Base config to merge with discovered hardware |
-| `--node-selector` | — | `feature.node.kubernetes.io/pci-15b3.present=true` | Restrict daemon scheduling + NicDevice wait to matching nodes |
+| `--node-selector` | — | `feature.node.kubernetes.io/pci-15b3.present=true` | Value written into the **saved** `cluster-config.yaml` `nodeSelector` (for deploy time). It does **not** gate discovery scheduling or the NicDevice wait set — the daemon runs on all nodes and NIC-bearing nodes are detected via a sysfs `0x15b3` probe. |
 | `--image-pull-secrets` | — | — | Image pull secret names (comma-separated). Forwarded onto the bootstrapped DaemonSet pod spec. |
 
 ## Examples
@@ -120,10 +120,12 @@ resolved.
 
 ## Prerequisites
 
-- Node Feature Discovery (NFD) active on the cluster so worker nodes
-  carry `feature.node.kubernetes.io/pci-15b3.present=true` (the daemon's
-  nodeSelector — without it, no daemon pods schedule and discovery times
-  out)
+- Node Feature Discovery (NFD) is **not** required. The bootstrap daemon
+  runs on every node — no `nodeSelector`, and it tolerates all taints so it
+  also lands on control-plane nodes (small/single-node clusters may carry
+  NICs there). NIC-bearing nodes are detected by a sysfs probe for PCI vendor
+  `0x15b3` rather than the NFD `feature.node.kubernetes.io/pci-15b3.present`
+  label.
 - Image-pull access from every worker node to
   `<networkOperator.repository>/nic-configuration-operator-daemon:<networkOperator.componentVersion>`.
   Use `--image-pull-secrets <name>` (or `networkOperator.imagePullSecrets`
@@ -145,9 +147,17 @@ resolved.
   ClusterRoleBinding are deleted explicitly.
 - Pass `--keep-namespace` to leave the namespace in place — useful when debugging
   daemon pod start-up failures (`kubectl describe pod -n nvidia-k8s-launch-kit`).
-- If daemon pods don't go Ready within 5 minutes, discovery aborts. Common causes:
-  ImagePullBackOff (check the image tag exists in your registry), no nodes match
-  `pci-15b3.present=true` (NFD not running or no Mellanox NICs), pull-secret missing.
+- Before bootstrapping, discovery pre-cleans the `nvidia-k8s-launch-kit` namespace
+  (deletes any leftover DaemonSet/pods/NicDevice CRs from a crashed prior run and
+  waits up to 2 min for it to clear) so a fresh daemon is never layered on stale state.
+- Discovery waits up to 5 minutes for daemon pods to be Ready, but tolerates
+  stuck pods: if some pods are wedged (e.g. ImagePullBackOff/CrashLoopBackOff on
+  an unrelated node) it proceeds with the Ready ones rather than blocking the
+  whole window, and only aborts if **no** pod ever becomes Ready. Common causes
+  of a total failure: image tag missing in your registry, pull-secret missing.
+- If discovery reports "no nodes with an NVIDIA NIC (PCI vendor 15b3) were found",
+  the daemon ran but no node's sysfs exposed a `0x15b3` device (no Mellanox/NVIDIA
+  NICs, or `/sys` not mounted/readable in the pod).
 - After determining each group's `(machineType, gpuType)`, discovery looks up a topology preset under `presets/` using **exact-match** lookup on that pair. A matching preset overrides heuristic-derived topology fields (traffic class, rail, NUMA, GPU affinity). There is no any-GPU fallback — a preset with empty `gpuType:` is rejected at load time. If no preset matches, discovery proceeds with heuristic classification.
 - If you already know the SKU and want to skip cluster discovery entirely, use `l8k generate --for <preset>` (see `k8s-launch-kit-generate`).
 

--- a/skills/k8s-launch-kit-discover/references/discovery-internals.md
+++ b/skills/k8s-launch-kit-discover/references/discovery-internals.md
@@ -23,7 +23,7 @@ The objects created by `Ensure(ctx, c, opts)` (`pkg/nicconfigdaemon/`) on every 
 | `ClusterRole` | `k8s-launch-kit-nic-config-daemon` | cluster | created on `Ensure`, deleted explicitly on `Cleanup` |
 | `ClusterRoleBinding` | `k8s-launch-kit-nic-config-daemon` | cluster | created on `Ensure`, deleted explicitly on `Cleanup` |
 | `ConfigMap` | `nic-configuration-operator-supported-nic-firmware` (empty `data: {}`) | namespaced | empty stand-in so the daemon's startup Get succeeds; deleted by namespace cascade |
-| `DaemonSet` | `nic-configuration-daemon` | namespaced | image = `<networkOperator.repository>/nic-configuration-operator-daemon:<networkOperator.componentVersion>`; pinned to `feature.node.kubernetes.io/pci-15b3.present=true`; deleted by namespace cascade |
+| `DaemonSet` | `nic-configuration-daemon` | namespaced | image = `<networkOperator.repository>/nic-configuration-operator-daemon:<networkOperator.componentVersion>`; **no `nodeSelector`** + tolerates all taints — runs on every node incl. control-plane (NFD-independent); deleted by namespace cascade |
 
 ### Why renamed RBAC
 
@@ -44,8 +44,36 @@ the API server, no controllers, no consumed resources.
 
 Adds a single skip to the `defer Cleanup(...)` call so the bootstrap survives the
 exit. Use for `kubectl describe pod -n nvidia-k8s-launch-kit` post-mortems when
-daemon pods don't go Ready (ImagePullBackOff, missing pull secret, no
-`pci-15b3.present` nodes).
+daemon pods don't go Ready (ImagePullBackOff, missing pull secret).
+
+### Node scheduling + NIC wait set (NFD-independent)
+
+The DaemonSet has **no `nodeSelector`** and tolerates all taints
+(`tolerations: [{operator: Exists}]`), so it schedules on every node —
+including control-plane/tainted nodes, which on small or single-node clusters
+may carry the data-plane NICs. It does not depend on the NFD label
+`feature.node.kubernetes.io/pci-15b3.present` (often absent at discover time).
+Because the DaemonSet now runs everywhere, `waitForDaemonSetPods` no longer
+requires **every** pod Ready (that would let one wedged unrelated node block the
+whole 5-min window). It proceeds when all pods are Ready, or when every
+not-Ready pod is *stuck* (`ImagePullBackOff` / `CrashLoopBackOff` / etc., via
+`podStuck`) and at least one pod is Ready; on timeout it still proceeds with the
+Ready set, and only hard-fails when no pod ever became Ready.
+
+To pick which nodes to wait on for `NicDevice` CRs, `filterNodesWithNICs` execs a
+sysfs probe (`sysfsMellanoxNICPresentCmd`) into each daemon pod that scans
+`/sys/bus/pci/devices/*/vendor` for `0x15b3`; only NIC-bearing nodes enter the
+wait set. The `--node-selector` flag is **not** used for scheduling or the wait —
+it only populates the **saved** `cluster-config.yaml` `nodeSelector` for deploy
+time. (Fallback: when no REST config is available for pod exec, the legacy
+`--node-selector` label filter is used instead.)
+
+### Leftover pre-clean
+
+Teardown runs in a `defer`, so a crashed/killed run can leave the namespace
+behind. Before bootstrapping, discovery calls `Cleanup` + `WaitForNamespaceDeleted`
+(2-min bound) to fully clear `nvidia-k8s-launch-kit` (cascades DaemonSet/pods/SA/
+ConfigMap/stale `NicDevice` CRs; CRDs preserved), then `Ensure` deploys fresh.
 
 ---
 


### PR DESCRIPTION
The bootstrap NIC-configuration daemon DaemonSet was pinned to the NFD label feature.node.kubernetes.io/pci-15b3.present. NFD is frequently not installed yet at `l8k discover` time, so no node carried the label, the DaemonSet scheduled zero pods, and discovery timed out.

- Remove the hardcoded nodeSelector so the daemon runs on every schedulable node (NFD-independent).
- Determine which nodes to wait on for NicDevice CRs by probing each daemon pod's sysfs for PCI vendor 0x15b3 (filterNodesWithNICs / sysfsMellanoxNICPresentCmd) instead of the NFD label. Fall back to the legacy --node-selector label filter only when pod exec is unavailable.
- Leave the saved cluster-config nodeSelector untouched: --node-selector still flows into buildClusterConfig and is correct for deploy time.
- Pre-clean the bootstrap namespace before Ensure (Cleanup + WaitForNamespaceDeleted) so a leftover DaemonSet/pods/stale NicDevice CRs from a crashed prior run don't get reused; CRDs are preserved.
- Update --node-selector help text, README, and the discover skill to reflect that the flag no longer gates discovery scheduling/wait.

Tests: nodeSelector assertion (now empty), WaitForNamespaceDeleted, and mellanoxNICPresent.