### PR TITLE
fix: use controller-runtime apply API

### DIFF
--- a/pkg/networkoperatorplugin/connectivity/daemonset.go
+++ b/pkg/networkoperatorplugin/connectivity/daemonset.go
@@ -102,7 +102,7 @@ func LoadExampleDaemonSets(manifestDir string) ([]*unstructured.Unstructured, []
 
 // ApplyDaemonSet performs a kubectl-style server-side apply of obj.
 func ApplyDaemonSet(ctx context.Context, c client.Client, obj *unstructured.Unstructured) error {
-	return c.Patch(ctx, obj, client.Apply, client.FieldOwner("l8k-connectivity"), client.ForceOwnership)
+	return c.Apply(ctx, client.ApplyConfigurationFromUnstructured(obj), client.FieldOwner("l8k-connectivity"), client.ForceOwnership)
 }
 
 // DeleteDaemonSet removes the DaemonSet by Namespace/Name, ignoring

--- a/pkg/networkoperatorplugin/deploy.go
+++ b/pkg/networkoperatorplugin/deploy.go
@@ -678,11 +678,11 @@ func sniffKind(b []byte) string {
 func applyUnstructured(ctx context.Context, c client.Client, obj *unstructured.Unstructured, dryRun bool) error {
 	// kubectl-style server-side apply. dryRun appends client.DryRunAll so the
 	// cluster validates the object without persisting it.
-	opts := []client.PatchOption{client.FieldOwner("l8k"), client.ForceOwnership}
+	opts := []client.ApplyOption{client.FieldOwner("l8k"), client.ForceOwnership}
 	if dryRun {
 		opts = append(opts, client.DryRunAll)
 	}
-	return c.Patch(ctx, obj, client.Apply, opts...)
+	return c.Apply(ctx, client.ApplyConfigurationFromUnstructured(obj), opts...)
 }
 
 // splitYAMLDocuments splits a YAML stream by lines that start with '---' (doc separators)
@@ -895,4 +895,3 @@ func buildPreflightInputs(kubeClient client.Client, manifestsDir string, opts De
 	in.GeneratedManifests = refs
 	return in, nil
 }
-


### PR DESCRIPTION
## Summary
- Replace deprecated `c.Patch(..., client.Apply, ...)` server-side apply calls with `c.Apply(...)`.
- Wrap unstructured objects with `client.ApplyConfigurationFromUnstructured` while preserving field ownership, force ownership, and dry-run behavior.

## Validation
- `GOCACHE=/private/tmp/k8s-l8k-pr107-go-cache go test ./pkg/networkoperatorplugin/... -count=1`
- `GOCACHE=/private/tmp/k8s-l8k-pr107-go-cache GOLANGCI_LINT_CACHE=/private/tmp/k8s-l8k-pr107-golangci-cache go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run ./...`
- `GOCACHE=/private/tmp/k8s-l8k-pr107-go-cache make build`
- `GOCACHE=/private/tmp/k8s-l8k-pr107-go-cache go test ./... -count=1 -skip 'TestGetPresetsDir_(NotFound|SkipsFiles)'`\n\nNote: full unskipped `go test ./... -count=1` only failed locally because `/usr/local/share/l8k/presets` exists on this machine, which changes the expected fallback result in `TestGetPresetsDir_NotFound` and `TestGetPresetsDir_SkipsFiles`.