### PR TITLE
presets: apply topology preset only on exact hardware match

### DIFF
--- a/docs/presets.rst
+++ b/docs/presets.rst
@@ -35,9 +35,9 @@ How Discovery Uses Presets
 During ``l8k discover``, after determining a node group's ``machineType`` and ``gpuType`` (from GPU operator labels or DMI/``nvidia-smi`` fallback), l8k:
 
 1. **Looks up** a preset whose YAML declares the exact same ``(machineType, gpuType)`` pair.
-2. **Validates** PCI addresses and device IDs between the preset and discovered NicDevices.
-3. **Applies** the preset's authoritative topology fields, preserving live state (RDMA device, network interface, PSID, part number).
-4. **Falls back** to heuristic discovery if no preset matches or validation fails.
+2. **Validates** PF count, PCI addresses, and device IDs between the preset and discovered NicDevices.
+3. **Applies** the preset's authoritative topology fields — **only when the hardware matches exactly** (no PF-count / PCI-address / device-ID deviation), preserving live state (RDMA device, network interface, PSID, part number).
+4. **Falls back** to heuristic discovery when no preset matches *or* when the matched preset deviates from the discovered hardware. In the deviation case the discrepancies are still recorded under ``clusterConfig[*].presetDeviation`` and a warning is emitted on every config load, but the preset's topology is **not** overlaid — overlaying a preset onto a different PCI layout would corrupt the live-discovered traffic/rail classification.
 
 Generating From a Preset (``--for``)
 ------------------------------------
@@ -76,13 +76,13 @@ Preset validation during ``l8k discover`` ensures the preset matches the actual 
      - On Mismatch
    * - PF count
      - Number of PFs in preset must match discovered count
-     - Preset rejected
+     - Preset not applied; deviation recorded
    * - PCI addresses
      - Every PCI address must match between preset and discovered hardware
-     - Preset rejected
+     - Preset not applied; deviation recorded
    * - Device IDs
      - Device ID at each PCI address must match
-     - Preset rejected
+     - Preset not applied; deviation recorded
    * - Part numbers
      - Part numbers may differ across vendor SKUs
      - Warning logged, discovered value used

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -224,19 +224,52 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 				"deviationCount", len(matchResult.Deviations))
 			switch matchResult.Status {
 			case presetmatch.StatusMatch, presetmatch.StatusDeviation:
-				// LoadPreset was successful — load it again to get
-				// the Topology so ApplyPreset can enrich the group.
-				// (MatchGroup intentionally doesn't mutate.)
-				if preset, err := presets.LoadPreset(group.MachineType, group.GPUType); err == nil && preset != nil {
-					presets.ApplyPreset(preset, group)
-				}
-				if matchResult.Status == presetmatch.StatusDeviation {
-					group.PresetDeviation = matchResult.Deviations
+				// Record any deviations regardless of whether we enrich,
+				// so `l8k validate` and every config load keep surfacing
+				// the drift.
+				group.PresetDeviation = matchResult.Deviations
+				if presets.HasTopologyDeviation(matchResult.Deviations) {
+					// Hardware drifts from the preset on PF count, PCI
+					// address, or device ID (NIC model). Applying the
+					// preset would clobber the live-discovered traffic/rail
+					// classification: ApplyPreset matches PFs by PCI
+					// address, so any address that coincidentally overlaps
+					// inherits the preset's unrelated traffic/rail/GPU
+					// fields (and rails are left non-contiguous because
+					// ApplyPreset doesn't renumber). Skip enrichment and
+					// keep the live results.
 					uiOutput.Warning(
-						"Preset for %s/%s applied with %d deviation(s) from the matched preset. The deployment is not certified — see 'presetDeviation' in cluster-config.yaml.",
+						"Preset for %s/%s NOT applied — discovered hardware deviates from the preset on %d field(s) (PF count / PCI address / device ID). Using live discovery results; see 'presetDeviation' in cluster-config.yaml.",
 						group.MachineType, group.GPUType, len(matchResult.Deviations))
-				} else {
+					break
+				}
+				// Exact topology match (or only benign deviations) — load
+				// the Topology again and enrich rail/NUMA/GPU fields.
+				// (MatchGroup intentionally doesn't mutate.)
+				preset, err := presets.LoadPreset(group.MachineType, group.GPUType)
+				switch {
+				case err != nil:
+					// MatchGroup already loaded this preset to produce the
+					// match, so a reload failure here is unexpected — surface
+					// it rather than silently falling back to live discovery.
+					uiOutput.Warning(
+						"Preset for %s/%s matched but could not be re-loaded to apply (%v). Using live discovery results.",
+						group.MachineType, group.GPUType, err)
+				case preset == nil:
+					uiOutput.Warning(
+						"Preset for %s/%s matched but was not found on re-load. Using live discovery results.",
+						group.MachineType, group.GPUType)
+				case presets.ApplyPreset(preset, group):
 					uiOutput.Info("Applied preset configuration for %s", group.MachineType)
+				default:
+					// Loaded fine but the all-or-nothing apply declined (PCI
+					// bijection not satisfied) — shouldn't happen given the
+					// HasTopologyDeviation gate above, but don't claim a
+					// preset we didn't actually apply.
+					log.Log.V(1).Info("Preset matched but not applied",
+						"group", group.Identifier,
+						"machineType", group.MachineType,
+						"gpuType", group.GPUType)
 				}
 			case presetmatch.StatusNotFound:
 				// No catalog entry — discovery continues without
@@ -927,10 +960,10 @@ func buildClusterConfig(devices []nicop.NicDevice, nodeLabels map[string]map[str
 			"willFallBackToHardwareProbe", machineType == "" || gpuType == "")
 
 		cc := config.ClusterConfig{
-			Identifier:    identifier,
-			MachineType:   machineType,
-			GPUType:   gpuType,
-			NodeSelector:  nodeSelector,
+			Identifier:   identifier,
+			MachineType:  machineType,
+			GPUType:      gpuType,
+			NodeSelector: nodeSelector,
 			Capabilities: &config.ClusterCapabilities{
 				Nodes: &config.NodesCapabilities{
 					Rdma:  g.hasRdma,

--- a/pkg/presets/presets.go
+++ b/pkg/presets/presets.go
@@ -301,22 +301,53 @@ func ListPresetSummaries() ([]PresetSummary, []SkippedPreset, error) {
 // validated preset. It matches PFs by PCI address and overrides topology-
 // derived fields (traffic, rail, NUMA, GPU affinity) while preserving
 // live-state fields (RDMA device, network interface, PSID, part number).
+// It returns true when the preset was applied.
+//
+// ApplyPreset is ALL-OR-NOTHING: it applies only when the group and the preset
+// describe the same set of PCI addresses (equal PF count and every group PF
+// present in the preset). On any partial match it makes NO changes and returns
+// false. A partial application is incoherent: a preset's rail numbers are
+// authored as one self-consistent set for the whole board, so overlaying them
+// onto a subset — or mixing preset-numbered PFs with PFs still carrying their
+// live, sequentially-assigned rails — produces gaps or duplicate rail indices,
+// and clobbers the correct live traffic classification for whichever PCI
+// addresses happen to overlap. The discovery path already gates on
+// presets.HasTopologyDeviation, but ApplyPreset enforces the invariant itself
+// so it is safe to call from any context.
+//
+// On a full match the preset's authoritative rail values are copied VERBATIM,
+// never renumbered: presets may legitimately number rails out of PCI-address
+// order (e.g. multi-PCI-domain layouts where rail 0 lives on domain 0001), and
+// that mapping is the certified intent.
 //
 // GPUType is no longer filled in from the preset: by the time ApplyPreset
 // runs, the discovered group's GPUType is what was passed to LoadPreset, so
 // it already matches the preset's GPUType exactly.
-func ApplyPreset(preset *Topology, group *config.ClusterConfig) {
+func ApplyPreset(preset *Topology, group *config.ClusterConfig) bool {
 	presetMap := make(map[string]*PresetPF, len(preset.PFs))
 	for i := range preset.PFs {
 		presetMap[preset.PFs[i].PciAddress] = &preset.PFs[i]
 	}
 
+	// Precondition: full PCI bijection between group and preset. Anything
+	// short of that can't be applied coherently (see doc comment), so make
+	// no changes and report that nothing was applied.
+	if len(group.PFs) != len(preset.PFs) {
+		log.Log.V(1).Info("Preset not applied — PF count differs from group",
+			"groupPFs", len(group.PFs), "presetPFs", len(preset.PFs))
+		return false
+	}
+	for i := range group.PFs {
+		if _, ok := presetMap[group.PFs[i].PciAddress]; !ok {
+			log.Log.V(1).Info("Preset not applied — group PF absent from preset",
+				"pciAddress", group.PFs[i].PciAddress)
+			return false
+		}
+	}
+
 	for i := range group.PFs {
 		pf := &group.PFs[i]
-		pp, ok := presetMap[pf.PciAddress]
-		if !ok {
-			continue
-		}
+		pp := presetMap[pf.PciAddress] // guaranteed present by the check above
 
 		pf.Traffic = pp.Traffic
 		pf.Rail = pp.Rail
@@ -335,4 +366,5 @@ func ApplyPreset(preset *Topology, group *config.ClusterConfig) {
 	}
 
 	group.PresetApplied = true
+	return true
 }

--- a/pkg/presets/presets_test.go
+++ b/pkg/presets/presets_test.go
@@ -750,7 +750,9 @@ func TestApplyPreset_OverridesTopologyFields(t *testing.T) {
 		},
 	}
 
-	ApplyPreset(preset, group)
+	if !ApplyPreset(preset, group) {
+		t.Fatal("expected ApplyPreset to apply on a full match")
+	}
 
 	// Verify preset-authoritative fields were overridden
 	pf0 := group.PFs[0]
@@ -826,22 +828,37 @@ func TestApplyPreset_OverridesTopologyFields(t *testing.T) {
 func TestApplyPreset_PreservesExistingGPUType(t *testing.T) {
 	preset := &Topology{
 		GPUType: "NVIDIA-H200",
-		PFs:         []PresetPF{},
+		PFs:     []PresetPF{},
 	}
 	group := &config.ClusterConfig{
 		GPUType: "NVIDIA-H100-NVL", // already set — should NOT be overwritten
-		PFs:         []config.PFConfig{},
+		PFs:     []config.PFConfig{},
 	}
 
-	ApplyPreset(preset, group)
+	applied := ApplyPreset(preset, group)
+
+	// Both PF slices are empty, so the bijection check passes vacuously:
+	// the preset "applies" (there are no PFs to mutate) and PresetApplied is
+	// set. Pin this degenerate zero-PF behaviour explicitly.
+	if !applied {
+		t.Error("expected ApplyPreset to return true for the empty-PF (vacuous) bijection")
+	}
+	if !group.PresetApplied {
+		t.Error("expected PresetApplied=true for the empty-PF (vacuous) bijection")
+	}
 
 	if group.GPUType != "NVIDIA-H100-NVL" {
 		t.Errorf("GPUType: expected NVIDIA-H100-NVL (preserved), got %q", group.GPUType)
 	}
 }
 
-func TestApplyPreset_UnmatchedPCIAddress(t *testing.T) {
-	// PF in group has no match in preset — should be left unchanged
+func TestApplyPreset_PartialMatch_NoOp(t *testing.T) {
+	// Group has a PF (0000:99:00.0) absent from the preset — a partial
+	// match. ApplyPreset is all-or-nothing: it must change nothing and
+	// return false, so the live-discovered classification is preserved
+	// intact rather than half-overwritten (half-overwriting would leave the
+	// overlapping PF reclassified while the rest keep live rails, producing
+	// gaps/duplicate rail indices).
 	preset := &Topology{
 		PFs: []PresetPF{
 			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", Traffic: "east-west", Rail: intPtr(0)},
@@ -854,19 +871,79 @@ func TestApplyPreset_UnmatchedPCIAddress(t *testing.T) {
 		},
 	}
 
-	ApplyPreset(preset, group)
-
-	// First PF should be updated
-	if group.PFs[0].Traffic != "east-west" {
-		t.Errorf("PF[0] Traffic: expected east-west, got %q", group.PFs[0].Traffic)
+	if ApplyPreset(preset, group) {
+		t.Error("expected ApplyPreset to return false on a partial match")
+	}
+	if group.PresetApplied {
+		t.Error("expected PresetApplied=false on a partial match")
 	}
 
-	// Second PF should remain unchanged (no match in preset)
+	// The overlapping PF must NOT have been touched.
+	if group.PFs[0].Traffic != "north-south" {
+		t.Errorf("PF[0] Traffic: expected north-south (untouched), got %q", group.PFs[0].Traffic)
+	}
+	if group.PFs[0].Rail != nil {
+		t.Errorf("PF[0] Rail: expected nil (untouched), got %v", group.PFs[0].Rail)
+	}
+	// The unmatched PF must be unchanged too.
 	if group.PFs[1].Traffic != "east-west" {
-		t.Errorf("PF[1] Traffic: expected east-west (unchanged), got %q", group.PFs[1].Traffic)
+		t.Errorf("PF[1] Traffic: expected east-west (untouched), got %q", group.PFs[1].Traffic)
 	}
 	if group.PFs[1].Rail == nil || *group.PFs[1].Rail != 5 {
-		t.Errorf("PF[1] Rail: expected 5 (unchanged), got %v", group.PFs[1].Rail)
+		t.Errorf("PF[1] Rail: expected 5 (untouched), got %v", group.PFs[1].Rail)
+	}
+}
+
+func TestApplyPreset_GroupSubsetOfPreset_NoOp(t *testing.T) {
+	// Group has fewer PFs than the preset (preset describes a device the
+	// hardware lacks). Applying would leave a rail gap where the missing PF
+	// would have been, so ApplyPreset must no-op and return false.
+	preset := &Topology{
+		PFs: []PresetPF{
+			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", Traffic: "east-west", Rail: intPtr(0)},
+			{DeviceID: "a2dc", PciAddress: "0000:3c:00.0", Traffic: "east-west", Rail: intPtr(1)},
+		},
+	}
+	group := &config.ClusterConfig{
+		PFs: []config.PFConfig{
+			{DeviceID: "a2dc", PciAddress: "0000:1a:00.0", Traffic: "east-west", Rail: intPtr(0)},
+		},
+	}
+
+	if ApplyPreset(preset, group) {
+		t.Error("expected ApplyPreset to return false when group is a subset of the preset")
+	}
+	if group.PresetApplied {
+		t.Error("expected PresetApplied=false when group is a subset of the preset")
+	}
+}
+
+func TestApplyPreset_PreservesOutOfOrderRails(t *testing.T) {
+	// Presets may number rails out of PCI-address order — real example:
+	// PowerEdge-XE7745 assigns rail 0 to a PCI-domain-0001 device. A full
+	// match must copy those rail values VERBATIM, never renumber them into
+	// PCI order.
+	preset := &Topology{
+		PFs: []PresetPF{
+			{PciAddress: "0000:44:00.0", Traffic: "east-west", Rail: intPtr(1)},
+			{PciAddress: "0001:05:00.0", Traffic: "east-west", Rail: intPtr(0)},
+		},
+	}
+	group := &config.ClusterConfig{
+		PFs: []config.PFConfig{
+			{PciAddress: "0000:44:00.0", Traffic: "east-west"},
+			{PciAddress: "0001:05:00.0", Traffic: "east-west"},
+		},
+	}
+
+	if !ApplyPreset(preset, group) {
+		t.Fatal("expected ApplyPreset to apply on a full match")
+	}
+	if group.PFs[0].Rail == nil || *group.PFs[0].Rail != 1 {
+		t.Errorf("PF[0] (0000:44:00.0) Rail: expected 1 (verbatim), got %v", group.PFs[0].Rail)
+	}
+	if group.PFs[1].Rail == nil || *group.PFs[1].Rail != 0 {
+		t.Errorf("PF[1] (0001:05:00.0) Rail: expected 0 (verbatim), got %v", group.PFs[1].Rail)
 	}
 }
 
@@ -909,8 +986,8 @@ func TestApplyPreset_LargePreset_PowerEdgeXE9680(t *testing.T) {
 			DeviceID:         pp.DeviceID,
 			PciAddress:       pp.PciAddress,
 			RdmaDevice:       "mlx5_" + pp.PciAddress, // synthetic
-			NetworkInterface: "eth" + pp.PciAddress,    // synthetic
-			Traffic:          "east-west",              // deliberately wrong for some
+			NetworkInterface: "eth" + pp.PciAddress,   // synthetic
+			Traffic:          "east-west",             // deliberately wrong for some
 			PSID:             "discovered-psid-" + pp.PciAddress,
 			PartNumber:       "discovered-part-" + pp.PciAddress,
 		}

--- a/pkg/presets/validate.go
+++ b/pkg/presets/validate.go
@@ -23,17 +23,48 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 )
 
+// Deviation field names, shared between ValidatePreset (which produces them)
+// and HasTopologyDeviation (which consumes them) so the two can't drift.
+const (
+	deviationFieldPFCount    = "pfCount"
+	deviationFieldPCIAddress = "pciAddress"
+	deviationFieldDeviceID   = "deviceID"
+)
+
+// HasTopologyDeviation reports whether any deviation reflects a hardware-shape
+// mismatch — PF count, PCI address, or device ID (NIC model). These are the
+// fields that make a preset unsafe to apply: overlaying a preset's
+// authoritative topology (traffic / rail / NUMA / GPU affinity) onto hardware
+// whose PCI layout differs corrupts the live-discovered classification, because
+// ApplyPreset matches PFs by PCI address — a single coincidentally-overlapping
+// address inherits the preset's unrelated fields. The discovery path uses this
+// to skip enrichment entirely when the hardware drifts from the preset.
+//
+// Part numbers and PSIDs are intentionally not deviation fields (firmware/SKU
+// variants are expected), so they never block application.
+func HasTopologyDeviation(deviations []config.PresetDeviationEntry) bool {
+	for _, d := range deviations {
+		switch d.Field {
+		case deviationFieldPFCount, deviationFieldPCIAddress, deviationFieldDeviceID:
+			return true
+		}
+	}
+	return false
+}
+
 // ValidatePreset compares a topology preset against the discovered hardware
 // for a single group and returns the field-level deviations (empty when
 // the preset matches exactly).
 //
 // Every discrepancy — PF count mismatch, PCI address drift, device-ID
-// drift — is a soft deviation rather than a hard rejection. The discovery
-// pipeline always applies the matched preset on a best-effort basis (so
-// rail/NUMA/topology fields populate for whichever PFs do line up),
-// records the deviations on ClusterConfig.PresetDeviation, and warns on
-// every subsequent config load. The operator gets a working deployment
-// plus a loud reminder that the cluster diverges from the matched preset.
+// drift — is recorded as a deviation. The discovery pipeline treats any of
+// these as a hard block on enrichment: when HasTopologyDeviation reports a
+// drift it does NOT call ApplyPreset (overlaying a preset onto hardware with
+// a different PCI layout corrupts the live-discovered traffic/rail
+// classification), records the deviations on ClusterConfig.PresetDeviation,
+// and warns on every subsequent config load. The operator keeps the live
+// discovery results plus a loud reminder that the cluster diverges from the
+// matched preset.
 //
 // Part numbers and PSIDs are not strict criteria (firmware variants are
 // expected) so they're not checked here.
@@ -42,7 +73,7 @@ func ValidatePreset(preset *Topology, discoveredPFs []config.PFConfig) []config.
 
 	if len(preset.PFs) != len(discoveredPFs) {
 		deviations = append(deviations, config.PresetDeviationEntry{
-			Field:    "pfCount",
+			Field:    deviationFieldPFCount,
 			Expected: fmt.Sprintf("%d", len(preset.PFs)),
 			Got:      fmt.Sprintf("%d", len(discoveredPFs)),
 			Detail:   "PF count differs from preset",
@@ -62,7 +93,7 @@ func ValidatePreset(preset *Topology, discoveredPFs []config.PFConfig) []config.
 	for addr := range presetAddrs {
 		if _, ok := discoveredAddrs[addr]; !ok {
 			deviations = append(deviations, config.PresetDeviationEntry{
-				Field:    "pciAddress",
+				Field:    deviationFieldPCIAddress,
 				Expected: addr,
 				Detail:   "preset PCI address not present on discovered hardware",
 			})
@@ -72,7 +103,7 @@ func ValidatePreset(preset *Topology, discoveredPFs []config.PFConfig) []config.
 	for addr := range discoveredAddrs {
 		if _, ok := presetAddrs[addr]; !ok {
 			deviations = append(deviations, config.PresetDeviationEntry{
-				Field:  "pciAddress",
+				Field:  deviationFieldPCIAddress,
 				Got:    addr,
 				Detail: "discovered PCI address not present in preset",
 			})
@@ -87,7 +118,7 @@ func ValidatePreset(preset *Topology, discoveredPFs []config.PFConfig) []config.
 		}
 		if presetDevID != discoveredDevID {
 			deviations = append(deviations, config.PresetDeviationEntry{
-				Field:    "deviceID",
+				Field:    deviationFieldDeviceID,
 				Expected: fmt.Sprintf("%s@%s", presetDevID, addr),
 				Got:      fmt.Sprintf("%s@%s", discoveredDevID, addr),
 				Detail:   "device ID at PCI address differs from preset",

--- a/pkg/presets/validate_test.go
+++ b/pkg/presets/validate_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package presets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+func TestHasTopologyDeviation(t *testing.T) {
+	tests := []struct {
+		name       string
+		deviations []config.PresetDeviationEntry
+		want       bool
+	}{
+		{
+			name:       "nil — exact match",
+			deviations: nil,
+			want:       false,
+		},
+		{
+			name:       "empty — exact match",
+			deviations: []config.PresetDeviationEntry{},
+			want:       false,
+		},
+		{
+			name:       "pfCount deviation blocks",
+			deviations: []config.PresetDeviationEntry{{Field: "pfCount", Expected: "12", Got: "6"}},
+			want:       true,
+		},
+		{
+			name:       "pciAddress deviation blocks",
+			deviations: []config.PresetDeviationEntry{{Field: "pciAddress", Got: "0000:05:00.0"}},
+			want:       true,
+		},
+		{
+			name:       "deviceID deviation blocks",
+			deviations: []config.PresetDeviationEntry{{Field: "deviceID", Expected: "1021@0000:21:00.0", Got: "a2dc@0000:21:00.0"}},
+			want:       true,
+		},
+		{
+			name: "any topology field among several blocks",
+			deviations: []config.PresetDeviationEntry{
+				{Field: "partNumber"},
+				{Field: "pciAddress", Got: "0000:85:00.0"},
+			},
+			want: true,
+		},
+		{
+			name:       "non-topology field does not block",
+			deviations: []config.PresetDeviationEntry{{Field: "partNumber", Expected: "pn-a", Got: "pn-b"}},
+			want:       false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, HasTopologyDeviation(tc.deviations))
+		})
+	}
+}
+
+// TestValidatePreset_DeviationFieldsAreDetectable guards the contract between
+// ValidatePreset (which emits deviations) and HasTopologyDeviation (which
+// classifies them): every deviation ValidatePreset produces for a shape
+// mismatch must be recognized as topology-blocking.
+func TestValidatePreset_DeviationFieldsAreDetectable(t *testing.T) {
+	preset := &Topology{
+		PFs: []PresetPF{
+			{PciAddress: "0000:21:00.0", DeviceID: "1021"},
+			{PciAddress: "0000:21:00.1", DeviceID: "1021"},
+		},
+	}
+	discovered := []config.PFConfig{
+		// Different count, different addresses, and a device-ID clash on
+		// the one shared address — exercises all three deviation fields.
+		{PciAddress: "0000:21:00.0", DeviceID: "a2dc"},
+	}
+
+	deviations := ValidatePreset(preset, discovered)
+	assert.NotEmpty(t, deviations)
+	assert.True(t, HasTopologyDeviation(deviations),
+		"shape-mismatch deviations from ValidatePreset must be topology-blocking")
+}

--- a/presets/ThinkSystem-SR675-V3-RTX-PRO-6000/topology.yaml
+++ b/presets/ThinkSystem-SR675-V3-RTX-PRO-6000/topology.yaml
@@ -1,9 +1,17 @@
 machineType: ThinkSystem-SR675-V3
 manufacturer: Lenovo
 gpuType: NVIDIA-RTX-PRO-6000-Blackwell-Server-Edition
-nicModel: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter (ConnectX-7)
+nicModel: NVIDIA BlueField-3 (integrated ConnectX-7) — 4x SuperNIC east-west + 1x dual-port DPU north-south
 gpuInterconnect: ""
 numaNodes: 2
+
+# All NICs are BlueField-3 (deviceID a2dc), in two SKUs:
+#   - SuperNIC, single-port, PSID mt_0000001069 / PN 900-9D3D4-00EN-HA0 — the
+#     east-west GPU rail fabric (4 PFs at 05/75/85/f5). Each sits on a PCIe
+#     switch shared with two GPUs (== PIX), so all four are rail NICs.
+#   - DPU, dual-port, PSID mt_0000000884 / PN 900-9D3B6-00CV-AA0 — north-south
+#     (61:00.0/.1, bonded as mlx5_bond_0 / bond0). Its switch has no GPU under
+#     it; it carries OOB/management traffic, not GPU rails.
 
 capabilities:
   nodes:
@@ -11,165 +19,76 @@ capabilities:
     rdma: true
     ib: true
 
-# nvidia-smi was not installed on this host; GPU proximity derived from lspci PCI-tree
-# inspection (shared PCIe root == PIX).
-# CX-7 (1021) is the dominant east-west fabric on this machine: ALL CX-7 PFs are
-# east-west. PIX'd PFs keep their connectedGPU; non-PIX CX-7 PFs are still east-west
-# with connectedGPU="" and gpuProximity=NODE.
-# BF3 dual-port 200G DPU (SN37C16116) is north-south by SKU despite being PIX'd to GPUs.
-# CX-6 Lx (101f) is always north-south.
-
 pfs:
   # --- NUMA 0 ---
-  # East-west: ConnectX-7 2-port (21:xx.x) — own PCIe root, no GPU under it
-  - deviceID: "1021"
-    rdmaDevice: mlx5_2
-    pciAddress: 0000:21:00.0
+  # East-west rail 0: BF3 SuperNIC on PCIe switch [02-08] shared with GPU0/GPU1
+  - deviceID: a2dc
+    rdmaDevice: mlx5_1
+    pciAddress: 0000:05:00.0
     networkInterface: ens15f0np0
     traffic: east-west
     rail: 0
     numaNode: 0
-    connectedGPU: ""
-    gpuProximity: NODE
-    psid: lnv0000000058
-    partNumber: SN37B06010
-    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
-  - deviceID: "1021"
-    rdmaDevice: mlx5_3
-    pciAddress: 0000:21:00.1
-    networkInterface: ens15f1np1
+    connectedGPU: GPU0
+    gpuProximity: PIX
+    psid: mt_0000001069
+    partNumber: 900-9D3D4-00EN-HA0
+
+  # North-south: BF3 dual-port 200G DPU (61:xx.x), bonded (mlx5_bond_0 / bond0).
+  # Own PCIe switch [61], no GPU under it.
+  - deviceID: a2dc
+    rdmaDevice: mlx5_bond_0
+    pciAddress: 0000:61:00.0
+    networkInterface: ens1f0np0
+    traffic: north-south
+    numaNode: 0
+    psid: mt_0000000884
+    partNumber: 900-9D3B6-00CV-AA0
+  - deviceID: a2dc
+    rdmaDevice: ""
+    pciAddress: 0000:61:00.1
+    networkInterface: ens1f1np1
+    traffic: north-south
+    numaNode: 0
+    psid: mt_0000000884
+    partNumber: 900-9D3B6-00CV-AA0
+
+  # East-west rail 1: BF3 SuperNIC on PCIe switch [72-77] shared with GPU2/GPU3
+  - deviceID: a2dc
+    rdmaDevice: mlx5_0
+    pciAddress: 0000:75:00.0
+    networkInterface: ens16f0np0
     traffic: east-west
     rail: 1
     numaNode: 0
-    connectedGPU: ""
-    gpuProximity: NODE
-    psid: lnv0000000058
-    partNumber: SN37B06010
-    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
-
-  # N-S: ConnectX-6 Lx OCP 10/25GbE (41:xx.x)
-  - deviceID: "101f"
-    rdmaDevice: mlx5_0
-    pciAddress: 0000:41:00.0
-    networkInterface: ens27f0np0
-    traffic: north-south
-    numaNode: 0
-    connectedGPU: ""
-    gpuProximity: NODE
-    psid: lnv0000000037
-    partNumber: SN37A28493
-    model: Mellanox ConnectX-6 Lx 10/25GbE SFP28 2-port OCP Ethernet Adapter
-  - deviceID: "101f"
-    rdmaDevice: mlx5_1
-    pciAddress: 0000:41:00.1
-    networkInterface: ens27f1np1
-    traffic: north-south
-    numaNode: 0
-    connectedGPU: ""
-    gpuProximity: NODE
-    psid: lnv0000000037
-    partNumber: SN37A28493
-    model: Mellanox ConnectX-6 Lx 10/25GbE SFP28 2-port OCP Ethernet Adapter
-
-  # East-west: ConnectX-7 IB (65:xx.x) — PIX to GPU2, GPU3
-  - deviceID: "1021"
-    rdmaDevice: mlx5_6
-    pciAddress: 0000:65:00.0
-    networkInterface: ibs16f0
-    traffic: east-west
-    rail: 2
-    numaNode: 0
     connectedGPU: GPU2
     gpuProximity: PIX
-    psid: lnv0000000058
-    partNumber: SN37B06010
-    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
-  - deviceID: "1021"
-    rdmaDevice: mlx5_7
-    pciAddress: 0000:65:00.1
-    networkInterface: ibs16f1
-    traffic: east-west
-    rail: 3
-    numaNode: 0
-    connectedGPU: GPU3
-    gpuProximity: PIX
-    psid: lnv0000000058
-    partNumber: SN37B06010
-    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
+    psid: mt_0000001069
+    partNumber: 900-9D3D4-00EN-HA0
 
   # --- NUMA 1 ---
-  # N-S: BlueField-3 dual-port 200G DPU (85:xx.x) — SKU-classified north-south despite PIX to GPU4/GPU5
+  # East-west rail 2: BF3 SuperNIC on PCIe switch [82-88] shared with GPU4/GPU5
   - deviceID: a2dc
-    rdmaDevice: mlx5_10
+    rdmaDevice: mlx5_5
     pciAddress: 0000:85:00.0
-    networkInterface: ens2f0np0
-    traffic: north-south
+    networkInterface: ens20f0np0
+    traffic: east-west
+    rail: 2
     numaNode: 1
     connectedGPU: GPU4
     gpuProximity: PIX
-    psid: lnv0000000075
-    partNumber: SN37C16116
-    model: NVIDIA BlueField-3 VPI QSFP112 2P 200G PCIe Gen5 x16 with Tin Plating Connector
+    psid: mt_0000001069
+    partNumber: 900-9D3D4-00EN-HA0
+
+  # East-west rail 3: BF3 SuperNIC on PCIe switch [f2-f7] shared with GPU6/GPU7
   - deviceID: a2dc
-    rdmaDevice: mlx5_11
-    pciAddress: 0000:85:00.1
-    networkInterface: ens2f1np1
-    traffic: north-south
-    numaNode: 1
-    connectedGPU: GPU5
-    gpuProximity: PIX
-    psid: lnv0000000075
-    partNumber: SN37C16116
-    model: NVIDIA BlueField-3 VPI QSFP112 2P 200G PCIe Gen5 x16 with Tin Plating Connector
-
-  # East-west: ConnectX-7 IB (c1:xx.x) — own PCIe root, no GPU
-  - deviceID: "1021"
-    rdmaDevice: mlx5_8
-    pciAddress: 0000:c1:00.0
-    networkInterface: ibs20f0
-    traffic: east-west
-    rail: 4
-    numaNode: 1
-    connectedGPU: ""
-    gpuProximity: NODE
-    psid: lnv0000000058
-    partNumber: SN37B06010
-    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
-  - deviceID: "1021"
-    rdmaDevice: mlx5_9
-    pciAddress: 0000:c1:00.1
-    networkInterface: ibs20f1
-    traffic: east-west
-    rail: 5
-    numaNode: 1
-    connectedGPU: ""
-    gpuProximity: NODE
-    psid: lnv0000000058
-    partNumber: SN37B06010
-    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
-
-  # East-west: ConnectX-7 IB (e5:xx.x) — PIX to GPU6, GPU7
-  - deviceID: "1021"
     rdmaDevice: mlx5_4
-    pciAddress: 0000:e5:00.0
-    networkInterface: ibs21f0
+    pciAddress: 0000:f5:00.0
+    networkInterface: ens21f0np0
     traffic: east-west
-    rail: 6
+    rail: 3
     numaNode: 1
     connectedGPU: GPU6
     gpuProximity: PIX
-    psid: lnv0000000058
-    partNumber: SN37B06010
-    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
-  - deviceID: "1021"
-    rdmaDevice: mlx5_5
-    pciAddress: 0000:e5:00.1
-    networkInterface: ibs21f1
-    traffic: east-west
-    rail: 7
-    numaNode: 1
-    connectedGPU: GPU7
-    gpuProximity: PIX
-    psid: lnv0000000058
-    partNumber: SN37B06010
-    model: Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter
+    psid: mt_0000001069
+    partNumber: 900-9D3D4-00EN-HA0

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -95,7 +95,7 @@ pfs:
 
 **Lookup is exact-match on `(machineType, gpuType)`.** No any-GPU fallback — a preset that doesn't declare `gpuType:` is rejected at load time. Multi-variant presets for the same machine (different GPU SKUs) live in separate directories with composite names like `PowerEdge-XE9680-H200` / `PowerEdge-XE9680-B200`. The directory name is shown by `l8k preset list` and is what `l8k generate --for <name>` accepts.
 
-**Validation deviations.** When the matched preset's PCI addresses or device IDs don't exactly match discovered hardware, the preset is **still applied** (so rail/NUMA topology fields are populated) and the discrepancies are recorded under `clusterConfig[*].presetDeviation`. Every subsequent config load re-emits a warning listing each deviation. Only a PF count mismatch is fatal (the preset is genuinely incompatible).
+**Validation deviations.** When the matched preset's PF count, PCI addresses, or device IDs don't exactly match discovered hardware, the preset is **NOT applied** — discovery keeps the live-discovered topology (traffic/rail/NUMA), because overlaying a preset onto a different PCI layout would corrupt the classification (a coincidentally-overlapping PCI address would inherit the preset's unrelated traffic/rail/GPU fields). The discrepancies are recorded under `clusterConfig[*].presetDeviation` and every subsequent config load re-emits a warning listing each deviation. The preset's authoritative topology is overlaid **only on an exact match** (zero deviations); `presetApplied: true` appears only in that case. Part-number and PSID differences are expected (firmware/SKU variants) and never block application.
 
 ## Common Edits
 


### PR DESCRIPTION
A discovered config showed a GPU-attached SuperNIC (85:00.0) marked north-south with rail 2 missing from the rail sequence (0,1,3). Root cause: the ThinkSystem-SR675-V3-RTX-PRO-6000 preset matched on (machineType, gpuType) labels but described entirely different hardware (12 ConnectX-7 PFs vs. the node's 6 BlueField-3 PFs). ApplyPreset matches PFs by PCI address, so the single coincidentally-overlapping address (85:00.0 — a north-south DPU port in that preset) inherited the preset's traffic/rail/GPU fields, clobbering the correct live classification and leaving a hole at rail 2 (ApplyPreset never renumbers).

Two fixes:

- Discovery now skips preset enrichment when the hardware deviates from the preset on PF count, PCI address, or device ID (NIC model), via the new presets.HasTopologyDeviation. Deviations are still recorded on ClusterConfig.PresetDeviation and warned about every load; the live-discovered topology is kept untouched. This realigns the code with the behavior docs/presets.rst already documented ("Preset rejected").

- ApplyPreset is now all-or-nothing and returns a bool: it applies only when the group and preset describe the same set of PCI addresses, and otherwise mutates nothing. On a full match it copies the preset's rail values verbatim and never renumbers, preserving presets that number rails out of PCI order (e.g. PowerEdge-XE7745, rail 0 on PCI domain 0001). This defends the invariant independent of the discovery gate, so a partial match can no longer produce gaps or duplicate rail indices.

Adds unit tests for HasTopologyDeviation and ApplyPreset's partial-match no-op, subset no-op, and verbatim-rail-order behavior.