### PR TITLE
Address SonarQube regulatory-report findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,18 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: read
-
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -35,12 +34,14 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -59,17 +60,19 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.11

--- a/.github/workflows/image-push-main.yml
+++ b/.github/workflows/image-push-main.yml
@@ -4,8 +4,9 @@ on:
     branches:
       - main
 
-permissions: write-all
-  
+permissions:
+  contents: read
+
 jobs:
   image-build-push:
     name: Image build and push
@@ -13,34 +14,35 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write # required to push the image to ghcr.io via GITHUB_TOKEN
     steps:
       - name: Set repository as lower-case output variable
         id: repo_name
         run: echo ::set-output name=repository::$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - name: Setup Go Proxy
         id: setup-go-proxy
-        uses: nv-gha-runners/setup-artifactory-go-proxy@main
+        uses: nv-gha-runners/setup-artifactory-go-proxy@a15ec16ff434e8ca3b0f76919f902080e66ebc14 # main
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/${{ steps.repo_name.outputs.repository }}
       - name: Build and push container image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy-url || 'direct' }}
         with:

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -12,29 +12,29 @@ jobs:
       id-token: write
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - name: Setup Go Proxy
         id: setup-go-proxy
-        uses: nv-gha-runners/setup-artifactory-go-proxy@main
+        uses: nv-gha-runners/setup-artifactory-go-proxy@a15ec16ff434e8ca3b0f76919f902080e66ebc14 # main
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to nvstaging container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: nvcr.io/nvstaging/mellanox
           username: ${{ secrets.NVCR_USERNAME }}
           password: ${{ secrets.NVCR_TOKEN }}
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: nvcr.io/nvstaging/mellanox/k8s-launch-kit
       - name: Build and push container image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy-url || 'direct' }}
         with:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -21,28 +21,27 @@ on:
     paths:
       - ".goreleaser.yml"
 
-permissions:
-  contents: read
-
 jobs:
   validate:
     name: Validate GoReleaser config
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Run GoReleaser dry-run
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,21 +24,19 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  id-token: write
-
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -54,23 +52,26 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Install syft (for SBOM generation)
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -85,6 +86,7 @@ jobs:
     needs: [test, goreleaser]
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
     steps:
       - name: Report job statuses
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,15 +39,21 @@ ARG TARGETOS
 ARG TARGETARCH
 
 # Build with make to apply all build logic defined in Makefile
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-$(go env GOOS)} GOARCH=${TARGETARCH:-$(go env GOARCH)} make build
+RUN CGO_ENABLED=0 GOOS="${TARGETOS:-$(go env GOOS)}" GOARCH="${TARGETARCH:-$(go env GOARCH)}" make build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM nvcr.io/nvidia/distroless/go:v4.0.4
 
 
-COPY . /src
+# Copy only the runtime assets l8k resolves relative to its working directory
+# (profiles, presets, l8k-config.yaml). Everything else — Go source, releases.yaml,
+# etc. — is either build-only or embedded via go:embed, so it must not leak into
+# the final image.
 WORKDIR /src
+COPY profiles /src/profiles
+COPY presets /src/presets
+COPY l8k-config.yaml /src/l8k-config.yaml
 COPY --from=builder /workspace/build/l8k /src/l8k
 
 ENTRYPOINT ["/src/l8k"]

--- a/pkg/cmd/flagnames.go
+++ b/pkg/cmd/flagnames.go
@@ -1,0 +1,26 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+// Flag names shared across multiple commands. Defining them once avoids typos
+// between flag registration and the later Lookup/MarkFlagsMutuallyExclusive/
+// setFlagGroup calls that reference the same flag by name.
+const (
+	flagGPUType          = "gpu-type"
+	flagLogLevel         = "log-level"
+	flagEnableDocaDriver = "enable-doca-driver"
+)

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -101,29 +101,29 @@ Optionally deploy the generated manifests with --deploy.`,
 		}
 
 		opts := options.Options{
-			UserConfig:     userConfig,
-			Fabric:         fabric,
-			DeploymentType: deploymentType,
-			Multirail:      multirail,
-			MultirailSet:   cmd.Flag("multirail").Changed,
-			SpectrumX:      spectrumXVersion != "",
-			SPCXVersion:             spectrumXVersion,
-			MultiplaneMode:          multiplaneMode,
-			NumberOfPlanes:          numberOfPlanes,
-			Groups:                  groups,
-			GpuType:                 gpuType,
-			NodeSelector:            generateNodeSelector,
-			ForPreset:               forPreset,
-			ImagePullSecrets:        imagePullSecrets,
-			PodNamespace:            podNamespace,
-			SaveDeploymentFiles:     saveDeploymentFiles,
-			Deploy:                  deploy,
-			OverwriteExisting:       overwriteExistingFlag,
-			Kubeconfig:              kubeconfig,
+			UserConfig:               userConfig,
+			Fabric:                   fabric,
+			DeploymentType:           deploymentType,
+			Multirail:                multirail,
+			MultirailSet:             cmd.Flag("multirail").Changed,
+			SpectrumX:                spectrumXVersion != "",
+			SPCXVersion:              spectrumXVersion,
+			MultiplaneMode:           multiplaneMode,
+			NumberOfPlanes:           numberOfPlanes,
+			Groups:                   groups,
+			GpuType:                  gpuType,
+			NodeSelector:             generateNodeSelector,
+			ForPreset:                forPreset,
+			ImagePullSecrets:         imagePullSecrets,
+			PodNamespace:             podNamespace,
+			SaveDeploymentFiles:      saveDeploymentFiles,
+			Deploy:                   deploy,
+			OverwriteExisting:        overwriteExistingFlag,
+			Kubeconfig:               kubeconfig,
 			NetworkOperatorNamespace: networkOperatorNamespace,
 			NetworkOperatorRelease:   networkOperatorRelease,
 			EnabledPlugins:           parseEnabledPlugins(enabledPlugins),
-			WorkloadManifest:        workloadManifest,
+			WorkloadManifest:         workloadManifest,
 			OutputFormat:             outputFormat,
 			Yes:                      yesFlag,
 			Quiet:                    quietFlag,
@@ -131,7 +131,7 @@ Optionally deploy the generated manifests with --deploy.`,
 		}
 
 		// Set EnableDocaDriver only if the flag was explicitly provided
-		if cmd.Flags().Lookup("enable-doca-driver").Changed {
+		if cmd.Flags().Lookup(flagEnableDocaDriver).Changed {
 			opts.EnableDocaDriver = &enableDocaDriver
 		}
 
@@ -189,15 +189,15 @@ func init() {
 	generateCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Multiplane mode: swplb, hwplb, uniplane (requires --spectrum-x)")
 	generateCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes (requires --spectrum-x)")
 	generateCmd.Flags().StringSliceVar(&groups, "groups", nil, "Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.")
-	generateCmd.Flags().StringVar(&gpuType, "gpu-type", "", "Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.")
-	generateCmd.MarkFlagsMutuallyExclusive("groups", "gpu-type")
+	generateCmd.Flags().StringVar(&gpuType, flagGPUType, "", "Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.")
+	generateCmd.MarkFlagsMutuallyExclusive("groups", flagGPUType)
 	generateCmd.Flags().StringVar(&forPreset, "for", "", forFlagHelp())
 	generateCmd.Flags().StringVar(&generateNodeSelector, "node-selector", "", "Node selector for the synthesized clusterConfig when --for is used (e.g., key=value,key2=value2). Required with --for.")
 
 	// Output
 	generateCmd.Flags().StringVar(&saveDeploymentFiles, "save-deployment-files", "", "Output directory for generated YAMLs")
 	generateCmd.Flags().StringVar(&podNamespace, "pod-namespace", "", "Namespace for pods and network resources")
-	generateCmd.Flags().BoolVar(&enableDocaDriver, "enable-doca-driver", false, "Enable DOCA driver deployment")
+	generateCmd.Flags().BoolVar(&enableDocaDriver, flagEnableDocaDriver, false, "Enable DOCA driver deployment")
 	generateCmd.Flags().StringVar(&workloadManifest, "workload-manifest", "", "Path to a custom workload manifest YAML")
 	generateCmd.Flags().StringVar(&networkOperatorNamespace, "network-operator-namespace", "", "Override operator namespace")
 	generateCmd.Flags().StringVar(&networkOperatorRelease, "network-operator-release", "",
@@ -224,7 +224,7 @@ func init() {
 	setFlagGroup(generateCmd, "multirail", GroupProfile)
 	setFlagGroup(generateCmd, "spectrum-x", GroupProfile)
 	setFlagGroup(generateCmd, "groups", GroupProfile)
-	setFlagGroup(generateCmd, "gpu-type", GroupProfile)
+	setFlagGroup(generateCmd, flagGPUType, GroupProfile)
 	setFlagGroup(generateCmd, "for", GroupProfile)
 	setFlagGroup(generateCmd, "node-selector", GroupProfile)
 
@@ -233,7 +233,7 @@ func init() {
 
 	setFlagGroup(generateCmd, "save-deployment-files", GroupGeneration)
 	setFlagGroup(generateCmd, "pod-namespace", GroupGeneration)
-	setFlagGroup(generateCmd, "enable-doca-driver", GroupGeneration)
+	setFlagGroup(generateCmd, flagEnableDocaDriver, GroupGeneration)
 	setFlagGroup(generateCmd, "workload-manifest", GroupGeneration)
 
 	setFlagGroup(generateCmd, "deploy", GroupDeploy)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -40,43 +40,43 @@ import (
 )
 
 var (
-	logLevel              string
-	logFile               string
-	fabric                string
-	deploymentType        string
-	multirail             bool
+	logLevel       string
+	logFile        string
+	fabric         string
+	deploymentType string
+	multirail      bool
 	// spectrumXVersion holds the value of --spectrum-x. Empty means
 	// Spectrum-X is disabled; a non-empty value is the SPC-X RA version
 	// (validated against config.SupportedSPCXVersions). The legacy --spcx-version
 	// flag has been folded into --spectrum-x; passing the version is now part
 	// of opting into Spectrum-X.
-	spectrumXVersion      string
-	multiplaneMode        string
-	numberOfPlanes        int
-	saveDeploymentFiles   string
-	deploy                bool
-	kubeconfig            string
-	userConfig            string
-	discoverClusterConfig bool
-	saveClusterConfig     string
-	logger                = log.Log.WithName("l8k")
-	enableDocaDriver            bool
-	enabledPlugins              string
-	networkOperatorNamespace    string
-	networkOperatorRelease      string
-	groups                      []string
-	gpuType                     string
-	nodeSelector                string
-	imagePullSecrets            []string
-	podNamespace                string
-	outputFormat                string
-	yesFlag                     bool
-	quietFlag                   bool
-	workloadManifest            string
-	dryRunFlag                  bool
-	forPreset                   string
-	deployTimeoutRoot           time.Duration
-	keepNamespace               bool
+	spectrumXVersion         string
+	multiplaneMode           string
+	numberOfPlanes           int
+	saveDeploymentFiles      string
+	deploy                   bool
+	kubeconfig               string
+	userConfig               string
+	discoverClusterConfig    bool
+	saveClusterConfig        string
+	logger                   = log.Log.WithName("l8k")
+	enableDocaDriver         bool
+	enabledPlugins           string
+	networkOperatorNamespace string
+	networkOperatorRelease   string
+	groups                   []string
+	gpuType                  string
+	nodeSelector             string
+	imagePullSecrets         []string
+	podNamespace             string
+	outputFormat             string
+	yesFlag                  bool
+	quietFlag                bool
+	workloadManifest         string
+	dryRunFlag               bool
+	forPreset                string
+	deployTimeoutRoot        time.Duration
+	keepNamespace            bool
 )
 
 // forFlagHelp builds the help string for `--for`. Computed at init() time so
@@ -146,41 +146,41 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
 		enabledPlugins := parseEnabledPlugins(enabledPlugins)
 		// Create application options from CLI flags
 		opts := options.Options{
-			LogLevel:              logLevel,
-			LogFile:               logFile,
-			UserConfig:            userConfig,
-			DiscoverClusterConfig: discoverClusterConfig,
-			Fabric:                fabric,
-			DeploymentType:        deploymentType,
-			Multirail:             multirail,
-			MultirailSet:         cmd.Flag("multirail").Changed,
-			SpectrumX:             spectrumXVersion != "",
-			SPCXVersion:           spectrumXVersion,
-			MultiplaneMode:        multiplaneMode,
-			NumberOfPlanes:        numberOfPlanes,
-			Groups:               groups,
-			GpuType:              gpuType,
-			NodeSelector:         nodeSelector,
-			ForPreset:            forPreset,
-			ImagePullSecrets:     imagePullSecrets,
-			PodNamespace:         podNamespace,
-			SaveDeploymentFiles:   saveDeploymentFiles,
-			Deploy:                deploy,
-			Kubeconfig:            kubeconfig,
-			DeployTimeout:         deployTimeoutRoot,
+			LogLevel:                 logLevel,
+			LogFile:                  logFile,
+			UserConfig:               userConfig,
+			DiscoverClusterConfig:    discoverClusterConfig,
+			Fabric:                   fabric,
+			DeploymentType:           deploymentType,
+			Multirail:                multirail,
+			MultirailSet:             cmd.Flag("multirail").Changed,
+			SpectrumX:                spectrumXVersion != "",
+			SPCXVersion:              spectrumXVersion,
+			MultiplaneMode:           multiplaneMode,
+			NumberOfPlanes:           numberOfPlanes,
+			Groups:                   groups,
+			GpuType:                  gpuType,
+			NodeSelector:             nodeSelector,
+			ForPreset:                forPreset,
+			ImagePullSecrets:         imagePullSecrets,
+			PodNamespace:             podNamespace,
+			SaveDeploymentFiles:      saveDeploymentFiles,
+			Deploy:                   deploy,
+			Kubeconfig:               kubeconfig,
+			DeployTimeout:            deployTimeoutRoot,
 			SaveClusterConfig:        saveClusterConfig,
 			NetworkOperatorNamespace: networkOperatorNamespace,
 			NetworkOperatorRelease:   networkOperatorRelease,
 			EnabledPlugins:           enabledPlugins,
-			WorkloadManifest:      workloadManifest,
-			OutputFormat:           outputFormat,
-			Yes:                    yesFlag,
-			Quiet:                  quietFlag,
-			DryRun:                 dryRunFlag,
+			WorkloadManifest:         workloadManifest,
+			OutputFormat:             outputFormat,
+			Yes:                      yesFlag,
+			Quiet:                    quietFlag,
+			DryRun:                   dryRunFlag,
 		}
 
 		// Set EnableDocaDriver only if the flag was explicitly provided
-		if cmd.Flags().Lookup("enable-doca-driver").Changed {
+		if cmd.Flags().Lookup(flagEnableDocaDriver).Changed {
 			opts.EnableDocaDriver = &enableDocaDriver
 		}
 
@@ -242,14 +242,14 @@ func init() {
 	rootCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Spectrum-X multiplane mode: swplb, hwplb, uniplane (requires --spectrum-x)")
 	rootCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes for Spectrum-X (requires --spectrum-x)")
 	rootCmd.Flags().StringSliceVar(&groups, "groups", nil, "Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.")
-	rootCmd.Flags().StringVar(&gpuType, "gpu-type", "", "Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.")
-	rootCmd.MarkFlagsMutuallyExclusive("groups", "gpu-type")
+	rootCmd.Flags().StringVar(&gpuType, flagGPUType, "", "Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.")
+	rootCmd.MarkFlagsMutuallyExclusive("groups", flagGPUType)
 	rootCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Filter nodes for discovery by label (e.g., key=value,key2=value2)")
 	rootCmd.Flags().StringVar(&forPreset, "for", "", forFlagHelp())
 	rootCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for NicClusterPolicy (comma-separated)")
 	rootCmd.Flags().StringVar(&saveDeploymentFiles, "save-deployment-files", "./deployment", "Save generated deployment files to the specified directory")
 	rootCmd.Flags().StringVar(&podNamespace, "pod-namespace", "", "Namespace for pods and network resources (overrides config podNamespace, default: 'default')")
-	rootCmd.Flags().BoolVar(&enableDocaDriver, "enable-doca-driver", false, "Enable DOCA driver deployment (overrides config file docaDriver.enable)")
+	rootCmd.Flags().BoolVar(&enableDocaDriver, flagEnableDocaDriver, false, "Enable DOCA driver deployment (overrides config file docaDriver.enable)")
 	rootCmd.Flags().StringVar(&workloadManifest, "workload-manifest", "", "Path to a custom workload manifest YAML (replaces the profile's default example workload)")
 
 	// Phase 3: Cluster deployment flags
@@ -264,7 +264,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "Preview what would be deployed without applying changes to the cluster")
 
 	// Logging flags
-	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "Enable logging at specified level (debug, info, warn, error)")
+	rootCmd.PersistentFlags().StringVar(&logLevel, flagLogLevel, "", "Enable logging at specified level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Write logs to file instead of stderr")
 
 	// Group the flags into labelled sections in --help output. The phase
@@ -287,7 +287,7 @@ func init() {
 	setFlagGroup(rootCmd, "multirail", GroupProfile)
 	setFlagGroup(rootCmd, "spectrum-x", GroupProfile)
 	setFlagGroup(rootCmd, "groups", GroupProfile)
-	setFlagGroup(rootCmd, "gpu-type", GroupProfile)
+	setFlagGroup(rootCmd, flagGPUType, GroupProfile)
 	setFlagGroup(rootCmd, "for", GroupProfile)
 
 	setFlagGroup(rootCmd, "multiplane-mode", GroupSpectrumX)
@@ -295,7 +295,7 @@ func init() {
 
 	setFlagGroup(rootCmd, "save-deployment-files", GroupGeneration)
 	setFlagGroup(rootCmd, "pod-namespace", GroupGeneration)
-	setFlagGroup(rootCmd, "enable-doca-driver", GroupGeneration)
+	setFlagGroup(rootCmd, flagEnableDocaDriver, GroupGeneration)
 	setFlagGroup(rootCmd, "workload-manifest", GroupGeneration)
 
 	setFlagGroup(rootCmd, "deploy", GroupDeploy)
@@ -305,7 +305,7 @@ func init() {
 	setFlagGroup(rootCmd, "output", GroupOutputLogging)
 	setFlagGroup(rootCmd, "yes", GroupOutputLogging)
 	setFlagGroup(rootCmd, "quiet", GroupOutputLogging)
-	setFlagGroup(rootCmd, "log-level", GroupOutputLogging)
+	setFlagGroup(rootCmd, flagLogLevel, GroupOutputLogging)
 	setFlagGroup(rootCmd, "log-file", GroupOutputLogging)
 
 	installGroupedUsage(rootCmd)
@@ -521,7 +521,7 @@ func resolveKubeconfig(flagValue string) (string, error) {
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
 	// Detect if --log-level was explicitly set
-	logLevelFlag := rootCmd.PersistentFlags().Lookup("log-level")
+	logLevelFlag := rootCmd.PersistentFlags().Lookup(flagLogLevel)
 	loggingEnabled := logLevelFlag.Changed
 
 	if loggingEnabled {

--- a/pkg/networkoperatorplugin/connectivity/rdma.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma.go
@@ -41,6 +41,9 @@ const rdmaServerSettleDelay = 2 * time.Second
 // Options.Timeout.
 const rdmaTestTimeout = 90 * time.Second
 
+// shellExec is the in-pod shell used to run connectivity test commands.
+const shellExec = "/bin/sh"
+
 // DiscoverRDMADevices runs once per test pod to map each multus
 // secondary-network interface to its RDMA device. Reads
 // /sys/class/net/<iface>/device/infiniband/ inside the pod — that
@@ -74,7 +77,7 @@ func DiscoverRDMADevices(ctx context.Context, restConfig *rest.Config, namespace
 	if b.Len() == 0 {
 		return out
 	}
-	res, err := kubeclient.ExecInPod(ctx, restConfig, namespace, pod, container, []string{"/bin/sh", "-c", b.String()})
+	res, err := kubeclient.ExecInPod(ctx, restConfig, namespace, pod, container, []string{shellExec, "-c", b.String()})
 	if err != nil {
 		return out
 	}
@@ -116,7 +119,7 @@ func RunRPing(ctx context.Context, restConfig *rest.Config, namespace string, se
 	defer cancel()
 
 	serverCmd := fmt.Sprintf("nohup rping -s -a %s -p 9999 -v >/tmp/rping-server.log 2>&1 & echo $!", test.DstIP)
-	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, namespace, serverPod, serverContainer, []string{"/bin/sh", "-c", serverCmd})
+	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, namespace, serverPod, serverContainer, []string{shellExec, "-c", serverCmd})
 	if err != nil {
 		r.Err = fmt.Errorf("rping server start: %w (stderr: %s)", err, srvRes.Stderr)
 		return r
@@ -133,7 +136,7 @@ func RunRPing(ctx context.Context, restConfig *rest.Config, namespace string, se
 	}
 
 	clientCmd := fmt.Sprintf("rping -c -a %s -p 9999 -C %d -v", test.DstIP, iterations)
-	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, namespace, clientPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
+	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, namespace, clientPod, clientContainer, []string{shellExec, "-c", clientCmd})
 	r.Stdout, r.Stderr = cliRes.Stdout, cliRes.Stderr
 	r.Err = cliErr
 	// rping exits 0 only on a clean run; non-zero exit propagates
@@ -169,7 +172,7 @@ func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, namespace string
 	// sides print the summary table.
 	serverCmd := fmt.Sprintf("nohup ib_write_bw -d %s -R -s 65536 --report_gbits -p %d >/tmp/ibwritebw-server.log 2>&1 & echo $!",
 		test.DstRDMADev, port)
-	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, namespace, serverPod, serverContainer, []string{"/bin/sh", "-c", serverCmd})
+	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, namespace, serverPod, serverContainer, []string{shellExec, "-c", serverCmd})
 	if err != nil {
 		r.Err = fmt.Errorf("ib_write_bw server start: %w (stderr: %s)", err, srvRes.Stderr)
 		return r
@@ -186,7 +189,7 @@ func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, namespace string
 
 	clientCmd := fmt.Sprintf("ib_write_bw -d %s -R -s 65536 --report_gbits -p %d %s",
 		test.SrcRDMADev, port, test.DstIP)
-	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, namespace, clientPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
+	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, namespace, clientPod, clientContainer, []string{shellExec, "-c", clientCmd})
 	r.Stdout, r.Stderr = cliRes.Stdout, cliRes.Stderr
 
 	bw, msgRate, parseOK := parseIbWriteBwOutput(cliRes.Stdout)
@@ -220,7 +223,7 @@ func killRDMAServer(restConfig *rest.Config, namespace, pod, container, prog, pi
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	cmd := fmt.Sprintf("kill %s 2>/dev/null; pkill -f %q 2>/dev/null; true", pid, prog)
-	_, _ = kubeclient.ExecInPod(ctx, restConfig, namespace, pod, container, []string{"/bin/sh", "-c", cmd})
+	_, _ = kubeclient.ExecInPod(ctx, restConfig, namespace, pod, container, []string{shellExec, "-c", cmd})
 }
 
 // ibWriteBwSummaryRe matches the single-row summary line that

--- a/pkg/networkoperatorplugin/connectivity/report.go
+++ b/pkg/networkoperatorplugin/connectivity/report.go
@@ -17,7 +17,7 @@
 package connectivity
 
 import (
-	_ "embed"
+	_ "embed" // required for the //go:embed directive that loads the HTML report template
 	"fmt"
 	"html/template"
 	"io"
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
-	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/preflight"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/crstate"
+	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/preflight"
 	"github.com/nvidia/k8s-launch-kit/pkg/presetmatch"
 )
 
@@ -66,12 +66,12 @@ type ReportData struct {
 	// Verdict is the overall pass/fail outcome rendered as a
 	// prominent banner at the top of the report. Computed by the
 	// caller (CLI) from the same inputs that drive the exit code.
-	Verdict OverallVerdict
-	Cluster        ClusterInfo
-	Profile        ProfileInfo
-	NodeGroups     []NodeGroupInfo
-	Nodes          []NodeInfo
-	Release        *networkoperatorplugin.VersionCheck
+	Verdict    OverallVerdict
+	Cluster    ClusterInfo
+	Profile    ProfileInfo
+	NodeGroups []NodeGroupInfo
+	Nodes      []NodeInfo
+	Release    *networkoperatorplugin.VersionCheck
 	// ComponentCheck cross-references the live NCP+NNP component
 	// versions against the embedded release catalog. Surfaced as a
 	// sub-table under "Network Operator release" in the HTML

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -18,7 +18,7 @@ package networkoperatorplugin
 
 import (
 	"context"
-	_ "embed"
+	_ "embed" // required for the //go:embed directive that loads ns-product-ids
 	"fmt"
 	"slices"
 	"sort"
@@ -41,6 +41,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// shellExec is the in-pod shell used to run discovery commands.
+const shellExec = "/bin/sh"
 
 //go:embed ns-product-ids
 var nsProductIDsData string
@@ -113,6 +116,8 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 	if !p.KeepNamespace {
 		defer func() {
 			uiOutput.Info("Tearing down namespace %q", nicconfigdaemon.Namespace)
+			// Use a fresh context for teardown: the discovery ctx may already be
+			// cancelled/timed out, but cleanup must still run.
 			if cleanupErr := nicconfigdaemon.Cleanup(context.Background(), c); cleanupErr != nil {
 				log.Log.Error(cleanupErr, "failed to tear down discover bootstrap namespace",
 					"namespace", nicconfigdaemon.Namespace)
@@ -1229,7 +1234,7 @@ func discoverHardwareTypes(ctx context.Context, restConfig *rest.Config,
 		log.Log.V(1).Info("Probing machine type via DMI",
 			"pod", targetPod.Name, "command", dmiCmd)
 		output, err := execInPod(ctx, restConfig, namespace, targetPod.Name, containerName,
-			[]string{"/bin/sh", "-c", dmiCmd})
+			[]string{shellExec, "-c", dmiCmd})
 		if err != nil {
 			log.Log.Error(err, "failed to read machine type from DMI", "pod", targetPod.Name)
 		} else {
@@ -1250,7 +1255,7 @@ func discoverHardwareTypes(ctx context.Context, restConfig *rest.Config,
 			`/host/usr/bin/nvidia-smi -q 2>/dev/null || true; fi`
 		log.Log.V(1).Info("Probing GPU product type via nvidia-smi", "pod", targetPod.Name)
 		output, err := execInPod(ctx, restConfig, namespace, targetPod.Name, containerName,
-			[]string{"/bin/sh", "-c", nvidiaSmiCmd})
+			[]string{shellExec, "-c", nvidiaSmiCmd})
 		if err != nil {
 			log.Log.Error(err, "failed to exec nvidia-smi probe", "pod", targetPod.Name)
 		} else {
@@ -1264,7 +1269,7 @@ func discoverHardwareTypes(ctx context.Context, restConfig *rest.Config,
 		if gpuType == "" {
 			log.Log.V(1).Info("Falling back to sysfs/pci.ids for GPU product type", "pod", targetPod.Name)
 			sysfsOutput, sysfsErr := execInPod(ctx, restConfig, namespace, targetPod.Name, containerName,
-				[]string{"/bin/sh", "-c", sysfsNvidiaGPUIDCmd})
+				[]string{shellExec, "-c", sysfsNvidiaGPUIDCmd})
 			if sysfsErr != nil {
 				log.Log.Error(sysfsErr, "failed to exec sysfs GPU probe", "pod", targetPod.Name)
 			} else {
@@ -1408,7 +1413,7 @@ func discoverPortFabric(ctx context.Context, restConfig *rest.Config,
 	} {
 		cmd := fmt.Sprintf("cat %s", base)
 		output, err := execInPod(ctx, restConfig, namespace, podName, containerName,
-			[]string{"/bin/sh", "-c", cmd})
+			[]string{shellExec, "-c", cmd})
 		if err != nil {
 			lastErr = err
 			log.Log.V(1).Info("Fabric port probe: read failed at this base",
@@ -1572,7 +1577,7 @@ done | TARGETS="$targets" awk "$awk_script" | sort -u`, modList)
 	log.Log.V(1).Info("Probing OFED-dependent kernel modules",
 		"pod", targetPod.Name, "ofedTargets", ofedTargetModules)
 	output, err := execInPod(ctx, restConfig, namespace, targetPod.Name, containerName,
-		[]string{"/bin/sh", "-c", script})
+		[]string{shellExec, "-c", script})
 	if err != nil {
 		return nil, fmt.Errorf("exec in pod %q failed: %w", targetPod.Name, err)
 	}

--- a/pkg/networkoperatorplugin/helm.go
+++ b/pkg/networkoperatorplugin/helm.go
@@ -305,7 +305,7 @@ func runUpgrade(
 func pullChart(_ context.Context, repoURL, chartName, chartVersion string) (string, func(), error) {
 	tmpDir, err := os.MkdirTemp("", "l8k-helm-chart-*")
 	if err != nil {
-		return "", func() {}, fmt.Errorf("create temp dir for chart pull: %w", err)
+		return "", func() { /* nothing to clean up on this error path */ }, fmt.Errorf("create temp dir for chart pull: %w", err)
 	}
 	cleanup := func() { _ = os.RemoveAll(tmpDir) }
 
@@ -327,7 +327,7 @@ func pullChart(_ context.Context, repoURL, chartName, chartVersion string) (stri
 	)
 	if err != nil {
 		cleanup()
-		return "", func() {}, fmt.Errorf("resolve %s@%s in %s: %w", chartName, chartVersion, repoURL, err)
+		return "", func() { /* nothing to clean up on this error path */ }, fmt.Errorf("resolve %s@%s in %s: %w", chartName, chartVersion, repoURL, err)
 	}
 
 	dl := downloader.ChartDownloader{
@@ -340,7 +340,7 @@ func pullChart(_ context.Context, repoURL, chartName, chartVersion string) (stri
 	saved, _, err := dl.DownloadTo(chartURL, chartVersion, tmpDir)
 	if err != nil {
 		cleanup()
-		return "", func() {}, fmt.Errorf("download %s: %w", chartURL, err)
+		return "", func() { /* nothing to clean up on this error path */ }, fmt.Errorf("download %s: %w", chartURL, err)
 	}
 	return saved, cleanup, nil
 }

--- a/pkg/networkoperatorplugin/helmclient/client.go
+++ b/pkg/networkoperatorplugin/helmclient/client.go
@@ -115,7 +115,9 @@ func (r *restClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
 		return nil, err
 	}
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(dc)
-	return restmapper.NewShortcutExpander(mapper, dc, func(s string) {}), nil
+	// The warning handler is intentionally a no-op: we suppress shortcut-expander
+	// deprecation warnings rather than surfacing them to l8k users.
+	return restmapper.NewShortcutExpander(mapper, dc, func(_ string) {}), nil
 }
 
 func (r *restClientGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {

--- a/pkg/networkoperatorplugin/internal/pciids/pciids.go
+++ b/pkg/networkoperatorplugin/internal/pciids/pciids.go
@@ -19,7 +19,7 @@
 package pciids
 
 import (
-	_ "embed"
+	_ "embed" // required for the //go:embed directive that loads the pci.ids snapshot
 	"strings"
 )
 

--- a/pkg/networkoperatorplugin/preflight/strays.go
+++ b/pkg/networkoperatorplugin/preflight/strays.go
@@ -19,6 +19,13 @@ import (
 	sigsyaml "sigs.k8s.io/yaml"
 )
 
+// API groups referenced repeatedly by managedKinds. Defined once so a typo in
+// one entry can't silently change which CRs the stray check enumerates.
+const (
+	groupMellanox     = "mellanox.com"
+	groupSriovNetwork = "sriovnetwork.openshift.io"
+)
+
 // kindInfo describes one Kind the stray-CRs check enumerates.
 // ClusterScoped=true means the check lists cluster-wide; otherwise it
 // lists only in Inputs.OperatorNamespace.
@@ -40,22 +47,22 @@ type kindInfo struct {
 // counterpart to compare against.
 var managedKinds = []kindInfo{
 	// Cluster-scoped — singletons or per-group resources.
-	{GVK: gvk("mellanox.com", "v1alpha1", "NicClusterPolicy"), ClusterScoped: true},
-	{GVK: gvk("mellanox.com", "v1alpha1", "NicNodePolicy"), ClusterScoped: true},
+	{GVK: gvk(groupMellanox, "v1alpha1", "NicClusterPolicy"), ClusterScoped: true},
+	{GVK: gvk(groupMellanox, "v1alpha1", "NicNodePolicy"), ClusterScoped: true},
 	{GVK: gvk("configuration.net.nvidia.com", "v1alpha1", "NicConfigurationTemplate"), ClusterScoped: true},
 	{GVK: gvk("configuration.net.nvidia.com", "v1alpha1", "NicInterfaceNameTemplate"), ClusterScoped: true},
 
 	// Namespaced — enumerated in the operator namespace.
-	{GVK: gvk("sriovnetwork.openshift.io", "v1", "SriovNetworkNodePolicy")},
-	{GVK: gvk("sriovnetwork.openshift.io", "v1", "SriovNetwork")},
-	{GVK: gvk("sriovnetwork.openshift.io", "v1", "SriovIBNetwork")},
-	{GVK: gvk("sriovnetwork.openshift.io", "v1", "SriovNetworkPoolConfig")},
-	{GVK: gvk("sriovnetwork.openshift.io", "v1", "OVSNetwork")},
+	{GVK: gvk(groupSriovNetwork, "v1", "SriovNetworkNodePolicy")},
+	{GVK: gvk(groupSriovNetwork, "v1", "SriovNetwork")},
+	{GVK: gvk(groupSriovNetwork, "v1", "SriovIBNetwork")},
+	{GVK: gvk(groupSriovNetwork, "v1", "SriovNetworkPoolConfig")},
+	{GVK: gvk(groupSriovNetwork, "v1", "OVSNetwork")},
 	{GVK: gvk("nv-ipam.nvidia.com", "v1alpha1", "IPPool")},
 	{GVK: gvk("nv-ipam.nvidia.com", "v1alpha1", "CIDRPool")},
-	{GVK: gvk("mellanox.com", "v1alpha1", "MacvlanNetwork")},
-	{GVK: gvk("mellanox.com", "v1alpha1", "IPoIBNetwork")},
-	{GVK: gvk("mellanox.com", "v1alpha1", "HostDeviceNetwork")},
+	{GVK: gvk(groupMellanox, "v1alpha1", "MacvlanNetwork")},
+	{GVK: gvk(groupMellanox, "v1alpha1", "IPoIBNetwork")},
+	{GVK: gvk(groupMellanox, "v1alpha1", "HostDeviceNetwork")},
 	{GVK: gvk("spectrumx.nvidia.com", "v1alpha1", "SpectrumXRailPoolConfig")},
 	{GVK: gvk("spectrumx.nvidia.com", "v1alpha2", "SpectrumXRailPoolConfig")},
 }

--- a/pkg/networkoperatorplugin/releases.go
+++ b/pkg/networkoperatorplugin/releases.go
@@ -17,7 +17,7 @@
 package networkoperatorplugin
 
 import (
-	_ "embed"
+	_ "embed" // required for the //go:embed directive that loads releases.yaml
 	"fmt"
 	"sort"
 	"sync"

--- a/pkg/ui/json_output.go
+++ b/pkg/ui/json_output.go
@@ -99,6 +99,8 @@ func (o *JSONOutput) StartProgress(message string) Progress {
 	return &noopProgress{output: o}
 }
 
+// Header is a no-op in JSON mode: headers are presentational and have no place
+// in structured machine-readable output.
 func (o *JSONOutput) Header(_ string) {}
 
 func (o *JSONOutput) Section(text string) {

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -67,13 +67,13 @@ SHARE_DIR="${PREFIX}/share/l8k"
 BIN_DIR="${PREFIX}/bin"
 
 # Verify binary exists
-if [ ! -f "${REPO_ROOT}/build/l8k" ]; then
-    echo "Error: binary not found at ${REPO_ROOT}/build/l8k"
-    echo "Run 'make build' first."
+if [[ ! -f "${REPO_ROOT}/build/l8k" ]]; then
+    echo "Error: binary not found at ${REPO_ROOT}/build/l8k" >&2
+    echo "Run 'make build' first." >&2
     exit 1
 fi
 
-if [ "$DEV_ENV" = true ]; then
+if [[ "$DEV_ENV" == true ]]; then
     echo "Installing l8k (dev mode — symlinks)..."
     mkdir -p "${BIN_DIR}"
     ln -sfn "${REPO_ROOT}/build/l8k" "${BIN_DIR}/l8k"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,7 +84,7 @@ case "$ARCH" in
     x86_64)         ARCH=amd64 ;;
     aarch64|arm64)  ARCH=arm64 ;;
     *)
-        echo "Error: unsupported architecture: $ARCH"
+        echo "Error: unsupported architecture: $ARCH" >&2
         exit 1
         ;;
 esac
@@ -92,7 +92,7 @@ esac
 case "$OS" in
     linux|darwin) ;;
     *)
-        echo "Error: unsupported OS: $OS (use Linux or macOS)"
+        echo "Error: unsupported OS: $OS (use Linux or macOS)" >&2
         exit 1
         ;;
 esac
@@ -106,7 +106,7 @@ else
     # Use redirect trick to avoid GitHub API rate limits.
     # The /releases/latest endpoint redirects to /releases/tag/vX.Y.Z —
     # we parse the version from the redirect URL.
-    REDIRECT_URL=$(curl -fsSIo /dev/null -w '%{redirect_url}' \
+    REDIRECT_URL=$(curl --proto '=https' --tlsv1.2 -fsSIo /dev/null -w '%{redirect_url}' \
         "https://github.com/${REPO}/releases/latest" 2>/dev/null || true)
     VERSION=$(echo "$REDIRECT_URL" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+[^/]*' || true)
 
@@ -115,7 +115,7 @@ else
     if [ -n "$VERSION" ]; then
         VERSION_NO_V_CHECK="${VERSION#v}"
         CHECK_URL="https://github.com/${REPO}/releases/download/${VERSION}/l8k_${VERSION_NO_V_CHECK}_${OS}_${ARCH}.tar.gz"
-        if ! curl -fsSIo /dev/null "$CHECK_URL" 2>/dev/null; then
+        if ! curl --proto '=https' --tlsv1.2 -fsSIo /dev/null "$CHECK_URL" 2>/dev/null; then
             echo "Latest stable release (${VERSION}) has no binary archives."
             echo "Checking for the most recent release with binaries..."
             VERSION=""
@@ -128,7 +128,9 @@ else
         if [ -n "${GITHUB_TOKEN:-}" ]; then
             AUTH_FLAG="-H \"Authorization: token ${GITHUB_TOKEN}\""
         fi
-        VERSION=$(eval curl -fsSL $AUTH_FLAG \
+        # eval expands the optional, header-bearing $AUTH_FLAG as separate
+        # arguments; all input here is constructed by this script, not the user.
+        VERSION=$(eval curl --proto "'=https'" --tlsv1.2 -fsSL $AUTH_FLAG \
             "https://api.github.com/repos/${REPO}/releases?per_page=10" 2>/dev/null \
             | grep -oE '"tag_name":\s*"v[^"]*"' \
             | head -1 \
@@ -136,8 +138,8 @@ else
     fi
 
     if [ -z "$VERSION" ]; then
-        echo "Error: could not determine latest version."
-        echo "Set L8K_VERSION explicitly or check https://github.com/${REPO}/releases"
+        echo "Error: could not determine latest version." >&2
+        echo "Set L8K_VERSION explicitly or check https://github.com/${REPO}/releases" >&2
         exit 1
     fi
 fi
@@ -158,8 +160,9 @@ if [ -n "${GITHUB_TOKEN:-}" ]; then
 fi
 
 echo "Downloading ${ARCHIVE}..."
-curl -fsSL ${AUTH_HEADER:+-H "$AUTH_HEADER"} "${BASE_URL}/${ARCHIVE}" -o "${WORK_DIR}/${ARCHIVE}"
-curl -fsSL ${AUTH_HEADER:+-H "$AUTH_HEADER"} "${BASE_URL}/checksums.txt" -o "${WORK_DIR}/checksums.txt"
+# --proto '=https' refuses any redirect that downgrades to a clear-text protocol.
+curl --proto '=https' --tlsv1.2 -fsSL ${AUTH_HEADER:+-H "$AUTH_HEADER"} "${BASE_URL}/${ARCHIVE}" -o "${WORK_DIR}/${ARCHIVE}"
+curl --proto '=https' --tlsv1.2 -fsSL ${AUTH_HEADER:+-H "$AUTH_HEADER"} "${BASE_URL}/checksums.txt" -o "${WORK_DIR}/checksums.txt"
 
 # --- Verify checksum ---
 cd "$WORK_DIR"
@@ -179,9 +182,9 @@ else
         if [ "$EXPECTED_SUM" = "$ACTUAL_SUM" ]; then
             echo "Checksum verified."
         else
-            echo "Error: checksum mismatch!"
-            echo "  Expected: ${EXPECTED_SUM}"
-            echo "  Got:      ${ACTUAL_SUM}"
+            echo "Error: checksum mismatch!" >&2
+            echo "  Expected: ${EXPECTED_SUM}" >&2
+            echo "  Got:      ${ACTUAL_SUM}" >&2
             exit 1
         fi
     fi

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,47 @@
+# SonarQube analysis configuration for k8s-launch-kit.
+#
+# The Jenkins "sonarqube-scan-all" job supplies sonar.projectKey,
+# sonar.projectBaseDir and sonar.host.url on the command line; this file only
+# carries repo-local settings (test classification, coverage, and rule tuning)
+# so they live with the code and apply to every scan.
+
+sonar.sources=.
+sonar.exclusions=**/vendor/**
+
+# Classify Go test files as tests so test-only rule profiles apply and test
+# code is excluded from the "Coverage on New Code" denominator.
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.go.coverage.reportPaths=coverage.out
+
+# --- Rule tuning: suppress false positives on Go test files ---------------
+#
+# These rules fire heavily on *_test.go but the flagged patterns are
+# idiomatic, intentional Go test style — "fixing" them would harm the tests.
+# Suppress them only under **/*_test.go; production code is still analysed.
+sonar.issue.ignore.multicriteria=test_naming,test_dupstr,test_hardcodedip,test_emptyfn,test_complexity
+
+# S100 — Go test functions idiomatically use underscores to separate the
+# subject under test from the scenario (e.g. TestSynthesizeConfig_FieldMapping).
+# Renaming them to drop underscores hurts readability and breaks convention.
+sonar.issue.ignore.multicriteria.test_naming.ruleKey=go:S100
+sonar.issue.ignore.multicriteria.test_naming.resourceKey=**/*_test.go
+
+# S1192 — duplicated string literals are normal in table-driven tests, where
+# expected values repeat across cases by design.
+sonar.issue.ignore.multicriteria.test_dupstr.ruleKey=go:S1192
+sonar.issue.ignore.multicriteria.test_dupstr.resourceKey=**/*_test.go
+
+# S1313 — hardcoded IP addresses in tests are fixtures, not deployment config.
+sonar.issue.ignore.multicriteria.test_hardcodedip.ruleKey=go:S1313
+sonar.issue.ignore.multicriteria.test_hardcodedip.resourceKey=**/*_test.go
+
+# S1186 — empty functions in tests are intentional stubs / no-op fakes used to
+# satisfy interfaces.
+sonar.issue.ignore.multicriteria.test_emptyfn.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.test_emptyfn.resourceKey=**/*_test.go
+
+# S3776 — high cognitive complexity in tests reflects long, linear table-driven
+# scenarios rather than tangled control flow.
+sonar.issue.ignore.multicriteria.test_complexity.ruleKey=go:S3776
+sonar.issue.ignore.multicriteria.test_complexity.resourceKey=**/*_test.go


### PR DESCRIPTION
## Summary

Grooms and fixes the actionable findings from the `k8s-launch-kit - main` SonarQube regulatory report. Based off `preset-fix` so the diff is just these fixes.

The report had 580 open findings (4 vulnerabilities, 67 security hotspots, 509 code smells), but ~75% (~436) are test-file false positives — mostly 232 "function naming" hits that are just idiomatic Go `TestXxx_Subtest` names. Those are handled with a scoped Sonar config rather than by mangling test code.

## Fixed

**Security — GitHub Actions workflows**
- Replaced `permissions: write-all` and workflow-level write/read grants with least-privilege, job-scoped permissions (clears all 4 vulnerabilities).
- Pinned all 16 action references to full commit SHAs (with version comments), including the previously mutable `nv-gha-runners/setup-artifactory-go-proxy@main`.

**Shell installers** (`scripts/`)
- Error messages → stderr; bash `[`→`[[`; `--proto '=https' --tlsv1.2` on release-download curls (anti clear-text downgrade). `install.sh` kept POSIX `sh`.

**Dockerfile**
- Narrowed the recursive `COPY . /src` to only the runtime assets l8k resolves relative to its workdir (`profiles/`, `presets/`, `l8k-config.yaml`) — everything else is build-only or `go:embed`-ed. Also quoted the cross-compile build args. Fixes the critical recursive-copy hotspot and shrinks the image.

**Production Go**
- Extracted duplicated literals into constants (CLI flag names, `/bin/sh`, `mellanox.com` / `sriovnetwork.openshift.io` API groups).
- Documented `_ "embed"` blank imports; commented intentionally-empty funcs, no-op closures, and the deliberate `context.Background()` teardown contexts.

**Sonar config**
- Added `sonar-project.properties`: classifies `*_test.go` as tests, wires coverage, and suppresses 5 rules under `**/*_test.go` whose patterns are idiomatic Go test style. Production code still analysed.

## Deliberately not changed
- 63 cognitive-complexity + 6 too-many-params refactors — too risky for behavior, deferred.
- `if`-short-var and a legitimate TODO — idiomatic Go / real future work.
- Dockerfile root-user & builder-stage `COPY .` — safe-as-is judgment hotspots.

## Verification
`go build ./...`, `go vet`, `gofmt`, and tests for all touched packages pass. (The 4 `pkg/presets` test failures are pre-existing and environmental — they assume no `/usr/local/share/l8k/presets` install — and are unrelated to this branch.) `golangci-lint` will run in CI.