### PR TITLE
Configure maintenance operation concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,35 @@ When neither the flag nor `selectedRelease` is set, behavior is unchanged: expli
 
 Adding a new release is a YAML-only change in `releases.yaml` — patch bumps update an existing entry in place; new minor lines add a new top-level key.
 
+### Maintenance and node upgrade concurrency
+
+The top-level `maintenance` section controls how many nodes can be disrupted at
+once by SR-IOV configuration and DOCA/OFED upgrades. The defaults allow four
+concurrent operations instead of the operators' single-node defaults:
+
+```yaml
+maintenance:
+  maxParallelOperations: 4
+  maxUnavailable: 4
+  maxNodeMaintenanceTimeSeconds: 3600
+  maxParallelUpgrades: 4
+```
+
+For Network Operator 26.1 and newer, l8k enables Maintenance Operator requestor
+mode in the generated Helm values. OFED upgrades use
+`operator.maintenanceOperator.useRequestor`; SR-IOV additionally requires both
+the Network Operator drain requestor and the SR-IOV external drainer. In this
+mode, `maxParallelOperations` and `maxUnavailable` are global Maintenance
+Operator limits. For older releases, `maxParallelUpgrades` controls OFED and
+`SriovNetworkPoolConfig.spec.maxUnavailable` controls the SR-IOV internal
+drainer.
+
+Changing to requestor mode modifies Helm values and operator Deployment
+environment variables. Upgrade an existing release with
+`--overwrite-existing`; applying only the generated custom resources cannot
+enable requestor mode. See [Maintenance and upgrade concurrency](docs/maintenance.rst)
+for value restrictions, zero-value behavior, and release-specific details.
+
 ### DOCA Driver
 
 The `docaDriver` section controls the OFED driver deployment in the NicClusterPolicy. Set `enable: true` to include the `ofedDriver` section in generated manifests, or `enable: false` to omit it. This can also be overridden via the `--enable-doca-driver` CLI flag.
@@ -666,6 +695,11 @@ docaDriver:
   unloadStorageModules: false
   enableNFSRDMA: false
   unloadThirdPartyRDMAModules: false
+maintenance:
+  maxParallelOperations: 4
+  maxUnavailable: 4
+  maxNodeMaintenanceTimeSeconds: 3600
+  maxParallelUpgrades: 4
 nvIpam:
   poolName: nv-ipam-pool
   subnets:

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -1,0 +1,138 @@
+Maintenance and upgrade concurrency
+===================================
+
+The ``maintenance`` section controls how many nodes l8k allows the NVIDIA
+operators to process simultaneously. It applies to host-cluster Network
+Operator profiles and defaults to four concurrent nodes so large clusters do
+not inherit the upstream single-node defaults.
+
+Configuration
+-------------
+
+.. code-block:: yaml
+
+   maintenance:
+     maxParallelOperations: 4
+     maxUnavailable: 4
+     maxNodeMaintenanceTimeSeconds: 3600
+     maxParallelUpgrades: 4
+
+If the section or an individual field is omitted, l8k fills that field with
+the default shown above.
+
+Fields and restrictions
+-----------------------
+
+.. list-table::
+   :widths: 24 13 63
+   :header-rows: 1
+
+   * - Field
+     - Default
+     - Meaning and accepted values
+   * - ``maxParallelOperations``
+     - ``4``
+     - Global Maintenance Operator work limit. Use a positive integer or a
+       percentage string from ``"1%"`` through ``"100%"``. Although the CRD
+       accepts integer ``0``, the current scheduler calculates zero available
+       slots, so l8k requires a positive value. A percentage is calculated
+       from all cluster nodes and rounded up.
+   * - ``maxUnavailable``
+     - ``4``
+     - Maximum unavailable nodes. Use a non-negative integer or a percentage
+       string from ``"1%"`` through ``"100%"``. Integer ``0`` pauses new
+       maintenance work. In requestor mode, nodes that are already cordoned or
+       NotReady consume this budget, even when another controller made them
+       unavailable, and a percentage is calculated from all cluster nodes and
+       rounded down. On the legacy SR-IOV path it is calculated from nodes in
+       the selected pool and also rounded down; a small percentage can
+       therefore resolve to zero.
+   * - ``maxNodeMaintenanceTimeSeconds``
+     - ``3600``
+     - Non-negative cleanup delay for a ``NodeMaintenance`` request after it
+       reaches Ready. ``0`` makes a Ready request immediately eligible for
+       garbage collection; it does not disable cleanup and is not an operation
+       timeout. Keep it below the idle interval of any cluster autoscaler.
+   * - ``maxParallelUpgrades``
+     - ``4``
+     - Non-negative OFED upgrade limit for Network Operator releases older
+       than 26.1. ``0`` means unlimited on that legacy path. Network Operator
+       requestor mode does not consult this field, so it has no effect on OFED
+       concurrency starting with release 26.1.
+
+Integer-or-percentage fields must be YAML integer scalars or strings ending in
+``%``. Numeric strings such as ``"4"``, fractional numbers such as ``1.5``,
+and percentages outside ``1%`` through ``100%`` are rejected.
+
+Two Maintenance Operator limits apply together: a request starts only while
+both ``maxParallelOperations`` and ``maxUnavailable`` have capacity. For
+example, with ``maxUnavailable: 4`` and two nodes already cordoned or NotReady,
+at most two additional nodes can become unavailable.
+
+Release-specific behavior
+-------------------------
+
+l8k gates requestor mode on ``networkOperator.selectedRelease``. Release 26.1
+and newer, as well as an empty release interpreted as latest, use requestor
+mode. Older releases retain the operators' internal drain paths.
+
+.. list-table::
+   :widths: 23 35 42
+   :header-rows: 1
+
+   * - Flow
+     - Before Network Operator 26.1
+     - Network Operator 26.1 and newer
+   * - DOCA/OFED upgrade
+     - Network Operator drains nodes directly.
+       ``maxParallelUpgrades`` is the effective limit.
+     - The generated Helm values set
+       ``operator.maintenanceOperator.useRequestor: true``. Network Operator
+       creates ``NodeMaintenance`` requests; the global Maintenance Operator
+       limits are effective and ``maxParallelUpgrades`` is ignored.
+   * - SR-IOV configuration
+     - The SR-IOV Operator internal drain controller is active.
+       ``SriovNetworkPoolConfig.spec.maxUnavailable`` is the effective pool
+       limit. Pod disruption budgets are still respected when the limit is
+       greater than one.
+     - The generated Helm values enable both
+       ``operator.maintenanceOperator.useDrainControllerRequestor`` and
+       ``sriov-network-operator.operator.externalDrainer.enabled``. Both are
+       required to hand draining from the SR-IOV internal controller to the
+       Network Operator requestor. The global Maintenance Operator limits are
+       effective; ``SriovNetworkPoolConfig.spec.maxUnavailable`` no longer
+       controls draining.
+
+The generated ``MaintenanceOperatorConfig`` receives
+``maxParallelOperations``, ``maxUnavailable``, and
+``maxNodeMaintenanceTimeSeconds``. In legacy mode, l8k also wires
+``maxUnavailable`` to ``SriovNetworkPoolConfig`` and
+``maxParallelUpgrades`` to the OFED upgrade policy. The same flat config can
+therefore be used across release upgrades while l8k selects the applicable
+controller.
+
+Upgrading an existing installation
+-----------------------------------
+
+Requestor mode is partly configured through Network Operator Helm values. The
+chart renders those values into environment variables on the Network Operator
+Deployment and into the SR-IOV Operator subchart. Applying only the generated
+custom resources out of band cannot enable these requestors.
+
+When an existing Helm release has different values, regenerate the deployment
+for the selected release and deploy with ``--overwrite-existing`` so l8k runs
+``helm upgrade --install``. Without that flag, l8k intentionally reports the
+values conflict instead of changing an existing release.
+
+.. code-block:: bash
+
+   l8k generate --user-config cluster-config.yaml \
+     --network-operator-release 26.1 \
+     --fabric ethernet --deployment-type sriov \
+     --save-deployment-files ./deployment \
+     --deploy --overwrite-existing --kubeconfig ~/.kube/config
+
+After the upgrade, verify the Network Operator Deployment and the
+``MaintenanceOperatorConfig`` before starting disruptive work. Do not enable
+only one of the two SR-IOV requestor settings: the external drainer and the
+Network Operator drain requestor are a coordinated handoff.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,4 +1,6 @@
-This quick start guide covers five essential networking configurations for different computational requirements:
+This quick start guide covers five essential networking configurations for
+different computational requirements. See :doc:`maintenance` when sizing node
+disruption and upgrade concurrency for larger clusters.
 
 .. toctree::
    :hidden:
@@ -10,6 +12,7 @@ This quick start guide covers five essential networking configurations for diffe
    IP over InfiniBand with RDMA Shared Device <ipoib-rdma-shared>
    MacVLAN Network with RDMA Shared Device <macvlan-rdma-shared>
    SR-IOV InfiniBand Network with RDMA <sriov-ib-rdma>
+   Maintenance and upgrade concurrency <maintenance>
 
 .. list-table::
    :widths: 20 25 20 30
@@ -59,3 +62,9 @@ This quick start guide covers five essential networking configurations for diffe
      - Large-scale HPC clusters, AI/ML training, research computing
        
        *Keywords: SR-IOV, InfiniBand, hardware-acceleration, ultra-high-bandwidth*
+
+.. seealso::
+
+   Large clusters can tune simultaneous SR-IOV configuration and DOCA/OFED
+   upgrades through the ``maintenance`` section. See :doc:`maintenance` for
+   the defaults, release gates, and disruption-budget restrictions.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,9 @@ func DefaultLaunchKitConfig() (*LaunchKitConfig, error) {
 	if err := yaml.Unmarshal(defaultConfigYAML, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse embedded default l8k-config: %w", err)
 	}
+	if err := NormalizeMaintenance(&cfg); err != nil {
+		return nil, fmt.Errorf("invalid embedded maintenance config: %w", err)
+	}
 	return &cfg, nil
 }
 
@@ -134,6 +137,7 @@ func SanitizeIdentifier(s string) string {
 type LaunchKitConfig struct {
 	NetworkOperator *NetworkOperatorConfig `yaml:"networkOperator,omitempty"`
 	DOCADriver      *DOCADriverConfig      `yaml:"docaDriver,omitempty"`
+	Maintenance     *MaintenanceConfig     `yaml:"maintenance,omitempty"`
 	NvIpam          *NvIpamConfig          `yaml:"nvIpam,omitempty"`
 	Sriov           *SriovConfig           `yaml:"sriov,omitempty"`
 	Hostdev         *HostdevConfig         `yaml:"hostdev,omitempty"`
@@ -433,6 +437,9 @@ func LoadFullConfig(configPath string, logger logr.Logger) (*LaunchKitConfig, er
 	if err := yaml.Unmarshal(configData, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse cluster config YAML %s: %w", configPath, err)
 	}
+	if err := NormalizeMaintenance(&config); err != nil {
+		return nil, fmt.Errorf("invalid maintenance config in %s: %w", configPath, err)
+	}
 
 	logger.Info("Cluster configuration loaded successfully",
 		"networkOperatorVersion", config.NetworkOperator.Version,
@@ -487,6 +494,12 @@ func emitPresetDeviationWarnings(cfg *LaunchKitConfig, logger logr.Logger) {
 
 // ValidateClusterConfig validates that essential fields are present in the cluster config
 func ValidateClusterConfig(config *LaunchKitConfig, profile string) error {
+	// Public callers may construct a config directly instead of using
+	// LoadFullConfig. Normalize again here so validation covers both paths.
+	if err := NormalizeMaintenance(config); err != nil {
+		return err
+	}
+
 	if config.NetworkOperator.Repository == "" {
 		return fmt.Errorf("networkOperator.repository is required")
 	}

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -41,6 +41,16 @@ docaDriver:
   unloadThirdPartyRDMAModules: true
   skipPreflightChecks: false
 
+maintenance:
+  # Global concurrency; positive integer or 1%-100%.
+  maxParallelOperations: 4
+  # Global or legacy SR-IOV limit; non-negative integer or 1%-100%.
+  maxUnavailable: 4
+  # Ready-request cleanup delay in seconds; non-negative.
+  maxNodeMaintenanceTimeSeconds: 3600
+  # Legacy OFED concurrency; non-negative, 0 is unlimited.
+  maxParallelUpgrades: 4
+
 nvIpam:
   poolName: nv-ipam-pool
   # --- Option 1: Auto-generate subnets (used when subnets list is empty) --- 

--- a/pkg/config/maintenance.go
+++ b/pkg/config/maintenance.go
@@ -1,0 +1,205 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	defaultMaxParallelOperations         int32 = 4
+	defaultMaxUnavailable                int32 = 4
+	defaultMaxNodeMaintenanceTimeSeconds int32 = 3600
+	defaultMaxParallelUpgrades                 = 4
+)
+
+// IntOrPercent is a YAML scalar that accepts either an integer or a percentage
+// string. It mirrors the Kubernetes int-or-string fields used by the
+// Maintenance Operator and SR-IOV Operator CRDs while keeping template output
+// scalar (for example, 4 or 25%) rather than exposing IntOrString internals.
+type IntOrPercent intstr.IntOrString
+
+// IntOrPercentFromInt32 creates an integer IntOrPercent value.
+func IntOrPercentFromInt32(value int32) *IntOrPercent {
+	result := IntOrPercent(intstr.FromInt32(value))
+	return &result
+}
+
+// IntOrPercentFromString creates a string IntOrPercent value. Validation by
+// NormalizeMaintenance requires the string to be a percentage in [1%, 100%].
+func IntOrPercentFromString(value string) *IntOrPercent {
+	result := IntOrPercent(intstr.FromString(value))
+	return &result
+}
+
+// String returns the scalar representation used by Go templates.
+func (value IntOrPercent) String() string {
+	converted := intstr.IntOrString(value)
+	return converted.String()
+}
+
+// MarshalYAML preserves the int-or-percentage value as a YAML scalar.
+func (value IntOrPercent) MarshalYAML() (interface{}, error) {
+	converted := intstr.IntOrString(value)
+	switch converted.Type {
+	case intstr.Int:
+		return converted.IntVal, nil
+	case intstr.String:
+		return converted.StrVal, nil
+	default:
+		return nil, fmt.Errorf("invalid IntOrPercent type %d", converted.Type)
+	}
+}
+
+// UnmarshalYAML accepts only integer and string YAML scalars. Semantic
+// validation (non-negative integers and bounded percentages) is performed by
+// NormalizeMaintenance because the minimum differs between fields.
+func (value *IntOrPercent) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var scalar interface{}
+	if err := unmarshal(&scalar); err != nil {
+		return err
+	}
+
+	switch typed := scalar.(type) {
+	case int:
+		if typed < math.MinInt32 || typed > math.MaxInt32 {
+			return fmt.Errorf("integer %d is outside the supported int32 range", typed)
+		}
+		*value = IntOrPercent(intstr.FromInt32(int32(typed)))
+	case string:
+		*value = IntOrPercent(intstr.FromString(typed))
+	default:
+		return fmt.Errorf("must be an integer or percentage string, got %T", scalar)
+	}
+
+	return nil
+}
+
+// MaintenanceConfig controls the concurrency policies used while operators
+// make disruptive changes to nodes. Pointer fields distinguish an omitted key
+// (which receives a default) from an explicit zero (which is preserved).
+type MaintenanceConfig struct {
+	MaxParallelOperations         *IntOrPercent `yaml:"maxParallelOperations,omitempty"`
+	MaxUnavailable                *IntOrPercent `yaml:"maxUnavailable,omitempty"`
+	MaxNodeMaintenanceTimeSeconds *int32        `yaml:"maxNodeMaintenanceTimeSeconds,omitempty"`
+	MaxParallelUpgrades           *int          `yaml:"maxParallelUpgrades,omitempty"`
+}
+
+// DefaultMaintenanceConfig returns a fresh maintenance configuration. The
+// caller may mutate it without affecting subsequent callers.
+func DefaultMaintenanceConfig() *MaintenanceConfig {
+	maxNodeMaintenanceTimeSeconds := defaultMaxNodeMaintenanceTimeSeconds
+	maxParallelUpgrades := defaultMaxParallelUpgrades
+	return &MaintenanceConfig{
+		MaxParallelOperations:         IntOrPercentFromInt32(defaultMaxParallelOperations),
+		MaxUnavailable:                IntOrPercentFromInt32(defaultMaxUnavailable),
+		MaxNodeMaintenanceTimeSeconds: &maxNodeMaintenanceTimeSeconds,
+		MaxParallelUpgrades:           &maxParallelUpgrades,
+	}
+}
+
+// NormalizeMaintenance fills omitted maintenance fields and validates the
+// result. Call it for programmatically-created LaunchKitConfig values before a
+// profile template dereferences Maintenance.
+func NormalizeMaintenance(config *LaunchKitConfig) error {
+	if config == nil {
+		return fmt.Errorf("launch kit config must not be nil")
+	}
+
+	defaults := DefaultMaintenanceConfig()
+	if config.Maintenance == nil {
+		config.Maintenance = defaults
+	} else {
+		if config.Maintenance.MaxParallelOperations == nil {
+			config.Maintenance.MaxParallelOperations = defaults.MaxParallelOperations
+		}
+		if config.Maintenance.MaxUnavailable == nil {
+			config.Maintenance.MaxUnavailable = defaults.MaxUnavailable
+		}
+		if config.Maintenance.MaxNodeMaintenanceTimeSeconds == nil {
+			config.Maintenance.MaxNodeMaintenanceTimeSeconds = defaults.MaxNodeMaintenanceTimeSeconds
+		}
+		if config.Maintenance.MaxParallelUpgrades == nil {
+			config.Maintenance.MaxParallelUpgrades = defaults.MaxParallelUpgrades
+		}
+	}
+
+	return validateMaintenance(config.Maintenance)
+}
+
+func validateMaintenance(config *MaintenanceConfig) error {
+	if err := validateIntOrPercent(
+		"maintenance.maxParallelOperations", config.MaxParallelOperations, false); err != nil {
+		return err
+	}
+	if err := validateIntOrPercent("maintenance.maxUnavailable", config.MaxUnavailable, true); err != nil {
+		return err
+	}
+	if *config.MaxNodeMaintenanceTimeSeconds < 0 {
+		return fmt.Errorf("maintenance.maxNodeMaintenanceTimeSeconds must be >= 0, got %d",
+			*config.MaxNodeMaintenanceTimeSeconds)
+	}
+	if *config.MaxParallelUpgrades < 0 {
+		return fmt.Errorf("maintenance.maxParallelUpgrades must be >= 0, got %d",
+			*config.MaxParallelUpgrades)
+	}
+	return nil
+}
+
+func validateIntOrPercent(field string, value *IntOrPercent, allowZero bool) error {
+	if value == nil {
+		return fmt.Errorf("%s must be set", field)
+	}
+
+	converted := intstr.IntOrString(*value)
+	switch converted.Type {
+	case intstr.Int:
+		minimum := int32(1)
+		if allowZero {
+			minimum = 0
+		}
+		if converted.IntVal < minimum {
+			if allowZero {
+				return fmt.Errorf("%s must be >= 0, got %d", field, converted.IntVal)
+			}
+			return fmt.Errorf("%s must be > 0, got %d", field, converted.IntVal)
+		}
+		return nil
+
+	case intstr.String:
+		if !strings.HasSuffix(converted.StrVal, "%") {
+			return fmt.Errorf("%s string value must be a percentage, got %q", field, converted.StrVal)
+		}
+		percentageText := strings.TrimSuffix(converted.StrVal, "%")
+		percentage, err := strconv.Atoi(percentageText)
+		if err != nil {
+			return fmt.Errorf("%s has invalid percentage %q: %w", field, converted.StrVal, err)
+		}
+		if percentage < 1 || percentage > 100 {
+			return fmt.Errorf("%s percentage must be between 1%% and 100%%, got %q", field, converted.StrVal)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("%s has invalid int-or-percent type %d", field, converted.Type)
+	}
+}

--- a/pkg/config/maintenance_test.go
+++ b/pkg/config/maintenance_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestNormalizeMaintenanceDefaults(t *testing.T) {
+	config := &LaunchKitConfig{}
+	require.NoError(t, NormalizeMaintenance(config))
+	require.NotNil(t, config.Maintenance)
+
+	assert.Equal(t, "4", config.Maintenance.MaxParallelOperations.String())
+	assert.Equal(t, "4", config.Maintenance.MaxUnavailable.String())
+	assert.Equal(t, int32(3600), *config.Maintenance.MaxNodeMaintenanceTimeSeconds)
+	assert.Equal(t, 4, *config.Maintenance.MaxParallelUpgrades)
+}
+
+func TestNormalizeMaintenancePartialPreservesExplicitZero(t *testing.T) {
+	zeroSeconds := int32(0)
+	zeroUpgrades := 0
+	config := &LaunchKitConfig{
+		Maintenance: &MaintenanceConfig{
+			MaxUnavailable:                IntOrPercentFromInt32(0),
+			MaxNodeMaintenanceTimeSeconds: &zeroSeconds,
+			MaxParallelUpgrades:           &zeroUpgrades,
+		},
+	}
+
+	require.NoError(t, NormalizeMaintenance(config))
+	assert.Equal(t, "4", config.Maintenance.MaxParallelOperations.String())
+	assert.Equal(t, "0", config.Maintenance.MaxUnavailable.String())
+	assert.Zero(t, *config.Maintenance.MaxNodeMaintenanceTimeSeconds)
+	assert.Zero(t, *config.Maintenance.MaxParallelUpgrades)
+}
+
+func TestDefaultMaintenanceConfigReturnsFreshCopy(t *testing.T) {
+	first := DefaultMaintenanceConfig()
+	second := DefaultMaintenanceConfig()
+
+	first.MaxUnavailable = IntOrPercentFromInt32(0)
+	*first.MaxNodeMaintenanceTimeSeconds = 1
+	*first.MaxParallelUpgrades = 1
+
+	assert.Equal(t, "4", second.MaxUnavailable.String())
+	assert.Equal(t, int32(3600), *second.MaxNodeMaintenanceTimeSeconds)
+	assert.Equal(t, 4, *second.MaxParallelUpgrades)
+}
+
+func TestLoadFullConfigMaintenanceDefaultsAndExplicitZeros(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	contents := `networkOperator:
+  version: v26.1.0
+  componentVersion: network-operator-v26.1.0
+  repository: nvcr.io/nvidia/mellanox
+  namespace: nvidia-network-operator
+maintenance:
+  maxUnavailable: 0
+  maxNodeMaintenanceTimeSeconds: 0
+  maxParallelUpgrades: 0
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(contents), 0o600))
+
+	config, err := LoadFullConfig(configPath, logr.Discard())
+	require.NoError(t, err)
+	require.NotNil(t, config.Maintenance)
+	assert.Equal(t, "4", config.Maintenance.MaxParallelOperations.String())
+	assert.Equal(t, "0", config.Maintenance.MaxUnavailable.String())
+	assert.Zero(t, *config.Maintenance.MaxNodeMaintenanceTimeSeconds)
+	assert.Zero(t, *config.Maintenance.MaxParallelUpgrades)
+}
+
+func TestMaintenanceIntOrPercentYAMLRoundTrip(t *testing.T) {
+	zeroUpgrades := 0
+	config := &LaunchKitConfig{
+		Maintenance: &MaintenanceConfig{
+			MaxParallelOperations:         IntOrPercentFromString("25%"),
+			MaxUnavailable:                IntOrPercentFromInt32(0),
+			MaxNodeMaintenanceTimeSeconds: int32Pointer(1200),
+			MaxParallelUpgrades:           &zeroUpgrades,
+		},
+	}
+	require.NoError(t, NormalizeMaintenance(config))
+
+	marshaled, err := yaml.Marshal(config)
+	require.NoError(t, err)
+	output := string(marshaled)
+	assert.Contains(t, output, "maxParallelOperations: 25%")
+	assert.Contains(t, output, "maxUnavailable: 0")
+	assert.NotContains(t, output, "intVal:")
+	assert.NotContains(t, output, "strVal:")
+
+	var reloaded LaunchKitConfig
+	require.NoError(t, yaml.Unmarshal(marshaled, &reloaded))
+	require.NoError(t, NormalizeMaintenance(&reloaded))
+	assert.Equal(t, "25%", reloaded.Maintenance.MaxParallelOperations.String())
+	assert.Equal(t, "0", reloaded.Maintenance.MaxUnavailable.String())
+	assert.Equal(t, int32(1200), *reloaded.Maintenance.MaxNodeMaintenanceTimeSeconds)
+	assert.Zero(t, *reloaded.Maintenance.MaxParallelUpgrades)
+}
+
+func TestMaintenanceValuesAreTemplateFriendly(t *testing.T) {
+	zeroUpgrades := 0
+	config := &LaunchKitConfig{
+		Maintenance: &MaintenanceConfig{
+			MaxParallelOperations:         IntOrPercentFromInt32(4),
+			MaxUnavailable:                IntOrPercentFromString("25%"),
+			MaxNodeMaintenanceTimeSeconds: int32Pointer(3600),
+			MaxParallelUpgrades:           &zeroUpgrades,
+		},
+	}
+	require.NoError(t, NormalizeMaintenance(config))
+
+	tmpl, err := template.New("maintenance").Parse(
+		`{{.Maintenance.MaxParallelOperations.String}}|{{.Maintenance.MaxUnavailable.String}}|` +
+			`{{.Maintenance.MaxNodeMaintenanceTimeSeconds}}|{{.Maintenance.MaxParallelUpgrades}}`)
+	require.NoError(t, err)
+	var output bytes.Buffer
+	require.NoError(t, tmpl.Execute(&output, config))
+	assert.Equal(t, "4|25%|3600|0", output.String())
+}
+
+func TestMaintenanceCommentsSurviveConfigRoundTrip(t *testing.T) {
+	config, err := DefaultLaunchKitConfig()
+	require.NoError(t, err)
+
+	marshaled, err := MarshalConfigWithComments(config, defaultConfigYAML, "")
+	require.NoError(t, err)
+	output := string(marshaled)
+	assert.Contains(t, output, "# Global concurrency; positive integer or 1%-100%.")
+	assert.Contains(t, output, "# Global or legacy SR-IOV limit; non-negative integer or 1%-100%.")
+
+	var reloaded LaunchKitConfig
+	require.NoError(t, yaml.Unmarshal(marshaled, &reloaded))
+	require.NoError(t, NormalizeMaintenance(&reloaded))
+	assert.Equal(t, "4", reloaded.Maintenance.MaxParallelOperations.String())
+	assert.Equal(t, "4", reloaded.Maintenance.MaxUnavailable.String())
+}
+
+func TestNormalizeMaintenanceValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		yaml       string
+		errorMatch string
+	}{
+		{
+			name:       "maxParallelOperations zero",
+			yaml:       "maxParallelOperations: 0",
+			errorMatch: "maintenance.maxParallelOperations must be > 0",
+		},
+		{
+			name:       "maxParallelOperations negative",
+			yaml:       "maxParallelOperations: -1",
+			errorMatch: "maintenance.maxParallelOperations must be > 0",
+		},
+		{
+			name:       "maxUnavailable negative",
+			yaml:       "maxUnavailable: -1",
+			errorMatch: "maintenance.maxUnavailable must be >= 0",
+		},
+		{
+			name:       "percentage zero",
+			yaml:       "maxUnavailable: 0%",
+			errorMatch: "percentage must be between 1% and 100%",
+		},
+		{
+			name:       "percentage over one hundred",
+			yaml:       "maxParallelOperations: 101%",
+			errorMatch: "percentage must be between 1% and 100%",
+		},
+		{
+			name:       "string is not percentage",
+			yaml:       `maxUnavailable: "4"`,
+			errorMatch: "string value must be a percentage",
+		},
+		{
+			name:       "negative cleanup timeout",
+			yaml:       "maxNodeMaintenanceTimeSeconds: -1",
+			errorMatch: "maintenance.maxNodeMaintenanceTimeSeconds must be >= 0",
+		},
+		{
+			name:       "negative parallel upgrades",
+			yaml:       "maxParallelUpgrades: -1",
+			errorMatch: "maintenance.maxParallelUpgrades must be >= 0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var config LaunchKitConfig
+			yamlDocument := "maintenance:\n  " + strings.ReplaceAll(test.yaml, "\n", "\n  ") + "\n"
+			require.NoError(t, yaml.Unmarshal([]byte(yamlDocument), &config))
+			err := NormalizeMaintenance(&config)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.errorMatch)
+		})
+	}
+}
+
+func TestIntOrPercentRejectsNonScalarNumber(t *testing.T) {
+	var config LaunchKitConfig
+	err := yaml.Unmarshal([]byte("maintenance:\n  maxUnavailable: 1.5\n"), &config)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be an integer or percentage string")
+}
+
+func int32Pointer(value int32) *int32 {
+	return &value
+}

--- a/pkg/networkoperatorplugin/maintenance_render_test.go
+++ b/pkg/networkoperatorplugin/maintenance_render_test.go
@@ -1,0 +1,317 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkoperatorplugin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/nvidia/k8s-launch-kit/pkg/profiles"
+	"github.com/stretchr/testify/require"
+	configyaml "gopkg.in/yaml.v2"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	renderedyaml "sigs.k8s.io/yaml"
+)
+
+type maintenanceProfileCase struct {
+	dir                string
+	fabric             string
+	deployment         string
+	wantOFEDRequestor  bool
+	wantDrainRequestor bool
+	wantExternalDrain  bool
+}
+
+var maintenanceProfileCases = []maintenanceProfileCase{
+	{dir: "host-device-rdma", fabric: "ethernet", deployment: "host_device", wantOFEDRequestor: true},
+	{dir: "ipoib-rdma-shared", fabric: "infiniband", deployment: "rdma_shared", wantOFEDRequestor: true},
+	{dir: "macvlan-rdma-shared", fabric: "ethernet", deployment: "rdma_shared", wantOFEDRequestor: true},
+	{
+		dir:                "sriov-ethernet-rdma",
+		fabric:             "ethernet",
+		deployment:         "sriov",
+		wantOFEDRequestor:  true,
+		wantDrainRequestor: true,
+		wantExternalDrain:  true,
+	},
+	{
+		dir:                "sriov-ib-rdma",
+		fabric:             "infiniband",
+		deployment:         "sriov",
+		wantOFEDRequestor:  true,
+		wantDrainRequestor: true,
+		wantExternalDrain:  true,
+	},
+	{
+		dir:                "spectrum-x-ra2.1",
+		fabric:             "ethernet",
+		deployment:         "sriov",
+		wantDrainRequestor: true,
+		wantExternalDrain:  true,
+	},
+	{
+		dir:                "spectrum-x",
+		fabric:             "ethernet",
+		deployment:         "sriov",
+		wantDrainRequestor: true,
+		wantExternalDrain:  true,
+	},
+}
+
+func maintenanceFromYAML(t *testing.T, source string) *config.MaintenanceConfig {
+	t.Helper()
+	if source == "" {
+		return nil
+	}
+	var parsed config.LaunchKitConfig
+	require.NoError(t, configyaml.Unmarshal([]byte(source), &parsed))
+	require.NotNil(t, parsed.Maintenance)
+	return parsed.Maintenance
+}
+
+func renderProfileValuesForMaintenance(
+	t *testing.T,
+	dir string,
+	release string,
+	withNCO bool,
+	maintenanceYAML string,
+) map[string]any {
+	t.Helper()
+	cfg := &config.LaunchKitConfig{
+		NetworkOperator: &config.NetworkOperatorConfig{
+			OperatorRepository: "nvcr.io/nvidia/cloud-native",
+			Namespace:          "network-operator",
+			SelectedRelease:    release,
+		},
+		Maintenance: maintenanceFromYAML(t, maintenanceYAML),
+	}
+	if withNCO {
+		cfg.NicConfigurationOperator = &config.NicConfigurationOperatorConfig{}
+	}
+	require.NoError(t, config.NormalizeMaintenance(cfg))
+
+	templatePath, err := filepath.Abs(filepath.Join("..", "..", "profiles", dir, helmValuesTemplateName))
+	require.NoError(t, err)
+	rendered, err := renderForScope(templatePath, cfg, nil, nil)
+	require.NoError(t, err)
+	require.Contains(t, rendered, helmValuesOutputName)
+
+	values := map[string]any{}
+	require.NoError(t, renderedyaml.UnmarshalStrict([]byte(rendered[helmValuesOutputName]), &values))
+	return values
+}
+
+func nestedMaintenanceMap(t *testing.T, root map[string]any, keys ...string) map[string]any {
+	t.Helper()
+	current := root
+	for _, key := range keys {
+		next, ok := current[key].(map[string]any)
+		require.Truef(t, ok, "%q is missing or is not a map in %v", key, current)
+		current = next
+	}
+	return current
+}
+
+func TestMaintenanceRequestorModeProfileMatrix(t *testing.T) {
+	releases := []string{"25.10", "26.1", "26.4", ""}
+	for _, profile := range maintenanceProfileCases {
+		for _, release := range releases {
+			releaseName := release
+			if releaseName == "" {
+				releaseName = "latest"
+			}
+			t.Run(profile.dir+"/"+releaseName, func(t *testing.T) {
+				values := renderProfileValuesForMaintenance(t, profile.dir, release, false, "")
+				requestorMode := versionGE(release, "26.1")
+
+				chartMaintenance := nestedMaintenanceMap(t, values, "maintenanceOperator")
+				require.Equal(t, requestorMode, chartMaintenance["enabled"])
+
+				operator := nestedMaintenanceMap(t, values, "operator")
+				requestorValues, hasRequestorValues := operator["maintenanceOperator"]
+				if !requestorMode {
+					require.False(t, hasRequestorValues)
+				} else {
+					want := map[string]any{}
+					if profile.wantOFEDRequestor {
+						want["useRequestor"] = true
+					}
+					if profile.wantDrainRequestor {
+						want["useDrainControllerRequestor"] = true
+					}
+					require.Equal(t, want, requestorValues,
+						"only the profile's requestor-mode booleans should override chart defaults")
+				}
+
+				sriovSubchart, hasSriovSubchart := values["sriov-network-operator"].(map[string]any)
+				if requestorMode && profile.wantExternalDrain {
+					require.True(t, hasSriovSubchart)
+					require.Equal(t, map[string]any{
+						"externalDrainer": map[string]any{"enabled": true},
+					}, sriovSubchart["operator"])
+				} else if hasSriovSubchart {
+					require.NotContains(t, sriovSubchart, "operator")
+				}
+
+				operatorConfig := nestedMaintenanceMap(t, values, "maintenance-operator-chart", "operatorConfig")
+				require.Equal(t, map[string]any{
+					"deploy":                        true,
+					"maxParallelOperations":         "4",
+					"maxUnavailable":                "4",
+					"maxNodeMaintenanceTimeSeconds": "3600",
+				}, operatorConfig)
+			})
+		}
+	}
+}
+
+func TestMaintenanceOperatorRemainsEnabledForNCOBeforeRequestorMode(t *testing.T) {
+	values := renderProfileValuesForMaintenance(t, "host-device-rdma", "25.10", true, "")
+	require.Equal(t, true, nestedMaintenanceMap(t, values, "maintenanceOperator")["enabled"])
+	require.NotContains(t, nestedMaintenanceMap(t, values, "operator"), "maintenanceOperator")
+}
+
+func TestMaintenanceOperatorValuesPreserveExplicitZero(t *testing.T) {
+	values := renderProfileValuesForMaintenance(t, "host-device-rdma", "26.1", false, `maintenance:
+  maxUnavailable: 0
+  maxNodeMaintenanceTimeSeconds: 0
+  maxParallelUpgrades: 0
+`)
+	require.Equal(t, map[string]any{
+		"deploy":                        true,
+		"maxParallelOperations":         "4",
+		"maxUnavailable":                "0",
+		"maxNodeMaintenanceTimeSeconds": "0",
+	}, nestedMaintenanceMap(t, values, "maintenance-operator-chart", "operatorConfig"))
+}
+
+func renderFullProfileForMaintenance(
+	t *testing.T,
+	profile maintenanceProfileCase,
+	release string,
+	maintenanceYAML string,
+) map[string]string {
+	t.Helper()
+	ctrllog.SetLogger(zap.New(zap.UseDevMode(true)))
+	cfg, err := config.LoadFullConfig(
+		filepath.Join("testdata", "grouping", "mixed-same-type.yaml"),
+		ctrllog.Log,
+	)
+	require.NoError(t, err)
+	cfg.NetworkOperator.SelectedRelease = release
+	cfg.Profile = &config.Profile{
+		Fabric:     profile.fabric,
+		Deployment: profile.deployment,
+		Multirail:  true,
+	}
+	cfg.Maintenance = maintenanceFromYAML(t, maintenanceYAML)
+
+	rendered, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(
+		loadProfileFromDir(t, profile.dir), cfg)
+	require.NoError(t, err)
+	return rendered
+}
+
+func TestMaxParallelUpgradesRendersInNCPAndNNP(t *testing.T) {
+	maintenanceYAML := `maintenance:
+  maxParallelUpgrades: 7
+`
+	for _, profile := range maintenanceProfileCases[:5] {
+		for _, release := range []string{"25.10", "26.1", "26.4", ""} {
+			releaseName := release
+			if releaseName == "" {
+				releaseName = "latest"
+			}
+			t.Run(profile.dir+"/"+releaseName, func(t *testing.T) {
+				rendered := renderFullProfileForMaintenance(t, profile, release, maintenanceYAML)
+				manifestFragment := "11-nicnodepolicy"
+				if release == "25.10" || release == "26.1" {
+					manifestFragment = "10-nicclusterpolicy"
+				}
+				names := fileNamesMatching(rendered, manifestFragment)
+				require.NotEmpty(t, names)
+				sawOFEDDriver := false
+				for _, name := range names {
+					if strings.Contains(rendered[name], "ofedDriver:") {
+						sawOFEDDriver = true
+						require.Contains(t, rendered[name], "maxParallelUpgrades: 7")
+					}
+				}
+				require.True(t, sawOFEDDriver)
+			})
+		}
+	}
+}
+
+func TestLegacySriovPoolConfigReleaseGate(t *testing.T) {
+	maintenanceYAML := `maintenance:
+  maxUnavailable: 37%
+`
+	for _, profile := range maintenanceProfileCases[3:5] {
+		for _, release := range []string{"25.10", "26.1", "26.4", ""} {
+			releaseName := release
+			if releaseName == "" {
+				releaseName = "latest"
+			}
+			t.Run(profile.dir+"/"+releaseName, func(t *testing.T) {
+				rendered := renderFullProfileForMaintenance(t, profile, release, maintenanceYAML)
+				names := fileNamesMatching(rendered, "35-sriovnetworkpoolconfig")
+				if release != "25.10" {
+					require.Empty(t, names, "requestor mode makes MaintenanceOperatorConfig authoritative")
+					return
+				}
+				require.Len(t, names, 1)
+				require.Contains(t, rendered[names[0]], "kind: SriovNetworkPoolConfig")
+				require.Contains(t, rendered[names[0]], "maxUnavailable: 37%")
+				require.Contains(t, rendered[names[0]], "nodeSelector:")
+			})
+		}
+	}
+}
+
+func TestSpectrumXPoolDoesNotRenderIneffectiveMaxUnavailable(t *testing.T) {
+	rendered := renderSpectrumXRA21(t, "mixed-same-type.yaml", "hwplb", 2)
+	_, pool := fileMatching(t, rendered, "40-sriovnetworkpoolconfig")
+	require.NotContains(t, pool, "maxUnavailable:")
+}
+
+func TestGenerateProfileDeploymentFilesNormalizesNilMaintenance(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), helmValuesTemplateName)
+	require.NoError(t, os.WriteFile(templatePath, []byte(`maintenance-operator-chart:
+  operatorConfig:
+    maxParallelOperations: "{{ .Maintenance.MaxParallelOperations.String }}"
+    maxUnavailable: "{{ .Maintenance.MaxUnavailable.String }}"
+    maxNodeMaintenanceTimeSeconds: "{{ .Maintenance.MaxNodeMaintenanceTimeSeconds }}"
+`), 0o644))
+	cfg := &config.LaunchKitConfig{
+		NetworkOperator: &config.NetworkOperatorConfig{},
+		Profile:         &config.Profile{},
+		Maintenance:     nil,
+	}
+	profile := &profiles.Profile{Templates: []string{templatePath}}
+
+	rendered, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(profile, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Maintenance)
+	require.Contains(t, rendered[helmValuesOutputName], `maxParallelOperations: "4"`)
+	require.Contains(t, rendered[helmValuesOutputName], `maxUnavailable: "4"`)
+	require.Contains(t, rendered[helmValuesOutputName], `maxNodeMaintenanceTimeSeconds: "3600"`)
+}

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -669,6 +669,10 @@ func groupFabric(group config.ClusterConfig) (string, bool) {
 
 // GenerateProfileDeploymentFiles processes all template files in a profile directory
 func (p *NetworkOperatorPlugin) GenerateProfileDeploymentFiles(profile *profiles.Profile, cfg *config.LaunchKitConfig) (map[string]string, error) {
+	if err := config.NormalizeMaintenance(cfg); err != nil {
+		return nil, fmt.Errorf("normalize maintenance configuration: %w", err)
+	}
+
 	// Apply --groups / --gpu-type filter to source groups before merging.
 	// `applyGroupFilter` enforces mutual exclusivity, errors on empty match,
 	// and is a no-op when neither flag is set.

--- a/profiles/host-device-rdma/00-values.yaml
+++ b/profiles/host-device-rdma/00-values.yaml
@@ -16,6 +16,10 @@ operator:
 {{- if .NetworkOperator.Version }}
   tag: {{ .NetworkOperator.Version }}
 {{- end }}
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  maintenanceOperator:
+    useRequestor: true
+{{- end }}
 {{- if .NetworkOperator.ImagePullSecrets }}
 
 imagePullSecrets:
@@ -25,7 +29,15 @@ imagePullSecrets:
 {{- end }}
 
 maintenanceOperator:
-  enabled: {{ if .NicConfigurationOperator }}true{{ else }}false{{ end }}
+  enabled: {{ if or .NicConfigurationOperator (versionGE .NetworkOperator.SelectedRelease "26.1") }}true{{ else }}false{{ end }}
+
+maintenance-operator-chart:
+  operatorConfig:
+    deploy: true
+    # Keep scalar overrides quoted: upstream truthiness guards omit numeric 0.
+    maxParallelOperations: "{{ .Maintenance.MaxParallelOperations.String }}"
+    maxUnavailable: "{{ .Maintenance.MaxUnavailable.String }}"
+    maxNodeMaintenanceTimeSeconds: "{{ .Maintenance.MaxNodeMaintenanceTimeSeconds }}"
 
 sriovNetworkOperator:
   enabled: false

--- a/profiles/host-device-rdma/10-nicclusterpolicy.yaml
+++ b/profiles/host-device-rdma/10-nicclusterpolicy.yaml
@@ -76,7 +76,7 @@ spec:
         enable: true
         force: true
         timeoutSeconds: 300
-      maxParallelUpgrades: 1
+      maxParallelUpgrades: {{ .Maintenance.MaxParallelUpgrades }}
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10

--- a/profiles/host-device-rdma/11-nicnodepolicy.yaml
+++ b/profiles/host-device-rdma/11-nicnodepolicy.yaml
@@ -40,7 +40,7 @@ spec:
         enable: true
         force: true
         timeoutSeconds: 300
-      maxParallelUpgrades: 1
+      maxParallelUpgrades: {{ .Maintenance.MaxParallelUpgrades }}
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10
@@ -97,4 +97,3 @@ spec:
         ]
       }
 {{- end }}
-

--- a/profiles/ipoib-rdma-shared/00-values.yaml
+++ b/profiles/ipoib-rdma-shared/00-values.yaml
@@ -16,6 +16,10 @@ operator:
 {{- if .NetworkOperator.Version }}
   tag: {{ .NetworkOperator.Version }}
 {{- end }}
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  maintenanceOperator:
+    useRequestor: true
+{{- end }}
 {{- if .NetworkOperator.ImagePullSecrets }}
 
 imagePullSecrets:
@@ -25,7 +29,15 @@ imagePullSecrets:
 {{- end }}
 
 maintenanceOperator:
-  enabled: {{ if .NicConfigurationOperator }}true{{ else }}false{{ end }}
+  enabled: {{ if or .NicConfigurationOperator (versionGE .NetworkOperator.SelectedRelease "26.1") }}true{{ else }}false{{ end }}
+
+maintenance-operator-chart:
+  operatorConfig:
+    deploy: true
+    # Keep scalar overrides quoted: upstream truthiness guards omit numeric 0.
+    maxParallelOperations: "{{ .Maintenance.MaxParallelOperations.String }}"
+    maxUnavailable: "{{ .Maintenance.MaxUnavailable.String }}"
+    maxNodeMaintenanceTimeSeconds: "{{ .Maintenance.MaxNodeMaintenanceTimeSeconds }}"
 
 sriovNetworkOperator:
   enabled: false

--- a/profiles/ipoib-rdma-shared/10-nicclusterpolicy.yaml
+++ b/profiles/ipoib-rdma-shared/10-nicclusterpolicy.yaml
@@ -80,7 +80,7 @@ spec:
         enable: true
         force: true
         timeoutSeconds: 300
-      maxParallelUpgrades: 1
+      maxParallelUpgrades: {{ .Maintenance.MaxParallelUpgrades }}
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10

--- a/profiles/ipoib-rdma-shared/11-nicnodepolicy.yaml
+++ b/profiles/ipoib-rdma-shared/11-nicnodepolicy.yaml
@@ -40,7 +40,7 @@ spec:
         enable: true
         force: true
         timeoutSeconds: 300
-      maxParallelUpgrades: 1
+      maxParallelUpgrades: {{ .Maintenance.MaxParallelUpgrades }}
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10
@@ -92,4 +92,3 @@ spec:
         ]
       }
 {{- end }}
-

--- a/profiles/macvlan-rdma-shared/00-values.yaml
+++ b/profiles/macvlan-rdma-shared/00-values.yaml
@@ -16,6 +16,10 @@ operator:
 {{- if .NetworkOperator.Version }}
   tag: {{ .NetworkOperator.Version }}
 {{- end }}
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  maintenanceOperator:
+    useRequestor: true
+{{- end }}
 {{- if .NetworkOperator.ImagePullSecrets }}
 
 imagePullSecrets:
@@ -25,7 +29,15 @@ imagePullSecrets:
 {{- end }}
 
 maintenanceOperator:
-  enabled: {{ if .NicConfigurationOperator }}true{{ else }}false{{ end }}
+  enabled: {{ if or .NicConfigurationOperator (versionGE .NetworkOperator.SelectedRelease "26.1") }}true{{ else }}false{{ end }}
+
+maintenance-operator-chart:
+  operatorConfig:
+    deploy: true
+    # Keep scalar overrides quoted: upstream truthiness guards omit numeric 0.
+    maxParallelOperations: "{{ .Maintenance.MaxParallelOperations.String }}"
+    maxUnavailable: "{{ .Maintenance.MaxUnavailable.String }}"
+    maxNodeMaintenanceTimeSeconds: "{{ .Maintenance.MaxNodeMaintenanceTimeSeconds }}"
 
 sriovNetworkOperator:
   enabled: false

--- a/profiles/macvlan-rdma-shared/10-nicclusterpolicy.yaml
+++ b/profiles/macvlan-rdma-shared/10-nicclusterpolicy.yaml
@@ -76,7 +76,7 @@ spec:
         enable: true
         force: true
         timeoutSeconds: 300
-      maxParallelUpgrades: 1
+      maxParallelUpgrades: {{ .Maintenance.MaxParallelUpgrades }}
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10

--- a/profiles/macvlan-rdma-shared/11-nicnodepolicy.yaml
+++ b/profiles/macvlan-rdma-shared/11-nicnodepolicy.yaml
@@ -40,7 +40,7 @@ spec:
         enable: true
         force: true
         timeoutSeconds: 300
-      maxParallelUpgrades: 1
+      maxParallelUpgrades: {{ .Maintenance.MaxParallelUpgrades }}
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10
@@ -90,4 +90,3 @@ spec:
         ]
       }
 {{- end }}
-

--- a/profiles/spectrum-x-ra2.1/00-values.yaml
+++ b/profiles/spectrum-x-ra2.1/00-values.yaml
@@ -16,6 +16,10 @@ operator:
 {{- if .NetworkOperator.Version }}
   tag: {{ .NetworkOperator.Version }}
 {{- end }}
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  maintenanceOperator:
+    useDrainControllerRequestor: true
+{{- end }}
 {{- if .NetworkOperator.ImagePullSecrets }}
 
 imagePullSecrets:
@@ -25,7 +29,15 @@ imagePullSecrets:
 {{- end }}
 
 maintenanceOperator:
-  enabled: {{ if .NicConfigurationOperator }}true{{ else }}false{{ end }}
+  enabled: {{ if or .NicConfigurationOperator (versionGE .NetworkOperator.SelectedRelease "26.1") }}true{{ else }}false{{ end }}
+
+maintenance-operator-chart:
+  operatorConfig:
+    deploy: true
+    # Keep scalar overrides quoted: upstream truthiness guards omit numeric 0.
+    maxParallelOperations: "{{ .Maintenance.MaxParallelOperations.String }}"
+    maxUnavailable: "{{ .Maintenance.MaxUnavailable.String }}"
+    maxNodeMaintenanceTimeSeconds: "{{ .Maintenance.MaxNodeMaintenanceTimeSeconds }}"
 
 sriovNetworkOperator:
   enabled: true
@@ -48,6 +60,11 @@ sriovNetworkOperator:
 # so the sriov daemon waits for NCO to finish per-node firmware/NIC config
 # before mutating VFs.
 sriov-network-operator:
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  operator:
+    externalDrainer:
+      enabled: true
+{{- end }}
   sriovOperatorConfig:
     deploy: true
     # See sriov-ethernet-rdma's 00-values.yaml for the rationale: both

--- a/profiles/spectrum-x/00-values.yaml
+++ b/profiles/spectrum-x/00-values.yaml
@@ -16,6 +16,10 @@ operator:
 {{- if .NetworkOperator.Version }}
   tag: {{ .NetworkOperator.Version }}
 {{- end }}
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  maintenanceOperator:
+    useDrainControllerRequestor: true
+{{- end }}
 {{- if .NetworkOperator.ImagePullSecrets }}
 
 imagePullSecrets:
@@ -25,7 +29,15 @@ imagePullSecrets:
 {{- end }}
 
 maintenanceOperator:
-  enabled: {{ if .NicConfigurationOperator }}true{{ else }}false{{ end }}
+  enabled: {{ if or .NicConfigurationOperator (versionGE .NetworkOperator.SelectedRelease "26.1") }}true{{ else }}false{{ end }}
+
+maintenance-operator-chart:
+  operatorConfig:
+    deploy: true
+    # Keep scalar overrides quoted: upstream truthiness guards omit numeric 0.
+    maxParallelOperations: "{{ .Maintenance.MaxParallelOperations.String }}"
+    maxUnavailable: "{{ .Maintenance.MaxUnavailable.String }}"
+    maxNodeMaintenanceTimeSeconds: "{{ .Maintenance.MaxNodeMaintenanceTimeSeconds }}"
 
 sriovNetworkOperator:
   enabled: true
@@ -49,6 +61,11 @@ sriovNetworkOperator:
 # so the sriov daemon waits for NCO to finish per-node firmware/NIC config
 # before mutating VFs.
 sriov-network-operator:
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  operator:
+    externalDrainer:
+      enabled: true
+{{- end }}
   sriovOperatorConfig:
     deploy: true
     # See sriov-ethernet-rdma's 00-values.yaml for the rationale: both

--- a/profiles/sriov-ethernet-rdma/00-values.yaml
+++ b/profiles/sriov-ethernet-rdma/00-values.yaml
@@ -16,6 +16,11 @@ operator:
 {{- if .NetworkOperator.Version }}
   tag: {{ .NetworkOperator.Version }}
 {{- end }}
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  maintenanceOperator:
+    useRequestor: true
+    useDrainControllerRequestor: true
+{{- end }}
 {{- if .NetworkOperator.ImagePullSecrets }}
 
 imagePullSecrets:
@@ -25,7 +30,15 @@ imagePullSecrets:
 {{- end }}
 
 maintenanceOperator:
-  enabled: {{ if .NicConfigurationOperator }}true{{ else }}false{{ end }}
+  enabled: {{ if or .NicConfigurationOperator (versionGE .NetworkOperator.SelectedRelease "26.1") }}true{{ else }}false{{ end }}
+
+maintenance-operator-chart:
+  operatorConfig:
+    deploy: true
+    # Keep scalar overrides quoted: upstream truthiness guards omit numeric 0.
+    maxParallelOperations: "{{ .Maintenance.MaxParallelOperations.String }}"
+    maxUnavailable: "{{ .Maintenance.MaxUnavailable.String }}"
+    maxNodeMaintenanceTimeSeconds: "{{ .Maintenance.MaxNodeMaintenanceTimeSeconds }}"
 
 sriovNetworkOperator:
   enabled: true
@@ -40,6 +53,11 @@ sriovNetworkOperator:
 # so the sriov daemon waits for NCO to finish per-node firmware/NIC config
 # before mutating VFs.
 sriov-network-operator:
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  operator:
+    externalDrainer:
+      enabled: true
+{{- end }}
   sriovOperatorConfig:
     deploy: true
     # Both optional helpers are turned off:

--- a/profiles/sriov-ethernet-rdma/10-nicclusterpolicy.yaml
+++ b/profiles/sriov-ethernet-rdma/10-nicclusterpolicy.yaml
@@ -75,7 +75,7 @@ spec:
         enable: true
         force: true
         timeoutSeconds: 300
-      maxParallelUpgrades: 1
+      maxParallelUpgrades: {{ .Maintenance.MaxParallelUpgrades }}
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10

--- a/profiles/sriov-ethernet-rdma/11-nicnodepolicy.yaml
+++ b/profiles/sriov-ethernet-rdma/11-nicnodepolicy.yaml
@@ -44,7 +44,7 @@ spec:
         enable: true
         force: true
         timeoutSeconds: 300
-      maxParallelUpgrades: 1
+      maxParallelUpgrades: {{ .Maintenance.MaxParallelUpgrades }}
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10

--- a/profiles/sriov-ethernet-rdma/35-sriovnetworkpoolconfig.yaml
+++ b/profiles/sriov-ethernet-rdma/35-sriovnetworkpoolconfig.yaml
@@ -1,0 +1,18 @@
+{{- if versionLT .NetworkOperator.SelectedRelease "26.1" }}
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkPoolConfig
+metadata:
+  name: sriov-node-pool-config{{suffix .ClusterConfig.Identifier}}
+  namespace: "{{.NetworkOperator.Namespace}}"
+spec:
+  maxUnavailable: {{ .Maintenance.MaxUnavailable.String }}
+  {{- if .ClusterConfig.NodeSelector }}
+  nodeSelector:
+    matchLabels:
+      {{- range $key, $value := .ClusterConfig.NodeSelector }}
+      {{ $key }}: "{{ $value }}"
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/profiles/sriov-ethernet-rdma/profile.yaml
+++ b/profiles/sriov-ethernet-rdma/profile.yaml
@@ -14,6 +14,7 @@ templates:
   - 11-nicnodepolicy.yaml
   - 20-ippool.yaml
   - 30-nicinterfacenametemplate.yaml
+  - 35-sriovnetworkpoolconfig.yaml
   - 40-sriovnetworknodepolicy.yaml
   - 50-sriovnetwork.yaml
   - 60-example-daemonset.yaml

--- a/profiles/sriov-ib-rdma/00-values.yaml
+++ b/profiles/sriov-ib-rdma/00-values.yaml
@@ -16,6 +16,11 @@ operator:
 {{- if .NetworkOperator.Version }}
   tag: {{ .NetworkOperator.Version }}
 {{- end }}
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  maintenanceOperator:
+    useRequestor: true
+    useDrainControllerRequestor: true
+{{- end }}
 {{- if .NetworkOperator.ImagePullSecrets }}
 
 imagePullSecrets:
@@ -25,7 +30,15 @@ imagePullSecrets:
 {{- end }}
 
 maintenanceOperator:
-  enabled: {{ if .NicConfigurationOperator }}true{{ else }}false{{ end }}
+  enabled: {{ if or .NicConfigurationOperator (versionGE .NetworkOperator.SelectedRelease "26.1") }}true{{ else }}false{{ end }}
+
+maintenance-operator-chart:
+  operatorConfig:
+    deploy: true
+    # Keep scalar overrides quoted: upstream truthiness guards omit numeric 0.
+    maxParallelOperations: "{{ .Maintenance.MaxParallelOperations.String }}"
+    maxUnavailable: "{{ .Maintenance.MaxUnavailable.String }}"
+    maxNodeMaintenanceTimeSeconds: "{{ .Maintenance.MaxNodeMaintenanceTimeSeconds }}"
 
 sriovNetworkOperator:
   enabled: true
@@ -40,6 +53,11 @@ sriovNetworkOperator:
 # so the sriov daemon waits for NCO to finish per-node firmware/NIC config
 # before mutating VFs.
 sriov-network-operator:
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  operator:
+    externalDrainer:
+      enabled: true
+{{- end }}
   sriovOperatorConfig:
     deploy: true
     # See sriov-ethernet-rdma's 00-values.yaml for the rationale: both

--- a/profiles/sriov-ib-rdma/10-nicclusterpolicy.yaml
+++ b/profiles/sriov-ib-rdma/10-nicclusterpolicy.yaml
@@ -76,7 +76,7 @@ spec:
         enable: true
         force: true
         timeoutSeconds: 300
-      maxParallelUpgrades: 1
+      maxParallelUpgrades: {{ .Maintenance.MaxParallelUpgrades }}
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10

--- a/profiles/sriov-ib-rdma/11-nicnodepolicy.yaml
+++ b/profiles/sriov-ib-rdma/11-nicnodepolicy.yaml
@@ -44,7 +44,7 @@ spec:
         enable: true
         force: true
         timeoutSeconds: 300
-      maxParallelUpgrades: 1
+      maxParallelUpgrades: {{ .Maintenance.MaxParallelUpgrades }}
     startupProbe:
       initialDelaySeconds: 10
       periodSeconds: 10

--- a/profiles/sriov-ib-rdma/35-sriovnetworkpoolconfig.yaml
+++ b/profiles/sriov-ib-rdma/35-sriovnetworkpoolconfig.yaml
@@ -1,0 +1,18 @@
+{{- if versionLT .NetworkOperator.SelectedRelease "26.1" }}
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkPoolConfig
+metadata:
+  name: sriov-node-pool-config{{suffix .ClusterConfig.Identifier}}
+  namespace: "{{.NetworkOperator.Namespace}}"
+spec:
+  maxUnavailable: {{ .Maintenance.MaxUnavailable.String }}
+  {{- if .ClusterConfig.NodeSelector }}
+  nodeSelector:
+    matchLabels:
+      {{- range $key, $value := .ClusterConfig.NodeSelector }}
+      {{ $key }}: "{{ $value }}"
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/profiles/sriov-ib-rdma/profile.yaml
+++ b/profiles/sriov-ib-rdma/profile.yaml
@@ -15,6 +15,7 @@ templates:
   - 11-nicnodepolicy.yaml
   - 20-ippool.yaml
   - 30-nicinterfacenametemplate.yaml
+  - 35-sriovnetworkpoolconfig.yaml
   - 40-sriovnetworknodepolicy.yaml
   - 50-sriovibnetwork.yaml
   - 60-example-daemonset.yaml

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: k8s-launch-kit-config
-version: 1.1.0
-description: "Use this skill when the user needs help understanding, creating, or editing a k8s-launch-kit (l8k) configuration file (l8k-config.yaml or cluster-config.yaml). Activate for: config file questions, parameter tuning, subnet configuration, NV-IPAM setup, DOCA driver settings, NIC configuration operator settings, changing MTU, VFs, resource names, or understanding what any config field does."
+version: 1.2.0
+description: "Use this skill when the user needs help understanding, creating, or editing a k8s-launch-kit (l8k) configuration file (l8k-config.yaml or cluster-config.yaml). Activate for: config file questions, parameter tuning, subnet configuration, NV-IPAM setup, DOCA driver settings, maintenance concurrency, NIC configuration operator settings, changing MTU, VFs, resource names, or understanding what any config field does."
 metadata:
   requires:
     skills: ["k8s-launch-kit-shared"]
@@ -40,6 +40,7 @@ l8k discover --user-config my-config.yaml \
 |---------|-----------------|
 | `networkOperator` | Operator namespace, version, image repository, helm chart repository (`helmRepoURL`) |
 | `docaDriver` | OFED/DOCA driver image, version, blacklist settings |
+| `maintenance` | Maintenance Operator, SR-IOV drain, and legacy OFED upgrade concurrency |
 | `nvIpam` | NV-IPAM IP pool ranges and subnet generation |
 | `sriov` | VF count, resource prefix, MTU, link type |
 | `hostdev` | Host device resource name |
@@ -63,7 +64,7 @@ Each `clusterConfig[]` entry has these key fields:
 - `workerNodes` — explicit hostnames (populated by discovery).
 
 For the full field-by-field reference with types, defaults, and descriptions,
-read `references/config-schema.md`.
+read `references/config-reference.md`.
 
 ## Topology Presets
 
@@ -113,6 +114,15 @@ sriov:
 docaDriver:
   version: "doca3.2.0-25.10-1.2.8.0-2"
 
+# Allow four simultaneous maintenance operations. Network Operator 26.1+
+# uses the global Maintenance Operator limits; older releases use the legacy
+# SR-IOV/OFED limits where applicable.
+maintenance:
+  maxParallelOperations: 4
+  maxUnavailable: 4
+  maxNodeMaintenanceTimeSeconds: 3600
+  maxParallelUpgrades: 4
+
 # Override the helm chart repository URL (rarely needed — the embedded
 # release catalog supplies the right URL for each MAJOR.MINOR release).
 # Useful only for mirrors or private chart hosts.
@@ -138,9 +148,11 @@ networkNamespaces: ["my-namespace"]
 - Start by running discovery (`l8k discover`) to generate a baseline, then edit it.
 - `nvIpam` subnets are auto-generated if not specified — one per rail using non-routable ranges.
 - `docaDriver.unloadThirdPartyRDMAModules: true` auto-populates `UNLOAD_THIRD_PARTY_RDMA_MODULES` from discovered OFED-dependent modules.
+- For release 26.1+, SR-IOV requestor mode requires both the Network Operator drain requestor and the SR-IOV external drainer. l8k renders both; applying only CRs cannot enable their Deployment environment variables.
+- Updating an existing release to the generated requestor-mode Helm values requires `--overwrite-existing`.
 
 ## See Also
 
 - [k8s-launch-kit-shared](../k8s-launch-kit-shared/SKILL.md) — Global flags
 - [k8s-launch-kit-discover](../k8s-launch-kit-discover/SKILL.md) — Generate a config from live cluster
-- `references/config-schema.md` — Full field reference
+- `references/config-reference.md` — Complete annotated YAML, including maintenance value restrictions

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -69,6 +69,43 @@ docaDriver:
   unloadThirdPartyRDMAModules: true
 
 # ============================================================================
+# Maintenance and Upgrade Concurrency
+# Controls Maintenance Operator request scheduling and legacy drain limits.
+# ============================================================================
+maintenance:
+  # int-or-percent | default: 4
+  # Global Maintenance Operator work limit. Use a positive integer or a
+  # percentage string from "1%" through "100%". Integer 0 is rejected because
+  # the current scheduler calculates zero available slots. Percentages use all
+  # cluster nodes and round up.
+  maxParallelOperations: 4
+
+  # int-or-percent | default: 4
+  # Global unavailable-node limit under requestor mode (Network Operator 26.1+).
+  # Before 26.1, this is wired to SriovNetworkPoolConfig for SR-IOV's internal
+  # drainer. A non-negative integer or "1%"-"100%" is accepted. Integer 0
+  # pauses new work. In requestor mode, already cordoned or NotReady nodes
+  # consume this budget. Requestor-mode percentages use all cluster nodes and
+  # round down; legacy SR-IOV percentages use the selected pool and round down.
+  maxUnavailable: 4
+
+  # int | default: 3600
+  # Non-negative delay before a Ready NodeMaintenance request can be garbage
+  # collected. 0 makes it immediately eligible; this is not an operation timeout.
+  # Keep it below any cluster-autoscaler idle interval.
+  maxNodeMaintenanceTimeSeconds: 3600
+
+  # int | default: 4
+  # Non-negative OFED upgrade limit used only before Network Operator 26.1.
+  # 0 means unlimited on the legacy path. Requestor mode ignores this field.
+  maxParallelUpgrades: 4
+
+# Network Operator 26.1+ enables OFED and SR-IOV requestors in generated Helm
+# values. SR-IOV needs both the Network Operator drain requestor and the SR-IOV
+# external drainer. Applying CRs alone cannot enable these Deployment settings;
+# upgrade an existing Helm release with --overwrite-existing.
+
+# ============================================================================
 # NV-IPAM (IP Address Management)
 # Controls IP allocation for secondary networks.
 # ============================================================================

--- a/skills/k8s-launch-kit-deploy/SKILL.md
+++ b/skills/k8s-launch-kit-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-deploy
-version: 1.2.0
+version: 1.3.0
 description: "Use this skill when the user wants to deploy generated NVIDIA networking manifests to a Kubernetes cluster using k8s-launch-kit (l8k). Activate for: applying manifests, deploying to cluster, the `l8k deploy` subcommand or the legacy --deploy flag on `l8k generate`, applying generated files, or any mention of pushing l8k output to a live cluster. Even if the user just says 'apply these' or 'push to cluster' after generating manifests, use this skill."
 metadata:
   requires:
@@ -24,6 +24,13 @@ l8k deploy [--deployment-files <DIR>] [--kubeconfig <PATH>] [--dry-run]
 `l8k deploy` reads YAML files from `--deployment-files` (default `./deployment`) and applies them in dependency order. It auto-prefers `<DIR>/network-operator/` (the layout `l8k generate` produces) and falls back to `<DIR>` itself.
 
 When the deployment directory contains a `values.yaml` (the `l8k generate` profile renderer emits one per profile), Phase 0 runs first: the Helm Go SDK installs (or upgrades, with `--overwrite-existing`) the `nvidia/network-operator` chart in the namespace from `networkOperator.namespace`. The chart version and Helm repo URL come from the embedded release catalog selected via `--network-operator-release`. Phase 0 is skipped silently when `values.yaml` is absent — backward compatible with users managing the chart out of band.
+
+Network Operator 26.1+ requestor mode is a Helm-level change: the generated
+values add Network Operator Deployment environment variables and enable the
+SR-IOV external drainer where applicable. Applying only the generated CRs
+cannot enable requestor mode. When upgrading an existing release whose values
+differ, pass `--overwrite-existing`; otherwise l8k intentionally stops at the
+values conflict.
 
 The legacy one-shot form (still supported, useful when you want to generate and apply in a single step):
 
@@ -51,6 +58,10 @@ l8k deploy --deployment-files /tmp/my-output --kubeconfig ~/.kube/config
 
 # Server-side dry-run before a production apply
 l8k deploy --dry-run
+
+# Apply newly generated requestor-mode values to an existing release
+l8k deploy --deployment-files ./output --kubeconfig ~/.kube/config \
+  --overwrite-existing
 
 # Agent mode
 l8k deploy --output json --yes 2>/dev/null
@@ -80,7 +91,15 @@ kubectl get nicclusterpolicy -o yaml          # Check policy state
 kubectl get nicnodepolicy                     # Per-group state
 kubectl get pods -n <operator-ns>             # Verify all pods Running
 kubectl get sriovnetworknodestates -A         # Check SR-IOV VF allocation
+kubectl get maintenanceoperatorconfigs -A -o yaml # Check global concurrency
+kubectl get nodemaintenances -A                # Check active requests
 ```
+
+For SR-IOV on release 26.1+, verify that the generated Helm values contain both
+`operator.maintenanceOperator.useDrainControllerRequestor: true` and
+`sriov-network-operator.operator.externalDrainer.enabled: true`. For OFED,
+verify `operator.maintenanceOperator.useRequestor: true`. Do not try to enable
+these by applying `MaintenanceOperatorConfig` alone.
 
 > [!CAUTION]
 > This is a **write** command — confirm with the user before executing on production clusters.

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-generate
-version: 1.1.0
+version: 1.2.0
 description: "Use this skill when the user wants to generate Kubernetes YAML manifests for NVIDIA networking deployment using k8s-launch-kit (l8k). Activate for: manifest generation, profile selection, choosing between SR-IOV/host-device/RDMA-shared/IPoIB/MacVLAN/Spectrum-X, creating deployment files, or when the user asks 'which profile should I use' or needs help choosing a network configuration."
 metadata:
   requires:
@@ -113,6 +113,21 @@ output/
 ```
 
 `values.yaml` is rendered from the profile's `00-values.yaml` template. `--network-operator-release <MAJOR.MINOR>` populates the chart repository URL and image tag from the embedded catalog. To install or upgrade the chart alongside the CRs, pass `--deploy` (and `--overwrite-existing` when the release already exists with different values).
+
+For Network Operator 26.1 and newer, the rendered values enable Maintenance
+Operator requestor mode. Profiles with DOCA/OFED enable
+`operator.maintenanceOperator.useRequestor`. Profiles that deploy the SR-IOV
+Operator enable both the Network Operator drain requestor and
+`sriov-network-operator.operator.externalDrainer`; the two SR-IOV switches are
+a coordinated handoff and must not be separated. The generated
+`MaintenanceOperatorConfig` gets the global limits from the config's
+`maintenance` section.
+
+Before release 26.1, OFED uses `maintenance.maxParallelUpgrades` and the SR-IOV
+internal drainer uses `maintenance.maxUnavailable` through
+`SriovNetworkPoolConfig`. Starting with 26.1, the global Maintenance Operator
+limits are effective for both flows; the legacy OFED and SR-IOV pool limits do
+not control requestor-mode concurrency.
 
 ## Auto-Detecting Multirail
 

--- a/skills/k8s-launch-kit-generate/references/profiles-summary.md
+++ b/skills/k8s-launch-kit-generate/references/profiles-summary.md
@@ -2,6 +2,13 @@
 
 Summary of all 7 l8k profile definitions from `profiles/*/profile.yaml`.
 
+Every profile renders the top-level `maintenance` settings into Helm values.
+For Network Operator 26.1+, those values enable Maintenance Operator, deploy a
+`MaintenanceOperatorConfig`, enable the OFED requestor in profiles with an OFED
+driver, and enable both the external drainer and Network Operator drain
+requestor in profiles with SR-IOV Operator. Older releases retain the legacy
+direct-drain controllers.
+
 ## 1. SR-IOV Ethernet RDMA
 
 - **Directory**: `profiles/sriov-ethernet-rdma/`

--- a/skills/k8s-network-engineer/SKILL.md
+++ b/skills/k8s-network-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-network-engineer
-version: 1.3.0
+version: 1.4.0
 description: "Embody a senior NVIDIA Networking Engineer who is an expert on deploying cloud-native networking on Kubernetes with k8s-launch-kit (l8k). Activate whenever the user mentions NVIDIA network profiles, SR-IOV, RDMA, Spectrum-X, BlueField, ConnectX, NIC configuration, Network Operator, DOCA drivers, multirail networking, l8k, k8s-launch-kit, or any Kubernetes networking topic involving NVIDIA hardware. Also activate when the user asks general questions about high-performance networking, GPU interconnect, or RDMA configuration."
 metadata:
   requires:
@@ -26,6 +26,7 @@ Senior NVIDIA Networking Engineer specializing in Kubernetes cloud-native networ
 
 - Discover cluster hardware: use `l8k discover` (skill: `k8s-launch-kit-discover`)
 - Understand/edit config: use `k8s-launch-kit-config`
+- Tune SR-IOV and OFED node concurrency: edit the top-level `maintenance` section with `k8s-launch-kit-config`
 - Choose profile + generate manifests: use `l8k generate` (skill: `k8s-launch-kit-generate`)
 - Skip discovery for known SKUs: use `l8k generate --for <preset>` (skill: `k8s-launch-kit-generate`)
 - Preview before applying: use `l8k generate --dry-run` (skill: `k8s-launch-kit-dryrun`)
@@ -57,12 +58,13 @@ Use `l8k preset list` to see available presets. Multi-variant presets (same mach
 - Always call l8k with `--output json 2>/dev/null` and parse the result with jq. Never use text mode. Do NOT add `--yes` — it doesn't work on subcommands; `--output json` auto-confirms.
 - When generating manifests, check the discovered config for multirail: if any group has `railNumber > 0` in physicalFunctions, add `--multirail` to the `l8k generate` command.
 - `--kubeconfig` is optional — l8k falls back to `$KUBECONFIG` env var if not specified.
+- For Network Operator 26.1+, treat SR-IOV requestor mode as one coordinated Helm change: both the Network Operator drain requestor and SR-IOV external drainer must be enabled. OFED uses its separate Maintenance Operator requestor. Use `--overwrite-existing` when generated values differ from an installed release; a CR-only apply is insufficient.
 
 ## Reference Documents
 
 - `references/profile-decision-tree.md` — Profile selection by fabric, NIC type, multiplane mode
 - `references/spectrum-x-guide.md` — Spectrum-X multiplane modes and OVS bridge config
-- `references/config-schema.md` — Full config field reference
+- `references/config-schema.md` — Full config field reference, including maintenance concurrency and release gates
 - `references/glossary.md` — East-west, north-south, rail, plane, PF, VF, RoCE, OFED, DOCA
 
 ## Tips

--- a/skills/k8s-network-engineer/references/config-schema.md
+++ b/skills/k8s-network-engineer/references/config-schema.md
@@ -36,6 +36,36 @@ When `unloadThirdPartyRDMAModules` is true and dependent modules are discovered,
 the generated NicClusterPolicy includes `UNLOAD_THIRD_PARTY_RDMA_MODULES` env var
 (space-separated module names) in the ofedDriver section.
 
+## maintenance
+
+Controls disruptive node-operation concurrency. Defaults are chosen for larger
+clusters; tune them to the cluster's actual availability budget.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `maxParallelOperations` | int or percent | `4` | Global Maintenance Operator work limit. Positive integer or `"1%"`-`"100%"`; integer `0` is rejected because the current scheduler yields zero slots. Percentages use all cluster nodes and round up. |
+| `maxUnavailable` | int or percent | `4` | Global unavailable-node budget in requestor mode; legacy SR-IOV pool limit before 26.1. Non-negative integer or `"1%"`-`"100%"`; integer `0` pauses new work. In requestor mode, already cordoned or NotReady nodes count toward it. Requestor-mode percentages use all cluster nodes; legacy percentages use the selected pool. Both round down. |
+| `maxNodeMaintenanceTimeSeconds` | int | `3600` | Non-negative cleanup delay after a NodeMaintenance request reaches Ready. `0` means immediately garbage-collection eligible, not disabled. Keep below the cluster-autoscaler idle interval. |
+| `maxParallelUpgrades` | int | `4` | OFED concurrency before Network Operator 26.1. Non-negative; `0` means unlimited on the legacy path. Ignored by OFED requestor mode in 26.1+. |
+
+Releases 26.1 and newer render these requestor settings in Helm values:
+
+- OFED: `operator.maintenanceOperator.useRequestor: true`.
+- SR-IOV: both
+  `operator.maintenanceOperator.useDrainControllerRequestor: true` and
+  `sriov-network-operator.operator.externalDrainer.enabled: true`.
+
+The two SR-IOV switches are required together. In requestor mode,
+`MaintenanceOperatorConfig.spec.maxParallelOperations` and
+`spec.maxUnavailable` are global and authoritative;
+`SriovNetworkPoolConfig.spec.maxUnavailable` no longer controls draining.
+Before 26.1, the SR-IOV internal drainer uses that pool field and OFED uses
+`maxParallelUpgrades`.
+
+These requestor switches become Deployment environment variables. Applying
+only generated CRs cannot enable them; use `--overwrite-existing` to upgrade an
+installed Helm release to changed generated values.
+
 ## nvIpam
 
 Controls NV-IPAM (NVIDIA IP Address Management) pool generation.

--- a/skills/k8s-network-engineer/references/glossary.md
+++ b/skills/k8s-network-engineer/references/glossary.md
@@ -45,6 +45,13 @@
 - **DOCA**: NVIDIA's Data Center Infrastructure-on-a-Chip Architecture. The DOCA driver is the containerized OFED driver deployed by the Network Operator.
 - **Third-party RDMA module handling**: Before loading DOCA/OFED drivers, kernel modules that depend on inbox MLX modules (e.g., `iw_cm`, `nfsrdma`) must be unloaded. Discovery detects these automatically (including transitive dependencies) and saves them as `thirdPartyRDMAModules` per group for visibility and warnings. `unloadThirdPartyRDMAModules: true` renders `UNLOAD_THIRD_PARTY_RDMA_MODULES: "true"` (a boolean flag) in generated manifests; the driver container has the 24 known third-party modules hardcoded.
 
+## Maintenance
+
+- **NodeMaintenance**: A request for the Maintenance Operator to make one node safe for disruptive work and return it to service afterward.
+- **Requestor mode**: Network Operator 26.1+ mode where OFED and SR-IOV ask the Maintenance Operator to coordinate drains instead of draining directly. SR-IOV requires both its external drainer and the Network Operator drain requestor.
+- **MaintenanceOperatorConfig**: Cluster policy that limits global active operations and unavailable nodes. Nodes already cordoned or NotReady consume the unavailable-node budget.
+- **Internal drainer**: The legacy SR-IOV drain controller used before Network Operator 26.1; its concurrency comes from `SriovNetworkPoolConfig.spec.maxUnavailable` rather than the global Maintenance Operator budget.
+
 ## l8k Concepts
 
 - **Group**: A set of worker nodes with identical NIC hardware layouts (same device IDs, same rail count). Discovery creates groups automatically. Multiple groups with compatible hardware may be merged.


### PR DESCRIPTION
## Summary

- add one top-level `maintenance` config section with validated defaults of four concurrent nodes
- render MaintenanceOperatorConfig globally, legacy SR-IOV pool limits before 26.1, and legacy OFED upgrade concurrency
- enable OFED and SR-IOV Maintenance Operator requestor mode for Network Operator 26.1 and newer
- document accepted values, zero behavior, release gates, and Helm upgrade requirements

## Validation

- `GOCACHE=/private/tmp/l8k-go-cache go test ./... -count=1 -skip "TestGetPresetsDir_(NotFound|SkipsFiles)"`
- `GOCACHE=/private/tmp/l8k-go-cache make build`
- rendered representative 25.10, 26.1, and 26.4 profiles, including percentage and explicit-zero overrides
- `helm template` passed with exact Network Operator v25.10.0 and v26.1.1 charts and the local 26.4 chart

The two skipped preset tests depend on `/usr/local/share/l8k/presets` being absent; they fail identically on unmodified main in this development environment.