### PR TITLE
refactor: remove legacy pod namespace setting

### DIFF
--- a/pkg/app/discover_profile_test.go
+++ b/pkg/app/discover_profile_test.go
@@ -91,6 +91,9 @@ func TestDiscoverFreshConfigIgnoresReferenceProfile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "# user-selected fabric",
 		"profile documentation comments should survive write-back")
+	assert.Contains(t, string(data), "networkNamespaces:")
+	assert.NotContains(t, string(data), "podNamespace:")
+	assert.NotContains(t, string(data), "currentNetworkNamespace:")
 }
 
 func TestDiscoverPreservesPartialUserProfileAndFillsMissingSettings(t *testing.T) {

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -115,7 +115,7 @@ Optionally deploy the generated manifests with --deploy.`,
 			NodeSelector:            generateNodeSelector,
 			ForPreset:               forPreset,
 			ImagePullSecrets:        imagePullSecrets,
-			NetworkNamespaces:       resolveNetworkNamespaces(networkNamespaces, podNamespace),
+			NetworkNamespaces:       networkNamespaces,
 			SaveDeploymentFiles:     saveDeploymentFiles,
 			Deploy:                  deploy,
 			OverwriteExisting:       overwriteExistingFlag,
@@ -197,8 +197,6 @@ func init() {
 	// Output
 	generateCmd.Flags().StringVar(&saveDeploymentFiles, "save-deployment-files", "", "Output directory for generated YAMLs")
 	generateCmd.Flags().StringSliceVar(&networkNamespaces, "network-namespaces", nil, "Comma-separated namespaces for the secondary-network CRs and example test DaemonSets. One independent copy is rendered per namespace (shared resources like IPPools and NodePolicies are NOT duplicated). Overrides config networkNamespaces; default: 'default'.")
-	generateCmd.Flags().StringVar(&podNamespace, "pod-namespace", "", "Deprecated: use --network-namespaces. Kept as a single-namespace alias for back-compat.")
-	_ = generateCmd.Flags().MarkDeprecated("pod-namespace", "use --network-namespaces instead")
 	generateCmd.Flags().BoolVar(&enableDocaDriver, "enable-doca-driver", false, "Enable DOCA driver deployment")
 	generateCmd.Flags().StringVar(&workloadManifest, "workload-manifest", "", "Path to a custom workload manifest YAML")
 	generateCmd.Flags().StringVar(&networkOperatorNamespace, "network-operator-namespace", "", "Override operator namespace")

--- a/pkg/cmd/network_namespaces_test.go
+++ b/pkg/cmd/network_namespaces_test.go
@@ -22,26 +22,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestResolveNetworkNamespaces locks the back-compat contract for the
-// deprecated --pod-namespace flag: it folds into a single-entry
-// --network-namespaces list, but --network-namespaces always wins when both
-// are supplied, and neither set leaves the result empty (the "default"
-// default is applied downstream in ApplyOptionsToConfig).
-func TestResolveNetworkNamespaces(t *testing.T) {
-	tests := []struct {
-		name              string
-		networkNamespaces []string
-		podNamespace      string
-		want              []string
-	}{
-		{"neither set", nil, "", nil},
-		{"only --network-namespaces", []string{"ns1", "ns2"}, "", []string{"ns1", "ns2"}},
-		{"only deprecated --pod-namespace", nil, "legacy-ns", []string{"legacy-ns"}},
-		{"--network-namespaces wins over --pod-namespace", []string{"ns1", "ns2"}, "legacy-ns", []string{"ns1", "ns2"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, resolveNetworkNamespaces(tt.networkNamespaces, tt.podNamespace))
-		})
-	}
+func TestNetworkNamespaceFlags(t *testing.T) {
+	assert.NotNil(t, rootCmd.Flags().Lookup("network-namespaces"))
+	assert.Nil(t, rootCmd.Flags().Lookup("pod-namespace"))
+	assert.NotNil(t, generateCmd.Flags().Lookup("network-namespaces"))
+	assert.Nil(t, generateCmd.Flags().Lookup("pod-namespace"))
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -70,7 +70,6 @@ var (
 	nodeSelector                string
 	imagePullSecrets            []string
 	networkNamespaces           []string
-	podNamespace                string // deprecated alias for --network-namespaces
 	outputFormat                string
 	yesFlag                     bool
 	quietFlag                   bool
@@ -85,18 +84,6 @@ var (
 // collapseNicRailsFlagHelp is the shared help text for --collapse-nic-rails on
 // both the root pipeline and the `discover` subcommand.
 const collapseNicRailsFlagHelp = "Advertise one rail per NIC: collapse a NIC's multi-plane PFs to its master PF, keeping a rail per port only for NICs whose VPD model is genuinely dual-port (\"2-port\"/\"Dual-port\"). Set to false to keep the legacy one-rail-per-PF behaviour (dev setups)."
-
-// resolveNetworkNamespaces folds the deprecated --pod-namespace flag into the
-// --network-namespaces list. --network-namespaces wins when both are given;
-// otherwise a non-empty --pod-namespace becomes the sole network namespace,
-// mirroring the config-file back-compat in ApplyOptionsToConfig. Returns nil
-// when neither is set, leaving the default ("default") to be applied downstream.
-func resolveNetworkNamespaces(networkNamespaces []string, podNamespace string) []string {
-	if len(networkNamespaces) == 0 && podNamespace != "" {
-		return []string{podNamespace}
-	}
-	return networkNamespaces
-}
 
 // forFlagHelp is intentionally static. --config-dir is parsed after command
 // initialization, so enumerating presets here would always show the default
@@ -184,7 +171,7 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
 			CollapseNicRails:     collapseNicRails,
 			ForPreset:            forPreset,
 			ImagePullSecrets:     imagePullSecrets,
-			NetworkNamespaces:    resolveNetworkNamespaces(networkNamespaces, podNamespace),
+			NetworkNamespaces:    networkNamespaces,
 			SaveDeploymentFiles:   saveDeploymentFiles,
 			Deploy:                deploy,
 			Kubeconfig:            kubeconfig,
@@ -270,8 +257,6 @@ func init() {
 	rootCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for NicClusterPolicy (comma-separated)")
 	rootCmd.Flags().StringVar(&saveDeploymentFiles, "save-deployment-files", "./deployment", "Save generated deployment files to the specified directory")
 	rootCmd.Flags().StringSliceVar(&networkNamespaces, "network-namespaces", nil, "Comma-separated namespaces for the secondary-network CRs and example test DaemonSets. One independent copy is rendered per namespace (shared resources like IPPools and NodePolicies are NOT duplicated). Overrides config networkNamespaces; default: 'default'.")
-	rootCmd.Flags().StringVar(&podNamespace, "pod-namespace", "", "Deprecated: use --network-namespaces. Kept as a single-namespace alias for back-compat.")
-	_ = rootCmd.Flags().MarkDeprecated("pod-namespace", "use --network-namespaces instead")
 	rootCmd.Flags().BoolVar(&enableDocaDriver, "enable-doca-driver", false, "Enable DOCA driver deployment (overrides config file docaDriver.enable)")
 	rootCmd.Flags().StringVar(&workloadManifest, "workload-manifest", "", "Path to a custom workload manifest YAML (replaces the profile's default example workload)")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -154,17 +154,17 @@ type LaunchKitConfig struct {
 	Macvlan         *MacvlanConfig         `yaml:"macvlan,omitempty"`
 	SpectrumX                *SpectrumXConfig                `yaml:"spectrumX,omitempty"`
 	NicConfigurationOperator *NicConfigurationOperatorConfig `yaml:"nicConfigurationOperator,omitempty"`
-	PodNamespace             string                          `yaml:"podNamespace,omitempty"`
 	// NetworkNamespaces is the set of namespaces the secondary-network CRs
 	// (SriovNetwork, SriovIBNetwork, HostDeviceNetwork, MacvlanNetwork,
 	// IPoIBNetwork) and their example test DaemonSets are rendered into —
 	// one independent copy per namespace. Shared resources (IPPool,
 	// NicNodePolicy, SriovNetworkNodePolicy, NicClusterPolicy, …) are NOT
-	// duplicated. Empty defaults to a single "default" namespace; a legacy
-	// scalar podNamespace is folded in as the sole entry. PodNamespace stays
-	// the "current" namespace scalar the templates read — the renderer
-	// overrides it per entry while fanning out.
+	// duplicated. Empty defaults to a single "default" namespace.
 	NetworkNamespaces        []string                        `yaml:"networkNamespaces,omitempty"`
+	// CurrentNetworkNamespace is transient render state. The renderer sets it
+	// to one NetworkNamespaces entry while producing that namespace's copy;
+	// it is never part of the persisted configuration schema.
+	CurrentNetworkNamespace  string                          `yaml:"-"`
 	Workload                 *WorkloadConfig                 `yaml:"workload,omitempty"`
 	Profile         *Profile               `yaml:"profile,omitempty"`
 	ClusterConfig   []ClusterConfig        `yaml:"clusterConfig,omitempty"`

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -28,7 +28,7 @@ networkOperator:
   # imagePullSecrets:
   #   - my-registry-secret
 
-podNamespace: default
+networkNamespaces: [default]
 
 # workload:
 #   manifest: /path/to/my-deployment.yaml  # Custom workload manifest (replaces default example DaemonSet)

--- a/pkg/config/network_namespaces_test.go
+++ b/pkg/config/network_namespaces_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestNetworkNamespacesAreTheOnlyPersistedNamespaceSetting(t *testing.T) {
+	cfg := LaunchKitConfig{
+		NetworkNamespaces:       []string{"ns1", "ns2"},
+		CurrentNetworkNamespace: "ns1",
+	}
+
+	data, err := yaml.Marshal(&cfg)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "networkNamespaces:")
+	assert.NotContains(t, string(data), "podNamespace")
+	assert.NotContains(t, string(data), "currentNetworkNamespace")
+}
+
+func TestLegacyPodNamespaceIsIgnored(t *testing.T) {
+	var cfg LaunchKitConfig
+	require.NoError(t, yaml.Unmarshal([]byte("podNamespace: legacy\n"), &cfg))
+	assert.Empty(t, cfg.NetworkNamespaces)
+	assert.Empty(t, cfg.CurrentNetworkNamespace)
+}

--- a/pkg/networkoperatorplugin/discovery/library_test.go
+++ b/pkg/networkoperatorplugin/discovery/library_test.go
@@ -125,7 +125,7 @@ func TestDiscover_WithPresetsDirRejectsMissingDirectoryBeforeClusterChanges(t *t
 // the supplied cfg lacks a NetworkOperator section.
 func TestDiscover_PreservesUserFields(t *testing.T) {
 	base := &config.LaunchKitConfig{
-		PodNamespace: "library-test-ns",
+		NetworkNamespaces: []string{"library-test-ns"},
 		// Deliberately no NetworkOperator: DiscoverClusterConfig requires
 		// it and will return early with a descriptive error. That gets
 		// us past the wiring step (which is what this test pins down)

--- a/pkg/networkoperatorplugin/networkoperator.go
+++ b/pkg/networkoperatorplugin/networkoperator.go
@@ -200,19 +200,10 @@ func (p *NetworkOperatorPlugin) ApplyOptionsToConfig(options options.Options, fu
 	if len(options.NetworkNamespaces) > 0 {
 		fullConfig.NetworkNamespaces = options.NetworkNamespaces
 	}
-	// Back-compat: a legacy scalar podNamespace becomes the sole network
-	// namespace when the list isn't set.
-	if len(fullConfig.NetworkNamespaces) == 0 && fullConfig.PodNamespace != "" {
-		fullConfig.NetworkNamespaces = []string{fullConfig.PodNamespace}
-	}
-	// Default to a single "default" namespace if neither config nor CLI set it.
+	// Default to a single "default" namespace when neither config nor CLI set it.
 	if len(fullConfig.NetworkNamespaces) == 0 {
 		fullConfig.NetworkNamespaces = []string{"default"}
 	}
-	// PodNamespace is the "current" namespace scalar the templates read; the
-	// renderer overrides it per network namespace while fanning out. Seed it
-	// with the first entry so non-fanned-out templates render deterministically.
-	fullConfig.PodNamespace = fullConfig.NetworkNamespaces[0]
 
 	// Default NicConfigurationOperator if not set
 	if fullConfig.NicConfigurationOperator == nil {

--- a/pkg/networkoperatorplugin/networkoperator_test.go
+++ b/pkg/networkoperatorplugin/networkoperator_test.go
@@ -127,6 +127,16 @@ func TestApplyOptionsToConfig(t *testing.T) {
 		err := p.ApplyOptionsToConfig(options.Options{Fabric: "ethernet"}, cfg)
 		require.NoError(t, err)
 		assert.Nil(t, cfg.Profile)
+		assert.Equal(t, []string{"default"}, cfg.NetworkNamespaces)
+		assert.Empty(t, cfg.CurrentNetworkNamespace)
+	})
+
+	t.Run("CLI network namespaces do not mutate transient render state", func(t *testing.T) {
+		cfg := &config.LaunchKitConfig{Profile: &config.Profile{}}
+		err := p.ApplyOptionsToConfig(options.Options{NetworkNamespaces: []string{"ns1", "ns2"}}, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"ns1", "ns2"}, cfg.NetworkNamespaces)
+		assert.Empty(t, cfg.CurrentNetworkNamespace)
 	})
 
 	t.Run("CLI fabric overrides config fabric", func(t *testing.T) {

--- a/pkg/networkoperatorplugin/render_plan.go
+++ b/pkg/networkoperatorplugin/render_plan.go
@@ -488,16 +488,16 @@ var networkNSReplicatedKinds = map[string]bool{
 // into. Replicated network Kinds fan out across cfg.NetworkNamespaces;
 // everything else (and every Spectrum-X Kind, which uses a distinct combined-CR
 // rendering path not amenable to independent per-namespace copies) renders once
-// into the current namespace (cfg.PodNamespace).
+// into the current namespace.
 func networkNamespacesForKind(cfg *config.LaunchKitConfig, kind string) []string {
 	if !isSpectrumX(cfg) && networkNSReplicatedKinds[kind] && len(cfg.NetworkNamespaces) > 0 {
 		return cfg.NetworkNamespaces
 	}
-	return []string{cfg.PodNamespace}
+	return []string{currentNetworkNamespace(cfg)}
 }
 
 // withRenderNamespaces returns a shallow copy of cfg scoped to a single
-// render: PodNamespace is the "current" namespace the templates read, and
+// render: CurrentNetworkNamespace is the namespace the templates read, and
 // NetworkNamespaces is narrowed to nsList — the exact set being rendered for
 // this Kind. For a replicated Kind nsList is the full cfg.NetworkNamespaces
 // (so `nsSuffix` sees len>1 and suffixes); for a shared Kind nsList is the
@@ -507,9 +507,19 @@ func networkNamespacesForKind(cfg *config.LaunchKitConfig, kind string) []string
 // on shared templates simply never calling the helper.
 func withRenderNamespaces(cfg *config.LaunchKitConfig, ns string, nsList []string) *config.LaunchKitConfig {
 	out := *cfg
-	out.PodNamespace = ns
+	out.CurrentNetworkNamespace = ns
 	out.NetworkNamespaces = nsList
 	return &out
+}
+
+func currentNetworkNamespace(cfg *config.LaunchKitConfig) string {
+	if cfg.CurrentNetworkNamespace != "" {
+		return cfg.CurrentNetworkNamespace
+	}
+	if len(cfg.NetworkNamespaces) > 0 {
+		return cfg.NetworkNamespaces[0]
+	}
+	return "default"
 }
 
 // suffixFilenamesWithNamespace appends "-<ns>" before the extension of every
@@ -610,4 +620,3 @@ func subnetsAt(planSubnets [][]config.NvIpamSubnetConfig, i int) []config.NvIpam
 	}
 	return planSubnets[i]
 }
-

--- a/pkg/networkoperatorplugin/sriov_render_test.go
+++ b/pkg/networkoperatorplugin/sriov_render_test.go
@@ -68,7 +68,7 @@ func renderSRIOV(t *testing.T, dir, fabric, networkTemplate string) map[string]s
 
 // renderSRIOVWithNamespaces is renderSRIOV with the network-namespace fan-out
 // the CLI's ApplyOptionsToConfig would normally seed: NetworkNamespaces drives
-// per-namespace duplication and PodNamespace is the first ("current") entry.
+// per-namespace duplication and the renderer selects each current entry.
 func renderSRIOVWithNamespaces(t *testing.T, dir, fabric, networkTemplate string, namespaces []string) map[string]string {
 	t.Helper()
 	ctrllog.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -86,7 +86,6 @@ func renderSRIOVWithNamespaces(t *testing.T, dir, fabric, networkTemplate string
 	}
 	if len(namespaces) > 0 {
 		cfg.NetworkNamespaces = namespaces
-		cfg.PodNamespace = namespaces[0]
 	}
 
 	plugin := &NetworkOperatorPlugin{}

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -71,7 +71,7 @@ var templateFuncs = template.FuncMap{
 	// secondary-network CR (and the network name the example DaemonSet
 	// references). With a single namespace it returns "" so the common case
 	// keeps its existing names unchanged. Called as
-	// `{{nsSuffix $.NetworkNamespaces $.PodNamespace}}` — type-agnostic so it
+	// `{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}` — type-agnostic so it
 	// works whether the template root is the bare config or a per-group ctx.
 	//
 	// The `namespaces` it reads is the *per-render* set: the renderer
@@ -672,6 +672,10 @@ func (p *NetworkOperatorPlugin) GenerateProfileDeploymentFiles(profile *profiles
 	if err := config.NormalizeMaintenance(cfg); err != nil {
 		return nil, fmt.Errorf("normalize maintenance configuration: %w", err)
 	}
+	if len(cfg.NetworkNamespaces) == 0 {
+		cfg.NetworkNamespaces = []string{"default"}
+	}
+	cfg.CurrentNetworkNamespace = cfg.NetworkNamespaces[0]
 
 	// Apply --groups / --gpu-type filter to source groups before merging.
 	// `applyGroupFilter` enforces mutual exclusivity, errors on empty match,

--- a/pkg/networkoperatorplugin/testdata/grouping/mixed-same-type.yaml
+++ b/pkg/networkoperatorplugin/testdata/grouping/mixed-same-type.yaml
@@ -40,7 +40,7 @@ nicConfigurationOperator:
   deployNicInterfaceNameTemplate: true
   rdmaPrefix: rdma_r%rail_id%
   netdevPrefix: eth_r%rail_id%
-podNamespace: default
+networkNamespaces: [default]
 clusterConfig:
 - identifier: group-0
   machineType: machine-a

--- a/pkg/networkoperatorplugin/testdata/grouping/same-ew-different-ns.yaml
+++ b/pkg/networkoperatorplugin/testdata/grouping/same-ew-different-ns.yaml
@@ -42,7 +42,7 @@ nicConfigurationOperator:
   deployNicInterfaceNameTemplate: true
   rdmaPrefix: rdma_r%rail_id%
   netdevPrefix: eth_r%rail_id%
-podNamespace: default
+networkNamespaces: [default]
 clusterConfig:
 - identifier: group-0
   machineType: machine-x

--- a/pkg/networkoperatorplugin/testdata/grouping/true-heterogeneous.yaml
+++ b/pkg/networkoperatorplugin/testdata/grouping/true-heterogeneous.yaml
@@ -40,7 +40,7 @@ nicConfigurationOperator:
   deployNicInterfaceNameTemplate: true
   rdmaPrefix: rdma_r%rail_id%
   netdevPrefix: eth_r%rail_id%
-podNamespace: default
+networkNamespaces: [default]
 clusterConfig:
 - identifier: group-0
   machineType: machine-a

--- a/pkg/networkoperatorplugin/workload.go
+++ b/pkg/networkoperatorplugin/workload.go
@@ -59,8 +59,8 @@ func patchWorkloadManifest(manifestPath string, cfg *config.LaunchKitConfig, gro
 
 	// Set namespace
 	meta := ensureMap(obj, "metadata")
-	if cfg.PodNamespace != "" {
-		meta["namespace"] = cfg.PodNamespace
+	if namespace := currentNetworkNamespace(cfg); namespace != "" {
+		meta["namespace"] = namespace
 	}
 
 	// Add group suffix to name if present

--- a/pkg/networkoperatorplugin/workload_test.go
+++ b/pkg/networkoperatorplugin/workload_test.go
@@ -32,7 +32,7 @@ func intPtr(i int) *int { return &i }
 // multirailSriovConfig returns a simple sriov config with 2 east-west PFs for testing.
 func multirailSriovConfig() (*config.LaunchKitConfig, *config.ClusterConfig) {
 	cfg := &config.LaunchKitConfig{
-		PodNamespace: "gpu-workloads",
+		NetworkNamespaces: []string{"gpu-workloads"},
 		Profile: &config.Profile{
 			Fabric:     "ethernet",
 			Deployment: "sriov",

--- a/profiles/host-device-rdma/30-hostdevicenetwork.yaml
+++ b/profiles/host-device-rdma/30-hostdevicenetwork.yaml
@@ -5,9 +5,9 @@
 apiVersion: mellanox.com/v1alpha1
 kind: HostDeviceNetwork
 metadata:
-  name: {{$.Hostdev.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+  name: {{$.Hostdev.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
 spec:
-  networkNamespace: "{{$.PodNamespace}}"
+  networkNamespace: "{{$.CurrentNetworkNamespace}}"
   resourceName: "{{$.Hostdev.ResourceName}}_rail_{{$pf.Rail}}"
   ipam: |
     {
@@ -21,9 +21,9 @@ spec:
 apiVersion: mellanox.com/v1alpha1
 kind: HostDeviceNetwork
 metadata:
-  name: {{.Hostdev.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+  name: {{.Hostdev.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
 spec:
-  networkNamespace: "{{$.PodNamespace}}"
+  networkNamespace: "{{$.CurrentNetworkNamespace}}"
   resourceName: "{{.Hostdev.ResourceName}}"
   ipam: |
     {

--- a/profiles/host-device-rdma/40-example-daemonset.yaml
+++ b/profiles/host-device-rdma/40-example-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: hostdev-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
-  namespace: "{{$.PodNamespace}}"
+  namespace: "{{$.CurrentNetworkNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -14,7 +14,7 @@ spec:
       labels:
         app: hostdev-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
-        k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Hostdev.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}{{- end}}{{- end}}
+        k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Hostdev.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}{{- end}}{{- end}}
     spec:
       {{- if .ClusterConfig.NodeSelector }}
       affinity:
@@ -67,7 +67,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: hostdev-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
-  namespace: "{{$.PodNamespace}}"
+  namespace: "{{$.CurrentNetworkNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -77,7 +77,7 @@ spec:
       labels:
         app: hostdev-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
-        k8s.v1.cni.cncf.io/networks: {{.Hostdev.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+        k8s.v1.cni.cncf.io/networks: {{.Hostdev.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
     spec:
       {{- if .ClusterConfig.NodeSelector }}
       affinity:

--- a/profiles/ipoib-rdma-shared/30-ipoibnetwork.yaml
+++ b/profiles/ipoib-rdma-shared/30-ipoibnetwork.yaml
@@ -5,9 +5,9 @@
 apiVersion: mellanox.com/v1alpha1
 kind: IPoIBNetwork
 metadata:
-  name: {{$.Ipoib.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+  name: {{$.Ipoib.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
 spec:
-  networkNamespace: "{{$.PodNamespace}}"
+  networkNamespace: "{{$.CurrentNetworkNamespace}}"
   master: "{{$pf.NetworkInterface}}"
   ipam: |
     {
@@ -22,9 +22,9 @@ spec:
 apiVersion: mellanox.com/v1alpha1
 kind: IPoIBNetwork
 metadata:
-  name: {{.Ipoib.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+  name: {{.Ipoib.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
 spec:
-  networkNamespace: "{{$.PodNamespace}}"
+  networkNamespace: "{{$.CurrentNetworkNamespace}}"
   master: "{{(index .ClusterConfig.PFs 0).NetworkInterface}}"
   ipam: |
     {

--- a/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ipoib-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
-  namespace: "{{$.PodNamespace}}"
+  namespace: "{{$.CurrentNetworkNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -14,7 +14,7 @@ spec:
       labels:
         app: ipoib-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
-        k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Ipoib.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}{{- end}}{{- end}}
+        k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Ipoib.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}{{- end}}{{- end}}
     spec:
       {{- if .ClusterConfig.NodeSelector }}
       affinity:
@@ -68,7 +68,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ipoib-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
-  namespace: "{{$.PodNamespace}}"
+  namespace: "{{$.CurrentNetworkNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -78,7 +78,7 @@ spec:
       labels:
         app: ipoib-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
       annotations:
-        k8s.v1.cni.cncf.io/networks: {{.Ipoib.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+        k8s.v1.cni.cncf.io/networks: {{.Ipoib.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
     spec:
       {{- if $.ClusterConfig.NodeSelector }}
       affinity:

--- a/profiles/macvlan-rdma-shared/30-macvlannetwork.yaml
+++ b/profiles/macvlan-rdma-shared/30-macvlannetwork.yaml
@@ -5,9 +5,9 @@
 apiVersion: mellanox.com/v1alpha1
 kind: MacvlanNetwork
 metadata:
-  name: {{$.Macvlan.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+  name: {{$.Macvlan.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
 spec:
-  networkNamespace: "{{$.PodNamespace}}"
+  networkNamespace: "{{$.CurrentNetworkNamespace}}"
   master: "{{$pf.NetworkInterface}}"
   mode: "bridge"
   # mtu: 0 → inherit master PF's MTU. The macvlan CNI enforces
@@ -32,9 +32,9 @@ spec:
 apiVersion: mellanox.com/v1alpha1
 kind: MacvlanNetwork
 metadata:
-  name: {{.Macvlan.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+  name: {{.Macvlan.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
 spec:
-  networkNamespace: "{{$.PodNamespace}}"
+  networkNamespace: "{{$.CurrentNetworkNamespace}}"
   master: "{{(index .ClusterConfig.PFs 0).NetworkInterface}}"
   mode: "bridge"
   # mtu: 0 → inherit master PF's MTU (see multirail branch above).

--- a/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: macvlan-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
-  namespace: "{{$.PodNamespace}}"
+  namespace: "{{$.CurrentNetworkNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -14,7 +14,7 @@ spec:
       labels:
         app: macvlan-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
-        k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Macvlan.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}{{- end}}{{- end}}
+        k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Macvlan.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}{{- end}}{{- end}}
     spec:
       {{- if .ClusterConfig.NodeSelector }}
       affinity:
@@ -68,7 +68,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: macvlan-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
-  namespace: "{{$.PodNamespace}}"
+  namespace: "{{$.CurrentNetworkNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -78,7 +78,7 @@ spec:
       labels:
         app: macvlan-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
       annotations:
-        k8s.v1.cni.cncf.io/networks: {{.Macvlan.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+        k8s.v1.cni.cncf.io/networks: {{.Macvlan.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
     spec:
       {{- if $.ClusterConfig.NodeSelector }}
       affinity:

--- a/profiles/spectrum-x-ra2.1/55-ovsnetwork.yaml
+++ b/profiles/spectrum-x-ra2.1/55-ovsnetwork.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   resourceName: rail_{{$railIdx}}_plane_{{$planeIdx}}
   interfaceType: dpdk
-  networkNamespace: "{{$.PodNamespace}}"
+  networkNamespace: "{{$.CurrentNetworkNamespace}}"
   mtu: 9216
   ipam: |
     {
@@ -45,7 +45,7 @@ metadata:
 spec:
   resourceName: rail_{{$railIdx}}
   interfaceType: dpdk
-  networkNamespace: "{{$.PodNamespace}}"
+  networkNamespace: "{{$.CurrentNetworkNamespace}}"
   mtu: 9216
   ipam: |
     {

--- a/profiles/spectrum-x-ra2.1/90-example-daemonset.yaml
+++ b/profiles/spectrum-x-ra2.1/90-example-daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: spectrum-x-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
-  namespace: "{{$.PodNamespace}}"
+  namespace: "{{$.CurrentNetworkNamespace}}"
 spec:
   selector:
     matchLabels:

--- a/profiles/spectrum-x/80-spectrumxrailpoolconfig.yaml
+++ b/profiles/spectrum-x/80-spectrumxrailpoolconfig.yaml
@@ -15,7 +15,7 @@ spec:
     {{ $key }}: "{{ $value }}"
     {{- end }}
   {{- end }}
-  networkNamespace: "{{.PodNamespace}}"
+  networkNamespace: "{{.CurrentNetworkNamespace}}"
   numVfs: 1
   railTopology:
   {{- range $railIdx := untilStep 0 $railCount 1 }}

--- a/profiles/spectrum-x/90-example-daemonset.yaml
+++ b/profiles/spectrum-x/90-example-daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: spectrum-x-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
-  namespace: "{{$.PodNamespace}}"
+  namespace: "{{$.CurrentNetworkNamespace}}"
 spec:
   selector:
     matchLabels:

--- a/profiles/sriov-ethernet-rdma/50-sriovnetwork.yaml
+++ b/profiles/sriov-ethernet-rdma/50-sriovnetwork.yaml
@@ -5,7 +5,7 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: {{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+  name: {{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
   namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   ipam: |
@@ -13,7 +13,7 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}"
     }
-  networkNamespace: "{{$.PodNamespace}}"
+  networkNamespace: "{{$.CurrentNetworkNamespace}}"
   resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
@@ -22,7 +22,7 @@ spec:
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+  name: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
   namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   ipam: |
@@ -30,5 +30,5 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}"
     }
-  networkNamespace: "{{$.PodNamespace}}"
+  networkNamespace: "{{$.CurrentNetworkNamespace}}"
   resourceName: {{.Sriov.ResourceName}}{{- end}}

--- a/profiles/sriov-ethernet-rdma/60-example-daemonset.yaml
+++ b/profiles/sriov-ethernet-rdma/60-example-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: sriov-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
-  namespace: "{{$.PodNamespace}}"
+  namespace: "{{$.CurrentNetworkNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -14,7 +14,7 @@ spec:
       labels:
         app: sriov-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
-        k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}{{- end}}{{- end}}
+        k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}{{- end}}{{- end}}
     spec:
       {{- if .ClusterConfig.NodeSelector }}
       affinity:
@@ -67,7 +67,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: sriov-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
-  namespace: "{{$.PodNamespace}}"
+  namespace: "{{$.CurrentNetworkNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -77,7 +77,7 @@ spec:
       labels:
         app: sriov-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
       annotations:
-        k8s.v1.cni.cncf.io/networks: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+        k8s.v1.cni.cncf.io/networks: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
     spec:
       {{- if $.ClusterConfig.NodeSelector }}
       affinity:

--- a/profiles/sriov-ib-rdma/50-sriovibnetwork.yaml
+++ b/profiles/sriov-ib-rdma/50-sriovibnetwork.yaml
@@ -5,7 +5,7 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovIBNetwork
 metadata:
-  name: {{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+  name: {{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
   namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   ipam: |
@@ -15,7 +15,7 @@ spec:
     }
   resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}
   linkState: enable
-  networkNamespace: "{{$.PodNamespace}}"
+  networkNamespace: "{{$.CurrentNetworkNamespace}}"
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
 {{- end -}}
@@ -23,7 +23,7 @@ spec:
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovIBNetwork
 metadata:
-  name: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+  name: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
   namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   ipam: |
@@ -33,5 +33,5 @@ spec:
     }
   resourceName: {{.Sriov.ResourceName}}
   linkState: enable
-  networkNamespace: "{{$.PodNamespace}}"
+  networkNamespace: "{{$.CurrentNetworkNamespace}}"
 {{- end}}

--- a/profiles/sriov-ib-rdma/60-example-daemonset.yaml
+++ b/profiles/sriov-ib-rdma/60-example-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: sriov-ib-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
-  namespace: "{{$.PodNamespace}}"
+  namespace: "{{$.CurrentNetworkNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -14,7 +14,7 @@ spec:
       labels:
         app: sriov-ib-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
       annotations:
-        k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}{{- end}}{{- end}}
+        k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}{{- end}}{{- end}}
     spec:
       {{- if .ClusterConfig.NodeSelector }}
       affinity:
@@ -67,7 +67,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: sriov-ib-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
-  namespace: "{{$.PodNamespace}}"
+  namespace: "{{$.CurrentNetworkNamespace}}"
 spec:
   selector:
     matchLabels:
@@ -77,7 +77,7 @@ spec:
       labels:
         app: sriov-ib-test{{boundedSuffix 48 $.ClusterConfig.Identifier}}
       annotations:
-        k8s.v1.cni.cncf.io/networks: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.PodNamespace}}
+        k8s.v1.cni.cncf.io/networks: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
     spec:
       {{- if $.ClusterConfig.NodeSelector }}
       affinity:

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -150,7 +150,6 @@ nvIpam:
 # Namespaces for the secondary-network CRs + example test DaemonSets.
 # One independent copy is rendered per namespace (shared resources like
 # IPPools and NodePolicies are NOT duplicated). Defaults to ["default"].
-# A legacy scalar `podNamespace:` is still honored as the sole entry.
 networkNamespaces: ["my-namespace"]
 ```
 

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -34,8 +34,7 @@ networkOperator:
 # reference the secondary networks. Shared resources (IPPool, NicNodePolicy,
 # SriovNetworkNodePolicy, NicClusterPolicy, ...) are NOT duplicated. With more
 # than one namespace, the per-namespace CR copies get a "-<namespace>" name
-# suffix so they don't collide. A legacy scalar `podNamespace:` is still
-# accepted and folded in as the sole entry.
+# suffix so they don't collide.
 networkNamespaces: ["default"]
 
 # ============================================================================

--- a/skills/k8s-network-engineer/references/config-schema.md
+++ b/skills/k8s-network-engineer/references/config-schema.md
@@ -18,7 +18,7 @@ Controls the NVIDIA Network Operator deployment settings.
 
 | Field               | Type     | Default       | Description                                       |
 |---------------------|----------|---------------|---------------------------------------------------|
-| `networkNamespaces` | []string | `["default"]` | Namespaces the secondary-network CRs (SriovNetwork, SriovIBNetwork, HostDeviceNetwork, MacvlanNetwork, IPoIBNetwork) and their example test DaemonSets are rendered into — one independent copy per namespace. Shared resources (IPPool, NicNodePolicy, SriovNetworkNodePolicy, NicClusterPolicy) are NOT duplicated. With >1 namespace, per-namespace CR copies get a `-<namespace>` name suffix. CLI: `--network-namespaces ns1,ns2`. A legacy scalar `podNamespace` is still accepted and folded in as the sole entry. |
+| `networkNamespaces` | []string | `["default"]` | Namespaces the secondary-network CRs (SriovNetwork, SriovIBNetwork, HostDeviceNetwork, MacvlanNetwork, IPoIBNetwork) and their example test DaemonSets are rendered into — one independent copy per namespace. Shared resources (IPPool, NicNodePolicy, SriovNetworkNodePolicy, NicClusterPolicy) are NOT duplicated. With >1 namespace, per-namespace CR copies get a `-<namespace>` name suffix. CLI: `--network-namespaces ns1,ns2`. |
 
 ## docaDriver
 


### PR DESCRIPTION
## Summary
- remove the persisted `podNamespace` field and deprecated `--pod-namespace` flag
- keep `networkNamespaces` as the single config and CLI setting, defaulting to `default`
- use transient render state so per-namespace manifest fan-out remains unchanged

## Compatibility
Configs and commands must use `networkNamespaces` / `--network-namespaces`. The removed `podNamespace` key is intentionally unsupported and ignored.

## Validation
- `GOCACHE=/private/tmp/l8k-go-cache go test ./... -count=1`
- `GOCACHE=/private/tmp/l8k-go-cache go build .`
- golangci-lint v2.11: `golangci-lint run ./...` (`0 issues`)
