### PR TITLE
fix: persist generate overrides to source config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ skills, which wrap the deterministic CLI commands.
 
 ### Generate Deployment Files
 Based on the discovered/provided configuration, generate a complete set of YAML deployment files tailored to your selected network profile.
+When generation uses a file-backed config, resolved defaults and CLI overrides
+are written back to that same file while its comments are preserved.
 
 ## Installation
 
@@ -447,6 +449,10 @@ l8k generate --user-config ./config.yaml \
     --fabric ethernet --deployment-type sriov --multirail \
     --save-deployment-files ./deployments
 ```
+
+After successful profile resolution, `generate` rewrites the source config with
+the final defaults and explicit CLI overrides before rendering manifests. The
+embedded config used by `--for` when no file is selected is not written.
 
 ### Generate Deployment Files for a Specific Node Group
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -19,6 +19,10 @@ are preserved, and explicit CLI flags take precedence over both.
    l8k generate --user-config ./cluster-config.yaml \
      --save-deployment-files ./deployment
 
+When ``generate`` uses a file-backed config, it writes resolved defaults and
+explicit CLI overrides back to that same file before rendering manifests.
+Comments in the original YAML are preserved.
+
 Discovery defaults ``deployment`` to ``sriov`` and ``multirail`` to ``true``.
 It derives ``fabric`` only when every discovered group reports the same
 confirmed link type. If the fabric cannot be confirmed, discovery still saves

--- a/pkg/app/generate.go
+++ b/pkg/app/generate.go
@@ -26,14 +26,21 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
 	"github.com/nvidia/k8s-launch-kit/pkg/presets"
 	"github.com/nvidia/k8s-launch-kit/pkg/profiles"
+	"gopkg.in/yaml.v2"
 )
 
 // executeGeneration handles the profile selection and manifest generation phase.
 // Returns nil if no profile is configured and generation is skipped.
 func (l *Launcher) executeGeneration(configPath string) error {
-	fullConfig, err := config.LoadFullConfig(configPath, l.logger)
+	fullConfig, srcConfigYAML, err := config.LoadFullConfigWithSource(configPath, l.logger)
 	if err != nil {
 		return fmt.Errorf("failed to load full config: %w", err)
+	}
+	var srcConfig config.LaunchKitConfig
+	if configPath != "" {
+		if err := yaml.Unmarshal(srcConfigYAML, &srcConfig); err != nil {
+			return fmt.Errorf("failed to parse source config %s for write-back: %w", configPath, err)
+		}
 	}
 
 	// Validate `--groups` / `--gpu-type` against the loaded config before
@@ -108,6 +115,14 @@ func (l *Launcher) executeGeneration(configPath string) error {
 		)
 	}
 
+	// Persist the exact config used for generation: hardware defaults fill
+	// missing fields, existing YAML values survive, and explicit CLI options
+	// win. Do this before --for substitutes a synthetic clusterConfig so only
+	// the resolved settings—not preset-only topology—are written back.
+	if err := l.saveResolvedConfig(configPath, fullConfig, srcConfig, srcConfigYAML); err != nil {
+		return err
+	}
+
 	// --for: replace clusterConfig with a synthesized group from a preset.
 	// This is the explicit ahead-of-time generation path that skips live
 	// discovery in favor of a static preset description. The CLI layer has
@@ -170,6 +185,41 @@ func (l *Launcher) executeGeneration(configPath string) error {
 	warnThirdPartyRDMAModules(fullConfig, "generate", l.ui)
 	warnStorageModules(fullConfig, "generate", l.ui)
 
+	return nil
+}
+
+func (l *Launcher) saveResolvedConfig(
+	configPath string,
+	fullConfig *config.LaunchKitConfig,
+	srcConfig config.LaunchKitConfig,
+	srcConfigYAML []byte,
+) error {
+	if configPath == "" {
+		return nil
+	}
+
+	writeBackConfig := *fullConfig
+	// LoadFullConfig materializes maintenance defaults and computed NV-IPAM
+	// reserve exclusions for rendering. Those are not profile/CLI resolution,
+	// so keep their original YAML forms rather than accumulating derived state
+	// every time generate rewrites the file.
+	writeBackConfig.Maintenance = srcConfig.Maintenance
+	writeBackConfig.NvIpam = srcConfig.NvIpam
+
+	data, err := config.MarshalConfigPreservingComments(&writeBackConfig, srcConfigYAML, "")
+	if err != nil {
+		return fmt.Errorf("failed to marshal resolved config: %w", err)
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to stat source config %s before write-back: %w", configPath, err)
+	}
+	if err := os.WriteFile(configPath, data, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("failed to write resolved config to %s: %w", configPath, err)
+	}
+
+	l.ui.Success("Resolved configuration saved: %s", configPath)
+	l.logger.Info("Resolved generation config saved", "path", configPath)
 	return nil
 }
 

--- a/pkg/app/generate_profile_test.go
+++ b/pkg/app/generate_profile_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
+	"github.com/nvidia/k8s-launch-kit/pkg/options"
+	"github.com/nvidia/k8s-launch-kit/pkg/ui"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestGeneratePersistsResolvedProfileToOriginalConfig(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	t.Chdir(filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..")))
+
+	cfg, err := config.DefaultLaunchKitConfig()
+	require.NoError(t, err)
+	require.NotEmpty(t, cfg.ClusterConfig)
+	cfg.Profile = &config.Profile{Deployment: "host_device"}
+	cfg.ClusterConfig[0].LinkType = "Ethernet"
+	cfg.NvIpam.ReserveFirstIPs = 2
+	cfg.NvIpam.Subnets = []config.NvIpamSubnetConfig{{
+		Subnet:  "192.168.50.0/24",
+		Gateway: "192.168.50.1",
+		Exclusions: []config.NvIpamExclusion{{
+			StartIP: "192.168.50.20",
+			EndIP:   "192.168.50.21",
+		}},
+	}}
+
+	raw, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	source := "# original config comment\n" + string(raw)
+	source = strings.Replace(source, "clusterConfig:\n", "clusterConfig: # hardware inventory comment\n", 1)
+	source = strings.Replace(source, "profile:\n", "profile:\n  # profile settings comment\n", 1)
+	source = strings.Replace(source, "linkType: Ethernet", "linkType: Ethernet # hardware detail comment", 1)
+
+	configPath := filepath.Join(t.TempDir(), "cluster-config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(source), 0o600))
+
+	launcher := New(options.Options{
+		DeploymentType: "sriov",
+		Multirail:      false,
+		MultirailSet:   true,
+	})
+	launcher.ui = ui.NewSilent()
+	launcher.plugins[networkoperatorplugin.PluginName] = &networkoperatorplugin.NetworkOperatorPlugin{}
+
+	require.NoError(t, launcher.executeGeneration(configPath))
+
+	got, err := config.LoadFullConfig(configPath, launcher.logger)
+	require.NoError(t, err)
+	require.NotNil(t, got.Profile)
+	assert.Equal(t, "ethernet", got.Profile.Fabric, "hardware default must be persisted")
+	assert.Equal(t, "sriov", got.Profile.Deployment, "CLI override must be persisted")
+	assert.False(t, got.Profile.Multirail, "explicit CLI false must be persisted")
+	assert.True(t, got.Profile.MultirailSet)
+
+	updated, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "# original config comment")
+	assert.Contains(t, string(updated), "# hardware inventory comment")
+	assert.Contains(t, string(updated), "# hardware detail comment")
+	assert.Contains(t, string(updated), "# profile settings comment")
+	var persisted config.LaunchKitConfig
+	require.NoError(t, yaml.Unmarshal(updated, &persisted))
+	require.Len(t, persisted.NvIpam.Subnets, 1)
+	assert.Len(t, persisted.NvIpam.Subnets[0].Exclusions, 1,
+		"computed reserve exclusions must not be written back as explicit input")
+
+	info, err := os.Stat(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "in-place write must preserve file permissions")
+
+	require.NoError(t, launcher.executeGeneration(configPath))
+	secondUpdate, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(updated), string(secondUpdate), "repeated generation must produce stable config YAML")
+}

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -45,6 +45,7 @@ var generateCmd = &cobra.Command{
 from a cluster configuration file.
 
 Supports SR-IOV, host-device, RDMA-shared, IPoIB, MacVLAN, and Spectrum-X profiles.
+File-backed configs are rewritten with resolved defaults and CLI overrides.
 Optionally deploy the generated manifests with --deploy.`,
 	Example: `  # SR-IOV Ethernet (most common for GPU clusters)
   l8k generate --user-config cluster-config.yaml \

--- a/pkg/config/comments.go
+++ b/pkg/config/comments.go
@@ -35,6 +35,17 @@ import (
 // unparseable, cfg is marshaled without transplanted comments (banner still
 // applied). Output uses 2-space indentation to match l8k's config style.
 func MarshalConfigWithComments(cfg *LaunchKitConfig, srcYAML []byte, banner string) ([]byte, error) {
+	return marshalConfigWithComments(cfg, srcYAML, banner, true)
+}
+
+// MarshalConfigPreservingComments marshals cfg while retaining comments from
+// every matching source key, including clusterConfig. It is intended for
+// in-place updates where the hardware inventory is not being regenerated.
+func MarshalConfigPreservingComments(cfg *LaunchKitConfig, srcYAML []byte, banner string) ([]byte, error) {
+	return marshalConfigWithComments(cfg, srcYAML, banner, false)
+}
+
+func marshalConfigWithComments(cfg *LaunchKitConfig, srcYAML []byte, banner string, skipClusterConfig bool) ([]byte, error) {
 	// Render cfg to a fresh node tree via a marshal/unmarshal round-trip.
 	raw, err := yaml3.Marshal(cfg)
 	if err != nil {
@@ -49,7 +60,7 @@ func MarshalConfigWithComments(cfg *LaunchKitConfig, srcYAML []byte, banner stri
 	if len(bytes.TrimSpace(srcYAML)) > 0 {
 		// Best-effort: a malformed source just means no comments to transplant.
 		if err := yaml3.Unmarshal(srcYAML, &src); err == nil {
-			transplantComments(&src, &dst)
+			transplantComments(&src, &dst, skipClusterConfig)
 		}
 	}
 
@@ -70,9 +81,9 @@ func MarshalConfigWithComments(cfg *LaunchKitConfig, srcYAML []byte, banner stri
 }
 
 // transplantComments recursively copies comments from src onto dst for nodes
-// that correspond (matching mapping keys). The top-level "clusterConfig" key is
-// skipped since discovery regenerates that section.
-func transplantComments(src, dst *yaml3.Node) {
+// that correspond (matching mapping keys). When skipClusterConfig is true, the
+// top-level clusterConfig key is skipped because discovery regenerates it.
+func transplantComments(src, dst *yaml3.Node, skipClusterConfig bool) {
 	if src == nil || dst == nil {
 		return
 	}
@@ -81,7 +92,7 @@ func transplantComments(src, dst *yaml3.Node) {
 	case src.Kind == yaml3.DocumentNode && dst.Kind == yaml3.DocumentNode:
 		copyComments(src, dst)
 		if len(src.Content) > 0 && len(dst.Content) > 0 {
-			transplantComments(src.Content[0], dst.Content[0])
+			transplantComments(src.Content[0], dst.Content[0], skipClusterConfig)
 		}
 
 	case src.Kind == yaml3.MappingNode && dst.Kind == yaml3.MappingNode:
@@ -95,7 +106,7 @@ func transplantComments(src, dst *yaml3.Node) {
 		for i := 0; i+1 < len(dst.Content); i += 2 {
 			dk := dst.Content[i]
 			dv := dst.Content[i+1]
-			if dk.Value == "clusterConfig" {
+			if skipClusterConfig && dk.Value == "clusterConfig" {
 				continue
 			}
 			sk, ok := srcKeyNode[dk.Value]
@@ -103,12 +114,24 @@ func transplantComments(src, dst *yaml3.Node) {
 				continue
 			}
 			copyComments(sk, dk)
-			transplantComments(srcValNode[dk.Value], dv)
+			transplantComments(srcValNode[dk.Value], dv, skipClusterConfig)
+		}
+
+	case src.Kind == yaml3.SequenceNode && dst.Kind == yaml3.SequenceNode:
+		copyComments(src, dst)
+		// Discovery historically treats sequences as regenerated values. An
+		// in-place write-back keeps their order, so index matching preserves
+		// comments within clusterConfig entries and other lists.
+		if !skipClusterConfig {
+			limit := min(len(src.Content), len(dst.Content))
+			for i := 0; i < limit; i++ {
+				transplantComments(src.Content[i], dst.Content[i], skipClusterConfig)
+			}
 		}
 
 	default:
-		// Scalars (and sequences we don't recurse into): copy the node's own
-		// comments, e.g. an inline `value # note`. Only when the shapes line up
+		// Scalars: copy the node's own comments, e.g. an inline `value # note`.
+		// Only when the shapes line up
 		// — a value-kind mismatch (e.g. source section is a mapping but cfg
 		// marshaled it as a scalar) means there are no value-level comments
 		// worth moving. Section doc comments live on the key nodes and are

--- a/pkg/config/comments_test.go
+++ b/pkg/config/comments_test.go
@@ -38,7 +38,7 @@ nvIpam:
   reserveFirstIPs: 10
 rdmaShared:
   resourceName: rdma_shared_resource # inline note about suffixes
-clusterConfig:
+clusterConfig: # inventory section comment
   - identifier: example   # this comment must NOT be carried over
 `
 	cfg := &LaunchKitConfig{
@@ -74,6 +74,7 @@ clusterConfig:
 	})
 	t.Run("clusterConfig comments are NOT carried over", func(t *testing.T) {
 		assert.NotContains(t, got, "must NOT be carried over")
+		assert.NotContains(t, got, "inventory section comment")
 	})
 	t.Run("discovered values win over source values", func(t *testing.T) {
 		assert.Contains(t, got, "identifier: discovered-group")
@@ -95,6 +96,13 @@ clusterConfig:
 		require.NoError(t, err)
 		assert.Contains(t, string(out), "# banner only")
 		assert.Contains(t, string(out), "poolName: nv-ipam-pool")
+	})
+
+	t.Run("in-place write-back preserves clusterConfig comments", func(t *testing.T) {
+		out, err := MarshalConfigPreservingComments(cfg, []byte(src), "")
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "# top of file banner from source")
+		assert.Contains(t, string(out), "# inventory section comment")
 	})
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -447,38 +447,47 @@ func AggregateCapabilities(groups []ClusterConfig) *ClusterCapabilities {
 // that does not exist remains an error (a typo'd --user-config should NOT
 // silently fall back to defaults).
 func LoadFullConfig(configPath string, logger logr.Logger) (*LaunchKitConfig, error) {
+	cfg, _, err := LoadFullConfigWithSource(configPath, logger)
+	return cfg, err
+}
+
+// LoadFullConfigWithSource loads and normalizes the same configuration as
+// LoadFullConfig and also returns the exact YAML bytes that were parsed. The
+// source snapshot lets in-place writers preserve comments without reading the
+// file a second time.
+func LoadFullConfigWithSource(configPath string, logger logr.Logger) (*LaunchKitConfig, []byte, error) {
 	if configPath == "" {
 		logger.Info("Loading embedded default l8k-config (no path provided)")
 		cfg, err := DefaultLaunchKitConfig()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		// emitPresetDeviationWarnings is a no-op for defaults (no
 		// ClusterConfig entries yet) but kept for shape parity.
 		emitPresetDeviationWarnings(cfg, logger)
-		return cfg, nil
+		return cfg, DefaultConfigYAML(), nil
 	}
 
 	logger.Info("Loading cluster configuration", "path", configPath)
 
 	// Check if config file exists
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("cluster config file does not exist: %s", configPath)
+		return nil, nil, fmt.Errorf("cluster config file does not exist: %s", configPath)
 	}
 
 	// Read the configuration file
 	configData, err := os.ReadFile(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read cluster config file %s: %w", configPath, err)
+		return nil, nil, fmt.Errorf("failed to read cluster config file %s: %w", configPath, err)
 	}
 
 	// Parse the YAML configuration
 	var config LaunchKitConfig
 	if err := yaml.Unmarshal(configData, &config); err != nil {
-		return nil, fmt.Errorf("failed to parse cluster config YAML %s: %w", configPath, err)
+		return nil, nil, fmt.Errorf("failed to parse cluster config YAML %s: %w", configPath, err)
 	}
 	if err := NormalizeMaintenance(&config); err != nil {
-		return nil, fmt.Errorf("invalid maintenance config in %s: %w", configPath, err)
+		return nil, nil, fmt.Errorf("invalid maintenance config in %s: %w", configPath, err)
 	}
 
 	logger.Info("Cluster configuration loaded successfully",
@@ -486,22 +495,23 @@ func LoadFullConfig(configPath string, logger logr.Logger) (*LaunchKitConfig, er
 		"namespace", config.NetworkOperator.Namespace)
 
 	if err := validateNvIpam(config.NvIpam); err != nil {
-		return nil, fmt.Errorf("invalid nvIpam config in %s: %w", configPath, err)
+		return nil, nil, fmt.Errorf("invalid nvIpam config in %s: %w", configPath, err)
 	}
 
 	// Finalize exclusions for explicitly-listed (manual) subnets. Auto-generated
-	// subnets are finalized in the render path after GenerateSubnets. l8k never
-	// rewrites nvIpam back to disk, so this runs exactly once per load.
+	// subnets are finalized in the render path after GenerateSubnets. Config
+	// write-back restores the source nvIpam form, so exclusions are applied once
+	// per load without accumulating in the file.
 	if config.NvIpam != nil && len(config.NvIpam.Subnets) > 0 {
 		if err := ApplyReservedExclusions(
 			config.NvIpam.Subnets, config.NvIpam.ReserveFirstIPs, config.NvIpam.ReserveLastIPs); err != nil {
-			return nil, fmt.Errorf("invalid nvIpam config in %s: %w", configPath, err)
+			return nil, nil, fmt.Errorf("invalid nvIpam config in %s: %w", configPath, err)
 		}
 	}
 
 	emitPresetDeviationWarnings(&config, logger)
 
-	return &config, nil
+	return &config, configData, nil
 }
 
 // emitPresetDeviationWarnings logs a warning for every group whose config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -83,6 +83,10 @@ profile:
 		assert.Equal(t, "sriov", config.Profile.Deployment)
 		assert.False(t, config.Profile.Multirail)
 		assert.Nil(t, config.Profile.SpectrumX)
+
+		_, source, err := LoadFullConfigWithSource(configPath, logger)
+		require.NoError(t, err)
+		assert.Equal(t, configContent, string(source))
 	})
 
 	t.Run("load config file that does not exist", func(t *testing.T) {

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -35,15 +35,16 @@ l8k discover --user-config my-config.yaml \
 
 ## Profile Resolution and Write-Back
 
-Discovery resolves and persists the `profile` section with this precedence:
+Discovery and file-backed generation resolve and persist settings with this precedence:
 
 1. Hardware and built-in defaults fill missing fields.
 2. Values already present in `--user-config` are preserved.
-3. Explicit discovery CLI flags override both.
+3. Explicit CLI flags override both.
 
-The final values are written back to the output YAML. On later discovery runs,
-only missing fields are recalculated. `multirail: false` is an explicit value,
-not a missing field, so it remains false across rewrites.
+Discovery writes to its selected output YAML; generation rewrites its source
+config in place. On later runs, only missing fields are recalculated.
+`multirail: false` is an explicit value, not a missing field, so it remains
+false across rewrites.
 
 ## Config Sections Quick Reference
 

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -21,7 +21,9 @@ l8k generate --user-config <CONFIG> \
 ```
 
 Configs produced by `l8k discover` already contain the resolved profile.
-Profile flags remain available as generation-time overrides.
+Profile flags remain available as generation-time overrides. When generation
+uses a file-backed config, resolved defaults and CLI overrides are written back
+to that source file; embedded `--for` generation does not write a config.
 
 ## Profile Selection Flags
 


### PR DESCRIPTION
## Summary
- rewrite a file-backed generate config with resolved hardware defaults and explicit CLI overrides
- preserve source comments, file permissions, and the original forms of render-only normalized settings
- leave embedded `--for` generation write-free and avoid persisting its synthetic topology

## Validation
- `GOCACHE=/private/tmp/l8k-go-cache go test ./... -count=1`
- `GOCACHE=/private/tmp/l8k-go-cache go build .`
- `GOCACHE=/private/tmp/l8k-go-cache go vet ./...`
- golangci-lint v2.11: `golangci-lint run ./...` (`0 issues`)
- live RTX config-copy test: missing fabric resolved to `ethernet`, CLI `rdma_shared` and `multirail=false` were written to the same YAML, six manifests rendered, and a second run was byte-stable
