### PR TITLE
feat: add source routing and ARP tuning profile options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ missing profile settings and stores the final values in `cluster-config.yaml`.
 ### Select the Deployment Profile
 Discovery fills missing profile values from hardware and built-in defaults.
 Values already present under `profile` are preserved, while explicit CLI flags
-(`--fabric`, `--deployment-type`, `--multirail`, `--spectrum-x`) take precedence.
+(`--fabric`, `--deployment-type`, `--multirail`, `--routing`, `--ignore-arp`,
+`--spectrum-x`) take precedence.
 AI-driven profile selection now lives in the `k8s-launch-kit-*` Claude Code
 skills, which wrap the deterministic CLI commands.
 
@@ -393,6 +394,23 @@ l8k discover --kubeconfig ~/.kube/config \
     --multirail=false \
     --save-cluster-config ./my-cluster-config.yaml
 ```
+
+For routed multi-rail IPv4/RoCE deployments, `--routing source-based` chains
+the automatic `sbr` CNI meta-plugin on generated non-Spectrum-X secondary
+networks. This creates source-selected routing tables so traffic sourced from a
+rail IP exits through that rail's interface and gateway.
+
+Use `--ignore-arp` when pod rails can observe ARP for each other, or when the
+fabric/VLAN isolation is not enough to prove that a rail IP can only be claimed
+by its own VF. Linux normally treats IPv4 addresses as local to the network
+namespace, so one pod interface can answer ARP for an address configured on
+another interface. In routed multi-rail RoCE this can teach a remote peer that a
+rail-0 IP lives behind a rail-3 VF MAC, sending traffic to the wrong HCA. The
+flag chains the `tuning` CNI meta-plugin before `sbr` and sets `arp_ignore=1`,
+`arp_announce=2`, and `rp_filter=0` at both `all` and `IFNAME` scopes.
+
+These settings apply to SR-IOV, SR-IOV IB, host-device, Macvlan RDMA-shared,
+and IPoIB RDMA-shared profiles. They do not apply to Spectrum-X profiles.
 
 Filter discovery to specific nodes using a label selector:
 
@@ -845,6 +863,8 @@ profile:
   fabric: ethernet
   deployment: sriov
   multirail: true
+  routing: destination-based
+  ignoreARP: false
 clusterConfig:
 - identifier: group-0
   capabilities:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -25,10 +25,24 @@ confirmed link type. If the fabric cannot be confirmed, discovery still saves
 the config with an empty fabric so it can be supplied explicitly later.
 
 All profile flags accepted by ``generate`` are also accepted by ``discover``:
-``--fabric``, ``--deployment-type``, ``--multirail``, ``--spectrum-x``,
-``--multiplane-mode``, and ``--number-of-planes``. Explicit false is supported
-for both YAML (``multirail: false``) and CLI (``--multirail=false``) and remains
-stable when discovery rewrites the file.
+``--fabric``, ``--deployment-type``, ``--multirail``, ``--routing``,
+``--ignore-arp``, ``--spectrum-x``, ``--multiplane-mode``, and
+``--number-of-planes``. Explicit false is supported for YAML
+(``multirail: false``, ``ignoreARP: false``) and CLI
+(``--multirail=false``, ``--ignore-arp=false``) and remains stable when
+discovery rewrites the file.
+
+For routed multi-rail IPv4/RoCE deployments, ``--routing source-based`` chains
+the automatic ``sbr`` CNI meta-plugin on generated non-Spectrum-X secondary
+networks so traffic sourced from a rail IP exits through that rail's interface
+and gateway. ``--ignore-arp`` chains the ``tuning`` CNI meta-plugin before
+``sbr`` and sets ``arp_ignore=1``, ``arp_announce=2``, and ``rp_filter=0`` at
+both ``all`` and ``IFNAME`` scopes. This is useful when pod rails can observe
+ARP for each other: Linux can otherwise answer ARP for a rail-0 IP from a
+rail-3 VF MAC inside the same network namespace, sending RoCE traffic to the
+wrong HCA even though the IP destination is correct. These settings apply to
+SR-IOV, SR-IOV IB, host-device, Macvlan RDMA-shared, and IPoIB RDMA-shared
+profiles; they do not apply to Spectrum-X profiles.
 
 .. code-block:: bash
 

--- a/pkg/app/profile_resolution.go
+++ b/pkg/app/profile_resolution.go
@@ -73,6 +73,8 @@ func (l *Launcher) recordResolvedProfile(fullConfig *config.LaunchKitConfig) {
 		"fabric":     fullConfig.Profile.Fabric,
 		"deployment": fullConfig.Profile.Deployment,
 		"multirail":  fmt.Sprintf("%v", fullConfig.Profile.Multirail),
+		"routing":    fullConfig.Profile.Routing,
+		"ignoreARP":  fmt.Sprintf("%v", fullConfig.Profile.IgnoreARP),
 	}
 	if spectrumX := fullConfig.Profile.SpectrumX; spectrumX != nil && spectrumX.Enable {
 		l.result.Profile["spectrumX"] = "true"

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -92,6 +92,9 @@ and writes the final profile back to cluster-config.yaml.`,
 			DeploymentType:           deploymentType,
 			Multirail:                multirail,
 			MultirailSet:             cmd.Flag("multirail").Changed,
+			Routing:                  routing,
+			IgnoreARP:                ignoreARP,
+			IgnoreARPSet:             cmd.Flag("ignore-arp").Changed,
 			SpectrumX:                spectrumXVersion != "",
 			SPCXVersion:              spectrumXVersion,
 			MultiplaneMode:           multiplaneMode,
@@ -143,6 +146,8 @@ func init() {
 	discoverCmd.Flags().StringVar(&fabric, "fabric", "", "Fabric type override: ethernet, infiniband")
 	discoverCmd.Flags().StringVar(&deploymentType, "deployment-type", "", "Deployment type override: sriov, rdma_shared, host_device")
 	discoverCmd.Flags().BoolVar(&multirail, "multirail", false, "Override multirail deployment (defaults to true when absent; use --multirail=false to opt out)")
+	discoverCmd.Flags().StringVar(&routing, "routing", "", "Secondary-network routing mode override: destination-based or source-based. source-based chains the automatic sbr CNI meta-plugin.")
+	discoverCmd.Flags().BoolVar(&ignoreARP, "ignore-arp", false, "Chain the tuning CNI meta-plugin to prevent ARP flux across pod rails")
 	discoverCmd.Flags().StringVar(&spectrumXVersion, "spectrum-x", "",
 		fmt.Sprintf("Enable Spectrum-X by passing the SPC-X RA version. Supported: %v",
 			config.SupportedSPCXVersions))
@@ -162,6 +167,8 @@ func init() {
 	setFlagGroup(discoverCmd, "fabric", GroupProfile)
 	setFlagGroup(discoverCmd, "deployment-type", GroupProfile)
 	setFlagGroup(discoverCmd, "multirail", GroupProfile)
+	setFlagGroup(discoverCmd, "routing", GroupProfile)
+	setFlagGroup(discoverCmd, "ignore-arp", GroupProfile)
 	setFlagGroup(discoverCmd, "spectrum-x", GroupProfile)
 	setFlagGroup(discoverCmd, "multiplane-mode", GroupSpectrumX)
 	setFlagGroup(discoverCmd, "number-of-planes", GroupSpectrumX)

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -100,30 +100,33 @@ Optionally deploy the generated manifests with --deploy.`,
 		}
 
 		opts := options.Options{
-			ConfigDir:     configDir,
-			UserConfig:     userConfig,
-			Fabric:         fabric,
-			DeploymentType: deploymentType,
-			Multirail:      multirail,
-			MultirailSet:   cmd.Flag("multirail").Changed,
-			SpectrumX:      spectrumXVersion != "",
-			SPCXVersion:             spectrumXVersion,
-			MultiplaneMode:          multiplaneMode,
-			NumberOfPlanes:          numberOfPlanes,
-			Groups:                  groups,
-			GpuType:                 gpuType,
-			NodeSelector:            generateNodeSelector,
-			ForPreset:               forPreset,
-			ImagePullSecrets:        imagePullSecrets,
-			NetworkNamespaces:       networkNamespaces,
-			SaveDeploymentFiles:     saveDeploymentFiles,
-			Deploy:                  deploy,
-			OverwriteExisting:       overwriteExistingFlag,
-			Kubeconfig:              kubeconfig,
+			ConfigDir:                configDir,
+			UserConfig:               userConfig,
+			Fabric:                   fabric,
+			DeploymentType:           deploymentType,
+			Multirail:                multirail,
+			MultirailSet:             cmd.Flag("multirail").Changed,
+			Routing:                  routing,
+			IgnoreARP:                ignoreARP,
+			IgnoreARPSet:             cmd.Flag("ignore-arp").Changed,
+			SpectrumX:                spectrumXVersion != "",
+			SPCXVersion:              spectrumXVersion,
+			MultiplaneMode:           multiplaneMode,
+			NumberOfPlanes:           numberOfPlanes,
+			Groups:                   groups,
+			GpuType:                  gpuType,
+			NodeSelector:             generateNodeSelector,
+			ForPreset:                forPreset,
+			ImagePullSecrets:         imagePullSecrets,
+			NetworkNamespaces:        networkNamespaces,
+			SaveDeploymentFiles:      saveDeploymentFiles,
+			Deploy:                   deploy,
+			OverwriteExisting:        overwriteExistingFlag,
+			Kubeconfig:               kubeconfig,
 			NetworkOperatorNamespace: networkOperatorNamespace,
 			NetworkOperatorRelease:   networkOperatorRelease,
 			EnabledPlugins:           parseEnabledPlugins(enabledPlugins),
-			WorkloadManifest:        workloadManifest,
+			WorkloadManifest:         workloadManifest,
 			OutputFormat:             outputFormat,
 			Yes:                      yesFlag,
 			Quiet:                    quietFlag,
@@ -183,6 +186,8 @@ func init() {
 	generateCmd.Flags().StringVar(&fabric, "fabric", "", "Fabric type: ethernet, infiniband")
 	generateCmd.Flags().StringVar(&deploymentType, "deployment-type", "", "Deployment type: sriov, rdma_shared, host_device")
 	generateCmd.Flags().BoolVar(&multirail, "multirail", false, "Override multirail deployment (defaults to true when absent; use --multirail=false to opt out)")
+	generateCmd.Flags().StringVar(&routing, "routing", "", "Secondary-network routing mode: destination-based or source-based. source-based chains the automatic sbr CNI meta-plugin.")
+	generateCmd.Flags().BoolVar(&ignoreARP, "ignore-arp", false, "Chain the tuning CNI meta-plugin to prevent ARP flux across pod rails")
 	generateCmd.Flags().StringVar(&spectrumXVersion, "spectrum-x", "",
 		fmt.Sprintf("Enable Spectrum-X by passing the SPC-X RA version (e.g. RA2.1, RA2.2). Supported: %v",
 			config.SupportedSPCXVersions))
@@ -222,6 +227,8 @@ func init() {
 	setFlagGroup(generateCmd, "fabric", GroupProfile)
 	setFlagGroup(generateCmd, "deployment-type", GroupProfile)
 	setFlagGroup(generateCmd, "multirail", GroupProfile)
+	setFlagGroup(generateCmd, "routing", GroupProfile)
+	setFlagGroup(generateCmd, "ignore-arp", GroupProfile)
 	setFlagGroup(generateCmd, "spectrum-x", GroupProfile)
 	setFlagGroup(generateCmd, "groups", GroupProfile)
 	setFlagGroup(generateCmd, "gpu-type", GroupProfile)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -40,45 +40,47 @@ import (
 )
 
 var (
-	logLevel              string
-	logFile               string
-	configDir             string
-	fabric                string
-	deploymentType        string
-	multirail             bool
+	logLevel       string
+	logFile        string
+	configDir      string
+	fabric         string
+	deploymentType string
+	multirail      bool
+	routing        string
+	ignoreARP      bool
 	// spectrumXVersion holds the value of --spectrum-x. Empty means
 	// Spectrum-X is disabled; a non-empty value is the SPC-X RA version
 	// (validated against config.SupportedSPCXVersions). The legacy --spcx-version
 	// flag has been folded into --spectrum-x; passing the version is now part
 	// of opting into Spectrum-X.
-	spectrumXVersion      string
-	multiplaneMode        string
-	numberOfPlanes        int
-	saveDeploymentFiles   string
-	deploy                bool
-	kubeconfig            string
-	userConfig            string
-	discoverClusterConfig bool
-	saveClusterConfig     string
-	logger                = log.Log.WithName("l8k")
-	enableDocaDriver            bool
-	enabledPlugins              string
-	networkOperatorNamespace    string
-	networkOperatorRelease      string
-	groups                      []string
-	gpuType                     string
-	nodeSelector                string
-	imagePullSecrets            []string
-	networkNamespaces           []string
-	outputFormat                string
-	yesFlag                     bool
-	quietFlag                   bool
-	workloadManifest            string
-	dryRunFlag                  bool
-	forPreset                   string
-	deployTimeoutRoot           time.Duration
-	keepNamespace               bool
-	collapseNicRails            bool
+	spectrumXVersion         string
+	multiplaneMode           string
+	numberOfPlanes           int
+	saveDeploymentFiles      string
+	deploy                   bool
+	kubeconfig               string
+	userConfig               string
+	discoverClusterConfig    bool
+	saveClusterConfig        string
+	logger                   = log.Log.WithName("l8k")
+	enableDocaDriver         bool
+	enabledPlugins           string
+	networkOperatorNamespace string
+	networkOperatorRelease   string
+	groups                   []string
+	gpuType                  string
+	nodeSelector             string
+	imagePullSecrets         []string
+	networkNamespaces        []string
+	outputFormat             string
+	yesFlag                  bool
+	quietFlag                bool
+	workloadManifest         string
+	dryRunFlag               bool
+	forPreset                string
+	deployTimeoutRoot        time.Duration
+	keepNamespace            bool
+	collapseNicRails         bool
 )
 
 // collapseNicRailsFlagHelp is the shared help text for --collapse-nic-rails on
@@ -152,39 +154,42 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
 		enabledPlugins := parseEnabledPlugins(enabledPlugins)
 		// Create application options from CLI flags
 		opts := options.Options{
-			LogLevel:              logLevel,
-			LogFile:               logFile,
-			ConfigDir:             configDir,
-			UserConfig:            userConfig,
-			DiscoverClusterConfig: discoverClusterConfig,
-			Fabric:                fabric,
-			DeploymentType:        deploymentType,
-			Multirail:             multirail,
-			MultirailSet:         cmd.Flag("multirail").Changed,
-			SpectrumX:             spectrumXVersion != "",
-			SPCXVersion:           spectrumXVersion,
-			MultiplaneMode:        multiplaneMode,
-			NumberOfPlanes:        numberOfPlanes,
-			Groups:               groups,
-			GpuType:              gpuType,
-			NodeSelector:         nodeSelector,
-			CollapseNicRails:     collapseNicRails,
-			ForPreset:            forPreset,
-			ImagePullSecrets:     imagePullSecrets,
-			NetworkNamespaces:    networkNamespaces,
-			SaveDeploymentFiles:   saveDeploymentFiles,
-			Deploy:                deploy,
-			Kubeconfig:            kubeconfig,
-			DeployTimeout:         deployTimeoutRoot,
+			LogLevel:                 logLevel,
+			LogFile:                  logFile,
+			ConfigDir:                configDir,
+			UserConfig:               userConfig,
+			DiscoverClusterConfig:    discoverClusterConfig,
+			Fabric:                   fabric,
+			DeploymentType:           deploymentType,
+			Multirail:                multirail,
+			MultirailSet:             cmd.Flag("multirail").Changed,
+			Routing:                  routing,
+			IgnoreARP:                ignoreARP,
+			IgnoreARPSet:             cmd.Flag("ignore-arp").Changed,
+			SpectrumX:                spectrumXVersion != "",
+			SPCXVersion:              spectrumXVersion,
+			MultiplaneMode:           multiplaneMode,
+			NumberOfPlanes:           numberOfPlanes,
+			Groups:                   groups,
+			GpuType:                  gpuType,
+			NodeSelector:             nodeSelector,
+			CollapseNicRails:         collapseNicRails,
+			ForPreset:                forPreset,
+			ImagePullSecrets:         imagePullSecrets,
+			NetworkNamespaces:        networkNamespaces,
+			SaveDeploymentFiles:      saveDeploymentFiles,
+			Deploy:                   deploy,
+			Kubeconfig:               kubeconfig,
+			DeployTimeout:            deployTimeoutRoot,
 			SaveClusterConfig:        saveClusterConfig,
 			NetworkOperatorNamespace: networkOperatorNamespace,
 			NetworkOperatorRelease:   networkOperatorRelease,
 			EnabledPlugins:           enabledPlugins,
-			WorkloadManifest:      workloadManifest,
-			OutputFormat:           outputFormat,
-			Yes:                    yesFlag,
-			Quiet:                  quietFlag,
-			DryRun:                 dryRunFlag,
+			WorkloadManifest:         workloadManifest,
+			OutputFormat:             outputFormat,
+			Yes:                      yesFlag,
+			Quiet:                    quietFlag,
+			DryRun:                   dryRunFlag,
 		}
 
 		// Set EnableDocaDriver only if the flag was explicitly provided
@@ -243,6 +248,8 @@ func init() {
 	rootCmd.Flags().StringVar(&fabric, "fabric", "", "Select the fabric type to deploy (infiniband, ethernet)")
 	rootCmd.Flags().StringVar(&deploymentType, "deployment-type", "", "Select the deployment type (sriov, rdma_shared, host_device)")
 	rootCmd.Flags().BoolVar(&multirail, "multirail", false, "Override multirail deployment (defaults to true when absent; use --multirail=false to opt out)")
+	rootCmd.Flags().StringVar(&routing, "routing", "", "Secondary-network routing mode: destination-based or source-based. source-based chains the automatic sbr CNI meta-plugin.")
+	rootCmd.Flags().BoolVar(&ignoreARP, "ignore-arp", false, "Chain the tuning CNI meta-plugin to prevent ARP flux across pod rails")
 	rootCmd.Flags().StringVar(&spectrumXVersion, "spectrum-x", "",
 		fmt.Sprintf("Enable Spectrum-X by passing the SPC-X RA version (folds in the legacy --spcx-version). Supported: %v",
 			config.SupportedSPCXVersions))
@@ -295,6 +302,8 @@ func init() {
 	setFlagGroup(rootCmd, "fabric", GroupProfile)
 	setFlagGroup(rootCmd, "deployment-type", GroupProfile)
 	setFlagGroup(rootCmd, "multirail", GroupProfile)
+	setFlagGroup(rootCmd, "routing", GroupProfile)
+	setFlagGroup(rootCmd, "ignore-arp", GroupProfile)
 	setFlagGroup(rootCmd, "spectrum-x", GroupProfile)
 	setFlagGroup(rootCmd, "groups", GroupProfile)
 	setFlagGroup(rootCmd, "gpu-type", GroupProfile)
@@ -423,6 +432,9 @@ func validateProfileFlagValues(opts *options.Options) error {
 	}
 	if opts.DeploymentType != "" && !slices.Contains([]string{"sriov", "rdma_shared", "host_device"}, opts.DeploymentType) {
 		return fmt.Errorf("--deployment-type must be one of: sriov, rdma_shared, host_device")
+	}
+	if opts.Routing != "" && !slices.Contains([]string{config.RoutingDestinationBased, config.RoutingSourceBased}, opts.Routing) {
+		return fmt.Errorf("--routing must be one of: %s, %s", config.RoutingDestinationBased, config.RoutingSourceBased)
 	}
 	return applySpectrumXSyntaxChecks(opts)
 }

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/releases"
 )
 
@@ -129,6 +130,16 @@ var schemaCmd = &cobra.Command{
 					Type:        "bool",
 					Default:     "true when absent",
 					Description: "Override multirail deployment. Explicit false values from YAML or --multirail=false are preserved.",
+				},
+				"--routing": {
+					Type:        "string",
+					Default:     config.RoutingDestinationBased,
+					Description: "Secondary-network routing mode: destination-based or source-based. source-based chains the automatic sbr CNI meta-plugin. Not applied to Spectrum-X profiles.",
+				},
+				"--ignore-arp": {
+					Type:        "bool",
+					Default:     "false",
+					Description: "Chain the tuning CNI meta-plugin to make ARP ownership interface-local and prevent ARP flux across pod rails. Not applied to Spectrum-X profiles.",
 				},
 				"--spectrum-x": {
 					Type:        "string",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,11 @@ const GPULabelKey = "nvidia.kubernetes-launch-kit.gpu"
 // MaxLabelValueLength is the Kubernetes hard limit for label values.
 const MaxLabelValueLength = 63
 
+const (
+	RoutingDestinationBased = "destination-based"
+	RoutingSourceBased      = "source-based"
+)
+
 // MachineLabelValue returns the per-source-group machine label value:
 // `<machineType>-<gpuType>` literal when it fits Kubernetes' 63-char
 // label-value limit, or a deterministic shortened form for long names
@@ -143,15 +148,15 @@ func SanitizeIdentifier(s string) string {
 
 // LaunchKitConfig represents the l8k-config.yaml structure
 type LaunchKitConfig struct {
-	NetworkOperator *NetworkOperatorConfig `yaml:"networkOperator,omitempty"`
-	DOCADriver      *DOCADriverConfig      `yaml:"docaDriver,omitempty"`
-	Maintenance     *MaintenanceConfig     `yaml:"maintenance,omitempty"`
-	NvIpam          *NvIpamConfig          `yaml:"nvIpam,omitempty"`
-	Sriov           *SriovConfig           `yaml:"sriov,omitempty"`
-	Hostdev         *HostdevConfig         `yaml:"hostdev,omitempty"`
-	RdmaShared      *RdmaSharedConfig      `yaml:"rdmaShared,omitempty"`
-	Ipoib           *IpoibConfig           `yaml:"ipoib,omitempty"`
-	Macvlan         *MacvlanConfig         `yaml:"macvlan,omitempty"`
+	NetworkOperator          *NetworkOperatorConfig          `yaml:"networkOperator,omitempty"`
+	DOCADriver               *DOCADriverConfig               `yaml:"docaDriver,omitempty"`
+	Maintenance              *MaintenanceConfig              `yaml:"maintenance,omitempty"`
+	NvIpam                   *NvIpamConfig                   `yaml:"nvIpam,omitempty"`
+	Sriov                    *SriovConfig                    `yaml:"sriov,omitempty"`
+	Hostdev                  *HostdevConfig                  `yaml:"hostdev,omitempty"`
+	RdmaShared               *RdmaSharedConfig               `yaml:"rdmaShared,omitempty"`
+	Ipoib                    *IpoibConfig                    `yaml:"ipoib,omitempty"`
+	Macvlan                  *MacvlanConfig                  `yaml:"macvlan,omitempty"`
 	SpectrumX                *SpectrumXConfig                `yaml:"spectrumX,omitempty"`
 	NicConfigurationOperator *NicConfigurationOperatorConfig `yaml:"nicConfigurationOperator,omitempty"`
 	// NetworkNamespaces is the set of namespaces the secondary-network CRs
@@ -160,27 +165,27 @@ type LaunchKitConfig struct {
 	// one independent copy per namespace. Shared resources (IPPool,
 	// NicNodePolicy, SriovNetworkNodePolicy, NicClusterPolicy, …) are NOT
 	// duplicated. Empty defaults to a single "default" namespace.
-	NetworkNamespaces        []string                        `yaml:"networkNamespaces,omitempty"`
+	NetworkNamespaces []string `yaml:"networkNamespaces,omitempty"`
 	// CurrentNetworkNamespace is transient render state. The renderer sets it
 	// to one NetworkNamespaces entry while producing that namespace's copy;
 	// it is never part of the persisted configuration schema.
-	CurrentNetworkNamespace  string                          `yaml:"-"`
-	Workload                 *WorkloadConfig                 `yaml:"workload,omitempty"`
-	Profile         *Profile               `yaml:"profile,omitempty"`
-	ClusterConfig   []ClusterConfig        `yaml:"clusterConfig,omitempty"`
+	CurrentNetworkNamespace string          `yaml:"-"`
+	Workload                *WorkloadConfig `yaml:"workload,omitempty"`
+	Profile                 *Profile        `yaml:"profile,omitempty"`
+	ClusterConfig           []ClusterConfig `yaml:"clusterConfig,omitempty"`
 }
 
 type NetworkOperatorConfig struct {
-	Version          string   `yaml:"version"`
-	ComponentVersion string   `yaml:"componentVersion"`
+	Version          string `yaml:"version"`
+	ComponentVersion string `yaml:"componentVersion"`
 	// SelectedRelease is the catalog key (MAJOR.MINOR, e.g. "26.4") chosen via
 	// --network-operator-release. Empty means "no release pinned"; templates
 	// treat that as "latest" so existing configs render the newest gates by
 	// default. When non-empty, ApplyOptionsToConfig has already populated
 	// Version/ComponentVersion/Repository and DOCADriver.Version from the
 	// embedded catalog.
-	SelectedRelease  string   `yaml:"selectedRelease,omitempty"`
-	Repository       string   `yaml:"repository"`
+	SelectedRelease string `yaml:"selectedRelease,omitempty"`
+	Repository      string `yaml:"repository"`
 	// OperatorRepository is the registry path for the network-operator
 	// BINARY image itself, distinct from Repository (which is the
 	// COMPONENT-images registry rendered into NicClusterPolicy /
@@ -199,11 +204,11 @@ type NetworkOperatorConfig struct {
 }
 
 type DOCADriverConfig struct {
-	Enable                      bool `yaml:"enable"`
+	Enable                      bool   `yaml:"enable"`
 	Version                     string `yaml:"version"`
-	UnloadStorageModules        bool `yaml:"unloadStorageModules"`
-	EnableNFSRDMA               bool `yaml:"enableNFSRDMA"`
-	UnloadThirdPartyRDMAModules bool `yaml:"unloadThirdPartyRDMAModules"`
+	UnloadStorageModules        bool   `yaml:"unloadStorageModules"`
+	EnableNFSRDMA               bool   `yaml:"enableNFSRDMA"`
+	UnloadThirdPartyRDMAModules bool   `yaml:"unloadThirdPartyRDMAModules"`
 	// SkipPreflightChecks controls the init container's module dependency check.
 	// When false (l8k default), the check runs and any blocking dependency fails
 	// the init container, preventing MOFED load. When true, the check is skipped
@@ -299,6 +304,18 @@ type Profile struct {
 	Fabric     string `yaml:"fabric"`
 	Deployment string `yaml:"deployment"`
 	Multirail  bool   `yaml:"multirail"`
+	// Routing controls whether generated secondary-network CRs chain the CNI
+	// source-based routing meta-plugin. destination-based preserves the kernel's
+	// normal destination route lookup. source-based adds the automatic sbr plugin
+	// after IPAM/tuning so each pod source address selects its matching rail.
+	Routing string `yaml:"routing,omitempty"`
+	// IgnoreARP controls whether generated secondary-network CRs chain the tuning
+	// meta-plugin to make ARP ownership interface-local. This prevents a pod rail
+	// from answering ARP for an IP that belongs to another rail.
+	IgnoreARP bool `yaml:"ignoreARP,omitempty"`
+	// IgnoreARPSet records whether ignoreARP was present in the source YAML.
+	// This lets config rewrites preserve an explicit `ignoreARP: false`.
+	IgnoreARPSet bool `yaml:"-"`
 	// MultirailSet records whether multirail was present in the source YAML.
 	// It is transient so the public YAML shape stays unchanged. The resolver
 	// needs this bit to distinguish an omitted value (eligible for the true
@@ -316,6 +333,8 @@ func (p *Profile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Fabric     string            `yaml:"fabric"`
 		Deployment string            `yaml:"deployment"`
 		Multirail  *bool             `yaml:"multirail"`
+		Routing    string            `yaml:"routing,omitempty"`
+		IgnoreARP  *bool             `yaml:"ignoreARP,omitempty"`
 		SpectrumX  *ProfileSpectrumX `yaml:"spectrumX,omitempty"`
 	}
 	if err := unmarshal(&raw); err != nil {
@@ -325,13 +344,39 @@ func (p *Profile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*p = Profile{
 		Fabric:     raw.Fabric,
 		Deployment: raw.Deployment,
+		Routing:    raw.Routing,
 		SpectrumX:  raw.SpectrumX,
 	}
 	if raw.Multirail != nil {
 		p.Multirail = *raw.Multirail
 		p.MultirailSet = true
 	}
+	if raw.IgnoreARP != nil {
+		p.IgnoreARP = *raw.IgnoreARP
+		p.IgnoreARPSet = true
+	}
 	return nil
+}
+
+func (p Profile) MarshalYAML() (interface{}, error) {
+	var raw struct {
+		Fabric     string            `yaml:"fabric"`
+		Deployment string            `yaml:"deployment"`
+		Multirail  bool              `yaml:"multirail"`
+		Routing    string            `yaml:"routing,omitempty"`
+		IgnoreARP  *bool             `yaml:"ignoreARP,omitempty"`
+		SpectrumX  *ProfileSpectrumX `yaml:"spectrumX,omitempty"`
+	}
+	raw.Fabric = p.Fabric
+	raw.Deployment = p.Deployment
+	raw.Multirail = p.Multirail
+	raw.Routing = p.Routing
+	raw.SpectrumX = p.SpectrumX
+	if p.IgnoreARP || p.IgnoreARPSet {
+		ignoreARP := p.IgnoreARP
+		raw.IgnoreARP = &ignoreARP
+	}
+	return raw, nil
 }
 
 type ProfileSpectrumX struct {
@@ -342,30 +387,30 @@ type ProfileSpectrumX struct {
 }
 
 type ClusterConfig struct {
-	Identifier           string               `yaml:"identifier"`
-	MachineType          string               `yaml:"machineType,omitempty"`
-	GPUType          string               `yaml:"gpuType,omitempty"`
+	Identifier  string `yaml:"identifier"`
+	MachineType string `yaml:"machineType,omitempty"`
+	GPUType     string `yaml:"gpuType,omitempty"`
 	// LinkType is the fabric type discovered for the group's east-west PFs:
 	// "Ethernet" or "InfiniBand". Set only when *every* east-west PF probe
 	// returns a confirmed verdict (port ACTIVE + matching link_layer + for
 	// IB, a non-zero sm_lid) and the verdicts agree. Otherwise omitted —
 	// the discovery couldn't prove the cluster is using a specific fabric,
 	// and downstream code should treat the field's absence as "unknown".
-	LinkType             string               `yaml:"linkType,omitempty"`
-	PresetApplied        bool                 `yaml:"presetApplied,omitempty"`
+	LinkType      string `yaml:"linkType,omitempty"`
+	PresetApplied bool   `yaml:"presetApplied,omitempty"`
 	// PresetDeviation lists discrepancies between the matched preset and
 	// the cluster's actually-discovered hardware. When non-empty, the
 	// preset was applied (so rail/NUMA topology fields are populated) but
 	// the cluster differs from the certified configuration. l8k re-warns
 	// every time the config is loaded.
-	PresetDeviation []PresetDeviationEntry `yaml:"presetDeviation,omitempty"`
-	Capabilities         *ClusterCapabilities `yaml:"capabilities"`
-	PFs                  []PFConfig           `yaml:"pfs"`
-	WorkerNodes          []string             `yaml:"workerNodes"`
-	NodeSelector         map[string]string    `yaml:"nodeSelector,omitempty"`
-	ThirdPartyRDMAModules []string            `yaml:"thirdPartyRDMAModules,omitempty"`
-	StorageModules        []string            `yaml:"storageModules,omitempty"`
-	RailPciAddresses     [][]string           `yaml:"-"` // Transient: per-rail merged PCI addresses (not serialized)
+	PresetDeviation       []PresetDeviationEntry `yaml:"presetDeviation,omitempty"`
+	Capabilities          *ClusterCapabilities   `yaml:"capabilities"`
+	PFs                   []PFConfig             `yaml:"pfs"`
+	WorkerNodes           []string               `yaml:"workerNodes"`
+	NodeSelector          map[string]string      `yaml:"nodeSelector,omitempty"`
+	ThirdPartyRDMAModules []string               `yaml:"thirdPartyRDMAModules,omitempty"`
+	StorageModules        []string               `yaml:"storageModules,omitempty"`
+	RailPciAddresses      [][]string             `yaml:"-"` // Transient: per-rail merged PCI addresses (not serialized)
 	// MergedIdentifier is the bucket-level identifier shared by all source
 	// groups that merge together by (gpuType, railCount). Used in templates
 	// for shared-resource references (resourceName, networkName, poolName,

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -128,6 +128,8 @@ profile:
   fabric: ethernet # infiniband, ethernet TODO consider ETH/IB
   deployment: sriov # rdma_shared, sriov, host_device
   multirail: false # explicit false is preserved; omit the key to use the true default
+  routing: destination-based # destination-based, source-based. source-based chains the automatic sbr CNI meta-plugin. Not applied to Spectrum-X.
+  ignoreARP: false # true chains tuning CNI sysctls to prevent ARP flux across pod rails. Not applied to Spectrum-X.
   spectrumX: # Spectrum-X configuration (set enable: true or use --spectrum-x CLI flag)
     enable: false # CLI parameter (overrides this value): --spectrum-x
     # spcxVersion: "RA2.2" # CLI parameter (overrides this value): --spectrum-x

--- a/pkg/config/profile_test.go
+++ b/pkg/config/profile_test.go
@@ -56,6 +56,50 @@ func TestProfileUnmarshalTracksMultirailPresence(t *testing.T) {
 	}
 }
 
+func TestProfileUnmarshalTracksIgnoreARPPresence(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantValue bool
+		wantSet   bool
+	}{
+		{
+			name: "missing",
+			yaml: `profile:
+  fabric: ethernet
+`,
+			wantValue: false,
+			wantSet:   false,
+		},
+		{
+			name: "explicit false",
+			yaml: `profile:
+  ignoreARP: false
+`,
+			wantValue: false,
+			wantSet:   true,
+		},
+		{
+			name: "explicit true",
+			yaml: `profile:
+  ignoreARP: true
+`,
+			wantValue: true,
+			wantSet:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg LaunchKitConfig
+			require.NoError(t, yaml.Unmarshal([]byte(tt.yaml), &cfg))
+			require.NotNil(t, cfg.Profile)
+			assert.Equal(t, tt.wantValue, cfg.Profile.IgnoreARP)
+			assert.Equal(t, tt.wantSet, cfg.Profile.IgnoreARPSet)
+		})
+	}
+}
+
 func TestProfileMultirailPresenceIsNotSerialized(t *testing.T) {
 	cfg := LaunchKitConfig{
 		Profile: &Profile{
@@ -71,4 +115,42 @@ func TestProfileMultirailPresenceIsNotSerialized(t *testing.T) {
 	assert.Contains(t, string(data), "multirail: false")
 	assert.NotContains(t, string(data), "multirailset")
 	assert.NotContains(t, string(data), "multirailSet")
+}
+
+func TestProfileIgnoreARPPresenceControlsSerialization(t *testing.T) {
+	tests := []struct {
+		name         string
+		profile      *Profile
+		wantContains string
+		wantOmit     bool
+	}{
+		{
+			name:         "missing false omitted",
+			profile:      &Profile{Fabric: "ethernet", Deployment: "sriov"},
+			wantContains: "ignoreARP:",
+			wantOmit:     true,
+		},
+		{
+			name:         "explicit false preserved",
+			profile:      &Profile{Fabric: "ethernet", Deployment: "sriov", IgnoreARPSet: true},
+			wantContains: "ignoreARP: false",
+		},
+		{
+			name:         "true serialized",
+			profile:      &Profile{Fabric: "ethernet", Deployment: "sriov", IgnoreARP: true},
+			wantContains: "ignoreARP: true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := yaml.Marshal(&LaunchKitConfig{Profile: tt.profile})
+			require.NoError(t, err)
+			if tt.wantOmit {
+				assert.NotContains(t, string(data), tt.wantContains)
+				return
+			}
+			assert.Contains(t, string(data), tt.wantContains)
+		})
+	}
 }

--- a/pkg/networkoperatorplugin/networkoperator.go
+++ b/pkg/networkoperatorplugin/networkoperator.go
@@ -92,7 +92,8 @@ func (p *NetworkOperatorPlugin) GetVersion() string {
 }
 
 func (p *NetworkOperatorPlugin) ProfileConfiguredInCmd(options options.Options) bool {
-	return options.Fabric != "" || options.DeploymentType != ""
+	return options.Fabric != "" || options.DeploymentType != "" ||
+		options.Routing != "" || options.IgnoreARPSet
 }
 
 func (p *NetworkOperatorPlugin) BuildProfileFromOptions(options options.Options, profile *config.Profile) error {
@@ -100,6 +101,9 @@ func (p *NetworkOperatorPlugin) BuildProfileFromOptions(options options.Options,
 	profile.Deployment = options.DeploymentType
 	profile.Multirail = options.Multirail
 	profile.MultirailSet = options.MultirailSet
+	profile.Routing = options.Routing
+	profile.IgnoreARP = options.IgnoreARP
+	profile.IgnoreARPSet = options.IgnoreARPSet
 
 	// Build SpectrumX nested struct if enabled
 	if options.SpectrumX {
@@ -233,6 +237,13 @@ func (p *NetworkOperatorPlugin) ApplyOptionsToConfig(options options.Options, fu
 	if options.MultirailSet {
 		fullConfig.Profile.Multirail = options.Multirail
 		fullConfig.Profile.MultirailSet = true
+	}
+	if options.Routing != "" {
+		fullConfig.Profile.Routing = options.Routing
+	}
+	if options.IgnoreARPSet {
+		fullConfig.Profile.IgnoreARP = options.IgnoreARP
+		fullConfig.Profile.IgnoreARPSet = true
 	}
 
 	// Apply workload manifest override from CLI

--- a/pkg/networkoperatorplugin/networkoperator_test.go
+++ b/pkg/networkoperatorplugin/networkoperator_test.go
@@ -36,6 +36,14 @@ func TestProfileConfiguredInCmd(t *testing.T) {
 		assert.True(t, p.ProfileConfiguredInCmd(options.Options{DeploymentType: "sriov"}))
 	})
 
+	t.Run("routing set", func(t *testing.T) {
+		assert.True(t, p.ProfileConfiguredInCmd(options.Options{Routing: config.RoutingSourceBased}))
+	})
+
+	t.Run("ignore arp set", func(t *testing.T) {
+		assert.True(t, p.ProfileConfiguredInCmd(options.Options{IgnoreARPSet: true}))
+	})
+
 	t.Run("neither set", func(t *testing.T) {
 		assert.False(t, p.ProfileConfiguredInCmd(options.Options{}))
 	})
@@ -101,6 +109,9 @@ func TestBuildProfileFromOptions(t *testing.T) {
 			Fabric:         "ethernet",
 			DeploymentType: "sriov",
 			Multirail:      true,
+			Routing:        config.RoutingSourceBased,
+			IgnoreARP:      true,
+			IgnoreARPSet:   true,
 			SpectrumX:      true,
 			SPCXVersion:    "RA2.2",
 			MultiplaneMode: "swplb",
@@ -112,6 +123,9 @@ func TestBuildProfileFromOptions(t *testing.T) {
 		assert.Equal(t, "ethernet", profile.Fabric)
 		assert.Equal(t, "sriov", profile.Deployment)
 		assert.True(t, profile.Multirail)
+		assert.Equal(t, config.RoutingSourceBased, profile.Routing)
+		assert.True(t, profile.IgnoreARP)
+		assert.True(t, profile.IgnoreARPSet)
 		require.NotNil(t, profile.SpectrumX)
 		assert.Equal(t, "RA2.2", profile.SpectrumX.SPCXVersion)
 		assert.Equal(t, "swplb", profile.SpectrumX.MultiplaneMode)
@@ -190,6 +204,34 @@ func TestApplyOptionsToConfig(t *testing.T) {
 		assert.True(t, cfg.Profile.MultirailSet)
 	})
 
+	t.Run("CLI routing overrides config routing", func(t *testing.T) {
+		cfg := &config.LaunchKitConfig{
+			Profile: &config.Profile{Routing: config.RoutingDestinationBased},
+		}
+		err := p.ApplyOptionsToConfig(options.Options{Routing: config.RoutingSourceBased}, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, config.RoutingSourceBased, cfg.Profile.Routing)
+	})
+
+	t.Run("CLI ignore-arp not passed does NOT override config true", func(t *testing.T) {
+		cfg := &config.LaunchKitConfig{
+			Profile: &config.Profile{IgnoreARP: true},
+		}
+		err := p.ApplyOptionsToConfig(options.Options{}, cfg)
+		require.NoError(t, err)
+		assert.True(t, cfg.Profile.IgnoreARP)
+	})
+
+	t.Run("CLI ignore-arp=false explicitly overrides config true", func(t *testing.T) {
+		cfg := &config.LaunchKitConfig{
+			Profile: &config.Profile{IgnoreARP: true},
+		}
+		err := p.ApplyOptionsToConfig(options.Options{IgnoreARP: false, IgnoreARPSet: true}, cfg)
+		require.NoError(t, err)
+		assert.False(t, cfg.Profile.IgnoreARP)
+		assert.True(t, cfg.Profile.IgnoreARPSet)
+	})
+
 	t.Run("empty CLI strings preserve config values", func(t *testing.T) {
 		cfg := &config.LaunchKitConfig{
 			Profile: &config.Profile{
@@ -242,9 +284,9 @@ func TestApplyOptionsToConfig(t *testing.T) {
 		}
 		err := p.ApplyOptionsToConfig(opts, cfg)
 		require.NoError(t, err)
-		assert.Equal(t, "RA2.2", cfg.Profile.SpectrumX.SPCXVersion)     // preserved
-		assert.Equal(t, "swplb", cfg.Profile.SpectrumX.MultiplaneMode)   // overridden
-		assert.Equal(t, 2, cfg.Profile.SpectrumX.NumberOfPlanes)         // preserved
+		assert.Equal(t, "RA2.2", cfg.Profile.SpectrumX.SPCXVersion)    // preserved
+		assert.Equal(t, "swplb", cfg.Profile.SpectrumX.MultiplaneMode) // overridden
+		assert.Equal(t, 2, cfg.Profile.SpectrumX.NumberOfPlanes)       // preserved
 	})
 
 	t.Run("CLI number-of-planes zero does NOT override config", func(t *testing.T) {

--- a/pkg/networkoperatorplugin/sriov_render_test.go
+++ b/pkg/networkoperatorplugin/sriov_render_test.go
@@ -141,6 +141,14 @@ func specString(t *testing.T, doc map[string]any, key string) string {
 	return v
 }
 
+func optionalSpecString(t *testing.T, doc map[string]any, key string) (string, bool) {
+	t.Helper()
+	spec, ok := doc["spec"].(map[string]any)
+	require.True(t, ok, "doc has no spec map")
+	v, ok := spec[key].(string)
+	return v, ok
+}
+
 // loadProfileFromDir reads a profile's real on-disk profile.yaml (including its
 // template list) so the test renders exactly what `l8k generate` would.
 func loadProfileFromDir(t *testing.T, dir string) *profiles.Profile {
@@ -158,12 +166,16 @@ func loadProfileFromDir(t *testing.T, dir string) *profiles.Profile {
 // renderProfile renders a whole profile (its real template set) against the
 // mixed-same-type grouping config in multirail mode.
 func renderProfile(t *testing.T, dir, fabric, deployment string) map[string]string {
+	return renderProfileWithProfile(t, dir, &config.Profile{Fabric: fabric, Deployment: deployment, Multirail: true})
+}
+
+func renderProfileWithProfile(t *testing.T, dir string, profile *config.Profile) map[string]string {
 	t.Helper()
 	ctrllog.SetLogger(zap.New(zap.UseDevMode(true)))
 	cfg, err := config.LoadFullConfig(
 		filepath.Join("testdata", "grouping", "mixed-same-type.yaml"), ctrllog.Log)
 	require.NoError(t, err)
-	cfg.Profile = &config.Profile{Fabric: fabric, Deployment: deployment, Multirail: true}
+	cfg.Profile = profile
 	rendered, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(loadProfileFromDir(t, dir), cfg)
 	require.NoError(t, err)
 	return rendered
@@ -230,6 +242,96 @@ func TestProfileManifestsAreValidMultiDocYAML(t *testing.T) {
 			}
 			require.True(t, sawIPPool, "expected an IPPool manifest in profile %s", p.dir)
 		})
+	}
+}
+
+func TestSecondaryNetworkMetaPluginsHelper(t *testing.T) {
+	t.Run("default empty", func(t *testing.T) {
+		require.Empty(t, secondaryNetworkMetaPlugins(&config.Profile{}))
+	})
+
+	t.Run("source based routing only", func(t *testing.T) {
+		meta := secondaryNetworkMetaPlugins(&config.Profile{Routing: config.RoutingSourceBased})
+		require.Contains(t, meta, `"type": "sbr"`)
+		require.NotContains(t, meta, `"type": "tuning"`)
+	})
+
+	t.Run("ignore arp only", func(t *testing.T) {
+		meta := secondaryNetworkMetaPlugins(&config.Profile{IgnoreARP: true})
+		require.Contains(t, meta, `"type": "tuning"`)
+		require.Contains(t, meta, `"net.ipv4.conf.IFNAME.arp_ignore": "1"`)
+		require.NotContains(t, meta, `"type": "sbr"`)
+	})
+
+	t.Run("tuning before sbr", func(t *testing.T) {
+		meta := secondaryNetworkMetaPlugins(&config.Profile{
+			Routing:   config.RoutingSourceBased,
+			IgnoreARP: true,
+		})
+		tuningIdx := strings.Index(meta, `"type": "tuning"`)
+		sbrIdx := strings.Index(meta, `"type": "sbr"`)
+		require.NotEqual(t, -1, tuningIdx)
+		require.NotEqual(t, -1, sbrIdx)
+		require.Less(t, tuningIdx, sbrIdx)
+	})
+
+	t.Run("spectrum x ignored", func(t *testing.T) {
+		meta := secondaryNetworkMetaPlugins(&config.Profile{
+			Routing:   config.RoutingSourceBased,
+			IgnoreARP: true,
+			SpectrumX: &config.ProfileSpectrumX{Enable: true},
+		})
+		require.Empty(t, meta)
+	})
+}
+
+func TestNonSpectrumXProfilesRenderMetaPlugins(t *testing.T) {
+	profilesUnderTest := []struct {
+		dir        string
+		fabric     string
+		deployment string
+		fileSubstr string
+	}{
+		{"sriov-ethernet-rdma", "ethernet", "sriov", "50-sriovnetwork"},
+		{"sriov-ib-rdma", "infiniband", "sriov", "50-sriovibnetwork"},
+		{"host-device-rdma", "ethernet", "host_device", "30-hostdevicenetwork"},
+		{"macvlan-rdma-shared", "ethernet", "rdma_shared", "30-macvlannetwork"},
+		{"ipoib-rdma-shared", "infiniband", "rdma_shared", "30-ipoibnetwork"},
+	}
+
+	for _, p := range profilesUnderTest {
+		t.Run(p.dir, func(t *testing.T) {
+			rendered := renderProfileWithProfile(t, p.dir, &config.Profile{
+				Fabric:     p.fabric,
+				Deployment: p.deployment,
+				Multirail:  true,
+				Routing:    config.RoutingSourceBased,
+				IgnoreARP:  true,
+			})
+			name, content := fileMatching(t, rendered, p.fileSubstr)
+			docs := parseDocs(t, name, content)
+			require.NotEmpty(t, docs)
+			for _, doc := range docs {
+				metaPlugins := specString(t, doc, "metaPlugins")
+				require.Contains(t, metaPlugins, `"type": "tuning"`)
+				require.Contains(t, metaPlugins, `"net.ipv4.conf.all.arp_ignore": "1"`)
+				require.Contains(t, metaPlugins, `"net.ipv4.conf.IFNAME.arp_announce": "2"`)
+				require.Contains(t, metaPlugins, `"type": "sbr"`)
+				require.Less(t,
+					strings.Index(metaPlugins, `"type": "tuning"`),
+					strings.Index(metaPlugins, `"type": "sbr"`),
+					"tuning must precede sbr")
+			}
+		})
+	}
+}
+
+func TestDefaultProfilesDoNotRenderMetaPlugins(t *testing.T) {
+	rendered := renderProfile(t, "sriov-ethernet-rdma", "ethernet", "sriov")
+	name, content := fileMatching(t, rendered, "50-sriovnetwork")
+	for _, doc := range parseDocs(t, name, content) {
+		_, ok := optionalSpecString(t, doc, "metaPlugins")
+		require.False(t, ok, "default destination-based routing with ignoreARP=false must not render metaPlugins")
 	}
 }
 

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -95,6 +95,11 @@ var templateFuncs = template.FuncMap{
 	// hash of the original (same algorithm as MachineLabelValue), so the result
 	// is deterministic across calls but never breaches maxLen.
 	"boundedSuffix": boundedSuffix,
+	// secondaryNetworkMetaPlugins renders the metaPlugins literal-block body
+	// shared by non-Spectrum-X secondary-network CRs. Keep tuning before sbr:
+	// tuning fixes per-interface ARP ownership before sbr installs
+	// source-selected route tables.
+	"secondaryNetworkMetaPlugins": secondaryNetworkMetaPlugins,
 	// pfsPerNic computes how many PFs share the same physical NIC by grouping
 	// east-west PFs by PCI bus:device prefix (everything before the last ".").
 	// E.g., 8 PFs across 8 NICs → 1; 8 PFs across 4 NICs → 2.
@@ -146,6 +151,48 @@ var templateFuncs = template.FuncMap{
 	// legacySriovDevicePluginConfigList does the same shape for the
 	// sriovDevicePlugin used by the 26.1 host-device profile.
 	"legacySriovDevicePluginConfigList": legacySriovDevicePluginConfigList,
+}
+
+func secondaryNetworkMetaPlugins(profile *config.Profile) string {
+	if profile == nil || (profile.SpectrumX != nil && profile.SpectrumX.Enable) {
+		return ""
+	}
+
+	plugins := make([]string, 0, 2)
+	if profile.IgnoreARP {
+		plugins = append(plugins, `{
+  "type": "tuning",
+  "sysctl": {
+    "net.ipv4.conf.all.arp_ignore": "1",
+    "net.ipv4.conf.all.arp_announce": "2",
+    "net.ipv4.conf.all.rp_filter": "0",
+    "net.ipv4.conf.IFNAME.arp_ignore": "1",
+    "net.ipv4.conf.IFNAME.arp_announce": "2",
+    "net.ipv4.conf.IFNAME.rp_filter": "0"
+  }
+}`)
+	}
+	if profile.Routing == config.RoutingSourceBased {
+		plugins = append(plugins, `{
+  "type": "sbr"
+}`)
+	}
+	if len(plugins) == 0 {
+		return ""
+	}
+	return indentBlock(strings.Join(plugins, ",\n"), 4)
+}
+
+func indentBlock(s string, spaces int) string {
+	if s == "" {
+		return ""
+	}
+	prefix := strings.Repeat(" ", spaces)
+	lines := strings.Split(s, "\n")
+	for i := range lines {
+		lines[i] = prefix + lines[i]
+	}
+	return strings.Join(lines, "\n")
 }
 
 // legacyRdmaSharedConfigList builds the configList array body for
@@ -634,7 +681,7 @@ func ProcessTemplate(templatePath string, cfg *config.LaunchKitConfig, groupFilt
 
 		ctx := &templateContext{
 			LaunchKitConfig: cfgForGroup,
-			ClusterConfig:          &renderGroup,
+			ClusterConfig:   &renderGroup,
 		}
 		var buf bytes.Buffer
 		if err := tmpl.Execute(&buf, ctx); err != nil {
@@ -866,8 +913,8 @@ func boundedSuffix(maxLen int, s string) string {
 // Single-entry buckets are returned as-is.
 func mergeCompatibleGroups(groups []config.ClusterConfig, useNameTemplates bool) ([]config.ClusterConfig, bool) {
 	type mergeKey struct {
-		gpuType string
-		railCount   int
+		gpuType   string
+		railCount int
 	}
 
 	// Group indices by (gpuType, railCount). Source groups carry a
@@ -1073,16 +1120,16 @@ func buildMergedGroup(groups []config.ClusterConfig, indices []int) config.Clust
 	// node alongside the machine label, so it's stable across merged
 	// source machineTypes by construction.
 	return config.ClusterConfig{
-		Identifier:           config.SanitizeIdentifier(gpuType),
-		MachineType:          first.MachineType,
-		GPUType:              gpuType,
-		LinkType:             first.LinkType,
-		Capabilities:         caps,
-		PFs:                  first.PFs, // Representative PFs from first group
-		WorkerNodes:          allNodes,
+		Identifier:            config.SanitizeIdentifier(gpuType),
+		MachineType:           first.MachineType,
+		GPUType:               gpuType,
+		LinkType:              first.LinkType,
+		Capabilities:          caps,
+		PFs:                   first.PFs, // Representative PFs from first group
+		WorkerNodes:           allNodes,
 		ThirdPartyRDMAModules: mergedDepMods,
 		StorageModules:        mergedStorageMods,
-		NodeSelector:         map[string]string{config.GPULabelKey: gpuType},
-		RailPciAddresses:     railPciAddresses,
+		NodeSelector:          map[string]string{config.GPULabelKey: gpuType},
+		RailPciAddresses:      railPciAddresses,
 	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -27,14 +27,14 @@ type Options struct {
 	// Phase 1: Cluster Discovery
 	// ConfigDir is an optional root containing l8k-config.yaml and/or presets/.
 	// Explicit --user-config still has higher precedence for the config file.
-	ConfigDir               string
-	UserConfig              string // Path to user-provided config (skips discovery)
-	DiscoverClusterConfig   bool   // Whether to discover cluster config
+	ConfigDir             string
+	UserConfig            string // Path to user-provided config (skips discovery)
+	DiscoverClusterConfig bool   // Whether to discover cluster config
 	// DiscoverOnly skips Phase 2 (manifest generation) entirely. Set by
 	// the standalone `l8k discover` subcommand so its run produces only
 	// cluster-config.yaml and never errors on "no profile selected".
-	DiscoverOnly      bool
-	SaveClusterConfig string // Path to save discovered config
+	DiscoverOnly             bool
+	SaveClusterConfig        string // Path to save discovered config
 	NetworkOperatorNamespace string // Override namespace for Network Operator (optional; ignored by `discover`)
 	// KeepNamespace, when true, suppresses teardown of the
 	// nvidia-k8s-launch-kit bootstrap namespace at the end of `discover` —
@@ -48,8 +48,8 @@ type Options struct {
 	// NetworkOperatorRelease is a MAJOR.MINOR catalog key (e.g. "26.4"), not
 	// a full semver. Selects component image tags + repository from the
 	// embedded releases catalog and drives version-gated template sections.
-	NetworkOperatorRelease  string
-	ImagePullSecrets        []string // Image pull secret names for NicClusterPolicy
+	NetworkOperatorRelease string
+	ImagePullSecrets       []string // Image pull secret names for NicClusterPolicy
 
 	// Phase 2: Deployment Generation
 	Fabric         string // Fabric type to deploy
@@ -64,10 +64,16 @@ type Options struct {
 	// correctly opts out. YAML presence is tracked separately by
 	// `config.Profile.MultirailSet`.
 	MultirailSet bool
-	SpectrumX    bool   // True when --spectrum-x is set; derived from SPCXVersion != ""
-	SPCXVersion         string // Spectrum-X RA version (the value of --spectrum-x; empty = disabled)
-	MultiplaneMode      string // Spectrum-X multiplane mode (default: swplb)
-	NumberOfPlanes      int    // Number of planes for Spectrum-X (default: 4)
+	Routing      string // destination-based or source-based routing for generated secondary networks
+	IgnoreARP    bool   // Whether to add ARP ownership tuning to generated secondary networks
+	// IgnoreARPSet is true when the user explicitly passed `--ignore-arp`
+	// (including `--ignore-arp=false`). This prevents the bool zero value from
+	// clobbering profile.ignoreARP from the config when the flag is omitted.
+	IgnoreARPSet   bool
+	SpectrumX      bool   // True when --spectrum-x is set; derived from SPCXVersion != ""
+	SPCXVersion    string // Spectrum-X RA version (the value of --spectrum-x; empty = disabled)
+	MultiplaneMode string // Spectrum-X multiplane mode (default: swplb)
+	NumberOfPlanes int    // Number of planes for Spectrum-X (default: 4)
 	// Groups limits `l8k generate` to the named source groups (matched
 	// case-sensitively against `clusterConfig[].identifier`). Comma-separated
 	// on the CLI (`--groups a,b`). Mutually exclusive with GpuType.
@@ -81,7 +87,7 @@ type Options struct {
 	// set, generate replaces fullConfig.ClusterConfig with a single group
 	// synthesized from the preset (skipping cluster discovery). Requires
 	// NodeSelector since the preset has no live worker-node list.
-	ForPreset           string
+	ForPreset string
 	// NetworkNamespaces is the comma-separated list from --network-namespaces:
 	// the namespaces the secondary-network CRs + example test DaemonSets are
 	// rendered into (one copy per namespace). Empty defaults to "default".

--- a/pkg/resolve/defaults.go
+++ b/pkg/resolve/defaults.go
@@ -55,6 +55,7 @@ func (d DefaultDecision) String() string {
 //	                       when groups disagree or any group has empty LinkType.
 //	--deployment-type     ← "sriov" (always).
 //	--multirail           ← true (unless config or CLI explicitly sets it).
+//	--routing             ← "destination-based" (unless config or CLI sets it).
 //	--multiplane-mode     ← per east-west PF deviceID (only when --spectrum-x):
 //	                       1021 (CX7) / a2dc (BF3 SuperNIC) → "uniplane"
 //	                       1023 (CX8) → "swplb"
@@ -121,6 +122,19 @@ func ApplyHardwareDefaults(cfg *config.LaunchKitConfig, opts options.Options) []
 			"current", cfg.Profile.Multirail,
 			"configSet", cfg.Profile.MultirailSet,
 			"cliSet", opts.MultirailSet)
+	}
+
+	// --routing ---------------------------------------------------------
+	if cfg.Profile.Routing == "" && opts.Routing == "" {
+		cfg.Profile.Routing = config.RoutingDestinationBased
+		decisions = append(decisions, DefaultDecision{
+			Flag: "--routing", Value: config.RoutingDestinationBased, Reason: "default",
+		})
+		log.Log.V(1).Info("HW default: --routing=destination-based (default)")
+	} else {
+		log.Log.V(1).Info("HW default: --routing skipped",
+			"current", cfg.Profile.Routing,
+			"cliValue", opts.Routing)
 	}
 
 	// Spectrum-X-specific defaults --------------------------------------

--- a/pkg/resolve/defaults_test.go
+++ b/pkg/resolve/defaults_test.go
@@ -46,7 +46,21 @@ func TestApplyHardwareDefaultsFillsMissingProfileSettings(t *testing.T) {
 	assert.Equal(t, "host_device", cfg.Profile.Deployment)
 	assert.True(t, cfg.Profile.Multirail)
 	assert.True(t, cfg.Profile.MultirailSet)
-	assert.Len(t, decisions, 2)
+	assert.Equal(t, config.RoutingDestinationBased, cfg.Profile.Routing)
+	assert.Len(t, decisions, 3)
+}
+
+func TestApplyHardwareDefaultsPreservesConfiguredRouting(t *testing.T) {
+	cfg := &config.LaunchKitConfig{
+		Profile: &config.Profile{Routing: config.RoutingSourceBased},
+	}
+
+	decisions := ApplyHardwareDefaults(cfg, options.Options{})
+
+	assert.Equal(t, config.RoutingSourceBased, cfg.Profile.Routing)
+	for _, decision := range decisions {
+		assert.NotEqual(t, "--routing", decision.Flag)
+	}
 }
 
 func TestApplyHardwareDefaultsHonorsExplicitCLIMultirailFalse(t *testing.T) {

--- a/pkg/resolve/validate.go
+++ b/pkg/resolve/validate.go
@@ -32,6 +32,9 @@ func ValidateResolvedConfig(cfg *config.LaunchKitConfig) error {
 	if cfg == nil || cfg.Profile == nil {
 		return nil
 	}
+	if err := validateRouting(cfg.Profile); err != nil {
+		return err
+	}
 
 	if cfg.Profile.SpectrumX != nil && cfg.Profile.SpectrumX.Enable {
 		return validateSpectrumXCohort(cfg)
@@ -53,6 +56,16 @@ func ValidateResolvedConfig(cfg *config.LaunchKitConfig) error {
 	return nil
 }
 
+func validateRouting(profile *config.Profile) error {
+	switch profile.Routing {
+	case "", config.RoutingDestinationBased, config.RoutingSourceBased:
+	default:
+		return fmt.Errorf("profile.routing must be one of: %s, %s",
+			config.RoutingDestinationBased, config.RoutingSourceBased)
+	}
+	return nil
+}
+
 // validateSpectrumXCohort enforces cross-flag rules for Spectrum-X
 // profiles after hardware defaults + CLI overlay. Same checks that
 // `pkg/cmd/applySpectrumXDefaults` ran, just sourced from cfg
@@ -69,6 +82,13 @@ func validateSpectrumXCohort(cfg *config.LaunchKitConfig) error {
 	}
 	if !cfg.Profile.Multirail {
 		return fmt.Errorf("--spectrum-x requires multirail=true")
+	}
+	if cfg.Profile.Routing != "" && cfg.Profile.Routing != config.RoutingDestinationBased {
+		return fmt.Errorf("--routing does not apply to Spectrum-X profiles; use %s or remove the field",
+			config.RoutingDestinationBased)
+	}
+	if cfg.Profile.IgnoreARP {
+		return fmt.Errorf("--ignore-arp does not apply to Spectrum-X profiles; remove the flag or set ignoreARP: false")
 	}
 
 	// SPCXVersion must be set and registered (Phase 1 enforces the

--- a/pkg/resolve/validate_test.go
+++ b/pkg/resolve/validate_test.go
@@ -28,3 +28,62 @@ func TestEmbeddedDefaultIsResolvedConfigValid(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, ValidateResolvedConfig(cfg))
 }
+
+func TestValidateResolvedConfigAllowsEmptyRoutingWithoutDefaulting(t *testing.T) {
+	cfg := &config.LaunchKitConfig{Profile: &config.Profile{}}
+
+	require.NoError(t, ValidateResolvedConfig(cfg))
+	require.Empty(t, cfg.Profile.Routing)
+}
+
+func TestValidateResolvedConfigRejectsInvalidRouting(t *testing.T) {
+	cfg := &config.LaunchKitConfig{
+		Profile: &config.Profile{Routing: "gateway-based"},
+	}
+
+	err := ValidateResolvedConfig(cfg)
+	require.ErrorContains(t, err, "profile.routing must be one of")
+}
+
+func TestValidateResolvedConfigRejectsRoutingForSpectrumX(t *testing.T) {
+	cfg := &config.LaunchKitConfig{
+		NetworkOperator: &config.NetworkOperatorConfig{SelectedRelease: "26.4"},
+		Profile: &config.Profile{
+			Fabric:     "ethernet",
+			Deployment: "sriov",
+			Multirail:  true,
+			Routing:    config.RoutingSourceBased,
+			SpectrumX: &config.ProfileSpectrumX{
+				Enable:         true,
+				SPCXVersion:    "RA2.2",
+				MultiplaneMode: "hwplb",
+				NumberOfPlanes: 4,
+			},
+		},
+	}
+
+	err := ValidateResolvedConfig(cfg)
+	require.ErrorContains(t, err, "--routing does not apply to Spectrum-X profiles")
+}
+
+func TestValidateResolvedConfigRejectsIgnoreARPForSpectrumX(t *testing.T) {
+	cfg := &config.LaunchKitConfig{
+		NetworkOperator: &config.NetworkOperatorConfig{SelectedRelease: "26.4"},
+		Profile: &config.Profile{
+			Fabric:     "ethernet",
+			Deployment: "sriov",
+			Multirail:  true,
+			Routing:    config.RoutingDestinationBased,
+			IgnoreARP:  true,
+			SpectrumX: &config.ProfileSpectrumX{
+				Enable:         true,
+				SPCXVersion:    "RA2.2",
+				MultiplaneMode: "hwplb",
+				NumberOfPlanes: 4,
+			},
+		},
+	}
+
+	err := ValidateResolvedConfig(cfg)
+	require.ErrorContains(t, err, "--ignore-arp does not apply to Spectrum-X profiles")
+}

--- a/profiles/host-device-rdma/30-hostdevicenetwork.yaml
+++ b/profiles/host-device-rdma/30-hostdevicenetwork.yaml
@@ -1,3 +1,4 @@
+{{- $metaPlugins := secondaryNetworkMetaPlugins .Profile -}}
 {{- if .Profile.Multirail -}}
 {{- /* Create separate HostDeviceNetwork per PF */ -}}
 {{- range $i, $pf := .ClusterConfig.PFs}}
@@ -14,6 +15,10 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}"
     }
+{{- if $metaPlugins }}
+  metaPlugins: |
+{{ $metaPlugins }}
+{{- end }}
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end -}}
 {{- end -}}
@@ -30,4 +35,8 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}"
     }
+{{- if $metaPlugins }}
+  metaPlugins: |
+{{ $metaPlugins }}
+{{- end }}
 {{- end}}

--- a/profiles/ipoib-rdma-shared/30-ipoibnetwork.yaml
+++ b/profiles/ipoib-rdma-shared/30-ipoibnetwork.yaml
@@ -1,3 +1,4 @@
+{{- $metaPlugins := secondaryNetworkMetaPlugins .Profile -}}
 {{- if .Profile.Multirail -}}
 {{- /* Create separate IPoIB networks for each PF network interface */ -}}
 {{- range $i, $pf := .ClusterConfig.PFs}}
@@ -14,6 +15,10 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}"
     }  
+{{- if $metaPlugins }}
+  metaPlugins: |
+{{ $metaPlugins }}
+{{- end }}
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
 {{- end}}
 {{- end -}}
@@ -31,4 +36,8 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}"
     }
+{{- if $metaPlugins }}
+  metaPlugins: |
+{{ $metaPlugins }}
+{{- end }}
 {{end}}

--- a/profiles/macvlan-rdma-shared/30-macvlannetwork.yaml
+++ b/profiles/macvlan-rdma-shared/30-macvlannetwork.yaml
@@ -1,3 +1,4 @@
+{{- $metaPlugins := secondaryNetworkMetaPlugins .Profile -}}
 {{if .Profile.Multirail}}
 {{- /* Create separate MacVLAN networks for each PF interface */ -}}
 {{range $i, $pf := .ClusterConfig.PFs}}
@@ -24,6 +25,10 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}"
     }
+{{- if $metaPlugins }}
+  metaPlugins: |
+{{ $metaPlugins }}
+{{- end }}
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end}}
 {{- end}}
 {{- end}}
@@ -44,4 +49,8 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}"
     }
+{{- if $metaPlugins }}
+  metaPlugins: |
+{{ $metaPlugins }}
+{{- end }}
 {{end}}

--- a/profiles/sriov-ethernet-rdma/50-sriovnetwork.yaml
+++ b/profiles/sriov-ethernet-rdma/50-sriovnetwork.yaml
@@ -1,3 +1,4 @@
+{{- $metaPlugins := secondaryNetworkMetaPlugins .Profile -}}
 {{- if .Profile.Multirail -}}
 {{- /* Create separate SR-IOV Ethernet networks for each PF interface */ -}}
 {{- range $i, $pf := .ClusterConfig.PFs}}
@@ -13,6 +14,10 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}"
     }
+{{- if $metaPlugins }}
+  metaPlugins: |
+{{ $metaPlugins }}
+{{- end }}
   networkNamespace: "{{$.CurrentNetworkNamespace}}"
   resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}
 {{if ne $i (sub (len $.ClusterConfig.PFs) 1)}}---{{end -}}
@@ -30,5 +35,9 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}"
     }
+{{- if $metaPlugins }}
+  metaPlugins: |
+{{ $metaPlugins }}
+{{- end }}
   networkNamespace: "{{$.CurrentNetworkNamespace}}"
   resourceName: {{.Sriov.ResourceName}}{{- end}}

--- a/profiles/sriov-ib-rdma/50-sriovibnetwork.yaml
+++ b/profiles/sriov-ib-rdma/50-sriovibnetwork.yaml
@@ -1,3 +1,4 @@
+{{- $metaPlugins := secondaryNetworkMetaPlugins .Profile -}}
 {{- if .Profile.Multirail -}}
 {{- /* Create separate SR-IOV IB networks for each PF interface */ -}}
 {{- range $i, $pf := .ClusterConfig.PFs}}
@@ -13,6 +14,10 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{$.NvIpam.PoolName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}"
     }
+{{- if $metaPlugins }}
+  metaPlugins: |
+{{ $metaPlugins }}
+{{- end }}
   resourceName: {{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}
   linkState: enable
   networkNamespace: "{{$.CurrentNetworkNamespace}}"
@@ -31,6 +36,10 @@ spec:
       "type": "nv-ipam",
       "poolName": "{{.NvIpam.PoolName}}{{suffix $.ClusterConfig.Identifier}}"
     }
+{{- if $metaPlugins }}
+  metaPlugins: |
+{{ $metaPlugins }}
+{{- end }}
   resourceName: {{.Sriov.ResourceName}}
   linkState: enable
   networkNamespace: "{{$.CurrentNetworkNamespace}}"


### PR DESCRIPTION
## Summary
- Add profile-level `routing` and `ignoreARP` settings plus `--routing` / `--ignore-arp` CLI overrides.
- Render `sbr` and `tuning` metaPlugins for all non-Spectrum-X secondary network profiles: SR-IOV Ethernet, SR-IOV IB, host-device, Macvlan RDMA-shared, and IPoIB RDMA-shared.
- Keep Spectrum-X excluded through resolved-config validation and the shared template helper.
- Document when `ignoreARP: true` is useful for multi-rail ARP-flux cases where one pod rail can answer ARP for another rail's IP.

## Validation
- `git fetch upstream main` and rebase onto `upstream/main` (`3385c58`)
- `GOCACHE=/private/tmp/l8k-sbr-go-cache GOMODCACHE=/private/tmp/l8k-sbr-go-mod go test ./pkg/config ./pkg/resolve ./pkg/cmd ./pkg/networkoperatorplugin -count=1`
- `GOCACHE=/private/tmp/l8k-sbr-go-cache GOMODCACHE=/private/tmp/l8k-sbr-go-mod go test ./... -count=1`
- `GOCACHE=/private/tmp/l8k-sbr-go-cache GOMODCACHE=/private/tmp/l8k-sbr-go-mod go build ./...`
- `git diff --check`
- Generated `/Users/amaslennikov/workspace/k8s-launch-kit/rtx-cluster/cluster-config.yaml` with `--routing source-based --ignore-arp` and verified tuning + sbr metaPlugins on each SR-IOV rail.
- Generated the same config with default routing and verified no metaPlugins are rendered.
- Generated the same config with `--routing source-based` only and verified only sbr metaPlugins are rendered.