### PR TITLE
feat: support filesystem config overrides

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,14 +54,11 @@ archives:
       - goos: windows
         formats:
           - zip
-    # In-repo layout: presets and the default l8k-config live under pkg/
-    # so they can be //go:embed'ed by their consuming packages. The archive
-    # preserves those paths; install scripts copy them out to the canonical
-    # share/l8k locations on the host so existing user workflows are unchanged.
+    # Presets and the default l8k-config are embedded in the binary. Profiles
+    # remain external because manifest generation reads their templates from
+    # the filesystem.
     files:
       - profiles/**/*
-      - pkg/presets/data/**/*
-      - pkg/config/default-config.yaml
       - LICENSE
     name_template: "l8k_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
@@ -122,7 +119,5 @@ brews:
     install: |
       bin.install "l8k"
       (share/"l8k").install "profiles"
-      (share/"l8k").install "presets"
-      (share/"l8k").install "l8k-config.yaml"
     test: |
       assert_match version.to_s, shell_output("#{bin}/l8k version")

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-$(go env GOOS)} GOARCH=${TARGETARCH:-$(go env
 FROM nvcr.io/nvidia/distroless/go:v4.0.8
 
 
-COPY . /src
 WORKDIR /src
 COPY --from=builder /workspace/build/l8k /src/l8k
+COPY --from=builder /workspace/profiles /src/profiles
 
 ENTRYPOINT ["/src/l8k"]

--- a/README.md
+++ b/README.md
@@ -56,20 +56,49 @@ make build
 
 The binary will be available at `build/l8k`.
 
-After building, install the binary, profiles, and config to `/usr/local`:
+After building, install the binary and profile templates to `/usr/local`:
 
 ```bash
-make install        # Copies binary, profiles, config to /usr/local
+make install        # Copies binary and profiles to /usr/local
 make dev-install    # Symlinks instead of copies (for development)
 ```
 
 This runs `scripts/install-local.sh`, which places:
 - `<prefix>/bin/l8k`
 - `<prefix>/share/l8k/profiles/`
-- `<prefix>/share/l8k/presets/`
-- `<prefix>/share/l8k/l8k-config.yaml`
 
 Default prefix is `/usr/local`. Override with `PREFIX=/opt/l8k make install`.
+
+The default `l8k-config.yaml` and topology presets are embedded in the binary;
+they are not copied into the installation prefix.
+
+### Override Embedded Configuration
+
+Use the persistent `--config-dir` flag to replace either embedded asset from
+the filesystem:
+
+```text
+/etc/l8k/
+├── l8k-config.yaml       # optional full replacement for the embedded default
+└── presets/              # optional authoritative preset catalog
+    └── <name>/topology.yaml
+```
+
+```bash
+# Discover using both overrides
+l8k discover --config-dir /etc/l8k --kubeconfig ~/.kube/config
+
+# Inspect the selected preset catalog
+l8k preset list --config-dir /etc/l8k
+```
+
+`--user-config <file>` has higher precedence than
+`--config-dir/l8k-config.yaml`; `--config-dir` still selects the preset
+catalog. If the directory provides only one asset, the other falls back to the
+embedded copy. A filesystem `presets/` directory replaces the complete
+embedded catalog rather than merging with it. Without `--config-dir`, the
+legacy current-directory/install-prefix lookup remains supported before the
+embedded fallback.
 
 ### Docker
 
@@ -178,6 +207,7 @@ Available Commands:
   version     Print the version number
 
 Common Flags:
+      --config-dir string                   Directory containing optional l8k-config.yaml and presets/ overrides
       --enabled-plugins string              Comma-separated list of plugins to enable (default "network-operator")
       --image-pull-secrets strings          Image pull secret names for NicClusterPolicy (comma-separated)
       --kubeconfig string                   Path to kubeconfig file for cluster deployment (required when using --deploy; falls back to $KUBECONFIG, then ~/.kube/config)
@@ -194,7 +224,7 @@ Discovery Flags:
 Profile Selection Flags:
       --deployment-type string   Select the deployment type (sriov, rdma_shared, host_device)
       --fabric string            Select the fabric type to deploy (infiniband, ethernet)
-      --for string               Generate for a known server preset (replaces clusterConfig from the preset). Requires --node-selector. Available: PowerEdge-R760xa-H100-NVL, PowerEdge-XE7745-RTX-PRO-4500, PowerEdge-XE9680-H200, ThinkSystem-SR650-V4-RTX-PRO-6000, ThinkSystem-SR675-V3-H200-NVL, ThinkSystem-SR675-V3-RTX-PRO-6000, ThinkSystem-SR680a-V3-H200, UCSC-885A-M8-H22-H200
+      --for string               Generate for a known server preset (replaces clusterConfig from the preset). Requires --node-selector. Run 'l8k preset list' with the same --config-dir to list available names.
       --gpu-type string          Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.
       --groups strings           Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.
       --multirail                Enable multirail deployment
@@ -333,6 +363,10 @@ l8k discover --kubeconfig ~/.kube/config \
     --save-cluster-config ./my-cluster-config.yaml
 ```
 
+When `--user-config` and a filesystem default are both absent, discovery uses
+the default configuration embedded in the binary. Pass `--config-dir` to use
+an external default and/or preset catalog instead.
+
 Filter discovery to specific nodes using a label selector:
 
 ```bash
@@ -403,9 +437,9 @@ When you have a known server SKU, use `--for <preset-name>` to skip cluster disc
 # List available presets (each shows machineType + gpuType)
 l8k preset list
 
-# Generate from a known SKU (no kubeconfig needed)
-l8k generate --user-config ./config.yaml \
-    --for ThinkSystem-SR680a-V3 \
+# Generate from a known SKU using the embedded default config (no kubeconfig needed)
+l8k generate \
+    --for ThinkSystem-SR680a-V3-H200 \
     --node-selector "nvidia.com/gpu.product=NVIDIA-H200" \
     --fabric ethernet --deployment-type sriov \
     --save-deployment-files ./deployments
@@ -1112,6 +1146,8 @@ discovered hardware topology, and writes the
 
 ```go
 import (
+    "path/filepath"
+
     l8kconfig "github.com/nvidia/k8s-launch-kit/pkg/config"
     l8kdisc   "github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/discovery"
 )
@@ -1122,8 +1158,22 @@ if err != nil { return err }
 cfg, err = l8kdisc.Discover(ctx, kubeClient, restConfig, cfg,
     l8kdisc.WithLogger(logr.FromSlogHandler(slog.Default().Handler())),
     // l8kdisc.WithRelease("26.1"),  // optional override
+    // l8kdisc.WithPresetsDir(filepath.Join(configDir, "presets")),
 )
 ```
+
+To replace the embedded default as well, load the filesystem copy before
+calling discovery:
+
+```go
+cfg, err := l8kconfig.LoadFullConfig(
+    filepath.Join(configDir, "l8k-config.yaml"), logger,
+)
+```
+
+`WithPresetsDir` selects an authoritative catalog for that call and does not
+mutate process-global preset state, so concurrent embedders can use different
+directories safely.
 
 The discovery package is deliberately Helm-free — importing it does NOT
 pull `helm.sh/helm/v3` or its transitive deps into the consumer's binary.

--- a/pkg/app/discover.go
+++ b/pkg/app/discover.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/nvidia/k8s-launch-kit/pkg/assets"
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
@@ -59,6 +60,16 @@ func DefaultConfigPath() string {
 	return ""
 }
 
+func defaultConfigSource(configPath, configRoot string) string {
+	if configPath != "" {
+		return configPath
+	}
+	if configRoot != "" {
+		return fmt.Sprintf("embedded (--config-dir %q has no %s)", configRoot, assets.DefaultConfigName)
+	}
+	return "embedded"
+}
+
 // discoverClusterConfig handles cluster configuration discovery
 func (l *Launcher) discoverClusterConfig() error {
 	l.ui.Info("Discovering cluster capabilities")
@@ -69,31 +80,31 @@ func (l *Launcher) discoverClusterConfig() error {
 	if l.options.UserConfig != "" {
 		configPath = l.options.UserConfig
 		l.ui.Info("Using base configuration: %s", configPath)
+	} else if l.options.ConfigDir != "" {
+		configPath = l.configAssets.DefaultConfigPath
 	} else {
 		configPath = DefaultConfigPath()
 	}
 
-	if configPath == "" {
-		return apperrors.NewValidationError(
-			"no configuration file found",
-			fmt.Errorf("checked ./l8k-config.yaml and /usr/local/share/l8k/l8k-config.yaml"),
-			"Provide --user-config <path> or run 'scripts/install.sh' to install the default config")
-	}
-
 	defaults, err := config.LoadFullConfig(configPath, l.logger)
 	if err != nil {
+		source := defaultConfigSource(configPath, l.options.ConfigDir)
 		return apperrors.NewValidationError(
-			fmt.Sprintf("cannot load config: %s", configPath), err,
-			fmt.Sprintf("Check that %s exists and is valid YAML", configPath))
+			fmt.Sprintf("cannot load config: %s", source), err,
+			fmt.Sprintf("Check that %s is valid YAML", source))
 	}
 
 	// Keep the annotated source bytes so the saved cluster-config.yaml can
 	// retain the field documentation comments (best-effort — a read failure
 	// just means the output won't carry comments).
-	srcConfigYAML, _ := os.ReadFile(configPath)
+	srcConfigYAML := config.DefaultConfigYAML()
+	if configPath != "" {
+		srcConfigYAML, _ = os.ReadFile(configPath)
+	}
 
 	if l.options.UserConfig == "" {
-		l.ui.Info("Using default configuration: %s", configPath)
+		source := defaultConfigSource(configPath, l.options.ConfigDir)
+		l.ui.Info("Using default configuration: %s", source)
 	}
 
 	// Override namespace from CLI flag if provided

--- a/pkg/app/discover_test.go
+++ b/pkg/app/discover_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultConfigSource(t *testing.T) {
+	assert.Equal(t, "/etc/l8k/l8k-config.yaml",
+		defaultConfigSource("/etc/l8k/l8k-config.yaml", "/etc/l8k"))
+	assert.Equal(t, "embedded", defaultConfigSource("", ""))
+	assert.Equal(t, `embedded (--config-dir "/etc/l8k" has no l8k-config.yaml)`,
+		defaultConfigSource("", "/etc/l8k"))
+}

--- a/pkg/app/generate.go
+++ b/pkg/app/generate.go
@@ -142,7 +142,7 @@ func (l *Launcher) executeGeneration(configPath string) error {
 	// already enforced --node-selector being set; here we do the substitution
 	// before the rest of the pipeline runs.
 	if l.options.ForPreset != "" {
-		preset, err := presets.LoadPresetByDir(l.options.ForPreset)
+		preset, err := l.presetCatalog.LoadPresetByDir(l.options.ForPreset)
 		if err != nil {
 			return apperrors.NewValidationError(
 				fmt.Sprintf("invalid --for value %q", l.options.ForPreset),

--- a/pkg/app/launcher.go
+++ b/pkg/app/launcher.go
@@ -28,12 +28,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/nvidia/k8s-launch-kit/pkg/assets"
 	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
 	"github.com/nvidia/k8s-launch-kit/pkg/kubeclient"
 	applog "github.com/nvidia/k8s-launch-kit/pkg/log"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
 	"github.com/nvidia/k8s-launch-kit/pkg/plugin"
+	"github.com/nvidia/k8s-launch-kit/pkg/presets"
 	"github.com/nvidia/k8s-launch-kit/pkg/profiles"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 )
@@ -49,6 +51,8 @@ type Launcher struct {
 	jsonOutput    *ui.JSONOutput // non-nil only in JSON mode
 	result        *ui.JSONResult // accumulated result for JSON output
 	foundProfiles []profiles.Profile // populated by executeGeneration, consumed by executeDeploy
+	configAssets  assets.ConfigDir
+	presetCatalog *presets.Catalog
 }
 
 // New creates a new Launcher instance with the given options
@@ -82,6 +86,27 @@ func (l *Launcher) Run() error {
 		}
 	}
 
+	resolvedAssets, err := assets.ResolveConfigDir(l.options.ConfigDir)
+	if err != nil {
+		return apperrors.NewValidationError(
+			"invalid --config-dir",
+			err,
+			"Provide an accessible directory; when present, l8k-config.yaml must be a file and presets/ a directory",
+		)
+	}
+	l.configAssets = resolvedAssets
+
+	catalog, err := presets.CatalogForConfigDir(resolvedAssets)
+	if err != nil {
+		return apperrors.NewValidationError(
+			"cannot load topology presets",
+			err,
+			"Check the presets/ directory under --config-dir",
+		)
+	}
+	l.presetCatalog = catalog
+	l.logger.V(1).Info("Using topology preset catalog", "source", catalog.Source())
+
 	for _, pluginName := range l.options.EnabledPlugins {
 		switch pluginName {
 		case networkoperatorplugin.PluginName:
@@ -91,6 +116,7 @@ func (l *Launcher) Run() error {
 				NodeSelector:     parseNodeSelector(l.options.NodeSelector),
 				KeepNamespace:    l.options.KeepNamespace,
 				CollapseNicRails: l.options.CollapseNicRails,
+				PresetCatalog:    l.presetCatalog,
 			}
 		default:
 			err := fmt.Errorf("unknown plugin: %s", pluginName)
@@ -114,7 +140,7 @@ func (l *Launcher) Run() error {
 		}
 	}
 
-	err := l.executeWorkflow()
+	err = l.executeWorkflow()
 
 	// Finalize JSON output if in JSON mode
 	if l.jsonOutput != nil {
@@ -163,6 +189,9 @@ func (l *Launcher) executeWorkflow() error {
 		configPath = l.options.SaveClusterConfig
 	} else {
 		configPath = l.options.UserConfig
+		if configPath == "" && l.options.ConfigDir != "" {
+			configPath = l.configAssets.DefaultConfigPath
+		}
 	}
 
 	if !l.options.DiscoverOnly {

--- a/pkg/assets/configdir.go
+++ b/pkg/assets/configdir.go
@@ -1,0 +1,86 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package assets resolves optional filesystem overrides for the runtime
+// configuration embedded in the l8k binary.
+package assets
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// DefaultConfigName is the user-facing filename for an on-disk override
+	// of the default configuration embedded in pkg/config.
+	DefaultConfigName = "l8k-config.yaml"
+	// PresetsDirName is the directory containing topology preset directories.
+	PresetsDirName = "presets"
+)
+
+// ConfigDir is the validated layout rooted at --config-dir. Empty paths mean
+// that the corresponding asset was not provided and its embedded counterpart
+// should be used.
+type ConfigDir struct {
+	Root              string
+	DefaultConfigPath string
+	PresetsDir        string
+}
+
+// ResolveConfigDir validates an explicit configuration directory and records
+// the optional assets it contains. An empty root is valid and returns an empty
+// ConfigDir so callers can preserve their legacy lookup chain.
+//
+// A supplied directory may override either the default config, the presets, or
+// both. An existing directory with neither asset is valid and selects both
+// embedded fallbacks; a nonexistent or mistyped root remains an error.
+func ResolveConfigDir(root string) (ConfigDir, error) {
+	if root == "" {
+		return ConfigDir{}, nil
+	}
+
+	info, err := os.Stat(root)
+	if err != nil {
+		return ConfigDir{}, fmt.Errorf("config directory %q is not accessible: %w", root, err)
+	}
+	if !info.IsDir() {
+		return ConfigDir{}, fmt.Errorf("config directory %q is not a directory", root)
+	}
+
+	resolved := ConfigDir{Root: root}
+	configPath := filepath.Join(root, DefaultConfigName)
+	if configInfo, statErr := os.Stat(configPath); statErr == nil {
+		if configInfo.IsDir() {
+			return ConfigDir{}, fmt.Errorf("default config override %q is a directory", configPath)
+		}
+		resolved.DefaultConfigPath = configPath
+	} else if !os.IsNotExist(statErr) {
+		return ConfigDir{}, fmt.Errorf("default config override %q is not accessible: %w", configPath, statErr)
+	}
+
+	presetsDir := filepath.Join(root, PresetsDirName)
+	if presetsInfo, statErr := os.Stat(presetsDir); statErr == nil {
+		if !presetsInfo.IsDir() {
+			return ConfigDir{}, fmt.Errorf("presets override %q is not a directory", presetsDir)
+		}
+		resolved.PresetsDir = presetsDir
+	} else if !os.IsNotExist(statErr) {
+		return ConfigDir{}, fmt.Errorf("presets override %q is not accessible: %w", presetsDir, statErr)
+	}
+
+	return resolved, nil
+}

--- a/pkg/assets/configdir_test.go
+++ b/pkg/assets/configdir_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package assets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveConfigDir(t *testing.T) {
+	t.Run("empty root preserves default resolution", func(t *testing.T) {
+		got, err := ResolveConfigDir("")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("resolves both supported assets", func(t *testing.T) {
+		root := t.TempDir()
+		configPath := filepath.Join(root, DefaultConfigName)
+		require.NoError(t, os.WriteFile(configPath, []byte("networkOperator: {}\n"), 0o644))
+		presetsDir := filepath.Join(root, PresetsDirName)
+		require.NoError(t, os.Mkdir(presetsDir, 0o755))
+
+		got, err := ResolveConfigDir(root)
+		require.NoError(t, err)
+		assert.Equal(t, root, got.Root)
+		assert.Equal(t, configPath, got.DefaultConfigPath)
+		assert.Equal(t, presetsDir, got.PresetsDir)
+	})
+
+	t.Run("allows a partial override", func(t *testing.T) {
+		root := t.TempDir()
+		presetsDir := filepath.Join(root, PresetsDirName)
+		require.NoError(t, os.Mkdir(presetsDir, 0o755))
+
+		got, err := ResolveConfigDir(root)
+		require.NoError(t, err)
+		assert.Empty(t, got.DefaultConfigPath)
+		assert.Equal(t, presetsDir, got.PresetsDir)
+	})
+
+	t.Run("allows an empty directory", func(t *testing.T) {
+		root := t.TempDir()
+		got, err := ResolveConfigDir(root)
+		require.NoError(t, err)
+		assert.Equal(t, root, got.Root)
+		assert.Empty(t, got.DefaultConfigPath)
+		assert.Empty(t, got.PresetsDir)
+	})
+
+	t.Run("rejects wrong path types", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(root, PresetsDirName), []byte("not a directory"), 0o644))
+
+		_, err := ResolveConfigDir(root)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "presets override")
+	})
+}

--- a/pkg/cmd/configdir.go
+++ b/pkg/cmd/configdir.go
@@ -1,0 +1,35 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"github.com/nvidia/k8s-launch-kit/pkg/assets"
+	"github.com/nvidia/k8s-launch-kit/pkg/presets"
+)
+
+func presetCatalogForConfigDir(configRoot string) (*presets.Catalog, assets.ConfigDir, error) {
+	resolved, err := assets.ResolveConfigDir(configRoot)
+	if err != nil {
+		return nil, assets.ConfigDir{}, err
+	}
+
+	catalog, err := presets.CatalogForConfigDir(resolved)
+	if err != nil {
+		return nil, assets.ConfigDir{}, err
+	}
+	return catalog, resolved, nil
+}

--- a/pkg/cmd/configdir_test.go
+++ b/pkg/cmd/configdir_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/assets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserConfigPathForConfigDir(t *testing.T) {
+	originalUserConfig := userConfig
+	originalDeploymentFiles := deploymentFiles
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		userConfig = originalUserConfig
+		deploymentFiles = originalDeploymentFiles
+		require.NoError(t, os.Chdir(originalWD))
+	})
+	userConfig = ""
+	deploymentFiles = ""
+
+	workingDir := t.TempDir()
+	require.NoError(t, os.Chdir(workingDir))
+	configRoot := t.TempDir()
+	overridePath := filepath.Join(configRoot, assets.DefaultConfigName)
+	require.NoError(t, os.WriteFile(overridePath, []byte("networkOperator: {}\n"), 0o644))
+
+	got, err := userConfigPathFor(configRoot)
+	require.NoError(t, err)
+	assert.Equal(t, overridePath, got)
+
+	clusterPath := filepath.Join(workingDir, "cluster-config.yaml")
+	require.NoError(t, os.WriteFile(clusterPath, []byte("clusterConfig: []\n"), 0o644))
+	got, err = userConfigPathFor(configRoot)
+	require.NoError(t, err)
+	assert.Equal(t, defaultUserConfigPath, got, "a discovered cluster config must outrank default overrides")
+}
+
+func TestUserConfigPathForGenerateDefersConfigDirResolution(t *testing.T) {
+	originalUserConfig := userConfig
+	originalDeploymentFiles := deploymentFiles
+	originalWD, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		userConfig = originalUserConfig
+		deploymentFiles = originalDeploymentFiles
+		require.NoError(t, os.Chdir(originalWD))
+	})
+	userConfig = ""
+	deploymentFiles = ""
+
+	workingDir := t.TempDir()
+	require.NoError(t, os.Chdir(workingDir))
+	missingConfigRoot := filepath.Join(t.TempDir(), "missing")
+
+	assert.Empty(t, userConfigPathForGenerate(missingConfigRoot),
+		"generate must leave config-dir validation and fallback to the launcher")
+
+	require.NoError(t, os.WriteFile(defaultUserConfigPath, []byte("clusterConfig: []\n"), 0o644))
+	assert.Equal(t, defaultUserConfigPath, userConfigPathForGenerate(missingConfigRoot),
+		"a discovered cluster config must still outrank config-dir defaults")
+}
+
+func TestPresetCatalogForConfigDirFallsBackPerAsset(t *testing.T) {
+	configRoot := t.TempDir()
+	catalog, resolved, err := presetCatalogForConfigDir(configRoot)
+	require.NoError(t, err)
+	assert.Equal(t, "embedded", catalog.Source())
+	assert.Empty(t, resolved.DefaultConfigPath)
+	assert.Empty(t, resolved.PresetsDir)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(configRoot, assets.DefaultConfigName),
+		[]byte("networkOperator: {}\n"),
+		0o644,
+	))
+
+	catalog, resolved, err = presetCatalogForConfigDir(configRoot)
+	require.NoError(t, err)
+	assert.Equal(t, "embedded", catalog.Source())
+	assert.Empty(t, resolved.PresetsDir)
+
+	presetsDir := filepath.Join(configRoot, assets.PresetsDirName)
+	require.NoError(t, os.Mkdir(presetsDir, 0o755))
+	catalog, resolved, err = presetCatalogForConfigDir(configRoot)
+	require.NoError(t, err)
+	assert.Equal(t, presetsDir, catalog.Source())
+	assert.Equal(t, presetsDir, resolved.PresetsDir)
+}
+
+func TestConfigDirFlagIsPersistent(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("config-dir")
+	require.NotNil(t, flag)
+	assert.Equal(t, "string", flag.Value.Type())
+}

--- a/pkg/cmd/deploy.go
+++ b/pkg/cmd/deploy.go
@@ -155,6 +155,7 @@ is used as the manifest directory.`,
 			RestConfig:        restConfig,
 		}
 		cfg, cfgPath, cfgErr := loadUserConfig(options.Options{
+			ConfigDir:                configDir,
 			NetworkOperatorNamespace: networkOperatorNamespace,
 		})
 		if cfgErr != nil {

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -72,6 +72,7 @@ NICs, and probes OFED-dependent modules.`,
 		}
 
 		opts := options.Options{
+			ConfigDir:               configDir,
 			DiscoverClusterConfig:   true,
 			DiscoverOnly:            true,
 			Kubeconfig:              resolved,

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -75,32 +75,32 @@ Optionally deploy the generated manifests with --deploy.`,
     --save-deployment-files ./output \
     --output json --yes 2>/dev/null
 
-  # Generate from a known server preset (no cluster discovery required)
-  l8k generate --user-config cluster-config.yaml \
-    --for ThinkSystem-SR680a-V3 \
+  # Generate from a known server preset using the embedded default config
+  l8k generate \
+    --for ThinkSystem-SR680a-V3-H200 \
     --node-selector "feature.node.kubernetes.io/pci-15b3.present=true" \
     --fabric ethernet --deployment-type sriov \
     --save-deployment-files ./output`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Resolve user-config via the shared lookup chain (deploy +
-		// validate use the same one). When --user-config wasn't passed,
-		// userConfigPath() will probe ./cluster-config.yaml,
-		// ./l8k-config.yaml, and the installed share-dir fallback in
-		// turn — none of those resolving is a hard error here since
-		// `l8k generate` needs a config to render against.
+		// Probe explicit/discovered cluster configs here, but leave an
+		// explicit --config-dir for Launcher.Run to resolve exactly once.
+		// Without --config-dir, retain the legacy local/install-prefix
+		// default lookup.
 		if userConfig == "" {
-			if resolved := userConfigPath(); resolved != "" {
+			resolved := userConfigPathForGenerate(configDir)
+			if resolved != "" {
 				userConfig = resolved
-			} else {
+			} else if forPreset == "" && configDir == "" {
 				exitWithError(apperrors.NewValidationError(
 					"no configuration file found",
-					fmt.Errorf("checked ./cluster-config.yaml, ./l8k-config.yaml, and installed paths"),
-					"Run 'l8k discover' first, or pass --user-config <path>",
+					fmt.Errorf("checked ./cluster-config.yaml, --config-dir, ./l8k-config.yaml, and installed paths"),
+					"Run 'l8k discover' first, pass --user-config <path>, or use --for with the embedded default",
 				), outputFormat)
 			}
 		}
 
 		opts := options.Options{
+			ConfigDir:     configDir,
 			UserConfig:     userConfig,
 			Fabric:         fabric,
 			DeploymentType: deploymentType,
@@ -177,7 +177,7 @@ func init() {
 	rootCmd.AddCommand(generateCmd)
 
 	// Config
-	generateCmd.Flags().StringVar(&userConfig, "user-config", "", "Cluster config file (auto-detected from ./cluster-config.yaml or installed path)")
+	generateCmd.Flags().StringVar(&userConfig, "user-config", "", "Cluster config file (otherwise auto-detected from ./cluster-config.yaml; --for can use embedded defaults)")
 
 	// Profile selection
 	generateCmd.Flags().StringVar(&fabric, "fabric", "", "Fabric type: ethernet, infiniband")

--- a/pkg/cmd/preset.go
+++ b/pkg/cmd/preset.go
@@ -19,9 +19,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
+	"github.com/nvidia/k8s-launch-kit/pkg/assets"
 	"github.com/nvidia/k8s-launch-kit/pkg/presets"
 )
 
@@ -44,25 +46,26 @@ matches and PCI topology validates.`,
 
 var presetListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List available local presets",
-	Long:  "List all predefined topology presets available in the local presets directory.",
+	Short: "List available presets",
+	Long:  "List topology presets from --config-dir, the legacy local directory, or the embedded catalog.",
 	Example: `  l8k preset list
-  l8k preset list --output json`,
+	  l8k preset list --config-dir /etc/l8k
+	  l8k preset list --output json`,
 	Run: func(cmd *cobra.Command, args []string) {
-		summaries, skipped, err := presets.ListPresetSummaries()
+		catalog, _, err := presetCatalogForConfigDir(configDir)
 		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
 			return
 		}
-
-		dir, _ := presets.GetPresetsDir()
-		if dir == "" {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No presets directory found.")
+		summaries, skipped, err := catalog.ListPresetSummaries()
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
 			return
 		}
+		source := catalog.Source()
 
 		if len(summaries) == 0 && len(skipped) == 0 {
-			fmt.Fprintf(cmd.OutOrStdout(), "No presets found in %s\n", dir)
+			fmt.Fprintf(cmd.OutOrStdout(), "No presets found in %s\n", source)
 			return
 		}
 
@@ -77,13 +80,13 @@ var presetListCmd = &cobra.Command{
 				}
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Available presets (%s):\n", dir)
+			fmt.Fprintf(cmd.OutOrStdout(), "Available presets (%s):\n", source)
 			fmt.Fprintf(cmd.OutOrStdout(), "  %-*s  %-*s  %s\n", nameW, "NAME", machineW, "MACHINETYPE", "GPUTYPE")
 			for _, s := range summaries {
 				fmt.Fprintf(cmd.OutOrStdout(), "  %-*s  %-*s  %s\n", nameW, s.DirName, machineW, s.MachineType, s.GPUType)
 			}
 		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "No valid presets found in %s\n", dir)
+			fmt.Fprintf(cmd.OutOrStdout(), "No valid presets found in %s\n", source)
 		}
 
 		if len(skipped) > 0 {
@@ -103,13 +106,25 @@ var presetUpdateCmd = &cobra.Command{
 Uses the GitHub API to list and fetch preset files. Set GITHUB_TOKEN
 environment variable for authenticated requests (avoids rate limits).`,
 	Example: `  l8k preset update
-  l8k preset update --repo nvidia/k8s-launch-kit --branch main
-  l8k preset update --dir /usr/local/share/l8k/presets`,
+	  l8k preset update --repo nvidia/k8s-launch-kit --branch main
+	  l8k preset update --config-dir /etc/l8k
+	  l8k preset update --dir /usr/local/share/l8k/presets`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		destination := presetDir
+		if destination == "" && configDir != "" {
+			resolved, err := assets.ResolveConfigDir(configDir)
+			if err != nil {
+				return fmt.Errorf("invalid --config-dir: %w", err)
+			}
+			destination = resolved.PresetsDir
+			if destination == "" {
+				destination = filepath.Join(resolved.Root, assets.PresetsDirName)
+			}
+		}
 		opts := presets.DownloadOptions{
 			Repo:   presetRepo,
 			Branch: presetBranch,
-			Dir:    presetDir,
+			Dir:    destination,
 		}
 
 		downloaded, err := presets.DownloadPresets(context.Background(), opts)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -36,13 +36,13 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/releases"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
-	"github.com/nvidia/k8s-launch-kit/pkg/presets"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 )
 
 var (
 	logLevel              string
 	logFile               string
+	configDir             string
 	fabric                string
 	deploymentType        string
 	multirail             bool
@@ -98,14 +98,11 @@ func resolveNetworkNamespaces(networkNamespaces []string, podNamespace string) [
 	return networkNamespaces
 }
 
-// forFlagHelp builds the help string for `--for`. Computed at init() time so
-// users see the live list of available preset directories alongside `--help`.
+// forFlagHelp is intentionally static. --config-dir is parsed after command
+// initialization, so enumerating presets here would always show the default
+// source rather than the source selected by the user.
 func forFlagHelp() string {
-	names, _ := presets.ListPresets()
-	if len(names) == 0 {
-		return "Generate for a known server preset (replaces clusterConfig from the preset). Requires --node-selector. No presets installed; run 'l8k preset update' to fetch them."
-	}
-	return fmt.Sprintf("Generate for a known server preset (replaces clusterConfig from the preset). Requires --node-selector. Available: %s", strings.Join(names, ", "))
+	return "Generate for a known server preset (replaces clusterConfig from the preset). Requires --node-selector. Run 'l8k preset list' with the same --config-dir to list available names."
 }
 
 // rootCmd represents the base command when called without any subcommands
@@ -167,6 +164,7 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
 		opts := options.Options{
 			LogLevel:              logLevel,
 			LogFile:               logFile,
+			ConfigDir:             configDir,
 			UserConfig:            userConfig,
 			DiscoverClusterConfig: discoverClusterConfig,
 			Fabric:                fabric,
@@ -281,6 +279,7 @@ func init() {
 	rootCmd.Flags().DurationVar(&deployTimeoutRoot, "deploy-timeout", 0, "Maximum end-to-end wall-clock budget for the deploy phase (e.g. 45m, 2h). 0 (the default) means no deadline; the deploy polls until every manifest reaches a terminal state.")
 
 	// Output control flags
+	rootCmd.PersistentFlags().StringVar(&configDir, "config-dir", "", "Directory containing optional l8k-config.yaml and presets/ overrides")
 	rootCmd.PersistentFlags().StringVar(&outputFormat, "output", "text", "Output format: text (default, human-readable) or json (structured, for automation and AI agents)")
 	rootCmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "Auto-confirm all prompts without interactive input")
 	rootCmd.Flags().BoolVarP(&quietFlag, "quiet", "q", false, "Suppress informational output (errors still shown)")
@@ -295,6 +294,7 @@ func init() {
 	// into the rendered help. installGroupedUsage propagates the template
 	// to every subcommand via cobra's parent lookup.
 	setFlagGroup(rootCmd, "enabled-plugins", GroupCommon)
+	setFlagGroup(rootCmd, "config-dir", GroupCommon)
 	setFlagGroup(rootCmd, "user-config", GroupCommon)
 	setFlagGroup(rootCmd, "kubeconfig", GroupCommon)
 	setFlagGroup(rootCmd, "network-operator-namespace", GroupCommon)
@@ -367,9 +367,9 @@ func validateConfig(options *options.Options) error {
 		return fmt.Errorf("no plugins enabled, use --enabled-plugins to enable plugins")
 	}
 
-	// At least one of user-config or discover-cluster-config should be provided
-	if options.UserConfig == "" && !options.DiscoverClusterConfig {
-		return fmt.Errorf("either --user-config or --discover-cluster-config must be provided")
+	// Require either a config source, a preset-generated config, or discovery.
+	if options.UserConfig == "" && options.ConfigDir == "" && options.ForPreset == "" && !options.DiscoverClusterConfig {
+		return fmt.Errorf("one of --user-config, --config-dir, --for, or --discover-cluster-config must be provided")
 	}
 
 	// --for synthesizes clusterConfig from a static preset, so it cannot be

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -100,6 +100,10 @@ var schemaCmd = &cobra.Command{
 				"5": "partial_success",
 			},
 			Flags: map[string]flagSchema{
+				"--config-dir": {
+					Type:        "string",
+					Description: "Directory containing optional l8k-config.yaml and presets/ overrides",
+				},
 				"--kubeconfig": {
 					Type:        "string",
 					Description: "Path to kubeconfig file for cluster access",

--- a/pkg/cmd/userconfig.go
+++ b/pkg/cmd/userconfig.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/app"
+	"github.com/nvidia/k8s-launch-kit/pkg/assets"
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
@@ -43,36 +44,62 @@ const defaultUserConfigPath = "./cluster-config.yaml"
 //     subcommand (deploymentFiles != "").
 //  4. <deployment-files>/cluster-config.yaml — fallback for users
 //     who keep the config inside the deployment dir.
-//  5. ./l8k-config.yaml — the generate-path's legacy default, used
-//     when neither `cluster-config.yaml` nor a deployment-files-anchored
-//     candidate is present.
-//  6. <share-dir>/l8k-config.yaml — the installed system-wide config
-//     (e.g. /usr/local/share/l8k/l8k-config.yaml), so that a `l8k`
-//     invocation with no local config can still pick up the operator
-//     defaults shipped with the binary.
+//  5. <config-dir>/l8k-config.yaml — the explicit default-config override,
+//     when --config-dir was supplied and the file exists.
+//  6. ./l8k-config.yaml — the generate-path's legacy default, used only when
+//     --config-dir was not supplied.
+//  7. <share-dir>/l8k-config.yaml — the legacy installed system-wide config
+//     (e.g. /usr/local/share/l8k/l8k-config.yaml), also used only when
+//     --config-dir was not supplied.
 //
 // Callers decide how to react to a missing config: validate softens its
 // per-check verdicts to "skipped"; deploy and generate treat it as an
 // error (deploy because Phase 0 + preflight would otherwise skip with no
-// useful signal; generate because there's nothing to render against).
-func userConfigPath() string {
-	candidates := []string{}
-	if userConfig != "" {
-		candidates = append(candidates, userConfig)
+// useful signal; generate unless --for can synthesize clusterConfig from a
+// preset and use the embedded default for the remaining fields).
+func userConfigPathFor(configRoot string) (string, error) {
+	if path := userConfigPathBeforeDefaults(); path != "" {
+		return path, nil
 	}
-	candidates = append(candidates, defaultUserConfigPath)
+	return defaultConfigPathFor(configRoot)
+}
+
+func userConfigPathBeforeDefaults() string {
+	if userConfig != "" {
+		return userConfig
+	}
+	candidates := []string{defaultUserConfigPath}
 	if deploymentFiles != "" {
 		candidates = append(candidates,
 			filepath.Join(deploymentFiles, "..", "cluster-config.yaml"),
 			filepath.Join(deploymentFiles, "cluster-config.yaml"),
 		)
 	}
-	// Generate-path legacy fallbacks: ./l8k-config.yaml then the
-	// installed system-wide config under <share-dir>.
-	candidates = append(candidates,
-		"l8k-config.yaml",
-		filepath.Join(app.ResolveShareDir(), "l8k-config.yaml"),
-	)
+	return firstExistingConfigPath(candidates)
+}
+
+func defaultConfigPathFor(configRoot string) (string, error) {
+	var candidates []string
+	if configRoot != "" {
+		resolved, err := assets.ResolveConfigDir(configRoot)
+		if err != nil {
+			return "", err
+		}
+		if resolved.DefaultConfigPath != "" {
+			candidates = append(candidates, resolved.DefaultConfigPath)
+		}
+	} else {
+		// Generate-path legacy fallbacks: ./l8k-config.yaml then the
+		// installed system-wide config under <share-dir>.
+		candidates = append(candidates,
+			"l8k-config.yaml",
+			filepath.Join(app.ResolveShareDir(), "l8k-config.yaml"),
+		)
+	}
+	return firstExistingConfigPath(candidates), nil
+}
+
+func firstExistingConfigPath(candidates []string) string {
 	for _, p := range candidates {
 		if p == "" {
 			continue
@@ -82,6 +109,27 @@ func userConfigPath() string {
 		}
 	}
 	return ""
+}
+
+// userConfigPathForGenerate resolves only explicit/discovered cluster config
+// paths when --config-dir is set. The launcher owns config-dir resolution so
+// the filesystem layout is statted once and used consistently for both the
+// default config and preset catalog. Without --config-dir, retain the legacy
+// local/install-prefix default lookup.
+func userConfigPathForGenerate(configRoot string) string {
+	if path := userConfigPathBeforeDefaults(); path != "" {
+		return path
+	}
+	if configRoot != "" {
+		return ""
+	}
+	path, _ := defaultConfigPathFor("")
+	return path
+}
+
+func userConfigPath() string {
+	path, _ := userConfigPathFor(configDir)
+	return path
 }
 
 // loadUserConfig reads the resolved user-config file and applies the
@@ -96,7 +144,10 @@ func userConfigPath() string {
 // caller should bail since downstream code would be making decisions
 // from incomplete state.
 func loadUserConfig(opts options.Options) (*config.LaunchKitConfig, string, error) {
-	path := userConfigPath()
+	path, err := userConfigPathFor(opts.ConfigDir)
+	if err != nil {
+		return nil, "", err
+	}
 	if path == "" {
 		return nil, "", nil
 	}

--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -162,6 +162,16 @@ connectivity-matrix failure.`,
 			exitWithError(err, outputFormat)
 		}
 
+		presetCatalog, _, catalogErr := presetCatalogForConfigDir(configDir)
+		if catalogErr != nil {
+			exitWithReport(apperrors.NewValidationError(
+				"invalid --config-dir",
+				catalogErr,
+				"Provide an accessible directory; when present, l8k-config.yaml must be a file and presets/ a directory",
+			))
+		}
+		log.Log.V(1).Info("Using topology preset catalog", "source", presetCatalog.Source())
+
 		resolved, err := resolveKubeconfig(kubeconfig)
 		if err != nil {
 			exitWithReport(apperrors.NewValidationError(
@@ -189,6 +199,7 @@ connectivity-matrix failure.`,
 		// can still target the right Helm release / live CRs.
 		selectedRelease := ""
 		cfg, cfgPath, cfgErr := loadUserConfig(options.Options{
+			ConfigDir:                configDir,
 			NetworkOperatorNamespace: networkOperatorNamespace,
 		})
 		if cfgErr != nil {
@@ -219,7 +230,7 @@ connectivity-matrix failure.`,
 			// informational — a deviation doesn't fail
 			// validate (matches the historical behaviour of
 			// presetDeviation), so the exit code is unchanged.
-			presetResults = presetmatch.MatchAll(cfg)
+			presetResults = presetmatch.MatchAllWithCatalog(cfg, presetCatalog)
 		}
 
 		log.Log.Info("Validating deployment",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"bytes"
 	_ "embed"
 	"encoding/binary"
 	"fmt"
@@ -37,6 +38,13 @@ import (
 //
 //go:embed default-config.yaml
 var defaultConfigYAML []byte
+
+// DefaultConfigYAML returns a copy of the embedded default configuration
+// source. Discovery uses it to preserve field comments when no filesystem
+// override is selected. The copy is safe for callers to mutate.
+func DefaultConfigYAML() []byte {
+	return bytes.Clone(defaultConfigYAML)
+}
 
 // DefaultLaunchKitConfig returns a freshly-parsed copy of the binary's
 // embedded default configuration. Returned value is safe to mutate; each call

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -153,6 +153,16 @@ func TestDefaultLaunchKitConfig_FreshCopy(t *testing.T) {
 		"second DefaultLaunchKitConfig() saw mutation made to the first — copies are not independent")
 }
 
+func TestDefaultConfigYAMLReturnsFreshCopy(t *testing.T) {
+	a := DefaultConfigYAML()
+	require.NotEmpty(t, a)
+	a[0] = 'X'
+
+	b := DefaultConfigYAML()
+	require.NotEmpty(t, b)
+	assert.NotEqual(t, byte('X'), b[0])
+}
+
 func TestValidateClusterConfig(t *testing.T) {
 	t.Run("validate config with missing network operator repository", func(t *testing.T) {
 		config := &LaunchKitConfig{
@@ -1082,4 +1092,3 @@ func TestValidateNvIpam(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
-

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -127,9 +127,9 @@ profile:
   multirail: false
   spectrumX: # Spectrum-X configuration (set enable: true or use --spectrum-x CLI flag)
     enable: false # CLI parameter (overrides this value): --spectrum-x
-    spcxVersion: "RA2.2" # CLI parameter (overrides this value): --spcx-version
-    multiplaneMode: swplb # CLI parameter (overrides this value): --multiplane-mode (swplb, hwplb, uniplane)
-    numberOfPlanes: 4 # CLI parameter (overrides this value): --number-of-planes, also used as pfsPerNic
+    # spcxVersion: "RA2.2" # CLI parameter (overrides this value): --spectrum-x
+    # multiplaneMode: swplb # CLI parameter (overrides this value): --multiplane-mode (swplb, hwplb, uniplane)
+    # numberOfPlanes: 4 # CLI parameter (overrides this value): --number-of-planes, also used as pfsPerNic
   ai: false
 
 clusterConfig:

--- a/pkg/networkoperatorplugin/discovery/discover.go
+++ b/pkg/networkoperatorplugin/discovery/discover.go
@@ -94,6 +94,11 @@ func isNorthSouthDevice(partNumber string) bool {
 // functional DiscoverOptions.
 func DiscoverClusterConfig(ctx context.Context, c client.Client, restConfig *rest.Config, cfg *config.LaunchKitConfig, opts Options) error {
 	uiOutput := ui.FromContext(ctx)
+	presetCatalog, err := resolvePresetCatalog(opts)
+	if err != nil {
+		return fmt.Errorf("resolve topology presets: %w", err)
+	}
+	log.Log.V(1).Info("Using topology preset catalog", "source", presetCatalog.Source())
 
 	if cfg.NetworkOperator == nil {
 		return fmt.Errorf("networkOperator section is required in config for discovery")
@@ -256,7 +261,7 @@ func DiscoverClusterConfig(ctx context.Context, c client.Client, restConfig *res
 			// applies the preset onto the group so rail/NUMA topology
 			// fields populate. Lookup is exact-match on (machineType,
 			// gpuType) — both must be known for a preset to apply.
-			matchResult := presetmatch.MatchGroup(*group)
+			matchResult := presetmatch.MatchGroupWithCatalog(*group, presetCatalog)
 			log.Log.V(1).Info("Preset match",
 				"group", group.Identifier,
 				"machineType", group.MachineType,
@@ -285,23 +290,16 @@ func DiscoverClusterConfig(ctx context.Context, c client.Client, restConfig *res
 						group.MachineType, group.GPUType, len(matchResult.Deviations))
 					break
 				}
-				// Exact topology match (or only benign deviations) — load
-				// the Topology again and enrich rail/NUMA/GPU fields.
-				// (MatchGroup intentionally doesn't mutate.)
-				preset, err := presets.LoadPreset(group.MachineType, group.GPUType)
+				// Exact topology match (or only benign deviations) — enrich
+				// rail/NUMA/GPU fields from the same catalog entry MatchGroup
+				// validated. Reusing the returned pointer avoids resolving a
+				// different source between validation and application.
 				switch {
-				case err != nil:
-					// MatchGroup already loaded this preset to produce the
-					// match, so a reload failure here is unexpected — surface
-					// it rather than silently falling back to live discovery.
+				case matchResult.Preset == nil:
 					uiOutput.Warning(
-						"Preset for %s/%s matched but could not be re-loaded to apply (%v). Using live discovery results.",
-						group.MachineType, group.GPUType, err)
-				case preset == nil:
-					uiOutput.Warning(
-						"Preset for %s/%s matched but was not found on re-load. Using live discovery results.",
+						"Preset for %s/%s matched but no topology was returned. Using live discovery results.",
 						group.MachineType, group.GPUType)
-				case presets.ApplyPreset(preset, group):
+				case presets.ApplyPreset(matchResult.Preset, group):
 					uiOutput.Info("Applied preset configuration for %s", group.MachineType)
 				default:
 					// Loaded fine but the all-or-nothing apply declined (PCI
@@ -373,6 +371,16 @@ func DiscoverClusterConfig(ctx context.Context, c client.Client, restConfig *res
 		"machineLabelledGroups", labelled)
 
 	return nil
+}
+
+func resolvePresetCatalog(opts Options) (*presets.Catalog, error) {
+	if opts.PresetCatalog != nil {
+		return opts.PresetCatalog, nil
+	}
+	if opts.PresetsDir != "" {
+		return presets.NewCatalogFromDir(opts.PresetsDir)
+	}
+	return presets.DefaultCatalog()
 }
 
 // applyMachineLabelToGroups walks each group and writes two l8k-specific
@@ -1737,4 +1745,3 @@ func execInPod(ctx context.Context, restConfig *rest.Config,
 	namespace, podName, containerName string, command []string) (string, error) {
 	return kubeclient.ExecStdoutInPod(ctx, restConfig, namespace, podName, containerName, command)
 }
-

--- a/pkg/networkoperatorplugin/discovery/library.go
+++ b/pkg/networkoperatorplugin/discovery/library.go
@@ -37,6 +37,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/releases"
+	"github.com/nvidia/k8s-launch-kit/pkg/presets"
 	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -87,6 +88,17 @@ type Options struct {
 	// already in cfg" — the default config ships with the currently
 	// recommended line baked in.
 	Release string
+
+	// PresetsDir selects an authoritative on-disk topology-preset catalog.
+	// Empty preserves the historical implicit lookup chain. Library callers
+	// normally set this through WithPresetsDir.
+	PresetsDir string
+
+	// PresetCatalog is an already-resolved catalog. It is primarily used by
+	// the CLI adapter so a partial --config-dir override can explicitly select
+	// the embedded catalog instead of falling through to legacy install paths.
+	// When set, it takes precedence over PresetsDir.
+	PresetCatalog *presets.Catalog
 }
 
 // DiscoverOption configures a Discover call. Functional-options seam for
@@ -151,6 +163,13 @@ func WithLogger(logger logr.Logger) DiscoverOption {
 // catalog enumeration / validation outside Discover.
 func WithRelease(release string) DiscoverOption {
 	return func(o *Options) { o.Release = release }
+}
+
+// WithPresetsDir replaces the embedded/default preset catalog with the
+// topology presets rooted at dir. The directory is authoritative: presets
+// missing from it are not filled from the embedded catalog.
+func WithPresetsDir(dir string) DiscoverOption {
+	return func(o *Options) { o.PresetsDir = dir }
 }
 
 // Discover walks the cluster and populates cfg with the discovered
@@ -288,4 +307,3 @@ func applyRelease(cfg *config.LaunchKitConfig, release string) error {
 	cfg.DOCADriver.Version = rel.DOCADriver.Version
 	return nil
 }
-

--- a/pkg/networkoperatorplugin/discovery/library_test.go
+++ b/pkg/networkoperatorplugin/discovery/library_test.go
@@ -18,6 +18,7 @@ package discovery
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -103,6 +104,17 @@ func TestDiscover_NilCfgRejected(t *testing.T) {
 	_, err := Discover(context.Background(), c, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cfg must not be nil")
+}
+
+func TestDiscover_WithPresetsDirRejectsMissingDirectoryBeforeClusterChanges(t *testing.T) {
+	cfg, err := config.DefaultLaunchKitConfig()
+	require.NoError(t, err)
+	c := fake.NewClientBuilder().Build()
+
+	_, err = Discover(context.Background(), c, nil, cfg,
+		WithPresetsDir(filepath.Join(t.TempDir(), "missing")))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolve topology presets")
 }
 
 // TestDiscover_PreservesUserFields checks that Discover hands the

--- a/pkg/networkoperatorplugin/networkoperator.go
+++ b/pkg/networkoperatorplugin/networkoperator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/releases"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
 	"github.com/nvidia/k8s-launch-kit/pkg/plugin"
+	"github.com/nvidia/k8s-launch-kit/pkg/presets"
 	"github.com/nvidia/k8s-launch-kit/pkg/profiles"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,6 +60,10 @@ type NetworkOperatorPlugin struct {
 	// master PF while genuinely dual-port NICs keep a rail per port. False
 	// restores the legacy one-rail-per-PF behaviour (handy on dev setups).
 	CollapseNicRails bool
+
+	// PresetCatalog is the topology-preset source selected for this launcher
+	// invocation. Nil preserves the historical implicit disk/embedded lookup.
+	PresetCatalog *presets.Catalog
 
 	// NetworkOperator is the resolved NetworkOperator config used by
 	// DeployProfile to drive the helm install in Phase 0. Populated by
@@ -293,6 +298,7 @@ func (p *NetworkOperatorPlugin) DiscoverClusterConfig(ctx context.Context, c cli
 		NodeSelector:     p.NodeSelector,
 		KeepNamespace:    p.KeepNamespace,
 		CollapseNicRails: p.CollapseNicRails,
+		PresetCatalog:    p.PresetCatalog,
 	})
 }
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -25,6 +25,9 @@ type Options struct {
 	LogFile  string // Path to log file (optional)
 
 	// Phase 1: Cluster Discovery
+	// ConfigDir is an optional root containing l8k-config.yaml and/or presets/.
+	// Explicit --user-config still has higher precedence for the config file.
+	ConfigDir               string
 	UserConfig              string // Path to user-provided config (skips discovery)
 	DiscoverClusterConfig   bool   // Whether to discover cluster config
 	// DiscoverOnly skips Phase 2 (manifest generation) entirely. Set by

--- a/pkg/presetmatch/presetmatch.go
+++ b/pkg/presetmatch/presetmatch.go
@@ -97,16 +97,30 @@ type Result struct {
 	Preset *presets.Topology
 }
 
-// MatchGroup runs the preset lookup + comparison for one group.
-// Does not mutate the group; callers that also want to enrich
-// rail/NUMA topology fields invoke presets.ApplyPreset separately.
+// MatchGroup runs the preset lookup + comparison for one group using the
+// historical default catalog resolution. Call MatchGroupWithCatalog when the
+// preset source must be selected explicitly.
+func MatchGroup(group config.ClusterConfig) Result {
+	if group.MachineType == "" || group.GPUType == "" {
+		return MatchGroupWithCatalog(group, nil)
+	}
+	catalog, err := presets.DefaultCatalog()
+	if err != nil {
+		return lookupFailure(group, err)
+	}
+	return MatchGroupWithCatalog(group, catalog)
+}
+
+// MatchGroupWithCatalog runs the preset lookup + comparison for one group.
+// It does not mutate the group; callers that also want to enrich rail/NUMA
+// topology fields invoke presets.ApplyPreset separately.
 //
 // Lookup is exact-match on (machineType, gpuType). Empty fields
 // short-circuit to StatusSkipped — without those values the preset
 // catalog can't be queried, and we don't fall back to fuzzy matching
 // because picking the wrong preset would silently rewrite the
 // deployment to target the wrong hardware shape.
-func MatchGroup(group config.ClusterConfig) Result {
+func MatchGroupWithCatalog(group config.ClusterConfig, catalog *presets.Catalog) Result {
 	res := Result{
 		Group:       group.Identifier,
 		MachineType: group.MachineType,
@@ -124,7 +138,10 @@ func MatchGroup(group config.ClusterConfig) Result {
 		}
 		return res
 	}
-	preset, err := presets.LoadPreset(group.MachineType, group.GPUType)
+	if catalog == nil {
+		return lookupFailure(group, fmt.Errorf("preset catalog must not be nil"))
+	}
+	preset, err := catalog.LoadPreset(group.MachineType, group.GPUType)
 	if err != nil {
 		res.Status = StatusNotFound
 		res.Reason = fmt.Sprintf("preset lookup failed: %v", err)
@@ -132,7 +149,7 @@ func MatchGroup(group config.ClusterConfig) Result {
 	}
 	if preset == nil {
 		res.Status = StatusNotFound
-		res.Reason = fmt.Sprintf("no preset matches (%s, %s) in the local presets directory", group.MachineType, group.GPUType)
+		res.Reason = fmt.Sprintf("no preset matches (%s, %s) in catalog %s", group.MachineType, group.GPUType, catalog.Source())
 		return res
 	}
 	deviations := presets.ValidatePreset(preset, group.PFs)
@@ -149,15 +166,43 @@ func MatchGroup(group config.ClusterConfig) Result {
 	return res
 }
 
+func lookupFailure(group config.ClusterConfig, err error) Result {
+	return Result{
+		Group:       group.Identifier,
+		MachineType: group.MachineType,
+		GPUType:     group.GPUType,
+		Status:      StatusNotFound,
+		Reason:      fmt.Sprintf("preset lookup failed: %v", err),
+	}
+}
+
 // MatchAll runs MatchGroup over every entry in cfg.ClusterConfig and
 // returns the results in the same order. cfg is never mutated.
 func MatchAll(cfg *config.LaunchKitConfig) []Result {
+	catalog, err := presets.DefaultCatalog()
+	if err != nil {
+		if cfg == nil {
+			return nil
+		}
+		out := make([]Result, 0, len(cfg.ClusterConfig))
+		for _, group := range cfg.ClusterConfig {
+			out = append(out, lookupFailure(group, err))
+		}
+		return out
+	}
+	return MatchAllWithCatalog(cfg, catalog)
+}
+
+// MatchAllWithCatalog runs MatchGroupWithCatalog over every entry in
+// cfg.ClusterConfig and returns the results in the same order. cfg is never
+// mutated.
+func MatchAllWithCatalog(cfg *config.LaunchKitConfig, catalog *presets.Catalog) []Result {
 	if cfg == nil {
 		return nil
 	}
 	out := make([]Result, 0, len(cfg.ClusterConfig))
 	for _, g := range cfg.ClusterConfig {
-		out = append(out, MatchGroup(g))
+		out = append(out, MatchGroupWithCatalog(g, catalog))
 	}
 	return out
 }

--- a/pkg/presetmatch/presetmatch_test.go
+++ b/pkg/presetmatch/presetmatch_test.go
@@ -17,10 +17,14 @@
 package presetmatch
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/nvidia/k8s-launch-kit/pkg/presets"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMatchGroup_SkippedWhenMachineOrGPUMissing(t *testing.T) {
@@ -74,6 +78,36 @@ func TestMatchAll(t *testing.T) {
 	assert.Equal(t, "b", results[1].Group)
 	// StatusNotFound when no preset catalog; never panics either way.
 	assert.NotEqual(t, StatusSkipped, results[1].Status)
+}
+
+func TestMatchAllWithCatalogUsesSelectedSource(t *testing.T) {
+	root := t.TempDir()
+	presetDir := filepath.Join(root, "machine-a-gpu-model-x")
+	require.NoError(t, os.MkdirAll(presetDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(presetDir, "topology.yaml"), []byte(`machineType: machine-a
+gpuType: gpu-model-x
+manufacturer: vendor-a
+pfs:
+  - deviceID: "1021"
+    pciAddress: "0000:01:00.0"
+`), 0o644))
+
+	catalog, err := presets.NewCatalogFromDir(root)
+	require.NoError(t, err)
+	cfg := &config.LaunchKitConfig{ClusterConfig: []config.ClusterConfig{{
+		Identifier:  "group-a",
+		MachineType: "machine-a",
+		GPUType:     "gpu-model-x",
+		PFs: []config.PFConfig{{
+			DeviceID:   "1021",
+			PciAddress: "0000:01:00.0",
+		}},
+	}}}
+
+	results := MatchAllWithCatalog(cfg, catalog)
+	require.Len(t, results, 1)
+	assert.Equal(t, StatusMatch, results[0].Status)
+	assert.Equal(t, "vendor-a", results[0].Manufacturer)
 }
 
 func TestAnyMatched(t *testing.T) {

--- a/pkg/presets/catalog_test.go
+++ b/pkg/presets/catalog_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package presets
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/assets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeCatalogPreset(t *testing.T, root, name, manufacturer string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	body := "machineType: machine-a\n" +
+		"gpuType: gpu-model-x\n" +
+		"manufacturer: " + manufacturer + "\n" +
+		"pfs: []\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "topology.yaml"), []byte(body), 0o644))
+}
+
+func TestEmbeddedCatalog(t *testing.T) {
+	catalog, err := EmbeddedCatalog()
+	require.NoError(t, err)
+	assert.Equal(t, "embedded", catalog.Source())
+
+	topology, err := catalog.LoadPreset("PowerEdge-XE9680", "NVIDIA-H200")
+	require.NoError(t, err)
+	require.NotNil(t, topology)
+	assert.Equal(t, "PowerEdge-XE9680", topology.MachineType)
+}
+
+func TestCatalogForConfigDir(t *testing.T) {
+	t.Run("no explicit root preserves default lookup", func(t *testing.T) {
+		expected, err := DefaultCatalog()
+		require.NoError(t, err)
+
+		catalog, err := CatalogForConfigDir(assets.ConfigDir{})
+		require.NoError(t, err)
+		assert.Equal(t, expected.Source(), catalog.Source())
+	})
+
+	t.Run("explicit root without presets uses embedded", func(t *testing.T) {
+		catalog, err := CatalogForConfigDir(assets.ConfigDir{Root: t.TempDir()})
+		require.NoError(t, err)
+		assert.Equal(t, "embedded", catalog.Source())
+	})
+
+	t.Run("explicit presets directory is authoritative", func(t *testing.T) {
+		root := t.TempDir()
+		presetsDir := filepath.Join(root, assets.PresetsDirName)
+		require.NoError(t, os.Mkdir(presetsDir, 0o755))
+
+		catalog, err := CatalogForConfigDir(assets.ConfigDir{
+			Root:       root,
+			PresetsDir: presetsDir,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, presetsDir, catalog.Source())
+	})
+}
+
+func TestDiskCatalogIsAuthoritative(t *testing.T) {
+	root := t.TempDir()
+	writeCatalogPreset(t, root, "custom", "vendor-a")
+
+	catalog, err := NewCatalogFromDir(root)
+	require.NoError(t, err)
+	assert.Equal(t, root, catalog.Source())
+
+	names, err := catalog.ListPresets()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"custom"}, names)
+
+	topology, err := catalog.LoadPreset("machine-a", "gpu-model-x")
+	require.NoError(t, err)
+	require.NotNil(t, topology)
+	assert.Equal(t, "vendor-a", topology.Manufacturer)
+
+	embeddedOnly, err := catalog.LoadPreset("PowerEdge-XE9680", "NVIDIA-H200")
+	require.NoError(t, err)
+	assert.Nil(t, embeddedOnly, "a disk catalog must not merge missing entries from embedded presets")
+}
+
+func TestCatalogsAreIndependent(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	writeCatalogPreset(t, rootA, "custom", "vendor-a")
+	writeCatalogPreset(t, rootB, "custom", "vendor-b")
+
+	catalogA, err := NewCatalogFromDir(rootA)
+	require.NoError(t, err)
+	catalogB, err := NewCatalogFromDir(rootB)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	manufacturers := make(chan string, 2)
+	for _, catalog := range []*Catalog{catalogA, catalogB} {
+		wg.Add(1)
+		go func(c *Catalog) {
+			defer wg.Done()
+			topology, loadErr := c.LoadPreset("machine-a", "gpu-model-x")
+			if loadErr == nil && topology != nil {
+				manufacturers <- topology.Manufacturer
+			}
+		}(catalog)
+	}
+	wg.Wait()
+	close(manufacturers)
+
+	got := map[string]bool{}
+	for manufacturer := range manufacturers {
+		got[manufacturer] = true
+	}
+	assert.Equal(t, map[string]bool{"vendor-a": true, "vendor-b": true}, got)
+}

--- a/pkg/presets/presets.go
+++ b/pkg/presets/presets.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/nvidia/k8s-launch-kit/pkg/assets"
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"gopkg.in/yaml.v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -98,12 +99,16 @@ func GetPresetsDir() (string, error) {
 	if exe, err := os.Executable(); err == nil {
 		candidates = append(candidates, filepath.Join(filepath.Dir(exe), "..", "share", "l8k", "presets"))
 	}
+	return findPresetsDir(candidates), nil
+}
+
+func findPresetsDir(candidates []string) string {
 	for _, p := range candidates {
 		if info, err := os.Stat(p); err == nil && info.IsDir() {
-			return p, nil
+			return p
 		}
 	}
-	return "", nil
+	return ""
 }
 
 // presetsSource describes the FS-rooted preset tree loadAllPresets walks. It
@@ -121,6 +126,75 @@ type presetsSource struct {
 	embedded bool
 }
 
+// Catalog is an immutable topology-preset source. A catalog is bound to one
+// filesystem root (or the embedded preset tree), so independent library calls
+// can use different overrides without mutating process-global state.
+type Catalog struct {
+	source *presetsSource
+}
+
+// NewCatalogFromDir returns a catalog rooted at an explicit on-disk presets
+// directory. The directory is authoritative: entries missing from it are not
+// filled from the embedded catalog.
+func NewCatalogFromDir(dir string) (*Catalog, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("presets directory must not be empty")
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("presets directory %q is not accessible: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("presets path %q is not a directory", dir)
+	}
+	return &Catalog{source: &presetsSource{FS: os.DirFS(dir), label: dir}}, nil
+}
+
+// EmbeddedCatalog returns a catalog backed by the preset tree compiled into
+// the binary.
+func EmbeddedCatalog() (*Catalog, error) {
+	sub, err := fs.Sub(embeddedPresets, "data")
+	if err != nil {
+		return nil, fmt.Errorf("failed to open embedded presets FS: %w", err)
+	}
+	return &Catalog{source: &presetsSource{FS: sub, label: "embedded", embedded: true}}, nil
+}
+
+// DefaultCatalog preserves the historical lookup chain used by the package-
+// level helpers: an implicit on-disk directory wins, with the embedded tree as
+// fallback. New CLI/library code that needs deterministic source selection
+// should use NewCatalogFromDir or EmbeddedCatalog directly.
+func DefaultCatalog() (*Catalog, error) {
+	source, err := resolvePresetsFS()
+	if err != nil {
+		return nil, err
+	}
+	return &Catalog{source: source}, nil
+}
+
+// CatalogForConfigDir selects the preset catalog for a validated config-dir
+// layout. With no explicit root it preserves the historical implicit
+// disk-to-embedded lookup. An explicit root selects its presets/ directory
+// when present and otherwise deliberately falls back to the embedded catalog.
+func CatalogForConfigDir(configDir assets.ConfigDir) (*Catalog, error) {
+	if configDir.Root == "" {
+		return DefaultCatalog()
+	}
+	if configDir.PresetsDir == "" {
+		return EmbeddedCatalog()
+	}
+	return NewCatalogFromDir(configDir.PresetsDir)
+}
+
+// Source returns the user-facing source label: "embedded" or the on-disk
+// presets directory.
+func (c *Catalog) Source() string {
+	if c == nil || c.source == nil {
+		return ""
+	}
+	return c.source.label
+}
+
 // resolvePresetsFS chooses the preset tree to load against. Disk wins over
 // embedded — an on-disk presets directory found via GetPresetsDir is the
 // user's override, kept ahead of the binary's baked-in copy so `l8k preset
@@ -134,11 +208,11 @@ func resolvePresetsFS() (*presetsSource, error) {
 	if dir != "" {
 		return &presetsSource{FS: os.DirFS(dir), label: dir}, nil
 	}
-	sub, err := fs.Sub(embeddedPresets, "data")
+	catalog, err := EmbeddedCatalog()
 	if err != nil {
-		return nil, fmt.Errorf("failed to open embedded presets FS: %w", err)
+		return nil, err
 	}
-	return &presetsSource{FS: sub, label: "embedded", embedded: true}, nil
+	return catalog.source, nil
 }
 
 // SkippedPreset describes a preset directory that loadAllPresets rejected.
@@ -151,21 +225,17 @@ type SkippedPreset struct {
 	Reason  string
 }
 
-// loadAllPresets returns every valid preset under the resolved preset source
-// (disk if present, embedded otherwise), sorted by directory name, plus a
-// list of skipped entries with reasons. Invalid entries (parse error,
-// missing machineType, missing gpuType) are skipped rather than failing the
-// whole load — keeps the lookup robust to stale or partial preset
-// directories. Returns (nil, nil, nil) when neither a disk presets dir nor
-// the embedded FS yields any entries (only happens in a misconfigured build).
-func loadAllPresets() ([]presetEntry, []SkippedPreset, error) {
-	src, err := resolvePresetsFS()
-	if err != nil {
-		return nil, nil, err
+// loadAllPresets returns every valid preset in this catalog's selected source,
+// sorted by directory name, plus a list of skipped entries with reasons.
+// Invalid entries (parse error, missing machineType, missing gpuType) are
+// skipped rather than failing the whole load — keeps the lookup robust to
+// stale or partial preset directories. Returns (nil, nil, nil) when the
+// selected source has no preset directories.
+func (c *Catalog) loadAllPresets() ([]presetEntry, []SkippedPreset, error) {
+	if c == nil || c.source == nil {
+		return nil, nil, fmt.Errorf("preset catalog source is not configured")
 	}
-	if src == nil {
-		return nil, nil, nil
-	}
+	src := c.source
 
 	entries, err := fs.ReadDir(src, ".")
 	if err != nil {
@@ -240,10 +310,9 @@ func (s *presetsSource) diagPath(rel string) string {
 
 // LoadPreset returns the topology preset whose YAML declares both machineType
 // and gpuType equal to the arguments. Lookup is exact-match — there is no
-// "any-GPU" fallback. Returns (nil, nil) when no preset matches or no presets
-// directory exists.
-func LoadPreset(machineType, gpuType string) (*Topology, error) {
-	all, _, err := loadAllPresets()
+// "any-GPU" fallback. Returns (nil, nil) when no preset matches.
+func (c *Catalog) LoadPreset(machineType, gpuType string) (*Topology, error) {
+	all, _, err := c.loadAllPresets()
 	if err != nil {
 		return nil, err
 	}
@@ -275,13 +344,23 @@ func LoadPreset(machineType, gpuType string) (*Topology, error) {
 	return &t, nil
 }
 
+// LoadPreset uses the historical default catalog resolution. Prefer a Catalog
+// method when the caller must select an explicit source.
+func LoadPreset(machineType, gpuType string) (*Topology, error) {
+	catalog, err := DefaultCatalog()
+	if err != nil {
+		return nil, err
+	}
+	return catalog.LoadPreset(machineType, gpuType)
+}
+
 // LoadPresetByDir returns the topology preset stored at <presets-dir>/<dirName>.
 // This is the lookup used by `--for`: the user passes a directory name (which
 // `l8k preset list` shows) and we hand back the parsed topology. Returns
 // (nil, error) with a typed error listing available presets when the directory
 // is missing or the preset is invalid.
-func LoadPresetByDir(dirName string) (*Topology, error) {
-	all, skipped, err := loadAllPresets()
+func (c *Catalog) LoadPresetByDir(dirName string) (*Topology, error) {
+	all, skipped, err := c.loadAllPresets()
 	if err != nil {
 		return nil, err
 	}
@@ -308,19 +387,29 @@ func LoadPresetByDir(dirName string) (*Topology, error) {
 	}
 	if len(available) == 0 {
 		if len(skipped) > 0 {
-			return nil, fmt.Errorf("unknown preset %q: %d preset(s) on disk but all were rejected at load time (see warnings); run 'l8k preset list' to inspect",
-				dirName, len(skipped))
+			return nil, fmt.Errorf("unknown preset %q: %d preset(s) in catalog %s were rejected at load time (see warnings); run 'l8k preset list' to inspect",
+				dirName, len(skipped), c.Source())
 		}
-		return nil, fmt.Errorf("unknown preset %q: no presets are installed (run 'l8k preset update')", dirName)
+		return nil, fmt.Errorf("unknown preset %q: catalog %s contains no valid presets (run 'l8k preset list' to inspect)", dirName, c.Source())
 	}
 	return nil, fmt.Errorf("unknown preset %q; available: %v", dirName, available)
+}
+
+// LoadPresetByDir uses the historical default catalog resolution. Prefer a
+// Catalog method when the caller must select an explicit source.
+func LoadPresetByDir(dirName string) (*Topology, error) {
+	catalog, err := DefaultCatalog()
+	if err != nil {
+		return nil, err
+	}
+	return catalog.LoadPresetByDir(dirName)
 }
 
 // ListPresets returns the directory names of all valid presets, sorted.
 // Returns nil if no presets directory exists. Invalid presets (missing
 // machineType / gpuType, parse failures) are filtered out with a warning.
-func ListPresets() ([]string, error) {
-	all, _, err := loadAllPresets()
+func (c *Catalog) ListPresets() ([]string, error) {
+	all, _, err := c.loadAllPresets()
 	if err != nil {
 		return nil, err
 	}
@@ -332,6 +421,16 @@ func ListPresets() ([]string, error) {
 		names = append(names, p.DirName)
 	}
 	return names, nil
+}
+
+// ListPresets uses the historical default catalog resolution. Prefer a Catalog
+// method when the caller must select an explicit source.
+func ListPresets() ([]string, error) {
+	catalog, err := DefaultCatalog()
+	if err != nil {
+		return nil, err
+	}
+	return catalog.ListPresets()
 }
 
 // ListPresetSummaries returns a summary row per valid preset: directory name
@@ -346,8 +445,8 @@ type PresetSummary struct {
 // ListPresetSummaries returns one summary per valid preset (sorted by
 // directory name) plus the list of skipped/invalid presets so callers can
 // surface rejection reasons.
-func ListPresetSummaries() ([]PresetSummary, []SkippedPreset, error) {
-	all, skipped, err := loadAllPresets()
+func (c *Catalog) ListPresetSummaries() ([]PresetSummary, []SkippedPreset, error) {
+	all, skipped, err := c.loadAllPresets()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -363,6 +462,16 @@ func ListPresetSummaries() ([]PresetSummary, []SkippedPreset, error) {
 		})
 	}
 	return out, skipped, nil
+}
+
+// ListPresetSummaries uses the historical default catalog resolution. Prefer
+// a Catalog method when the caller must select an explicit source.
+func ListPresetSummaries() ([]PresetSummary, []SkippedPreset, error) {
+	catalog, err := DefaultCatalog()
+	if err != nil {
+		return nil, nil, err
+	}
+	return catalog.ListPresetSummaries()
 }
 
 // ApplyPreset enriches a discovered ClusterConfig group with data from a

--- a/pkg/presets/presets_test.go
+++ b/pkg/presets/presets_test.go
@@ -52,16 +52,10 @@ func TestGetPresetsDir_CWD(t *testing.T) {
 }
 
 func TestGetPresetsDir_NotFound(t *testing.T) {
-	// Use a temp dir with no presets subdirectory
+	// Test the candidate scanner directly so a developer's system-wide l8k
+	// installation cannot satisfy a later fallback candidate.
 	tmpDir := t.TempDir()
-	origDir, _ := os.Getwd()
-	defer func() { _ = os.Chdir(origDir) }()
-	_ = os.Chdir(tmpDir)
-
-	dir, err := GetPresetsDir()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	dir := findPresetsDir([]string{filepath.Join(tmpDir, "presets")})
 	if dir != "" {
 		t.Errorf("expected empty string for missing presets dir, got %q", dir)
 	}
@@ -75,14 +69,7 @@ func TestGetPresetsDir_SkipsFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	origDir, _ := os.Getwd()
-	defer func() { _ = os.Chdir(origDir) }()
-	_ = os.Chdir(tmpDir)
-
-	dir, err := GetPresetsDir()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	dir := findPresetsDir([]string{presetsFile})
 	if dir != "" {
 		t.Errorf("expected empty string when 'presets' is a file, got %q", dir)
 	}

--- a/pkg/resolve/validate_test.go
+++ b/pkg/resolve/validate_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resolve
+
+import (
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbeddedDefaultIsResolvedConfigValid(t *testing.T) {
+	cfg, err := config.DefaultLaunchKitConfig()
+	require.NoError(t, err)
+	require.NoError(t, ValidateResolvedConfig(cfg))
+}

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Install l8k binary, profiles, and default config to system paths.
+# Install the l8k binary and external profile templates to system paths.
 #
 # Usage:
 #   scripts/install-local.sh                     # Install to /usr/local (copies files)
@@ -25,8 +25,9 @@
 # Install layout:
 #   <prefix>/bin/l8k                       # Binary
 #   <prefix>/share/l8k/profiles/           # Profile templates
-#   <prefix>/share/l8k/presets/            # Predefined cluster topology presets
-#   <prefix>/share/l8k/l8k-config.yaml    # Default configuration
+#
+# The default config and topology presets are embedded in the binary. Existing
+# filesystem overrides are preserved and can be selected with --config-dir.
 
 set -euo pipefail
 
@@ -50,9 +51,6 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --dev-env              Create symlinks instead of copies (for development)"
             echo "  --prefix               Install prefix (default: /usr/local)"
-            echo ""
-            echo "Presets are installed from the bundled \`presets/\` tree only."
-            echo "To fetch the latest presets from GitHub, run \`l8k preset update\` after install."
             exit 0
             ;;
         *)
@@ -79,8 +77,6 @@ if [ "$DEV_ENV" = true ]; then
     ln -sfn "${REPO_ROOT}/build/l8k" "${BIN_DIR}/l8k"
     mkdir -p "${SHARE_DIR}"
     ln -sfn "${REPO_ROOT}/profiles" "${SHARE_DIR}/profiles"
-    ln -sfn "${REPO_ROOT}/pkg/presets/data" "${SHARE_DIR}/presets"
-    ln -sfn "${REPO_ROOT}/pkg/config/default-config.yaml" "${SHARE_DIR}/l8k-config.yaml"
 else
     echo "Installing l8k..."
     mkdir -p "${BIN_DIR}"
@@ -88,17 +84,14 @@ else
     mkdir -p "${SHARE_DIR}"
     rm -rf "${SHARE_DIR}/profiles"
     cp -r "${REPO_ROOT}/profiles" "${SHARE_DIR}/profiles"
-    rm -rf "${SHARE_DIR}/presets"
-    cp -r "${REPO_ROOT}/pkg/presets/data" "${SHARE_DIR}/presets"
-    cp "${REPO_ROOT}/pkg/config/default-config.yaml" "${SHARE_DIR}/l8k-config.yaml"
 fi
 
 echo ""
 echo "Installed successfully:"
 echo "  Binary:   ${BIN_DIR}/l8k"
 echo "  Profiles: ${SHARE_DIR}/profiles"
-echo "  Presets:  ${SHARE_DIR}/presets"
-echo "  Config:   ${SHARE_DIR}/l8k-config.yaml"
-echo ""
-echo "Presets installed from the bundled \`presets/\` tree."
-echo "Run \`l8k preset update\` to fetch the latest presets from GitHub."
+if [ -e "${SHARE_DIR}/presets" ] || [ -e "${SHARE_DIR}/l8k-config.yaml" ]; then
+    echo ""
+    echo "Existing config overrides were preserved under ${SHARE_DIR}."
+    echo "Select them explicitly with: l8k --config-dir ${SHARE_DIR} ..."
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -201,10 +201,8 @@ INSTALL_CMDS="
     mkdir -p '${INSTALL_DIR}/bin'
     install -m 755 '${WORK_DIR}/extracted/l8k' '${INSTALL_DIR}/bin/l8k'
     mkdir -p '${INSTALL_DIR}/share/l8k'
-    rm -rf '${INSTALL_DIR}/share/l8k/profiles' '${INSTALL_DIR}/share/l8k/presets'
+    rm -rf '${INSTALL_DIR}/share/l8k/profiles'
     cp -r '${WORK_DIR}/extracted/profiles' '${INSTALL_DIR}/share/l8k/'
-    cp -r '${WORK_DIR}/extracted/pkg/presets/data' '${INSTALL_DIR}/share/l8k/presets'
-    cp '${WORK_DIR}/extracted/pkg/config/default-config.yaml' '${INSTALL_DIR}/share/l8k/l8k-config.yaml'
 "
 
 if [ "$NEED_SUDO" = true ]; then
@@ -222,8 +220,11 @@ echo ""
 echo "Installed successfully:"
 echo "  Binary:   ${INSTALL_DIR}/bin/l8k"
 echo "  Profiles: ${INSTALL_DIR}/share/l8k/profiles"
-echo "  Presets:  ${INSTALL_DIR}/share/l8k/presets"
-echo "  Config:   ${INSTALL_DIR}/share/l8k/l8k-config.yaml"
+if [ -e "${INSTALL_DIR}/share/l8k/presets" ] || [ -e "${INSTALL_DIR}/share/l8k/l8k-config.yaml" ]; then
+    echo ""
+    echo "Existing config overrides were preserved under ${INSTALL_DIR}/share/l8k."
+    echo "Select them explicitly with: l8k --config-dir ${INSTALL_DIR}/share/l8k ..."
+fi
 echo ""
 "${INSTALL_DIR}/bin/l8k" version
 


### PR DESCRIPTION
## Summary
- Add a persistent --config-dir flag that selects optional l8k-config.yaml and authoritative presets/ filesystem overrides, with per-asset fallback to the embedded copies and --user-config retaining highest config precedence.
- Add immutable preset catalogs and a library WithPresetsDir option so concurrent discovery callers can select independent sources without process-global state.
- Stop packaging the embedded default config and presets in release archives, Homebrew, Docker, and install scripts while retaining external profile templates and preserving existing filesystem overrides.
- Document the layout, precedence, CLI usage, and library usage in this repository README only.

## Validation
- GOCACHE=/private/tmp/l8k-config-dir-go-cache go test ./... -count=1
- GOCACHE=/private/tmp/l8k-config-dir-go-cache go vet ./...
- GOCACHE=/private/tmp/l8k-config-dir-go-cache make build
- bash -n scripts/install.sh scripts/install-local.sh
- Parsed .goreleaser.yml with Ruby YAML
- CLI smoke-tested embedded fallback, a one-entry authoritative preset catalog, filesystem default-config loading, and config-less preset generation

## Notes
- The network-operator-docs repository is intentionally unchanged.