### PR TITLE
feat(nvipam): generate IPPool IP exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,50 @@ With the auto-generation example above, a cluster with 2 groups (4 east-west PFs
 
 The `offset` parameter controls how many subnet blocks to skip between consecutive subnets (offset=1 is contiguous, offset=2 skips every other).
 
+**IP exclusions** — l8k can populate the IPPool `spec.exclusions` so addresses
+reserved for infrastructure (gateways, EVPN endpoints) are never handed to pods.
+Two mechanisms combine:
+
+- `reserveFirstIPs` / `reserveLastIPs` — a global, mask-agnostic pattern applied
+  to **every** subnet (including each auto-generated per-rail subnet). They
+  reserve the first N host addresses (from the network address upward) and the
+  last N (down from the broadcast address).
+- per-subnet `exclusions` — optional explicit `startIP`/`endIP` ranges on a
+  manually-listed subnet, for anything the reserve pattern doesn't cover.
+
+The computed reserve ranges are prepended to any explicit `exclusions`. The
+gateway is not excluded automatically — it is covered by the low reserve block.
+
+```yaml
+nvIpam:
+  poolName: nv-ipam-pool
+  startingSubnet: "192.168.0.0"
+  mask: 24
+  offset: 1
+  reserveFirstIPs: 10   # reserve .0–.9 on every /24
+  reserveLastIPs: 6     # reserve .250–.255 on every /24
+  # Optional explicit ranges on a manual subnet, merged on top of the reserve pattern:
+  # subnets:
+  # - subnet: 192.168.0.0/24
+  #   gateway: 192.168.0.1
+  #   exclusions:
+  #   - {startIP: 192.168.0.2, endIP: 192.168.0.3}
+```
+
+For a `/24` this reserves `.0–.9` and `.250–.255`, leaving a usable range of
+`.10–.249`. The rendered IPPool then carries:
+
+```yaml
+spec:
+  subnet: 192.168.0.0/24
+  gateway: 192.168.0.1
+  exclusions:
+  - startIP: 192.168.0.0
+    endIP: 192.168.0.9
+  - startIP: 192.168.0.250
+    endIP: 192.168.0.255
+```
+
 Example of the configuration file discovered from the cluster:
 
 ```yaml

--- a/l8k-config.yaml
+++ b/l8k-config.yaml
@@ -48,10 +48,18 @@ nvIpam:
   startingSubnet: "192.168.0.0"
   mask: 22
   offset: 1
+  # IP exclusions (optional). reserveFirstIPs/reserveLastIPs apply to EVERY
+  # subnet, including each auto-generated per-rail subnet — they reserve the
+  # first N and last N host addresses (gateway is covered by the low block).
+  # reserveFirstIPs: 10   # e.g. .0–.9 on a /24
+  # reserveLastIPs: 6     # e.g. .250–.255 on a /24
   # Option 2: Manually list subnets (takes precedence if non-empty)
   # subnets:
   # - subnet: 192.168.2.0/24
   #   gateway: 192.168.2.1
+  #   # explicit per-subnet exclusions are merged on top of the reserve pattern:
+  #   exclusions:
+  #   - {startIP: 192.168.2.2, endIP: 192.168.2.3}
   # - subnet: 192.168.3.0/24
   #   gateway: 192.168.3.1
   # - subnet: 192.168.4.0/24

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -171,11 +171,29 @@ type NvIpamConfig struct {
 	StartingSubnet string               `yaml:"startingSubnet,omitempty"`
 	Mask           int                  `yaml:"mask,omitempty"`
 	Offset         int                  `yaml:"offset,omitempty"`
+	// ReserveFirstIPs excludes the first N host addresses of EVERY subnet
+	// (network address upward, e.g. 10 → .0–.9 on a /24). Applied to both
+	// auto-generated and manually-listed subnets. Mask-agnostic.
+	ReserveFirstIPs int `yaml:"reserveFirstIPs,omitempty"`
+	// ReserveLastIPs excludes the last N host addresses of EVERY subnet
+	// (broadcast address downward, e.g. 6 → .250–.255 on a /24).
+	ReserveLastIPs int `yaml:"reserveLastIPs,omitempty"`
 }
 
 type NvIpamSubnetConfig struct {
 	Subnet  string `yaml:"subnet"`
 	Gateway string `yaml:"gateway"`
+	// Exclusions are IP ranges removed from the pool's allocatable set. The
+	// computed ReserveFirstIPs/ReserveLastIPs ranges are prepended to any
+	// ranges listed here (reserve first, then explicit).
+	Exclusions []NvIpamExclusion `yaml:"exclusions,omitempty"`
+}
+
+// NvIpamExclusion is a contiguous [StartIP, EndIP] range (inclusive) excluded
+// from an IPPool. Mirrors the NV-IPAM IPPool CRD's spec.exclusions[] shape.
+type NvIpamExclusion struct {
+	StartIP string `yaml:"startIP"`
+	EndIP   string `yaml:"endIP"`
 }
 
 type SriovConfig struct {
@@ -363,6 +381,20 @@ func LoadFullConfig(configPath string, logger logr.Logger) (*LaunchKubernetesCon
 	logger.Info("Cluster configuration loaded successfully",
 		"networkOperatorVersion", config.NetworkOperator.Version,
 		"namespace", config.NetworkOperator.Namespace)
+
+	if err := validateNvIpam(config.NvIpam); err != nil {
+		return nil, fmt.Errorf("invalid nvIpam config in %s: %w", configPath, err)
+	}
+
+	// Finalize exclusions for explicitly-listed (manual) subnets. Auto-generated
+	// subnets are finalized in the render path after GenerateSubnets. l8k never
+	// rewrites nvIpam back to disk, so this runs exactly once per load.
+	if config.NvIpam != nil && len(config.NvIpam.Subnets) > 0 {
+		if err := ApplyReservedExclusions(
+			config.NvIpam.Subnets, config.NvIpam.ReserveFirstIPs, config.NvIpam.ReserveLastIPs); err != nil {
+			return nil, fmt.Errorf("invalid nvIpam config in %s: %w", configPath, err)
+		}
+	}
 
 	emitPresetDeviationWarnings(&config, logger)
 
@@ -593,4 +625,137 @@ func GenerateSubnets(startingSubnet string, mask, offset, count int) ([]NvIpamSu
 	}
 
 	return subnets, nil
+}
+
+// uint32ToIP renders a big-endian uint32 as a dotted-quad IPv4 string.
+func uint32ToIP(v uint32) string {
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, v)
+	return ip.String()
+}
+
+// reservedExclusions computes the low/high reserved IP ranges for a subnet CIDR.
+// reserveFirst host addresses from the network address upward and reserveLast
+// from the broadcast address downward are returned as inclusive ranges. Returns
+// nil when both counts are <= 0.
+func reservedExclusions(subnetCIDR string, reserveFirst, reserveLast int) ([]NvIpamExclusion, error) {
+	if reserveFirst <= 0 && reserveLast <= 0 {
+		return nil, nil
+	}
+
+	_, ipnet, err := net.ParseCIDR(subnetCIDR)
+	if err != nil {
+		return nil, fmt.Errorf("invalid subnet %q: %w", subnetCIDR, err)
+	}
+	ip4 := ipnet.IP.To4()
+	if ip4 == nil {
+		return nil, fmt.Errorf("subnet %q must be IPv4", subnetCIDR)
+	}
+
+	network := binary.BigEndian.Uint32(ip4)
+	ones, bits := ipnet.Mask.Size()
+	blockSize := uint32(1) << uint(bits-ones)
+	broadcast := network + blockSize - 1
+
+	if uint64(reserveFirst)+uint64(reserveLast) >= uint64(blockSize) {
+		return nil, fmt.Errorf(
+			"reserveFirstIPs (%d) + reserveLastIPs (%d) leaves no usable addresses in %s (block size %d)",
+			reserveFirst, reserveLast, subnetCIDR, blockSize)
+	}
+
+	var out []NvIpamExclusion
+	if reserveFirst > 0 {
+		out = append(out, NvIpamExclusion{
+			StartIP: uint32ToIP(network),
+			EndIP:   uint32ToIP(network + uint32(reserveFirst) - 1),
+		})
+	}
+	if reserveLast > 0 {
+		out = append(out, NvIpamExclusion{
+			StartIP: uint32ToIP(broadcast - uint32(reserveLast) + 1),
+			EndIP:   uint32ToIP(broadcast),
+		})
+	}
+	return out, nil
+}
+
+// ApplyReservedExclusions finalizes each subnet's Exclusions list by prepending
+// the computed reserve ranges (ReserveFirstIPs/ReserveLastIPs) to any explicit
+// exclusions already present. It is a no-op when both reserve counts are <= 0.
+// Call exactly once per subnet slice (slices built by GenerateSubnets are fresh
+// per render path; manual subnets are finalized once at load time).
+func ApplyReservedExclusions(subnets []NvIpamSubnetConfig, reserveFirst, reserveLast int) error {
+	if reserveFirst <= 0 && reserveLast <= 0 {
+		return nil
+	}
+	for i := range subnets {
+		reserved, err := reservedExclusions(subnets[i].Subnet, reserveFirst, reserveLast)
+		if err != nil {
+			return err
+		}
+		if len(reserved) > 0 {
+			subnets[i].Exclusions = append(reserved, subnets[i].Exclusions...)
+		}
+	}
+	return nil
+}
+
+// validateNvIpam checks the nvIpam exclusion settings before any rendering.
+// It validates the reserve counts and any explicit per-subnet exclusion ranges.
+func validateNvIpam(nv *NvIpamConfig) error {
+	if nv == nil {
+		return nil
+	}
+	if nv.ReserveFirstIPs < 0 {
+		return fmt.Errorf("nvIpam.reserveFirstIPs must be >= 0, got %d", nv.ReserveFirstIPs)
+	}
+	if nv.ReserveLastIPs < 0 {
+		return fmt.Errorf("nvIpam.reserveLastIPs must be >= 0, got %d", nv.ReserveLastIPs)
+	}
+
+	// For auto-generated subnets there are no entries to iterate at load time,
+	// so verify the reserve counts are feasible against the configured mask up
+	// front rather than failing mid-render.
+	if len(nv.Subnets) == 0 && nv.StartingSubnet != "" && nv.Mask > 0 &&
+		(nv.ReserveFirstIPs > 0 || nv.ReserveLastIPs > 0) {
+		cidr := fmt.Sprintf("%s/%d", nv.StartingSubnet, nv.Mask)
+		if _, err := reservedExclusions(cidr, nv.ReserveFirstIPs, nv.ReserveLastIPs); err != nil {
+			return err
+		}
+	}
+
+	for _, s := range nv.Subnets {
+		var ipnet *net.IPNet
+		if s.Subnet != "" {
+			var err error
+			if _, ipnet, err = net.ParseCIDR(s.Subnet); err != nil {
+				return fmt.Errorf("nvIpam subnet %q is not valid CIDR: %w", s.Subnet, err)
+			}
+		}
+		// Reserve counts must leave usable addresses in each manual subnet.
+		if ipnet != nil && (nv.ReserveFirstIPs > 0 || nv.ReserveLastIPs > 0) {
+			if _, err := reservedExclusions(s.Subnet, nv.ReserveFirstIPs, nv.ReserveLastIPs); err != nil {
+				return err
+			}
+		}
+		for _, ex := range s.Exclusions {
+			start := net.ParseIP(ex.StartIP)
+			end := net.ParseIP(ex.EndIP)
+			if start == nil || start.To4() == nil {
+				return fmt.Errorf("nvIpam exclusion has invalid IPv4 startIP %q", ex.StartIP)
+			}
+			if end == nil || end.To4() == nil {
+				return fmt.Errorf("nvIpam exclusion has invalid IPv4 endIP %q", ex.EndIP)
+			}
+			if binary.BigEndian.Uint32(start.To4()) > binary.BigEndian.Uint32(end.To4()) {
+				return fmt.Errorf("nvIpam exclusion startIP %q must be <= endIP %q", ex.StartIP, ex.EndIP)
+			}
+			// Explicit ranges must fall within their own subnet, else NV-IPAM
+			// rejects the IPPool at apply time — surface it at config load.
+			if ipnet != nil && (!ipnet.Contains(start) || !ipnet.Contains(end)) {
+				return fmt.Errorf("nvIpam exclusion %s-%s is outside subnet %s", ex.StartIP, ex.EndIP, s.Subnet)
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -859,3 +859,190 @@ func TestGenerateSubnets(t *testing.T) {
 	})
 }
 
+func TestReservedExclusions(t *testing.T) {
+	t.Run("user case: /24 reserve 10 low and 6 high", func(t *testing.T) {
+		ex, err := reservedExclusions("192.168.0.0/24", 10, 6)
+		require.NoError(t, err)
+		require.Len(t, ex, 2)
+		assert.Equal(t, NvIpamExclusion{StartIP: "192.168.0.0", EndIP: "192.168.0.9"}, ex[0])
+		assert.Equal(t, NvIpamExclusion{StartIP: "192.168.0.250", EndIP: "192.168.0.255"}, ex[1])
+	})
+
+	t.Run("non-zero base subnet keeps ranges relative to its own network", func(t *testing.T) {
+		ex, err := reservedExclusions("192.168.5.0/24", 10, 6)
+		require.NoError(t, err)
+		require.Len(t, ex, 2)
+		assert.Equal(t, NvIpamExclusion{StartIP: "192.168.5.0", EndIP: "192.168.5.9"}, ex[0])
+		assert.Equal(t, NvIpamExclusion{StartIP: "192.168.5.250", EndIP: "192.168.5.255"}, ex[1])
+	})
+
+	t.Run("/16 subnet", func(t *testing.T) {
+		ex, err := reservedExclusions("10.1.0.0/16", 10, 6)
+		require.NoError(t, err)
+		require.Len(t, ex, 2)
+		assert.Equal(t, NvIpamExclusion{StartIP: "10.1.0.0", EndIP: "10.1.0.9"}, ex[0])
+		assert.Equal(t, NvIpamExclusion{StartIP: "10.1.255.250", EndIP: "10.1.255.255"}, ex[1])
+	})
+
+	t.Run("reserve first only", func(t *testing.T) {
+		ex, err := reservedExclusions("192.168.0.0/24", 5, 0)
+		require.NoError(t, err)
+		require.Len(t, ex, 1)
+		assert.Equal(t, NvIpamExclusion{StartIP: "192.168.0.0", EndIP: "192.168.0.4"}, ex[0])
+	})
+
+	t.Run("reserve last only", func(t *testing.T) {
+		ex, err := reservedExclusions("192.168.0.0/24", 0, 5)
+		require.NoError(t, err)
+		require.Len(t, ex, 1)
+		assert.Equal(t, NvIpamExclusion{StartIP: "192.168.0.251", EndIP: "192.168.0.255"}, ex[0])
+	})
+
+	t.Run("both zero returns nil", func(t *testing.T) {
+		ex, err := reservedExclusions("192.168.0.0/24", 0, 0)
+		require.NoError(t, err)
+		assert.Nil(t, ex)
+	})
+
+	t.Run("reserve exceeding block size errors", func(t *testing.T) {
+		_, err := reservedExclusions("192.168.0.0/24", 200, 200)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no usable addresses")
+	})
+
+	t.Run("invalid CIDR errors", func(t *testing.T) {
+		_, err := reservedExclusions("not-a-cidr", 1, 1)
+		require.Error(t, err)
+	})
+}
+
+func TestApplyReservedExclusions(t *testing.T) {
+	t.Run("prepends reserve before explicit exclusions", func(t *testing.T) {
+		subnets := []NvIpamSubnetConfig{{
+			Subnet:  "192.168.0.0/24",
+			Gateway: "192.168.0.1",
+			Exclusions: []NvIpamExclusion{
+				{StartIP: "192.168.0.100", EndIP: "192.168.0.100"},
+			},
+		}}
+		require.NoError(t, ApplyReservedExclusions(subnets, 10, 6))
+		require.Len(t, subnets[0].Exclusions, 3)
+		assert.Equal(t, NvIpamExclusion{StartIP: "192.168.0.0", EndIP: "192.168.0.9"}, subnets[0].Exclusions[0])
+		assert.Equal(t, NvIpamExclusion{StartIP: "192.168.0.250", EndIP: "192.168.0.255"}, subnets[0].Exclusions[1])
+		assert.Equal(t, NvIpamExclusion{StartIP: "192.168.0.100", EndIP: "192.168.0.100"}, subnets[0].Exclusions[2])
+	})
+
+	t.Run("no-op when both counts zero, explicit preserved", func(t *testing.T) {
+		subnets := []NvIpamSubnetConfig{{
+			Subnet:     "192.168.0.0/24",
+			Exclusions: []NvIpamExclusion{{StartIP: "192.168.0.5", EndIP: "192.168.0.5"}},
+		}}
+		require.NoError(t, ApplyReservedExclusions(subnets, 0, 0))
+		require.Len(t, subnets[0].Exclusions, 1)
+		assert.Equal(t, NvIpamExclusion{StartIP: "192.168.0.5", EndIP: "192.168.0.5"}, subnets[0].Exclusions[0])
+	})
+
+	t.Run("applies across every subnet in the slice", func(t *testing.T) {
+		subnets := []NvIpamSubnetConfig{
+			{Subnet: "192.168.0.0/24"},
+			{Subnet: "192.168.1.0/24"},
+		}
+		require.NoError(t, ApplyReservedExclusions(subnets, 10, 6))
+		require.Len(t, subnets[0].Exclusions, 2)
+		require.Len(t, subnets[1].Exclusions, 2)
+		assert.Equal(t, "192.168.1.250", subnets[1].Exclusions[1].StartIP)
+		assert.Equal(t, "192.168.1.255", subnets[1].Exclusions[1].EndIP)
+	})
+}
+
+func TestValidateNvIpam(t *testing.T) {
+	t.Run("nil is valid", func(t *testing.T) {
+		assert.NoError(t, validateNvIpam(nil))
+	})
+
+	t.Run("negative reserveFirstIPs", func(t *testing.T) {
+		err := validateNvIpam(&NvIpamConfig{ReserveFirstIPs: -1})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reserveFirstIPs must be >= 0")
+	})
+
+	t.Run("negative reserveLastIPs", func(t *testing.T) {
+		err := validateNvIpam(&NvIpamConfig{ReserveLastIPs: -1})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reserveLastIPs must be >= 0")
+	})
+
+	t.Run("oversized reserve against manual subnet", func(t *testing.T) {
+		err := validateNvIpam(&NvIpamConfig{
+			ReserveFirstIPs: 200,
+			ReserveLastIPs:  200,
+			Subnets:         []NvIpamSubnetConfig{{Subnet: "192.168.0.0/24"}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no usable addresses")
+	})
+
+	t.Run("oversized reserve against auto-gen subnet caught at load time", func(t *testing.T) {
+		err := validateNvIpam(&NvIpamConfig{
+			StartingSubnet:  "192.168.0.0",
+			Mask:            24,
+			ReserveFirstIPs: 300,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no usable addresses")
+	})
+
+	t.Run("invalid manual subnet CIDR", func(t *testing.T) {
+		err := validateNvIpam(&NvIpamConfig{
+			Subnets: []NvIpamSubnetConfig{{Subnet: "not-a-cidr"}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not valid CIDR")
+	})
+
+	t.Run("explicit exclusion outside its subnet", func(t *testing.T) {
+		err := validateNvIpam(&NvIpamConfig{
+			Subnets: []NvIpamSubnetConfig{{
+				Subnet:     "192.168.0.0/24",
+				Exclusions: []NvIpamExclusion{{StartIP: "192.168.5.2", EndIP: "192.168.5.3"}},
+			}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside subnet")
+	})
+
+	t.Run("invalid explicit startIP", func(t *testing.T) {
+		err := validateNvIpam(&NvIpamConfig{
+			Subnets: []NvIpamSubnetConfig{{
+				Subnet:     "192.168.0.0/24",
+				Exclusions: []NvIpamExclusion{{StartIP: "nope", EndIP: "192.168.0.9"}},
+			}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid IPv4 startIP")
+	})
+
+	t.Run("inverted explicit range", func(t *testing.T) {
+		err := validateNvIpam(&NvIpamConfig{
+			Subnets: []NvIpamSubnetConfig{{
+				Subnet:     "192.168.0.0/24",
+				Exclusions: []NvIpamExclusion{{StartIP: "192.168.0.9", EndIP: "192.168.0.1"}},
+			}},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be <= endIP")
+	})
+
+	t.Run("valid reserve + explicit", func(t *testing.T) {
+		err := validateNvIpam(&NvIpamConfig{
+			ReserveFirstIPs: 10,
+			ReserveLastIPs:  6,
+			Subnets: []NvIpamSubnetConfig{{
+				Subnet:     "192.168.0.0/24",
+				Exclusions: []NvIpamExclusion{{StartIP: "192.168.0.2", EndIP: "192.168.0.3"}},
+			}},
+		})
+		assert.NoError(t, err)
+	})
+}
+

--- a/pkg/networkoperatorplugin/ippool_exclusions_test.go
+++ b/pkg/networkoperatorplugin/ippool_exclusions_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkoperatorplugin
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// TestIPPoolReservedExclusionsRenderPerRail verifies the reserve-count pattern
+// is applied to each auto-generated per-rail subnet: every rendered IPPool doc
+// carries a spec.exclusions block whose low range starts at that rail's own
+// network address.
+func TestIPPoolReservedExclusionsRenderPerRail(t *testing.T) {
+	ctrllog.SetLogger(zap.New(zap.UseDevMode(true)))
+	cfg, err := config.LoadFullConfig(
+		filepath.Join("testdata", "grouping", "mixed-same-type.yaml"), ctrllog.Log)
+	require.NoError(t, err)
+	cfg.Profile = &config.Profile{Fabric: "ethernet", Deployment: "sriov", Multirail: true}
+	require.NotNil(t, cfg.NvIpam)
+	cfg.NvIpam.ReserveFirstIPs = 10
+	cfg.NvIpam.ReserveLastIPs = 6
+
+	rendered, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(
+		loadProfileFromDir(t, "sriov-ethernet-rdma"), cfg)
+	require.NoError(t, err)
+
+	names := fileNamesMatching(rendered, "ippool")
+	require.NotEmpty(t, names, "expected at least one IPPool manifest")
+
+	sawDoc := false
+	for _, name := range names {
+		for _, doc := range parseDocs(t, name, rendered[name]) {
+			spec, ok := doc["spec"].(map[string]any)
+			require.True(t, ok)
+			subnet, ok := spec["subnet"].(string)
+			require.True(t, ok)
+
+			ex, ok := spec["exclusions"].([]any)
+			require.Truef(t, ok, "IPPool for subnet %s is missing exclusions", subnet)
+			require.Lenf(t, ex, 2, "expected low+high exclusion ranges for subnet %s", subnet)
+
+			networkIP := strings.SplitN(subnet, "/", 2)[0]
+			low, ok := ex[0].(map[string]any)
+			require.True(t, ok)
+			// Low range begins at the rail's own network address (.0).
+			assert.Equal(t, networkIP, low["startIP"], "low exclusion must start at the subnet network address")
+			assert.NotEmpty(t, low["endIP"])
+
+			high, ok := ex[1].(map[string]any)
+			require.True(t, ok)
+			assert.NotEmpty(t, high["startIP"])
+			assert.NotEmpty(t, high["endIP"])
+			sawDoc = true
+		}
+	}
+	require.True(t, sawDoc, "expected at least one IPPool document with exclusions")
+}
+
+// TestIPPoolNoExclusionsWhenReserveUnset confirms the default (no reserve, no
+// explicit exclusions) renders no exclusions block — byte-compatible with the
+// pre-feature output.
+func TestIPPoolNoExclusionsWhenReserveUnset(t *testing.T) {
+	ctrllog.SetLogger(zap.New(zap.UseDevMode(true)))
+	cfg, err := config.LoadFullConfig(
+		filepath.Join("testdata", "grouping", "mixed-same-type.yaml"), ctrllog.Log)
+	require.NoError(t, err)
+	cfg.Profile = &config.Profile{Fabric: "ethernet", Deployment: "sriov", Multirail: true}
+
+	rendered, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(
+		loadProfileFromDir(t, "sriov-ethernet-rdma"), cfg)
+	require.NoError(t, err)
+
+	for _, name := range fileNamesMatching(rendered, "ippool") {
+		assert.NotContains(t, rendered[name], "exclusions:",
+			"IPPool should have no exclusions block when reserve is unset")
+	}
+}

--- a/pkg/networkoperatorplugin/render_plan.go
+++ b/pkg/networkoperatorplugin/render_plan.go
@@ -572,6 +572,9 @@ func preallocatePlanSubnets(cfg *config.LaunchKubernetesConfig, plans []RenderBu
 	if err != nil {
 		return nil, fmt.Errorf("auto-generate subnets: %w", err)
 	}
+	if err := config.ApplyReservedExclusions(all, cfg.NvIpam.ReserveFirstIPs, cfg.NvIpam.ReserveLastIPs); err != nil {
+		return nil, fmt.Errorf("auto-generate subnets: %w", err)
+	}
 	out := make([][]config.NvIpamSubnetConfig, len(plans))
 	off := 0
 	for i, n := range counts {

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -666,6 +666,10 @@ func ProcessTemplate(templatePath string, cfg *config.LaunchKubernetesConfig, gr
 		if err != nil {
 			return nil, fmt.Errorf("failed to auto-generate subnets: %w", err)
 		}
+		if err := config.ApplyReservedExclusions(
+			allSubnets, cfg.NvIpam.ReserveFirstIPs, cfg.NvIpam.ReserveLastIPs); err != nil {
+			return nil, fmt.Errorf("failed to auto-generate subnets: %w", err)
+		}
 
 		groupSubnets = make([][]config.NvIpamSubnetConfig, len(groups))
 		subnetOffset := 0

--- a/profiles/host-device-rdma/20-ippool.yaml
+++ b/profiles/host-device-rdma/20-ippool.yaml
@@ -11,6 +11,13 @@ spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
   perNodeBlockSize: 50
   gateway: {{(index $.NvIpam.Subnets $i).Gateway}}
+  {{- with (index $.NvIpam.Subnets $i).Exclusions }}
+  exclusions:
+  {{- range . }}
+  - startIP: {{ .StartIP }}
+    endIP: {{ .EndIP }}
+  {{- end }}
+  {{- end }}
   {{- if $.ClusterConfig.SourceMachineLabels }}
   nodeSelector:
     nodeSelectorTerms:
@@ -49,6 +56,13 @@ spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
   perNodeBlockSize: 50
   gateway: {{(index .NvIpam.Subnets 0).Gateway}}
+  {{- with (index .NvIpam.Subnets 0).Exclusions }}
+  exclusions:
+  {{- range . }}
+  - startIP: {{ .StartIP }}
+    endIP: {{ .EndIP }}
+  {{- end }}
+  {{- end }}
   {{- if .ClusterConfig.SourceMachineLabels }}
   nodeSelector:
     nodeSelectorTerms:

--- a/profiles/ipoib-rdma-shared/20-ippool.yaml
+++ b/profiles/ipoib-rdma-shared/20-ippool.yaml
@@ -11,6 +11,13 @@ spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
   perNodeBlockSize: 50
   gateway: {{(index $.NvIpam.Subnets $i).Gateway}}
+  {{- with (index $.NvIpam.Subnets $i).Exclusions }}
+  exclusions:
+  {{- range . }}
+  - startIP: {{ .StartIP }}
+    endIP: {{ .EndIP }}
+  {{- end }}
+  {{- end }}
   {{- if $.ClusterConfig.SourceMachineLabels }}
   nodeSelector:
     nodeSelectorTerms:
@@ -50,6 +57,13 @@ spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
   perNodeBlockSize: 50
   gateway: {{(index .NvIpam.Subnets 0).Gateway}}
+  {{- with (index .NvIpam.Subnets 0).Exclusions }}
+  exclusions:
+  {{- range . }}
+  - startIP: {{ .StartIP }}
+    endIP: {{ .EndIP }}
+  {{- end }}
+  {{- end }}
   {{- if $.ClusterConfig.SourceMachineLabels }}
   nodeSelector:
     nodeSelectorTerms:

--- a/profiles/macvlan-rdma-shared/20-ippool.yaml
+++ b/profiles/macvlan-rdma-shared/20-ippool.yaml
@@ -11,6 +11,13 @@ spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
   perNodeBlockSize: 50
   gateway: {{(index $.NvIpam.Subnets $i).Gateway}}
+  {{- with (index $.NvIpam.Subnets $i).Exclusions }}
+  exclusions:
+  {{- range . }}
+  - startIP: {{ .StartIP }}
+    endIP: {{ .EndIP }}
+  {{- end }}
+  {{- end }}
   {{- if $.ClusterConfig.SourceMachineLabels }}
   nodeSelector:
     nodeSelectorTerms:
@@ -50,6 +57,13 @@ spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
   perNodeBlockSize: 50
   gateway: {{(index .NvIpam.Subnets 0).Gateway}}
+  {{- with (index .NvIpam.Subnets 0).Exclusions }}
+  exclusions:
+  {{- range . }}
+  - startIP: {{ .StartIP }}
+    endIP: {{ .EndIP }}
+  {{- end }}
+  {{- end }}
   {{- if $.ClusterConfig.SourceMachineLabels }}
   nodeSelector:
     nodeSelectorTerms:

--- a/profiles/sriov-ethernet-rdma/20-ippool.yaml
+++ b/profiles/sriov-ethernet-rdma/20-ippool.yaml
@@ -11,6 +11,13 @@ spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
   perNodeBlockSize: 50
   gateway: {{(index $.NvIpam.Subnets $i).Gateway}}
+  {{- with (index $.NvIpam.Subnets $i).Exclusions }}
+  exclusions:
+  {{- range . }}
+  - startIP: {{ .StartIP }}
+    endIP: {{ .EndIP }}
+  {{- end }}
+  {{- end }}
   {{- if $.ClusterConfig.SourceMachineLabels }}
   nodeSelector:
     nodeSelectorTerms:
@@ -49,6 +56,13 @@ spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
   perNodeBlockSize: 50
   gateway: {{(index .NvIpam.Subnets 0).Gateway}}
+  {{- with (index .NvIpam.Subnets 0).Exclusions }}
+  exclusions:
+  {{- range . }}
+  - startIP: {{ .StartIP }}
+    endIP: {{ .EndIP }}
+  {{- end }}
+  {{- end }}
   {{- if $.ClusterConfig.SourceMachineLabels }}
   nodeSelector:
     nodeSelectorTerms:

--- a/profiles/sriov-ib-rdma/20-ippool.yaml
+++ b/profiles/sriov-ib-rdma/20-ippool.yaml
@@ -11,6 +11,13 @@ spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
   perNodeBlockSize: 50
   gateway: {{(index $.NvIpam.Subnets $i).Gateway}}
+  {{- with (index $.NvIpam.Subnets $i).Exclusions }}
+  exclusions:
+  {{- range . }}
+  - startIP: {{ .StartIP }}
+    endIP: {{ .EndIP }}
+  {{- end }}
+  {{- end }}
   {{- if $.ClusterConfig.SourceMachineLabels }}
   nodeSelector:
     nodeSelectorTerms:
@@ -49,6 +56,13 @@ spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
   perNodeBlockSize: 50
   gateway: {{(index .NvIpam.Subnets 0).Gateway}}
+  {{- with (index .NvIpam.Subnets 0).Exclusions }}
+  exclusions:
+  {{- range . }}
+  - startIP: {{ .StartIP }}
+    endIP: {{ .EndIP }}
+  {{- end }}
+  {{- end }}
   {{- if $.ClusterConfig.SourceMachineLabels }}
   nodeSelector:
     nodeSelectorTerms:

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -94,13 +94,31 @@ nvIpam:
   # offset=1 means gateway = network_address + 1 (e.g., 192.168.0.1).
   offset: 1
 
+  # --- IP exclusions (optional) ---
+
+  # int | default: 0
+  # Reserve the first N host addresses of EVERY subnet (network address upward),
+  # applied to both auto-generated and manual subnets. Mask-agnostic.
+  # Renders into the IPPool spec.exclusions[]. e.g. 10 → .0–.9 on a /24.
+  # reserveFirstIPs: 10
+
+  # int | default: 0
+  # Reserve the last N host addresses of EVERY subnet (broadcast downward).
+  # e.g. 6 → .250–.255 on a /24. The gateway is NOT auto-excluded — it is
+  # covered by the low reserve block.
+  # reserveLastIPs: 6
+
   # --- Manual mode (takes precedence if non-empty) ---
 
   # list | default: [] (empty, triggers auto-generation)
   # Explicit subnet definitions. Provide one entry per rail across all groups.
+  # Each subnet may carry its own `exclusions` (startIP/endIP) ranges; the
+  # computed reserveFirstIPs/reserveLastIPs ranges are prepended to them.
   # subnets:
   #   - subnet: 192.168.2.0/24     # CIDR notation
   #     gateway: 192.168.2.1       # Gateway IP within the subnet
+  #     exclusions:                # optional, merged on top of the reserve pattern
+  #       - {startIP: 192.168.2.2, endIP: 192.168.2.3}
   #   - subnet: 192.168.3.0/24
   #     gateway: 192.168.3.1
 

--- a/skills/k8s-network-engineer/references/config-schema.md
+++ b/skills/k8s-network-engineer/references/config-schema.md
@@ -46,6 +46,8 @@ Controls NV-IPAM (NVIDIA IP Address Management) pool generation.
 | `startingSubnet` | string   | `192.168.0.0`    | Base subnet for auto-generation                      |
 | `mask`           | int      | `22`             | Subnet mask length for auto-generated subnets        |
 | `offset`         | int      | `1`              | Offset from network address for gateway (gateway = network + offset) |
+| `reserveFirstIPs`| int      | `0`              | Exclude the first N host addresses of every subnet (network upward) |
+| `reserveLastIPs` | int      | `0`              | Exclude the last N host addresses of every subnet (broadcast downward) |
 | `subnets`        | list     | `[]` (empty)     | Manual subnet list; takes precedence over auto-generation |
 
 ### Auto-Generation (Option 1)
@@ -67,6 +69,31 @@ subnets:
 ```
 
 Manual subnets take precedence over auto-generation.
+
+### IP Exclusions
+
+l8k can populate the IPPool's `spec.exclusions` so reserved addresses (floating
+gateway, EVPN endpoints, etc.) are never allocated to pods:
+
+- `reserveFirstIPs` / `reserveLastIPs` — a mask-agnostic pattern applied to
+  **every** subnet (auto-generated and manual). On a `/24`, `reserveFirstIPs: 10`
+  and `reserveLastIPs: 6` reserve `.0–.9` and `.250–.255`, leaving `.10–.249`.
+- Each manual subnet may also carry explicit `exclusions` (`startIP`/`endIP`)
+  ranges; the computed reserve ranges are prepended to them.
+
+The gateway is not excluded automatically — it falls inside the low reserve
+block. Each auto-generated per-rail subnet gets the reserve ranges computed
+relative to its own network address.
+
+```yaml
+nvIpam:
+  poolName: nv-ipam-pool
+  startingSubnet: "192.168.0.0"
+  mask: 24
+  offset: 1
+  reserveFirstIPs: 10
+  reserveLastIPs: 6
+```
 
 ## sriov
 


### PR DESCRIPTION
## What

Lets users declare NV-IPAM IPPool **IP exclusions** in `l8k-host-config.yaml` so addresses reserved for infrastructure (floating gateway, EVPN endpoints, …) are never handed to pods. l8k now emits `spec.exclusions` on every generated IPPool — including auto-generated per-rail subnets.

## Why

Operators use `.1` as a floating gateway and `.2`/`.3` as real EVPN gateways, and typically mask out a low + high block (e.g. `.0–.9` and `.250–.255` on a `/24`, leaving `.10–.249`). The IPPool CRD supports `spec.exclusions`, but l8k had no way to populate it — every generated IPPool had to be hand-edited, which is especially painful when subnets are auto-generated one `/24` per rail.

## How

Two mechanisms, combined (reserve ranges are prepended to explicit ranges):

- **`nvIpam.reserveFirstIPs` / `reserveLastIPs`** — a mask-agnostic pattern applied to **every** subnet (incl. each auto-generated per-rail subnet). l8k computes the absolute `startIP`/`endIP` relative to each subnet's own network/broadcast addresses.
- **per-subnet `exclusions`** — optional explicit `startIP`/`endIP` ranges on a manually-listed subnet.

```yaml
nvIpam:
  poolName: nv-ipam-pool
  startingSubnet: "192.168.0.0"
  mask: 24
  offset: 1
  reserveFirstIPs: 10   # .0–.9
  reserveLastIPs: 6     # .250–.255
```

Implementation:
- `reservedExclusions` + `ApplyReservedExclusions` + `validateNvIpam` in `pkg/config/config.go`.
- Called once per fresh subnet slice: after `GenerateSubnets` in both auto-gen paths (`preallocatePlanSubnets`, the legacy `ProcessTemplate` block) and once for manual subnets in `LoadFullConfig`.
- All five `profiles/*/20-ippool.yaml` render `Exclusions` verbatim into `spec.exclusions`. The gateway is **not** auto-excluded (it falls in the low reserve block). The Spectrum-X `CIDRPool` is unaffected (index-based `perNodeExclusions`).

## Tests

- Unit: `TestReservedExclusions`, `TestApplyReservedExclusions`, `TestValidateNvIpam` (`pkg/config`).
- Render: `TestIPPoolReservedExclusionsRenderPerRail`, `TestIPPoolNoExclusionsWhenReserveUnset` (`pkg/networkoperatorplugin`).
- Smoke-rendered the sriov-ethernet-rdma profile end-to-end — each per-rail `/22` IPPool carries exclusions computed relative to its own network address.

## Docs

Updated all four surfaces per repo discipline: `CLAUDE.md`, `README.md`, `l8k-config.yaml`, and the `k8s-launch-kit-config` / `k8s-network-engineer` skill references.

> Note: `golangci-lint` is not installed on the dev box, so it was not run; `go build`, `go vet`, and `go test` pass (the 4 `pkg/presets` failures are the documented environmental ones caused by an installed `/usr/local/share/l8k/presets`).