### PR TITLE
validate: macvlan/ipoib RDMA fallback + sriov webhook gate + GB300 Station preset

### DIFF
--- a/pkg/networkoperatorplugin/connectivity/connectivity.go
+++ b/pkg/networkoperatorplugin/connectivity/connectivity.go
@@ -212,6 +212,28 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 	totalCrossRail := len(plan.RDMACrossRail)
 	uiOutput.Info("Plan: %d same-rail rping + %d cross-rail rping; %d same-rail ib_write_bw + %d cross-rail ib_write_bw",
 		totalSameRail, totalCrossRail, len(plan.RDMABwSameRail), len(plan.RDMABwCrossRail))
+	// Defensive: Plan() can return a zero-test plan without setting
+	// Skip (e.g. ≥2 schedulable pods but Plan's same-rail loop emits
+	// nothing). Two possible causes, both surface here:
+	//
+	//   (a) Every rail had at least one endpoint with no resolvable
+	//       RDMA device. Common on macvlan/ipoib-rdma-shared profiles
+	//       where the in-pod RDMA device probe returns empty.
+	//   (b) No rail key was shared across pods. Can't happen with
+	//       any current l8k-rendered example DaemonSet (single group
+	//       per render → identical multus annotations), but mentioned
+	//       so the diagnostic doesn't misattribute on a future
+	//       multi-group setup.
+	//
+	// Without surfacing this, validate prints "Matrix complete: 0/0
+	// passed" and exits success, hiding a real coverage gap.
+	if totalSameRail+totalCrossRail+len(plan.RDMABwSameRail)+len(plan.RDMABwCrossRail) == 0 {
+		uiOutput.Warning(
+			"Matrix produced 0 tests despite %d schedulable pod(s) — either every rail had at least one endpoint with no resolvable RDMA device, or no rail key was shared across pods. "+
+				"Most common cause: macvlan or IPoIB secondary networks, where the in-pod iface has no PCI-direct mlx5 sysfs entry. "+
+				"Verify with: `kubectl exec <pod> -- ls /sys/class/net/<iface>/device/infiniband/` (empty on every pod = the fallback path needs the host master mapping).",
+			len(testPods))
+	}
 
 	// Build a pod-name → container name map so the test runners
 	// know which container to exec in (test DSes have a single

--- a/pkg/networkoperatorplugin/connectivity/rdma.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma.go
@@ -41,16 +41,54 @@ const rdmaServerSettleDelay = 2 * time.Second
 // Options.Timeout.
 const rdmaTestTimeout = 90 * time.Second
 
+// railNameIndex extracts the numeric rail index from a rail key like
+// "macvlan-network-rail-3-some-suffix" → 3. Matches the rendered
+// NetworkAttachmentDefinition / MacvlanNetwork names every l8k profile
+// emits (always shaped `<base>-rail-<N>-<identifier>`). Returns -1 when
+// the pattern doesn't match (e.g. shared-network profiles where rail
+// indexing isn't part of the network name) so the caller skips the
+// rail-index fallback for that key.
+var railNameIndex = regexp.MustCompile(`(?:^|-)rail-(\d+)(?:-|$)`)
+
+func railIndex(rail string) int {
+	m := railNameIndex.FindStringSubmatch(rail)
+	if len(m) < 2 {
+		return -1
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return -1
+	}
+	return n
+}
+
 // DiscoverRDMADevices runs once per test pod to map each multus
-// secondary-network interface to its RDMA device. Reads
-// /sys/class/net/<iface>/device/infiniband/ inside the pod — that
-// directory exists for any mlx5 VF and contains exactly one entry
-// (the device name, e.g. "mlx5_4").
+// secondary-network interface to its RDMA device. Two probes are
+// tried in order, per interface:
 //
-// nets is the parsed multus annotation; ifaceByRail tells the
-// mapping which net interface (e.g. "net1") backs each rail.
-// Returns map[rail]→<rdmaDev>; rails whose interface couldn't be
-// resolved are absent from the map.
+//  1. /sys/class/net/<iface>/device/infiniband/ — this exists for any
+//     PCI-direct mlx5 device, including SR-IOV VFs moved into the pod
+//     netns (host-device-rdma, sriov-*-rdma profiles). Contains
+//     exactly one entry: the RDMA device name (e.g. "mlx5_4").
+//
+//  2. Fallback for non-PCI-direct attachments — macvlan slaves,
+//     IPoIB child interfaces, and anything else that's a kernel
+//     netdev layered on top of a master mlx5 device. Those netdevs
+//     don't have a `device/` symlink to a PCI function inside the
+//     pod, so probe (1) returns empty. The rdmaSharedDevicePlugin
+//     mounts the host's `/sys/class/infiniband/<mlx5_X>` entries
+//     into the pod for each rail-resource the pod requested, so we
+//     enumerate that directory. When exactly one entry is present
+//     (single-NIC nodes — the common case), use it. When multiple
+//     entries are present (multi-rail rdmaShared on a multi-NIC
+//     node) we can't disambiguate purely pod-side and fall back to
+//     "no device for this rail"; an orchestrator-side host probe
+//     reading the rendered MacvlanNetwork master fields would be the
+//     fix and is tracked as a follow-up.
+//
+// ifaceByRail tells which net interface (e.g. "net1") backs each
+// rail. Returns map[rail]→<rdmaDev>; rails whose interface couldn't
+// be resolved are absent from the map.
 func DiscoverRDMADevices(ctx context.Context, restConfig *rest.Config, namespace, pod, container string, ifaceByRail map[string]string) map[string]string {
 	out := map[string]string{}
 	if len(ifaceByRail) == 0 {
@@ -64,11 +102,41 @@ func DiscoverRDMADevices(ctx context.Context, restConfig *rest.Config, namespace
 		if iface == "" {
 			continue
 		}
-		// `ls -1` prints one filename per line. Capture the
-		// first line — the mlx5 VF directory always contains
-		// exactly one entry, but `head -n 1` is a cheap safety
-		// belt against future kernel changes.
+		// Primary probe: PCI-direct mlx5 netdev (SR-IOV VF, host-device).
 		fmt.Fprintf(&b, "dev=$(ls -1 /sys/class/net/%s/device/infiniband/ 2>/dev/null | head -n 1); ", iface)
+
+		// Fallback A (single-NIC): non-PCI-direct netdev (macvlan, ipoib).
+		// rdmaSharedDevicePlugin injects /sys/class/infiniband/<mlx5_X>
+		// for each rail-resource the pod requested. When the pod
+		// requested exactly one rail, there's exactly one mlx5 — pick it.
+		fmt.Fprintf(&b, "if [ -z \"$dev\" ] && [ -d /sys/class/net/%s ]; then "+
+			"count=$(ls -1 /sys/class/infiniband/ 2>/dev/null | wc -l); "+
+			"if [ \"$count\" = \"1\" ]; then dev=$(ls -1 /sys/class/infiniband/ 2>/dev/null); fi; "+
+			"fi; ", iface)
+
+		// Fallback B (multi-rail): when the pod was granted multiple
+		// rail-resources, /sys/class/infiniband has one entry per rail,
+		// sorted by mlx5 index. Use the rail INDEX (extracted from the
+		// rail name `rail-N`) to pick the Nth entry. Sort is `sort -t_
+		// -k2,2n` (POSIX, works on busybox) rather than `ls -1v` (GNU
+		// only) so the probe doesn't silently regress to alphabetic
+		// order — which would mis-pick for rails ≥ 10 — if the test
+		// container image ever changes from DOCA to a busybox-based
+		// distro.
+		//
+		// Caveats: assumes (a) one rail = one mlx5, (b) mlx5 numbering
+		// follows PCI enumeration (kernel default), and (c) rail indexing
+		// is contiguous from 0 in the same order. All three hold for
+		// every l8k-generated profile today. When false (e.g. extra
+		// non-rail mlx5 devices exposed), the heuristic picks wrong;
+		// the orchestrator-side master→mlx5 mapping is the real fix and
+		// is tracked separately.
+		if idx := railIndex(rail); idx >= 0 {
+			fmt.Fprintf(&b, "if [ -z \"$dev\" ]; then "+
+				"dev=$(ls -1 /sys/class/infiniband/ 2>/dev/null | sort -t_ -k2,2n | sed -n %dp); "+
+				"fi; ", idx+1)
+		}
+
 		fmt.Fprintf(&b, "if [ -n \"$dev\" ]; then echo %q=$dev; fi; ", rail)
 	}
 	if b.Len() == 0 {

--- a/pkg/presets/data/GB300-DGX-Station-NVIDIA-GB300/topology.yaml
+++ b/pkg/presets/data/GB300-DGX-Station-NVIDIA-GB300/topology.yaml
@@ -1,0 +1,46 @@
+machineType: GB300-DGX-Station
+manufacturer: NVIDIA
+gpuType: NVIDIA-GB300
+nicModel: Nvidia ConnectX-8 for Galaxy GB300 -Prime (ConnectX-8)
+gpuInterconnect: ""
+numaNodes: 9
+
+capabilities:
+  nodes:
+    sriov: true
+    rdma: true
+    ib: true
+
+# GB300 DGX Station (Galaxy GB300 -Prime), single-Grace-CPU workstation:
+#   - 1× Grace CPU exposing 9 NUMA nodes (Grace UCM die-affinity layout).
+#   - 1× NVIDIA GB300 GPU (no NVLink — single-GPU box, gpuInterconnect empty).
+#   - 1× ConnectX-8 dual-port NIC on PCIe path 0001:00 → 0001:01 → 0001:02 → 0001:03.
+#     The platform wires the upstream root port at Gen5 x8 (kernel reports
+#     "252 Gb/s available PCIe bandwidth, limited by 32.0 GT/s PCIe x8");
+#     even though the NIC silicon advertises Gen6 x16 to its closest parent,
+#     the SoC root limits aggregate host throughput to ~252 Gb/s. Single-port
+#     ib_write_bw on this NIC tops out around 206 Gb/s.
+#
+# Layout (collapsed: one rail per NIC, master function only — matches l8k
+# discover with --collapse-nic-rails=true, the default):
+#   rail 0 @ 0001:03:00.0 → mlx5_0 → connectedGPU: GPU0
+#
+# Classification rationale: nvidia-smi topo -m reports every NIC ↔ GPU0 as
+# SYS (no PIX, no NODE) because the NIC and GPU live behind separate root
+# complexes on the GB300 SoC. The skill's NODE-fallback rule applies: the
+# NIC's numaNode (0) overlaps with the GPU's NUMA Affinity (0-8), so the
+# NIC is east-west tied to GPU0 with gpuProximity: NODE.
+
+pfs:
+  - deviceID: "1023"
+    rdmaDevice: mlx5_0
+    pciAddress: "0001:03:00.0"
+    networkInterface: enP1p3s0f0np0
+    traffic: east-west
+    rail: 0
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: NODE
+    psid: nvd0000000110
+    partNumber: MLX000717
+    model: Nvidia ConnectX-8 for Galaxy GB300 -Prime

--- a/profiles/spectrum-x-ra2.1/00-values.yaml
+++ b/profiles/spectrum-x-ra2.1/00-values.yaml
@@ -50,6 +50,12 @@ sriovNetworkOperator:
 sriov-network-operator:
   sriovOperatorConfig:
     deploy: true
+    # See sriov-ethernet-rdma's 00-values.yaml for the rationale: both
+    # optional helpers (auto-resource injector + validating webhook)
+    # depend on TLS secrets the subchart's post-install Job creates,
+    # which doesn't always re-run on cross-profile upgrades.
+    enableInjector: false
+    enableOperatorWebhook: false
 {{- if .NicConfigurationOperator }}
     configDaemonNodeSelector:
       network.nvidia.com/operator.nic-configuration.wait: "false"

--- a/profiles/spectrum-x/00-values.yaml
+++ b/profiles/spectrum-x/00-values.yaml
@@ -51,6 +51,12 @@ sriovNetworkOperator:
 sriov-network-operator:
   sriovOperatorConfig:
     deploy: true
+    # See sriov-ethernet-rdma's 00-values.yaml for the rationale: both
+    # optional helpers (auto-resource injector + validating webhook)
+    # depend on TLS secrets the subchart's post-install Job creates,
+    # which doesn't always re-run on cross-profile upgrades.
+    enableInjector: false
+    enableOperatorWebhook: false
 {{- if .NicConfigurationOperator }}
     configDaemonNodeSelector:
       network.nvidia.com/operator.nic-configuration.wait: "false"

--- a/profiles/sriov-ethernet-rdma/00-values.yaml
+++ b/profiles/sriov-ethernet-rdma/00-values.yaml
@@ -42,6 +42,19 @@ sriovNetworkOperator:
 sriov-network-operator:
   sriovOperatorConfig:
     deploy: true
+    # Both optional helpers are turned off:
+    #   - network-resources-injector: rewrites pod specs to add resource
+    #     requests from net-attach-def annotations. l8k renders resource
+    #     requests explicitly in its example DaemonSets, so the injector
+    #     is unused — and its admission webhook requires a TLS secret the
+    #     subchart's post-install Job creates, which doesn't always re-run
+    #     across cross-profile upgrades (e.g. macvlan→sriov), leading to a
+    #     stuck Reconcile loop with a `<nil>` secretName error.
+    #   - operator validating webhook: validates SriovNetworkNodePolicy on
+    #     admission. l8k pre-validates via the crstate registry, so this is
+    #     redundant and brings the same TLS-secret fragility.
+    enableInjector: false
+    enableOperatorWebhook: false
 {{- if .NicConfigurationOperator }}
     configDaemonNodeSelector:
       network.nvidia.com/operator.nic-configuration.wait: "false"

--- a/profiles/sriov-ib-rdma/00-values.yaml
+++ b/profiles/sriov-ib-rdma/00-values.yaml
@@ -42,6 +42,15 @@ sriovNetworkOperator:
 sriov-network-operator:
   sriovOperatorConfig:
     deploy: true
+    # See sriov-ethernet-rdma's 00-values.yaml for the rationale: both
+    # optional helpers (auto-resource injector + validating webhook)
+    # require TLS secrets that the subchart's post-install Job creates,
+    # which doesn't always re-run on cross-profile upgrades and leaves
+    # the operator stuck reconciling against a `<nil>` secretName.
+    # l8k renders resource requests explicitly and pre-validates
+    # NodePolicies via the crstate registry, so both helpers are unused.
+    enableInjector: false
+    enableOperatorWebhook: false
 {{- if .NicConfigurationOperator }}
     configDaemonNodeSelector:
       network.nvidia.com/operator.nic-configuration.wait: "false"


### PR DESCRIPTION
## Summary

Follow-up to #105. Four small fixes surfaced during real-world bring-up of macvlan-rdma-shared + cross-profile flips on a GB300 DGX Station cluster.

* **connectivity: macvlan/IPoIB RDMA device fallback.** The in-pod probe used to read `/sys/class/net/<iface>/device/infiniband/`, which works for SR-IOV VFs (real PCI mlx5 in the pod netns) but returns empty for macvlan slaves (kernel netdevs layered on the master). The planner silently dropped every pair, validate showed `Plan: 0 same-rail …` and exited success. Two new fallbacks:
   1. Single-mlx5 case (single-NIC node, single rail) — picks the only entry exposed by the rdmaSharedDevicePlugin.
   2. Multi-rail case — extracts the rail index from the rail key (`rail-N` pattern) and indexes naturally-sorted `/sys/class/infiniband/`. Works because every l8k profile numbers rails contiguously from 0 in PCI order matching the kernel's mlx5 enumeration. Limitation: 1 rail = 1 mlx5 on this node; multi-NIC multi-rail rdmaShared still needs the orchestrator-side master→mlx5 mapping (deferred — would read the rendered MacvlanNetwork CR's `master` field on the host side).
* **connectivity: zero-tests-despite-pods warning.** When `Plan()` returns 0 tests but ≥2 pods are schedulable (i.e. every rail had an unresolvable RDMA device on at least one endpoint), surface an explicit warning. The previous behaviour printed `Matrix complete: 0/0 passed` and exited success — false-pass on a real coverage gap.
* **profiles: disable `enableInjector` and `enableOperatorWebhook` on every profile that enables the SR-IOV subchart.** Both helpers depend on TLS secrets the subchart's post-install Job creates, which doesn't always re-run on cross-profile upgrades (`--overwrite-existing` from macvlan-rdma-shared → sriov-ethernet-rdma), leaving the operator stuck reconciling against a `<nil>` secretName for the `network-resources-injector` DS. Neither helper is functionally needed: l8k renders resource requests explicitly (no injector consumer) and pre-validates NodePolicies via the crstate registry (no webhook consumer). Cost of disabling: nothing.
* **presets: add `GB300-DGX-Station-NVIDIA-GB300`.** Built from a real Galaxy GB300 -Prime topology-collector report. Single PF (collapsed master), `connectedGPU: GPU0`, `gpuProximity: NODE` (no PIX exists between NIC and GPU on the GB300 SoC; NODE-fallback applies since the NIC's numaNode=0 overlaps GPU0's NUMA Affinity 0-8). Header comment documents the platform's PCIe Gen5 x8 ceiling so the observed ~206 Gb/s ib_write_bw expectation is up-front in the preset definition.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/networkoperatorplugin/connectivity/... ./pkg/presets/...` green (the two `TestGetPresetsDir_*` failures are the known pre-existing env failures from `make install` having populated `/usr/local/share/l8k/presets/` — unrelated to this PR)
- [x] Field-tested: `l8k validate` on a 2-node macvlan-rdma-shared cluster with a single dual-port CX-8 per node now emits `Plan: 4 same-rail rping + 2 cross-rail rping; 4 same-rail ib_write_bw + 2 cross-rail ib_write_bw` and runs the tests. (Subsequent ib_write_bw failures in one direction are a separate RoCE-over-macvlan / PFC issue, not a planner problem.)
- [x] Field-tested: `l8k deploy --overwrite-existing` flipping macvlan-rdma-shared → sriov-ethernet-rdma now lands `SriovOperatorConfig/default` without the `network-resources-injector` DS rejection loop.
- [ ] Optional: run `l8k discover` against a GB300 DGX Station and confirm the new preset matches the live `cluster-config.yaml` PFs (1 east-west PF at 0001:03:00.0 with PSID `nvd0000000110`).