### PR TITLE
docs: fix server-side apply comment

### DIFF
--- a/pkg/networkoperatorplugin/deploy.go
+++ b/pkg/networkoperatorplugin/deploy.go
@@ -421,7 +421,7 @@ func applyAndWait(ctx context.Context, c client.Client, registry *crstate.Regist
 		return nil
 	}
 
-	// applyUnstructured does an SSA Patch that returns the
+	// applyUnstructured does a server-side apply that returns the
 	// server-decided object on `obj`. Its current resourceVersion
 	// is "the version right after our apply". If the spec changed
 	// AND this Kind's validator reads .status from the CR itself


### PR DESCRIPTION
## Summary
- Update the observation-gate comment to refer to server-side apply instead of the old SSA Patch wording.
- This carries forward the Greptile note from PR #115 after that PR was merged before the amended comment-only fix landed.

## Validation
- `git diff --check`
- `GOCACHE=/private/tmp/k8s-l8k-pr107-go-cache go test ./pkg/networkoperatorplugin -count=1`