### PR TITLE
discover: advertise one rail per NIC by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ network capabilities and hardware configuration by using --discover-cluster-conf
 This phase can be skipped if you provide your own configuration file by using --user-config.
 This phase requires --kubeconfig to be specified.
 
+By default discovery advertises **one rail per NIC**. When a NIC exposes several
+east-west PFs that are planes of a single physical port (e.g. Spectrum-X
+multi-plane ConnectX-8/9), only the master PF is written to `cluster-config.yaml`
+so the rail count reflects physical NICs, not PFs. A NIC whose VPD model name is
+genuinely dual-port (e.g. "... QSFP112 **2-port** ...", "... **Dual-port** ...")
+keeps a rail per port. Pass `--collapse-nic-rails=false` to restore the legacy
+behaviour of one rail per PF (useful on dev setups). The model string is read
+from `NicDevice.Status.modelName`; when it is empty the NIC is collapsed by
+default.
+
 ### Generate Deployment Files
 Based on the discovered or provided configuration,
 generate a complete set of YAML deployment files for the selected network profile.
@@ -167,6 +177,7 @@ Common Flags:
       --user-config string                  Use provided cluster configuration file (as base config for discovery or as full config without discovery)
 
 Discovery Flags:
+      --collapse-nic-rails           Advertise one rail per NIC: collapse a NIC's multi-plane PFs to its master PF, keeping a rail per port only for NICs whose VPD model is genuinely dual-port ("2-port"/"Dual-port"). Set to false to keep the legacy one-rail-per-PF behaviour (dev setups). (default true)
       --discover-cluster-config      Deploy a thin Network Operator profile to discover cluster capabilities
       --save-cluster-config string   Save discovered cluster configuration to the specified path (defaults to --user-config path if set, otherwise ./cluster-config.yaml)
 

--- a/pkg/app/launcher.go
+++ b/pkg/app/launcher.go
@@ -86,10 +86,11 @@ func (l *Launcher) Run() error {
 		switch pluginName {
 		case networkoperatorplugin.PluginName:
 			l.plugins[pluginName] = &networkoperatorplugin.NetworkOperatorPlugin{
-				Groups:        l.options.Groups,
-				GpuType:       l.options.GpuType,
-				NodeSelector:  parseNodeSelector(l.options.NodeSelector),
-				KeepNamespace: l.options.KeepNamespace,
+				Groups:           l.options.Groups,
+				GpuType:          l.options.GpuType,
+				NodeSelector:     parseNodeSelector(l.options.NodeSelector),
+				KeepNamespace:    l.options.KeepNamespace,
+				CollapseNicRails: l.options.CollapseNicRails,
 			}
 		default:
 			err := fmt.Errorf("unknown plugin: %s", pluginName)

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -80,6 +80,7 @@ NICs, and probes OFED-dependent modules.`,
 			NetworkOperatorNamespace: networkOperatorNamespace,
 			NetworkOperatorRelease:   networkOperatorRelease,
 			KeepNamespace:            keepNamespace,
+			CollapseNicRails:         collapseNicRails,
 			NodeSelector:            nodeSelector,
 			ImagePullSecrets:        imagePullSecrets,
 			EnabledPlugins:           parseEnabledPlugins(enabledPlugins),
@@ -113,6 +114,7 @@ func init() {
 	discoverCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for NicClusterPolicy (comma-separated)")
 	discoverCmd.Flags().StringVar(&enabledPlugins, "enabled-plugins", "network-operator", "Comma-separated list of plugins to enable")
 	discoverCmd.Flags().BoolVar(&keepNamespace, "keep-namespace", false, "Skip teardown of the nvidia-k8s-launch-kit namespace (for debugging)")
+	discoverCmd.Flags().BoolVar(&collapseNicRails, "collapse-nic-rails", true, collapseNicRailsFlagHelp)
 
 	setFlagGroup(discoverCmd, "kubeconfig", GroupCommon)
 	setFlagGroup(discoverCmd, "user-config", GroupCommon)
@@ -123,4 +125,5 @@ func init() {
 	setFlagGroup(discoverCmd, "enabled-plugins", GroupCommon)
 	setFlagGroup(discoverCmd, "save-cluster-config", GroupDiscovery)
 	setFlagGroup(discoverCmd, "keep-namespace", GroupDiscovery)
+	setFlagGroup(discoverCmd, "collapse-nic-rails", GroupDiscovery)
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -77,7 +77,12 @@ var (
 	forPreset                   string
 	deployTimeoutRoot           time.Duration
 	keepNamespace               bool
+	collapseNicRails            bool
 )
+
+// collapseNicRailsFlagHelp is the shared help text for --collapse-nic-rails on
+// both the root pipeline and the `discover` subcommand.
+const collapseNicRailsFlagHelp = "Advertise one rail per NIC: collapse a NIC's multi-plane PFs to its master PF, keeping a rail per port only for NICs whose VPD model is genuinely dual-port (\"2-port\"/\"Dual-port\"). Set to false to keep the legacy one-rail-per-PF behaviour (dev setups)."
 
 // forFlagHelp builds the help string for `--for`. Computed at init() time so
 // users see the live list of available preset directories alongside `--help`.
@@ -161,6 +166,7 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
 			Groups:               groups,
 			GpuType:              gpuType,
 			NodeSelector:         nodeSelector,
+			CollapseNicRails:     collapseNicRails,
 			ForPreset:            forPreset,
 			ImagePullSecrets:     imagePullSecrets,
 			PodNamespace:         podNamespace,
@@ -245,6 +251,7 @@ func init() {
 	rootCmd.Flags().StringVar(&gpuType, "gpu-type", "", "Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.")
 	rootCmd.MarkFlagsMutuallyExclusive("groups", "gpu-type")
 	rootCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe")
+	rootCmd.Flags().BoolVar(&collapseNicRails, "collapse-nic-rails", true, collapseNicRailsFlagHelp)
 	rootCmd.Flags().StringVar(&forPreset, "for", "", forFlagHelp())
 	rootCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for NicClusterPolicy (comma-separated)")
 	rootCmd.Flags().StringVar(&saveDeploymentFiles, "save-deployment-files", "./deployment", "Save generated deployment files to the specified directory")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -297,6 +297,14 @@ type PFConfig struct {
 	Rail             *int   `yaml:"rail,omitempty"`
 	PSID             string `yaml:"psid,omitempty"`
 	PartNumber       string `yaml:"partNumber,omitempty"`
+	// Model is the human-readable NIC model/description string read from the
+	// device VPD (e.g. "Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5
+	// x16 InfiniBand Adapter"). Populated during discovery from
+	// NicDevice.Status.ModelName. It records why the rail-collapse decision was
+	// made (a "2-port"/"Dual-port" model keeps one rail per port; anything else
+	// collapses to one rail per NIC) and is empty when the daemon couldn't read
+	// VPD.
+	Model string `yaml:"model,omitempty"`
 	// Topology fields (populated from presets when available)
 	NumaNode     *int   `yaml:"numaNode,omitempty"`
 	ConnectedGPU string `yaml:"connectedGPU,omitempty"`

--- a/pkg/networkoperatorplugin/collapse_test.go
+++ b/pkg/networkoperatorplugin/collapse_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkoperatorplugin
+
+import (
+	"testing"
+
+	nicop "github.com/Mellanox/nic-configuration-operator/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+func TestIsDualPortModel(t *testing.T) {
+	cases := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{"cx7 2-port", "Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter", true},
+		{"cx8 dual-port", "NVIDIA ConnectX-8 C8240 HHHL SuperNIC, 400GbE / 400Gb/s IB, Dual-port QSFP112", true},
+		{"spaced 2 port", "Some Adapter 2 port QSFP", true},
+		{"spaced dual port", "Some Adapter Dual port QSFP", true},
+		{"bf3 single 1P", "Nvidia BlueField-3 VPI QSFP112 1P 400G PCIe Gen5 x16", false},
+		{"single-port", "ConnectX-7 Single-port QSFP112", false},
+		{"qsfp112 no false positive", "Nvidia ConnectX-7 QSFP112 PCIe Gen5 x16 Adapter", false},
+		{"digit-adjacent token no false positive", "Some NIC Gen2 port adapter", false},
+		{"qsfp112 followed by 2-port still matches", "Nvidia ConnectX-7 QSFP112 2-port Adapter", true},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isDualPortModel(tc.model))
+		})
+	}
+}
+
+func TestCollapsePFsToOnePerNIC(t *testing.T) {
+	t.Run("multi-plane NIC collapses to master", func(t *testing.T) {
+		// Two PFs on one NIC (same bus:device), no port-count keyword in model
+		// → planes of one rail → keep the master (.0) only.
+		pfs := []config.PFConfig{
+			{PciAddress: "0000:18:00.0", Model: "ConnectX-8 SuperNIC"},
+			{PciAddress: "0000:18:00.1", Model: "ConnectX-8 SuperNIC"},
+		}
+		kept, dropped := collapsePFsToOnePerNIC(pfs)
+		require.Len(t, kept, 1)
+		assert.Equal(t, "0000:18:00.0", kept[0].PciAddress)
+		assert.Equal(t, 1, dropped)
+	})
+
+	t.Run("dual-port NIC keeps every port", func(t *testing.T) {
+		pfs := []config.PFConfig{
+			{PciAddress: "0000:18:00.0", Model: "ConnectX-7 QSFP112 2-port Adapter"},
+			{PciAddress: "0000:18:00.1", Model: "ConnectX-7 QSFP112 2-port Adapter"},
+		}
+		kept, dropped := collapsePFsToOnePerNIC(pfs)
+		assert.Len(t, kept, 2)
+		assert.Equal(t, 0, dropped)
+	})
+
+	t.Run("master is lowest function even when listed out of order", func(t *testing.T) {
+		pfs := []config.PFConfig{
+			{PciAddress: "0000:18:00.1", Model: "multi-plane"},
+			{PciAddress: "0000:18:00.0", Model: "multi-plane"},
+		}
+		kept, dropped := collapsePFsToOnePerNIC(pfs)
+		require.Len(t, kept, 1)
+		assert.Equal(t, "0000:18:00.0", kept[0].PciAddress)
+		assert.Equal(t, 1, dropped)
+	})
+
+	t.Run("mixed NICs: one dual-port, one multi-plane", func(t *testing.T) {
+		pfs := []config.PFConfig{
+			{PciAddress: "0000:18:00.0", Model: "ConnectX-7 2-port"},
+			{PciAddress: "0000:18:00.1", Model: "ConnectX-7 2-port"},
+			{PciAddress: "0000:51:00.0", Model: "ConnectX-8 SuperNIC"},
+			{PciAddress: "0000:51:00.1", Model: "ConnectX-8 SuperNIC"},
+		}
+		kept, dropped := collapsePFsToOnePerNIC(pfs)
+		require.Len(t, kept, 3)
+		got := []string{kept[0].PciAddress, kept[1].PciAddress, kept[2].PciAddress}
+		assert.Equal(t, []string{"0000:18:00.0", "0000:18:00.1", "0000:51:00.0"}, got)
+		assert.Equal(t, 1, dropped)
+	})
+
+	t.Run("three or more sibling PFs collapse to a single master", func(t *testing.T) {
+		// A 4-plane NIC (e.g. ConnectX-9 hwplb) presents four function-split PFs
+		// on one bus:device → all but the master are dropped.
+		pfs := []config.PFConfig{
+			{PciAddress: "0000:18:00.0", Model: "ConnectX-9 SuperNIC"},
+			{PciAddress: "0000:18:00.1", Model: "ConnectX-9 SuperNIC"},
+			{PciAddress: "0000:18:00.2", Model: "ConnectX-9 SuperNIC"},
+			{PciAddress: "0000:18:00.3", Model: "ConnectX-9 SuperNIC"},
+		}
+		kept, dropped := collapsePFsToOnePerNIC(pfs)
+		require.Len(t, kept, 1)
+		assert.Equal(t, "0000:18:00.0", kept[0].PciAddress)
+		assert.Equal(t, 3, dropped)
+	})
+
+	t.Run("single-PF NICs are unchanged", func(t *testing.T) {
+		pfs := []config.PFConfig{
+			{PciAddress: "0000:18:00.0", Model: "ConnectX-7 1P"},
+			{PciAddress: "0000:51:00.0", Model: "ConnectX-7 1P"},
+		}
+		kept, dropped := collapsePFsToOnePerNIC(pfs)
+		assert.Len(t, kept, 2)
+		assert.Equal(t, 0, dropped)
+	})
+
+	t.Run("malformed PCI address is kept, never dropped", func(t *testing.T) {
+		pfs := []config.PFConfig{
+			{PciAddress: "bogus", Model: "multi-plane"},
+			{PciAddress: "0000:18:00.0", Model: "multi-plane"},
+			{PciAddress: "0000:18:00.1", Model: "multi-plane"},
+		}
+		kept, dropped := collapsePFsToOnePerNIC(pfs)
+		require.Len(t, kept, 2)
+		assert.Equal(t, "bogus", kept[0].PciAddress)
+		assert.Equal(t, "0000:18:00.0", kept[1].PciAddress)
+		assert.Equal(t, 1, dropped)
+	})
+}
+
+// nicDeviceWithPorts builds a NicDevice CR with two function-split ports on a
+// single NIC (bus:device prefix), as the discovery daemon would publish for a
+// multi-plane / dual-port adapter.
+func nicDeviceWithPorts(node, deviceID, partNumber, model, busDevice string) nicop.NicDevice {
+	return nicop.NicDevice{
+		Status: nicop.NicDeviceStatus{
+			Node:       node,
+			Type:       deviceID,
+			PartNumber: partNumber,
+			PSID:       "psid-test",
+			ModelName:  model,
+			Ports: []nicop.NicDevicePortSpec{
+				{PCI: busDevice + ".0", RdmaInterface: "mlx5_0", NetworkInterface: "eth0"},
+				{PCI: busDevice + ".1", RdmaInterface: "mlx5_1", NetworkInterface: "eth1"},
+			},
+		},
+	}
+}
+
+func eastWestPFsOf(group config.ClusterConfig) []config.PFConfig {
+	var out []config.PFConfig
+	for _, pf := range group.PFs {
+		if pf.Traffic == "east-west" {
+			out = append(out, pf)
+		}
+	}
+	return out
+}
+
+func TestBuildClusterConfig_CollapseNicRails(t *testing.T) {
+	// One node, two ConnectX-8 NICs, each presenting two function-split PFs
+	// (multi-plane). deviceID 1023 is not a DPU and < 5 PFs, so the part-number
+	// frequency heuristic doesn't run — all four PFs default to east-west.
+	devices := []nicop.NicDevice{
+		nicDeviceWithPorts("worker-0", "1023", "pn-test-rdma", "ConnectX-8 SuperNIC", "0000:18:00"),
+		nicDeviceWithPorts("worker-0", "1023", "pn-test-rdma", "ConnectX-8 SuperNIC", "0000:51:00"),
+	}
+
+	t.Run("collapse on: one rail per NIC", func(t *testing.T) {
+		groups, _ := buildClusterConfig(devices, nil, nil, true)
+		require.Len(t, groups, 1)
+		ew := eastWestPFsOf(groups[0])
+		require.Len(t, ew, 2, "two multi-plane NICs collapse to two east-west PFs")
+		// Rails numbered 0,1 over the collapsed set; the surviving PFs are the
+		// masters (.0) of each NIC, and Model is carried through.
+		require.NotNil(t, ew[0].Rail)
+		require.NotNil(t, ew[1].Rail)
+		assert.Equal(t, 0, *ew[0].Rail)
+		assert.Equal(t, 1, *ew[1].Rail)
+		assert.Equal(t, "0000:18:00.0", ew[0].PciAddress)
+		assert.Equal(t, "0000:51:00.0", ew[1].PciAddress)
+		assert.Equal(t, "ConnectX-8 SuperNIC", ew[0].Model)
+	})
+
+	t.Run("collapse off: one rail per PF", func(t *testing.T) {
+		groups, _ := buildClusterConfig(devices, nil, nil, false)
+		require.Len(t, groups, 1)
+		ew := eastWestPFsOf(groups[0])
+		require.Len(t, ew, 4, "legacy behaviour keeps every PF as its own rail")
+		for i, pf := range ew {
+			require.NotNil(t, pf.Rail)
+			assert.Equal(t, i, *pf.Rail)
+		}
+	})
+
+	t.Run("dual-port model keeps every port even with collapse on", func(t *testing.T) {
+		dualPort := []nicop.NicDevice{
+			nicDeviceWithPorts("worker-0", "1021", "pn-test-rdma",
+				"Nvidia ConnectX-7 NDR200/HDR QSFP112 2-port PCIe Gen5 x16 InfiniBand Adapter", "0000:18:00"),
+		}
+		groups, _ := buildClusterConfig(dualPort, nil, nil, true)
+		require.Len(t, groups, 1)
+		ew := eastWestPFsOf(groups[0])
+		require.Len(t, ew, 2, "a genuine dual-port NIC keeps a rail per port")
+		assert.Equal(t, 0, *ew[0].Rail)
+		assert.Equal(t, 1, *ew[1].Rail)
+	})
+}

--- a/pkg/networkoperatorplugin/discovery.go
+++ b/pkg/networkoperatorplugin/discovery.go
@@ -193,7 +193,7 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 		return err
 	}
 
-	clusterConfig, nsWarnings := buildClusterConfig(devices.Items, nodeLabels, p.NodeSelector)
+	clusterConfig, nsWarnings := buildClusterConfig(devices.Items, nodeLabels, p.NodeSelector, p.CollapseNicRails)
 	defaultConfig.ClusterConfig = clusterConfig
 
 	for _, w := range nsWarnings {
@@ -735,6 +735,12 @@ type nodePFEntry struct {
 	IsExplicitEastWest bool
 	PSID               string
 	PartNumber         string
+	// ModelName is NicDevice.Status.ModelName — the VPD model/description
+	// string, which carries the physical port count ("2-port"/"Dual-port"/"1P").
+	// Used to decide whether a multi-PF NIC is genuinely dual-port (keep a rail
+	// per port) or multi-plane (collapse to one rail per NIC). Empty when VPD
+	// couldn't be read.
+	ModelName string
 }
 
 // fetchNodeLabels lists all Kubernetes nodes and returns a map of nodeName → labels.
@@ -893,7 +899,32 @@ type nodeInfo struct {
 	hasPCI  bool
 }
 
-func buildClusterConfig(devices []nicop.NicDevice, nodeLabels map[string]map[string]string, nodeSelector map[string]string) ([]config.ClusterConfig, []string) {
+// collapseGroupRails reduces a group's east-west PFs to one per NIC (one rail
+// per NIC) via collapsePFsToOnePerNIC, while preserving every dual-port NIC's
+// per-port PFs and leaving north-south PFs untouched. It returns the re-sorted
+// PF slice and the number of PFs dropped; when nothing is collapsed it returns
+// the input unchanged.
+func collapseGroupRails(pfs []config.PFConfig) ([]config.PFConfig, int) {
+	var ew, ns []config.PFConfig
+	for _, pf := range pfs {
+		if pf.Traffic == "east-west" {
+			ew = append(ew, pf)
+		} else {
+			ns = append(ns, pf)
+		}
+	}
+	collapsedEW, dropped := collapsePFsToOnePerNIC(ew)
+	if dropped == 0 {
+		return pfs, 0
+	}
+	out := append(collapsedEW, ns...)
+	slices.SortFunc(out, func(a, b config.PFConfig) int {
+		return strings.Compare(a.PciAddress, b.PciAddress)
+	})
+	return out, dropped
+}
+
+func buildClusterConfig(devices []nicop.NicDevice, nodeLabels map[string]map[string]string, nodeSelector map[string]string, collapseNicRails bool) ([]config.ClusterConfig, []string) {
 	// Step 1: Build per-node PF map and track capabilities per node
 	nodeMap := map[string]*nodeInfo{}
 
@@ -943,6 +974,7 @@ func buildClusterConfig(devices []nicop.NicDevice, nodeLabels map[string]map[str
 				IsExplicitEastWest: isBF3SuperNIC,
 				PSID:               d.Status.PSID,
 				PartNumber:         d.Status.PartNumber,
+				ModelName:          d.Status.ModelName,
 			}
 			ni.pfs = append(ni.pfs, entry)
 			if p.RdmaInterface != "" {
@@ -1044,6 +1076,7 @@ func buildClusterConfig(devices []nicop.NicDevice, nodeLabels map[string]map[str
 				Traffic:    traffic,
 				PSID:       entry.PSID,
 				PartNumber: entry.PartNumber,
+				Model:      entry.ModelName,
 			}
 			if singleGroup || len(g.nodes) == 1 {
 				// Safe to include RDMA/net device names when only one node in group
@@ -1055,6 +1088,21 @@ func buildClusterConfig(devices []nicop.NicDevice, nodeLabels map[string]map[str
 		slices.SortFunc(pfs, func(a, b config.PFConfig) int {
 			return strings.Compare(a.PciAddress, b.PciAddress)
 		})
+
+		// Collapse multi-plane NICs to one rail per NIC (the default). A NIC
+		// whose VPD model is genuinely dual-port keeps a rail per port; every
+		// other NIC drops all but its master PF, since its sibling PFs are
+		// planes of a single rail. North-south PFs are left untouched.
+		// --collapse-nic-rails=false skips this and keeps one rail per PF.
+		if collapseNicRails {
+			collapsed, dropped := collapseGroupRails(pfs)
+			if dropped > 0 {
+				pfs = collapsed
+				log.Log.Info("Collapsed multi-plane PFs to one rail per NIC; pass --collapse-nic-rails=false to keep one rail per PF",
+					"groupIndex", i, "identifier", identifier,
+					"droppedPFs", dropped, "eastWestRails", len(filterEastWestPFs(pfs)))
+			}
+		}
 
 		// Assign rail numbers sequentially over the E/W set. No PF has
 		// GPUProximity populated yet at this stage, so the helper's PIX-gate

--- a/pkg/networkoperatorplugin/networkoperator.go
+++ b/pkg/networkoperatorplugin/networkoperator.go
@@ -50,6 +50,12 @@ type NetworkOperatorPlugin struct {
 	// for debugging a failed discovery.
 	KeepNamespace bool
 
+	// CollapseNicRails (default true, set from --collapse-nic-rails) makes
+	// discovery advertise one rail per NIC: multi-plane NICs collapse to their
+	// master PF while genuinely dual-port NICs keep a rail per port. False
+	// restores the legacy one-rail-per-PF behaviour (handy on dev setups).
+	CollapseNicRails bool
+
 	// NetworkOperator is the resolved NetworkOperator config used by
 	// DeployProfile to drive the helm install in Phase 0. Populated by
 	// the launcher after ApplyOptionsToConfig has merged the catalog with

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -22,6 +22,7 @@ import (
 	"hash/fnv"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -444,11 +445,10 @@ func masterPFsByNIC(pfs []config.PFConfig) []string {
 	master := map[string]string{} // bus:device → lowest-function PCI address seen
 	order := []string{}           // NIC bus:device prefixes in first-seen order
 	for _, pf := range pfs {
-		idx := strings.LastIndex(pf.PciAddress, ".")
-		if idx <= 0 {
+		prefix, ok := pciBusDevicePrefix(pf.PciAddress)
+		if !ok {
 			continue
 		}
-		prefix := pf.PciAddress[:idx]
 		if existing, ok := master[prefix]; !ok {
 			master[prefix] = pf.PciAddress
 			order = append(order, prefix)
@@ -461,6 +461,92 @@ func masterPFsByNIC(pfs []config.PFConfig) []string {
 		out = append(out, master[prefix])
 	}
 	return out
+}
+
+// pciBusDevicePrefix returns the "domain:bus:device" portion of a PCI address
+// — everything before the final ".<function>" — which is shared by all PFs that
+// live on the same physical NIC. Returns ok=false for a malformed address that
+// has no function suffix.
+func pciBusDevicePrefix(pciAddress string) (string, bool) {
+	idx := strings.LastIndex(pciAddress, ".")
+	if idx <= 0 {
+		return "", false
+	}
+	return pciAddress[:idx], true
+}
+
+// dualPortModelRe matches a port-count keyword that designates a genuinely
+// dual-port adapter. "dual-port"/"dual port" are matched directly. The numeric
+// form requires the "2" to sit on a word boundary (`\b`) so digit-adjacent
+// tokens like "QSFP112" or "Gen2" cannot trigger a false positive; the
+// separator may be a hyphen or a space ("2-port", "2 port"). Case-insensitive.
+var dualPortModelRe = regexp.MustCompile(`(?i)(dual[- ]port|\b2[- ]port)`)
+
+// isDualPortModel reports whether a NIC VPD model/description string indicates a
+// genuinely dual-port adapter — two physical ports that each terminate a
+// separate fabric and therefore each deserve their own rail. NVIDIA VPD strings
+// spell this as "2-port"/"Dual-port" (e.g. "... QSFP112 2-port PCIe ...",
+// "... Dual-port QSFP112 ..."). Single-port adapters say "1P"/"single-port" and
+// multi-plane adapters — whose extra PFs are planes of one physical port — carry
+// no port-count keyword at all. Matching is deliberately conservative: the
+// numeric "2" must stand on a word boundary, so substrings like "QSFP112" or
+// "Gen2" cannot trigger a false positive that would leave a multi-plane NIC
+// uncollapsed. An empty/unknown string returns false, which makes the caller
+// collapse to one rail per NIC by default.
+func isDualPortModel(model string) bool {
+	return dualPortModelRe.MatchString(model)
+}
+
+// collapsePFsToOnePerNIC reduces a set of PFs to one per NIC (PCI bus:device
+// prefix): for a NIC whose VPD model is dual-port (isDualPortModel) every PF is
+// kept — each physical port is its own rail — while for any other NIC only the
+// master (lowest-function) PF survives, since its sibling PFs are planes of a
+// single rail rather than independent rails. Input order is preserved among the
+// kept PFs, and the count of dropped PFs is returned so the caller can log a
+// summary.
+//
+// It is intended to run on the east-west subset only; north-south PFs should be
+// filtered out by the caller (they are excluded from rails and manifests
+// anyway). A PF with a malformed PCI address (no function suffix) is always
+// kept, never silently dropped.
+func collapsePFsToOnePerNIC(pfs []config.PFConfig) (kept []config.PFConfig, dropped int) {
+	type nicInfo struct {
+		dualPort bool
+		master   string
+	}
+	nics := map[string]*nicInfo{}
+	for i := range pfs {
+		prefix, ok := pciBusDevicePrefix(pfs[i].PciAddress)
+		if !ok {
+			continue
+		}
+		info := nics[prefix]
+		if info == nil {
+			info = &nicInfo{master: pfs[i].PciAddress}
+			nics[prefix] = info
+		} else if pfs[i].PciAddress < info.master {
+			info.master = pfs[i].PciAddress
+		}
+		if isDualPortModel(pfs[i].Model) {
+			info.dualPort = true
+		}
+	}
+
+	kept = make([]config.PFConfig, 0, len(pfs))
+	for i := range pfs {
+		prefix, ok := pciBusDevicePrefix(pfs[i].PciAddress)
+		if !ok {
+			kept = append(kept, pfs[i])
+			continue
+		}
+		info := nics[prefix]
+		if info.dualPort || pfs[i].PciAddress == info.master {
+			kept = append(kept, pfs[i])
+		} else {
+			dropped++
+		}
+	}
+	return kept, dropped
 }
 
 // templateContext wraps the full config but presents a single ClusterConfig group.

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -37,6 +37,11 @@ type Options struct {
 	// nvidia-k8s-launch-kit bootstrap namespace at the end of `discover` —
 	// useful for debugging a failed run.
 	KeepNamespace bool
+	// CollapseNicRails (default true; --collapse-nic-rails) makes discovery
+	// advertise one rail per NIC — multi-plane NICs collapse to their master
+	// PF, while genuinely dual-port NIC models keep a rail per port. False
+	// restores the legacy one-rail-per-PF behaviour for dev setups.
+	CollapseNicRails bool
 	// NetworkOperatorRelease is a MAJOR.MINOR catalog key (e.g. "26.4"), not
 	// a full semver. Selects component image tags + repository from the
 	// embedded releases catalog and drives version-gated template sections.

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -57,7 +57,8 @@ Each `clusterConfig[]` entry has these key fields:
 - `machineType` — server model (e.g. `PowerEdge-XE9680`); populated from `nvidia.com/gpu.machine` label or DMI fallback.
 - `gpuType` — GPU SKU (e.g. `NVIDIA-H200`); populated from `nvidia.com/gpu.product` label or `nvidia-smi` fallback. **Note:** this field used to be called `productType` — the rename happened to disambiguate it from the server model. Old `productType:` keys in hand-authored configs must be renamed to `gpuType:`.
 - `capabilities.nodes.{sriov,rdma,ib}` — what the underlying hardware supports.
-- `pfs[]` — physical function list with PCI address, device ID, RDMA device, network interface, traffic class, rail, NUMA, GPU affinity.
+- `pfs[]` — physical function list with PCI address, device ID, RDMA device, network interface, traffic class, rail, NUMA, GPU affinity, and `model` (the VPD model/description string read from `NicDevice.Status.modelName`).
+  - **One rail per NIC (default).** Discovery advertises one rail per physical NIC: a NIC's multi-plane east-west PFs (planes of one port, e.g. Spectrum-X ConnectX-8/9) collapse to the master PF, so an 8-PF node lists 4 east-west PFs / 4 rails. A NIC whose `model` is genuinely dual-port (`2-port`/`Dual-port`) keeps a rail per port. Run `l8k discover --collapse-nic-rails=false` to emit one rail per PF (legacy/dev behaviour).
 - `nodeSelector` — Kubernetes node selector for this group. Source groups key on the machine label written by `l8k discover`: `nvidia.kubernetes-launch-kit.machine: <machineType>-<gpuType>`. Auto-merged groups (different machineTypes sharing a GPU type) key on `nvidia.kubernetes-launch-kit.gpu: <gpuType>` instead — discovery writes both labels onto every node, so the merged selector binds correctly across source machineTypes.
 - `workerNodes` — explicit hostnames (populated by discovery).
 

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -286,6 +286,11 @@ clusterConfig:
         networkInterface: "net1" # Network interface name (single-node groups only)
         traffic: east-west       # "east-west" (fabric) or "north-south" (DPU)
         rail: 0                  # Sequential rail number (east-west PFs only)
+        model: "ConnectX-8 ..."  # VPD model string (NicDevice.Status.modelName).
+                                 # Drives rail collapsing: a "2-port"/"Dual-port"
+                                 # model keeps a rail per port; other multi-PF
+                                 # NICs collapse to one rail (the master PF).
+                                 # See `l8k discover --collapse-nic-rails`.
 
     # map[string]string — Labels that uniquely select nodes in this group
     nodeSelector:

--- a/skills/k8s-launch-kit-discover/SKILL.md
+++ b/skills/k8s-launch-kit-discover/SKILL.md
@@ -44,6 +44,7 @@ l8k discover --save-cluster-config <OUTPUT> [--kubeconfig <PATH>]
 | `--kubeconfig` | — | `$KUBECONFIG` env var | Path to kubeconfig (optional — falls back to env var) |
 | `--save-cluster-config` | Yes | — | Output path for cluster-config.yaml |
 | `--keep-namespace` | — | `false` | Skip teardown of the `nvidia-k8s-launch-kit` bootstrap namespace (for debugging) |
+| `--collapse-nic-rails` | — | `true` | Advertise one rail per NIC: collapse a NIC's multi-plane east-west PFs to its master PF, keeping a rail per port only for NICs whose VPD model is genuinely dual-port ("2-port"/"Dual-port"). Set `=false` to keep one rail per PF (dev setups). See "Rail collapsing" below. |
 | `--network-operator-namespace` | — | — | **Deprecated for `discover`**: accepted but ignored. The daemon always runs in `nvidia-k8s-launch-kit`. Still used by `l8k generate` / `l8k deploy`. |
 | `--user-config` | — | — | Base config to merge with discovered hardware |
 | `--node-selector` | — | `feature.node.kubernetes.io/pci-15b3.present=true` | Value written into the **saved** `cluster-config.yaml` `nodeSelector` (for deploy time). It does **not** gate discovery scheduling or the NicDevice wait set — the daemon runs on all nodes and NIC-bearing nodes are detected via a sysfs `0x15b3` probe. |
@@ -160,6 +161,27 @@ resolved.
   NICs, or `/sys` not mounted/readable in the pod).
 - After determining each group's `(machineType, gpuType)`, discovery looks up a topology preset under `presets/` using **exact-match** lookup on that pair. A matching preset overrides heuristic-derived topology fields (traffic class, rail, NUMA, GPU affinity). There is no any-GPU fallback — a preset with empty `gpuType:` is rejected at load time. If no preset matches, discovery proceeds with heuristic classification.
 - If you already know the SKU and want to skip cluster discovery entirely, use `l8k generate --for <preset>` (see `k8s-launch-kit-generate`).
+
+## Rail collapsing (one rail per NIC)
+
+By default (`--collapse-nic-rails`, default `true`) discovery advertises **one
+rail per NIC**, not one per PF. A single NIC can expose several east-west PFs
+that are *planes* of one physical port (Spectrum-X multi-plane ConnectX-8/9). For
+those, only the **master PF** (lowest PCI function) is written to
+`cluster-config.yaml`, so the rail count reflects physical NICs — e.g. an 8-PF
+ConnectX-8 node yields 4 rails, not 8. The per-PF planes are reconstructed at
+generate time from the multiplane mode + `numberOfPlanes`.
+
+The exception is a **genuinely dual-port NIC**: when the NIC's VPD model name
+(read from `NicDevice.Status.modelName`, surfaced as the `model` field on each
+PF) contains a port-count keyword like `2-port`/`Dual-port`, each port is kept as
+its own rail. Single-port (`1P`) and multi-plane models (no port-count keyword)
+collapse. An empty/unreadable model collapses by default.
+
+Pass `--collapse-nic-rails=false` to restore the legacy one-rail-per-PF behaviour
+(handy on dev setups). Note: a collapsed group no longer has the same PF count as
+a full-PF topology preset, so such presets won't apply by exact match and the
+live (collapsed) classification is kept (a preset-deviation warning is emitted).
 
 ## See Also
 


### PR DESCRIPTION
## Problem

`l8k discover` numbered **one rail per east-west PF**. For multi-plane hardware (Spectrum-X ConnectX-8/9) a single NIC exposes several PFs that are *planes* of one physical port, so this inflated the rail count in `cluster-config.yaml` — an 8-PF ConnectX-8 node became 8 rails instead of 4 — and drove the Spectrum-X `railCount` to the wrong value.

## Change

Discovery now advertises **one rail per NIC** by default:

- A NIC's multi-plane east-west PFs collapse to the **master PF** (lowest PCI function); the planes are reconstructed at generate time from the multiplane mode + `numberOfPlanes`.
- A NIC whose VPD model name is **genuinely dual-port** (`2-port`/`Dual-port`) keeps a rail per port.
- The model string is read from the existing `NicDevice.Status.ModelName` (the operator populates it from VPD via `mlxvpd`/`mstvpd`) and recorded on a new `PFConfig.Model` field — **no new hardware probe**. An empty/unreadable model collapses by default.
- New flag **`--collapse-nic-rails`** (default `true`, on both the root pipeline and `discover`) restores the legacy one-rail-per-PF behaviour with `=false` for dev setups.

Generation is unchanged and benefits: the Spectrum-X templates already render master PFs only, so a collapsed config matches what is emitted and `railCount` now equals the NIC count.

## Verification

- `go build ./...`, `go test ./pkg/...` green (the 4 `presets` env-dependent tests fail only on workstations with `/usr/local/share/l8k/presets/` installed, as documented — not a regression).
- New unit + integration tests: `isDualPortModel`, `collapsePFsToOnePerNIC`, and `buildClusterConfig` collapse paths (collapse on/off, dual-port exception).
- Smoke-rendered a collapsed 4-NIC ConnectX-8 SPC-X config: `hwplb` → 4 `railTopology` entries (`rail0`–`rail3`), `swplb` → 8 (`rail{0..3}p{0,1}`), `pfsPerNic: 2`.

## Note / follow-up

A collapsed group no longer has the same PF count as a full-PF topology preset, so `ApplyPreset`'s exact-PCI-bijection check fails against today's presets → the preset is treated as a topology deviation (not applied, warning emitted) and the live collapsed classification is kept. Re-authoring presets one-PF-per-NIC (and mirroring the rule in the `topology-report-to-yaml` skill) is a recommended follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)