### PR TITLE
presets: add NVIDIA DGX Spark topology

### DIFF
--- a/pkg/presets/data/NVIDIA-DGX-Spark-NVIDIA-GB10/topology.yaml
+++ b/pkg/presets/data/NVIDIA-DGX-Spark-NVIDIA-GB10/topology.yaml
@@ -1,0 +1,78 @@
+machineType: NVIDIA_DGX_Spark
+manufacturer: NVIDIA
+gpuType: NVIDIA-GB10
+nicModel: NVIDIA DGX Spark, P4242-0000, 2-port QSFP up to 200G, Ethernet, PCIe5 (ConnectX-7)
+gpuInterconnect: ""
+numaNodes: 1
+
+capabilities:
+  nodes:
+    sriov: true
+    rdma: true
+    ib: false
+
+# NVIDIA DGX Spark (P4242), single-GB10 workstation:
+#   - 1x NVIDIA GB10 GPU (no GPU-to-GPU interconnect).
+#   - 2x ConnectX-7 NICs, each exposing two Ethernet ports.
+#   - nvidia-smi reports every GPU-to-NIC relationship as NODE, so the
+#     single-NUMA-node fallback assigns all four ports to GPU0.
+#
+# The kernel reports numa_node=-1 for the integrated NICs. Because the system
+# exposes only NUMA node 0 and GPU0 has NUMA affinity 0, all PFs are assigned
+# to NUMA 0. Both ports are retained because the VPD model is explicitly
+# dual-port, matching l8k discovery's default rail-collapse behavior.
+# Each PF advertises 4 total VFs; use sriov.numVfs <= 4 for SR-IOV generation.
+
+pfs:
+  # --- NUMA 0: GPU0, CPUs 0-19 ---
+  - deviceID: "1021"
+    rdmaDevice: rocep1s0f0
+    pciAddress: "0000:01:00.0"
+    networkInterface: enp1s0f0np0
+    traffic: east-west
+    rail: 0
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: NODE
+    psid: nvd0000000087
+    partNumber: P4242-0000
+    model: NVIDIA DGX Spark, P4242-0000, 2-port QSFP up to 200G, Ethernet, PCIe5
+
+  - deviceID: "1021"
+    rdmaDevice: rocep1s0f1
+    pciAddress: "0000:01:00.1"
+    networkInterface: enp1s0f1np1
+    traffic: east-west
+    rail: 1
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: NODE
+    psid: nvd0000000087
+    partNumber: P4242-0000
+    model: NVIDIA DGX Spark, P4242-0000, 2-port QSFP up to 200G, Ethernet, PCIe5
+
+  - deviceID: "1021"
+    rdmaDevice: roceP2p1s0f0
+    pciAddress: "0002:01:00.0"
+    networkInterface: enP2p1s0f0np0
+    traffic: east-west
+    rail: 2
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: NODE
+    psid: nvd0000000087
+    partNumber: P4242-0000
+    model: NVIDIA DGX Spark, P4242-0000, 2-port QSFP up to 200G, Ethernet, PCIe5
+
+  - deviceID: "1021"
+    rdmaDevice: roceP2p1s0f1
+    pciAddress: "0002:01:00.1"
+    networkInterface: enP2p1s0f1np1
+    traffic: east-west
+    rail: 3
+    numaNode: 0
+    connectedGPU: GPU0
+    gpuProximity: NODE
+    psid: nvd0000000087
+    partNumber: P4242-0000
+    model: NVIDIA DGX Spark, P4242-0000, 2-port QSFP up to 200G, Ethernet, PCIe5


### PR DESCRIPTION
## Summary
- Add a topology preset for the exact `(NVIDIA_DGX_Spark, NVIDIA-GB10)` discovery key.
- Model the two dual-port ConnectX-7 devices as four east-west rails attached to GPU0 through the single-NUMA `NODE` fallback.
- Preserve the report PCI, RDMA, netdev, PSID, part-number, and VPD model data, and document the four-VF hardware limit.

## Input audit
- The ThinkSystem SR675 V3 / RTX PRO 6000 report matches the existing preset PF fingerprint exactly.
- The ThinkSystem SR680a V3 / H200 and UCSC-885A-M8-H22 / H200 reports also match their existing preset PF fingerprints exactly.
- The ThinkSystem SR680a V4 input contains only a collection timeout and no hardware inventory, so no unsafe preset was synthesized from it.

## Validation
- `GOCACHE=/private/tmp/l8k-era-presets-go-cache make build`
- `GOCACHE=/private/tmp/l8k-era-presets-go-cache go test ./... -count=1 -skip 'TestGetPresetsDir_(NotFound|SkipsFiles)'`
- `./build/l8k preset list --output json`
- `./build/l8k generate --for NVIDIA-DGX-Spark-NVIDIA-GB10 ... --output json`
- `git diff --check origin/main...HEAD`

`make lint` could not run because `golangci-lint` is not installed on this machine; this PR contains no Go changes.
