### PR TITLE
feat: add Spectrum-X DRA option

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,12 @@ An explicit CLI or config value is preserved and the pair is validated:
 "RA2.1 requires --network-operator-release in [26.1]" message rather than a
 generic "no applicable profile found".
 
+For the RA2.2 `spectrum-x` profile, `profile.spectrumX.useDRA` defaults to `false`.
+When set to `true`, l8k enables the SR-IOV operator `dynamicResourceAllocation`
+feature gate, sets `SpectrumXRailPoolConfig.spec.draEnabled: true`, emits
+`ResourceClaimTemplate` manifests, and renders the example workload with DRA
+claims instead of `nvidia.com/rail_*` device-plugin resource requests.
+
 For non-Spectrum-X profiles, leaving both the flag and `selectedRelease` empty
 continues to render the newest gates (treated as "latest").
 
@@ -865,6 +871,8 @@ profile:
   multirail: true
   routing: destination-based
   ignoreARP: false
+  spectrumX:
+    useDRA: false                       # Set true to generate Spectrum-X DRA ResourceClaimTemplates
 clusterConfig:
 - identifier: group-0
   capabilities:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -384,6 +384,7 @@ type ProfileSpectrumX struct {
 	SPCXVersion    string `yaml:"spcxVersion"`    // e.g., "RA2.2"
 	MultiplaneMode string `yaml:"multiplaneMode"` // swplb, hwplb, uniplane
 	NumberOfPlanes int    `yaml:"numberOfPlanes"` // 2 or 4
+	UseDRA         bool   `yaml:"useDRA"`         // enable DRA ResourceClaimTemplate-based workload allocation
 }
 
 type ClusterConfig struct {
@@ -466,9 +467,10 @@ type PFConfig struct {
 	// VPD.
 	Model string `yaml:"model,omitempty"`
 	// Topology fields (populated from presets when available)
-	NumaNode     *int   `yaml:"numaNode,omitempty"`
-	ConnectedGPU string `yaml:"connectedGPU,omitempty"`
-	GPUProximity string `yaml:"gpuProximity,omitempty"`
+	NumaNode               *int   `yaml:"numaNode,omitempty"`
+	ConnectedGPU           string `yaml:"connectedGPU,omitempty"`
+	ConnectedGPUPCIAddress string `yaml:"connectedGPUPCIAddress,omitempty"`
+	GPUProximity           string `yaml:"gpuProximity,omitempty"`
 }
 
 // AggregateCapabilities computes the union of capabilities across all cluster config groups.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -368,6 +368,7 @@ profile:
     spcxVersion: "RA2.2"
     multiplaneMode: hwplb
     numberOfPlanes: 4
+    useDRA: true
   ai: true
 `
 		err := os.WriteFile(configPath, []byte(configContent), 0644)
@@ -391,6 +392,7 @@ profile:
 		assert.Equal(t, "RA2.2", config.Profile.SpectrumX.SPCXVersion)
 		assert.Equal(t, "hwplb", config.Profile.SpectrumX.MultiplaneMode)
 		assert.Equal(t, 4, config.Profile.SpectrumX.NumberOfPlanes)
+		assert.True(t, config.Profile.SpectrumX.UseDRA)
 		assert.True(t, config.Profile.Multirail)
 	})
 

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -135,6 +135,7 @@ profile:
     # spcxVersion: "RA2.2" # CLI parameter (overrides this value): --spectrum-x
     # multiplaneMode: swplb # CLI parameter (overrides this value): --multiplane-mode (swplb, hwplb, uniplane)
     # numberOfPlanes: 4 # CLI parameter (overrides this value): --number-of-planes, also used as pfsPerNic
+    useDRA: false # Enables DRA ResourceClaimTemplate-based Spectrum-X workload allocation
   ai: false
 
 clusterConfig:

--- a/pkg/networkoperatorplugin/discovery/gputopology.go
+++ b/pkg/networkoperatorplugin/discovery/gputopology.go
@@ -566,6 +566,7 @@ func discoverGPUTopology(ctx context.Context, restConfig *rest.Config,
 		usage[chosen]++
 
 		pf.ConnectedGPU = fmt.Sprintf("GPU%d", chosen)
+		pf.ConnectedGPUPCIAddress = data.gpuPCI[chosen]
 		pf.GPUProximity = best.String()
 
 		numaStr := "unknown"

--- a/pkg/networkoperatorplugin/grouping_test.go
+++ b/pkg/networkoperatorplugin/grouping_test.go
@@ -49,11 +49,13 @@ func loadSpectrumXProfile(t *testing.T) *profiles.Profile {
 			},
 		},
 		Templates: []string{
+			"00-values.yaml",
 			"10-nicclusterpolicy.yaml",
 			"30-nicconfigurationtemplate.yaml",
 			"25-nicinterfacenametemplate.yaml",
 			"60-cidrpool.yaml",
 			"80-spectrumxrailpoolconfig.yaml",
+			"85-resourceclaimtemplate.yaml",
 			"90-example-daemonset.yaml",
 		},
 	}
@@ -65,6 +67,10 @@ func loadSpectrumXProfile(t *testing.T) *profiles.Profile {
 // profile metadata the CLI would normally attach via ApplyOptionsToConfig, and
 // runs GenerateProfileDeploymentFiles exactly as the generate pipeline does.
 func renderSpectrumX(t *testing.T, configName, multiplaneMode string, numberOfPlanes int) map[string]string {
+	return renderSpectrumXWithDRA(t, configName, multiplaneMode, numberOfPlanes, false)
+}
+
+func renderSpectrumXWithDRA(t *testing.T, configName, multiplaneMode string, numberOfPlanes int, useDRA bool) map[string]string {
 	t.Helper()
 	ctrllog.SetLogger(zap.New(zap.UseDevMode(true)))
 
@@ -84,6 +90,7 @@ func renderSpectrumX(t *testing.T, configName, multiplaneMode string, numberOfPl
 			SPCXVersion:    "RA2.2",
 			MultiplaneMode: multiplaneMode,
 			NumberOfPlanes: numberOfPlanes,
+			UseDRA:         useDRA,
 		},
 	}
 
@@ -230,6 +237,8 @@ func TestSpectrumXGrouping_MergedRailPoolContent(t *testing.T) {
 
 	require.Contains(t, merged, `nvidia.kubernetes-launch-kit.gpu: "gpu-model-y"`,
 		"merged rail pool must select by gpuType so it covers all y-model machines")
+	require.Contains(t, merged, "draEnabled: false",
+		"Spectrum-X DRA must stay disabled unless profile.spectrumX.useDRA is true")
 	require.Contains(t, merged, `pfNames: ["eth_p0_r0"]`,
 		"merged rail pool must reference the renamed netdev names, not raw PCI")
 	require.NotContains(t, merged, "0000:19:00.0",
@@ -242,6 +251,85 @@ func TestSpectrumXGrouping_MergedRailPoolContent(t *testing.T) {
 	require.True(t, ok, "unmerged z-model rail pool manifest should exist")
 	require.Contains(t, z, `nvidia.com/gpu.machine: "machine-c"`,
 		"unmerged z-model rail pool must preserve the source group's full nodeSelector")
+}
+
+func TestSpectrumXDRAOptInRendering(t *testing.T) {
+	rendered := renderSpectrumXWithDRA(t, "mixed-same-type.yaml", "none", 1, true)
+
+	values := rendered["values.yaml"]
+	require.Contains(t, values, "dynamicResourceAllocation: true",
+		"DRA mode must enable the SR-IOV operator DRA feature gate")
+
+	railPool := rendered["80-spectrumxrailpoolconfig-gpu-model-y.yaml"]
+	require.Contains(t, railPool, "draEnabled: true",
+		"SpectrumXRailPoolConfig must opt into DRA when useDRA is true")
+
+	claimTemplates := fileNamesMatching(rendered, "85-resourceclaimtemplate")
+	require.Equal(t, []string{"85-resourceclaimtemplate-gpu-model-y.yaml"}, claimTemplates)
+	claims := rendered["85-resourceclaimtemplate-gpu-model-y.yaml"]
+	require.Contains(t, claims, "kind: ResourceClaimTemplate")
+	require.Contains(t, claims, "deviceClassName: gpu.nvidia.com")
+	require.Contains(t, claims, "deviceClassName: sriovnetwork.k8snetworkplumbingwg.io")
+	require.Contains(t, claims, `device.attributes["k8s.cni.cncf.io"].resourceName == "nvidia.com/rail_0"`)
+	require.Contains(t, claims, `device.attributes["resource.kubernetes.io"].pcieRoot == "pci0000:00"`)
+
+	workload := rendered["90-example-daemonset-gpu-model-y.yaml"]
+	require.Contains(t, workload, "resourceClaims:")
+	require.Contains(t, workload, "resourceClaimTemplateName: rail-0-template-gpu-model-y")
+	require.Contains(t, workload, "claims:")
+	require.NotContains(t, workload, "nvidia.com/rail_0: \"1\"",
+		"DRA workload must use resource claims instead of device-plugin resource requests")
+}
+
+func TestSpectrumXDRAOptInRenderingSWPLB(t *testing.T) {
+	rendered := renderSpectrumXWithDRA(t, "mixed-same-type.yaml", "swplb", 2, true)
+
+	claimTemplates := fileNamesMatching(rendered, "85-resourceclaimtemplate")
+	require.Equal(t, []string{"85-resourceclaimtemplate-gpu-model-y.yaml"}, claimTemplates)
+
+	claims := rendered["85-resourceclaimtemplate-gpu-model-y.yaml"]
+	require.Contains(t, claims, "name: rail-0-plane-0-template-gpu-model-y")
+	require.Contains(t, claims, "name: rail-0-plane-1-template-gpu-model-y")
+	require.Contains(t, claims, `device.attributes["k8s.cni.cncf.io"].resourceName == "nvidia.com/rail_0_plane_0"`)
+	require.Contains(t, claims, `device.attributes["k8s.cni.cncf.io"].resourceName == "nvidia.com/rail_0_plane_1"`)
+	require.NotContains(t, claims, "count: 2",
+		"swplb DRA must request one VF per rail-plane claim")
+
+	workload := rendered["90-example-daemonset-gpu-model-y.yaml"]
+	require.Contains(t, workload, "- name: rail-0-plane-0")
+	require.Contains(t, workload, "- name: rail-0-plane-1")
+	require.Contains(t, workload, "resourceClaimTemplateName: rail-0-plane-0-template-gpu-model-y")
+	require.Contains(t, workload, "resourceClaimTemplateName: rail-0-plane-1-template-gpu-model-y")
+	require.NotContains(t, workload, "nvidia.com/rail_0_plane_0: \"1\"",
+		"swplb DRA workload must use resource claims instead of device-plugin resource requests")
+}
+
+func TestSpectrumXDRADisabledByDefault(t *testing.T) {
+	rendered := renderSpectrumX(t, "mixed-same-type.yaml", "none", 1)
+
+	values := rendered["values.yaml"]
+	require.NotContains(t, values, "dynamicResourceAllocation",
+		"non-DRA mode must not enable SR-IOV operator DRA")
+
+	railPool := rendered["80-spectrumxrailpoolconfig-gpu-model-y.yaml"]
+	require.Contains(t, railPool, "draEnabled: false",
+		"SpectrumXRailPoolConfig must explicitly disable DRA by default")
+
+	require.Empty(t, fileNamesMatching(rendered, "85-resourceclaimtemplate"),
+		"non-DRA mode must not generate ResourceClaimTemplate manifests")
+
+	workload := rendered["90-example-daemonset-gpu-model-y.yaml"]
+	require.NotContains(t, workload, "resourceClaims:")
+	require.Contains(t, workload, "nvidia.com/rail_0: \"1\"",
+		"non-DRA mode must keep device-plugin resource requests")
+}
+
+func TestPCIeRoot(t *testing.T) {
+	require.Equal(t, "pci0000:00", pcieRoot("0000:3b:00.0"))
+	require.Equal(t, "pci0000:00", pcieRoot("3b:00.0"))
+	require.Equal(t, "pci0001:00", pcieRoot("0001:3b:00.0"))
+	require.Empty(t, pcieRoot(""))
+	require.Empty(t, pcieRoot("3b"))
 }
 
 // TestSpectrumXModeBSubsetFilter exercises the Mode B path of Unit 7's

--- a/pkg/networkoperatorplugin/scopes.go
+++ b/pkg/networkoperatorplugin/scopes.go
@@ -92,13 +92,14 @@ var crScopeByKind = map[string]CRScope{
 	"DaemonSet": ScopeAggregate,
 
 	// Bucketed (no node selector; names reference shared bucket id)
-	"SriovNetwork":      ScopeBucketed,
-	"SriovIBNetwork":    ScopeBucketed,
-	"HostDeviceNetwork": ScopeBucketed,
-	"IPoIBNetwork":      ScopeBucketed,
-	"MacvlanNetwork":    ScopeBucketed,
-	"OVSNetwork":        ScopeBucketed,
-	"CIDRPool":          ScopeBucketed,
+	"SriovNetwork":          ScopeBucketed,
+	"SriovIBNetwork":        ScopeBucketed,
+	"HostDeviceNetwork":     ScopeBucketed,
+	"IPoIBNetwork":          ScopeBucketed,
+	"MacvlanNetwork":        ScopeBucketed,
+	"OVSNetwork":            ScopeBucketed,
+	"CIDRPool":              ScopeBucketed,
+	"ResourceClaimTemplate": ScopeBucketed,
 
 	// Simple flat-map nodeSelector — render once per bucket in Mode A,
 	// once per source under Mode B. Shared resources (resourceName,

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -109,6 +109,13 @@ var templateFuncs = template.FuncMap{
 	"railPciGroups": func(pfs []config.PFConfig, planes int) [][]string {
 		return railPciGroups(pfs, planes)
 	},
+	"spectrumXPFForRailPlane": func(pfs []config.PFConfig, rail, plane, planes int) config.PFConfig {
+		return spectrumXPFForRailPlane(pfs, rail, plane, planes)
+	},
+	"spectrumXUseDRA": func(profile *config.Profile) bool {
+		return profile != nil && profile.SpectrumX != nil && profile.SpectrumX.UseDRA
+	},
+	"pcieRoot": pcieRoot,
 	// railCount returns how many rails are present in the east-west PFs.
 	// Authoritative source is the PFConfig.Rail field — a rail is a logical
 	// group of NICs feeding the same fabric stripe, and the firmware splits
@@ -437,6 +444,60 @@ func railPciGroups(pfs []config.PFConfig, planes int) [][]string {
 		groups = append(groups, masterPFsByNIC(rails[rail]))
 	}
 	return groups
+}
+
+func spectrumXPFForRailPlane(pfs []config.PFConfig, rail, plane, planes int) config.PFConfig {
+	ewPFs := pfutil.FilterEastWestPFs(pfs)
+	if len(ewPFs) == 0 {
+		return config.PFConfig{}
+	}
+
+	if allHaveRail(ewPFs) {
+		rails, _ := groupPFsByRail(ewPFs)
+		railPFs := append([]config.PFConfig(nil), rails[rail]...)
+		sort.Slice(railPFs, func(i, j int) bool {
+			return railPFs[i].PciAddress < railPFs[j].PciAddress
+		})
+		if plane >= 0 && plane < len(railPFs) {
+			return railPFs[plane]
+		}
+		if len(railPFs) > 0 {
+			return railPFs[0]
+		}
+		return config.PFConfig{}
+	}
+
+	if planes < 1 {
+		planes = 1
+	}
+	idx := rail*planes + plane
+	if idx < len(ewPFs) {
+		return ewPFs[idx]
+	}
+	idx = rail * planes
+	if idx < len(ewPFs) {
+		return ewPFs[idx]
+	}
+	return config.PFConfig{}
+}
+
+func pcieRoot(pciAddress string) string {
+	parts := strings.Split(strings.TrimSpace(pciAddress), ":")
+	if len(parts) < 2 {
+		return ""
+	}
+	domainPart := "0000"
+	if len(parts) >= 3 {
+		domainPart = parts[0]
+	}
+	domain := strings.ToLower(strings.TrimLeft(domainPart, "0"))
+	if domain == "" {
+		domain = "0"
+	}
+	if len(domain) < 4 {
+		domain = strings.Repeat("0", 4-len(domain)) + domain
+	}
+	return "pci" + domain + ":00"
 }
 
 // railCount returns how many distinct rails are present in the east-west

--- a/profiles/spectrum-x/00-values.yaml
+++ b/profiles/spectrum-x/00-values.yaml
@@ -80,5 +80,8 @@ sriov-network-operator:
 {{- end }}
     featureGates:
       manageSoftwareBridges: true
+{{- if spectrumXUseDRA .Profile }}
+      dynamicResourceAllocation: true
+{{- end }}
     disablePlugins:
       - mellanox

--- a/profiles/spectrum-x/80-spectrumxrailpoolconfig.yaml
+++ b/profiles/spectrum-x/80-spectrumxrailpoolconfig.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   withBCM: false
-  draEnabled: true
+  draEnabled: {{ spectrumXUseDRA .Profile }}
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:
     {{- range $key, $value := .ClusterConfig.NodeSelector }}

--- a/profiles/spectrum-x/85-resourceclaimtemplate.yaml
+++ b/profiles/spectrum-x/85-resourceclaimtemplate.yaml
@@ -1,0 +1,87 @@
+{{- if spectrumXUseDRA .Profile }}
+{{- /* DRA ResourceClaimTemplates for Spectrum-X workloads.
+       The SR-IOV operator owns DeviceClass/SriovResourcePolicy/DeviceAttributes
+       generation when dynamicResourceAllocation is enabled. These templates
+       follow the Spectrum-X DRA guidance: each claim requests a GPU and the
+       matching SR-IOV VF(s), using resource.kubernetes.io/pcieRoot selectors
+       when launch-kit has discovered the corresponding PCI roots. */ -}}
+{{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
+{{- $railCount := railCount .ClusterConfig.PFs $planes }}
+{{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
+{{- $first := true }}
+{{- range $railIdx := untilStep 0 $railCount 1 }}
+{{- if $swplb }}
+{{- range $planeIdx := untilStep 0 $planes 1 }}
+{{- $pf := spectrumXPFForRailPlane $.ClusterConfig.PFs $railIdx $planeIdx $planes }}
+{{- $gpuRoot := pcieRoot $pf.ConnectedGPUPCIAddress }}
+{{- $vfRoot := pcieRoot $pf.PciAddress }}
+{{- if not $first }}---
+{{ end }}{{- $first = false -}}
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rail-{{$railIdx}}-plane-{{$planeIdx}}-template{{boundedSuffix 32 $.ClusterConfig.MergedIdentifier}}
+  namespace: "{{$.CurrentNetworkNamespace}}"
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 1
+          {{- if $gpuRoot }}
+          selectors:
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"].pcieRoot == "{{$gpuRoot}}"'
+          {{- end }}
+      - name: vf
+        exactly:
+          deviceClassName: sriovnetwork.k8snetworkplumbingwg.io
+          count: 1
+          selectors:
+          - cel:
+              expression: 'device.attributes["k8s.cni.cncf.io"].resourceName == "nvidia.com/rail_{{$railIdx}}_plane_{{$planeIdx}}"'
+          {{- if $vfRoot }}
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"].pcieRoot == "{{$vfRoot}}"'
+          {{- end }}
+{{ end }}
+{{- else }}
+{{- $pf := spectrumXPFForRailPlane $.ClusterConfig.PFs $railIdx 0 $planes }}
+{{- $gpuRoot := pcieRoot $pf.ConnectedGPUPCIAddress }}
+{{- $vfRoot := pcieRoot $pf.PciAddress }}
+{{- if not $first }}---
+{{ end }}{{- $first = false -}}
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rail-{{$railIdx}}-template{{boundedSuffix 38 $.ClusterConfig.MergedIdentifier}}
+  namespace: "{{$.CurrentNetworkNamespace}}"
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 1
+          {{- if $gpuRoot }}
+          selectors:
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"].pcieRoot == "{{$gpuRoot}}"'
+          {{- end }}
+      - name: vf
+        exactly:
+          deviceClassName: sriovnetwork.k8snetworkplumbingwg.io
+          count: {{$planes}}
+          selectors:
+          - cel:
+              expression: 'device.attributes["k8s.cni.cncf.io"].resourceName == "nvidia.com/rail_{{$railIdx}}"'
+          {{- if $vfRoot }}
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"].pcieRoot == "{{$vfRoot}}"'
+          {{- end }}
+{{ end }}
+{{- end }}
+{{- end }}

--- a/profiles/spectrum-x/90-example-daemonset.yaml
+++ b/profiles/spectrum-x/90-example-daemonset.yaml
@@ -51,6 +51,19 @@ spec:
         securityContext:
           capabilities:
             add: ["IPC_LOCK", "NET_RAW"]
+        {{- if spectrumXUseDRA .Profile }}
+        resources:
+          claims:
+            {{- range $railIdx := untilStep 0 $railCount 1 }}
+            {{- if $swplb }}
+            {{- range $planeIdx := untilStep 0 $planes 1 }}
+          - name: rail-{{$railIdx}}-plane-{{$planeIdx}}
+            {{- end }}
+            {{- else }}
+          - name: rail-{{$railIdx}}
+            {{- end }}
+            {{- end }}
+        {{- else }}
         resources:
           requests:
             {{- range $railIdx := untilStep 0 $railCount 1 }}
@@ -72,6 +85,7 @@ spec:
             nvidia.com/rail_{{$railIdx}}: "1"
             {{- end }}
             {{- end }}
+        {{- end }}
         command:
         - sh
         - -c
@@ -85,3 +99,17 @@ spec:
           echo ""
           echo "Sleeping indefinitely for manual testing..."
           sleep infinity
+      {{- if spectrumXUseDRA .Profile }}
+      resourceClaims:
+        {{- range $railIdx := untilStep 0 $railCount 1 }}
+        {{- if $swplb }}
+        {{- range $planeIdx := untilStep 0 $planes 1 }}
+      - name: rail-{{$railIdx}}-plane-{{$planeIdx}}
+        resourceClaimTemplateName: rail-{{$railIdx}}-plane-{{$planeIdx}}-template{{boundedSuffix 32 $.ClusterConfig.MergedIdentifier}}
+        {{- end }}
+        {{- else }}
+      - name: rail-{{$railIdx}}
+        resourceClaimTemplateName: rail-{{$railIdx}}-template{{boundedSuffix 38 $.ClusterConfig.MergedIdentifier}}
+        {{- end }}
+        {{- end }}
+      {{- end }}

--- a/profiles/spectrum-x/README.md
+++ b/profiles/spectrum-x/README.md
@@ -12,6 +12,7 @@ The Spectrum-X profile provides optimized multi-rail networking with OVS hardwar
 - **Advanced Firmware Configuration**: Spectrum-X optimized firmware with RA2.2 support
 - **Multiple Plane Modes**: Supports none, swplb, hwplb, and uniplane configurations
 - **Dynamic Interface Naming**: Automatic NIC interface naming based on plane and rail topology
+- **Optional DRA Workload Allocation**: `profile.spectrumX.useDRA` enables ResourceClaimTemplate-based GPU/VF allocation
 
 ## Profile Requirements
 
@@ -41,6 +42,13 @@ nodeCapabilities:
   - `hwplb`: Hardware plane load balancing
   - `uniplane`: Unified plane mode
 - **numberOfPlanes**: Number of planes (1, 2, or 4)
+
+### Spectrum-X Profile Options
+
+- **useDRA**: `false` by default. When `true`, l8k enables the SR-IOV operator
+  `dynamicResourceAllocation` feature gate, sets `SpectrumXRailPoolConfig.spec.draEnabled`
+  to `true`, emits `ResourceClaimTemplate` manifests, and renders the example workload
+  with DRA claims instead of device-plugin resource requests.
 
 ### OVS Configuration
 
@@ -94,10 +102,16 @@ The profile generates the following Kubernetes Custom Resources:
 
 5. **SpectrumXRailPoolConfig** (`80-spectrumxrailpoolconfig.yaml`)
    - Single `v1alpha2` resource with `railTopology[]`. In swplb, one entry per
-     rail-plane; otherwise one entry per rail grouping all planes.
+     rail-plane; otherwise one entry per rail grouping all planes. `draEnabled`
+     is rendered from `profile.spectrumX.useDRA`; the default is explicit `false`.
 
-6. **Example DaemonSet** (`90-example-daemonset.yaml`)
+6. **ResourceClaimTemplate** (`85-resourceclaimtemplate.yaml`)
+   - Rendered only when `profile.spectrumX.useDRA: true`. Each template requests
+     a GPU and matching SR-IOV VF resources using DRA device classes.
+
+7. **Example DaemonSet** (`90-example-daemonset.yaml`)
    - Example workload requesting one VF per rail (non-swplb) or per rail-plane (swplb).
+     In DRA mode, it references the generated `ResourceClaimTemplate` resources instead.
 
 `NicFirmwareSource` and `NicFirmwareTemplate` must be applied separately by the
 operator; l8k does not generate them.
@@ -138,6 +152,7 @@ profile:
     spcxVersion: RA2.2
     multiplaneMode: hwplb
     numberOfPlanes: 4
+    useDRA: false
 ```
 
 ## Deployment

--- a/profiles/spectrum-x/profile.yaml
+++ b/profiles/spectrum-x/profile.yaml
@@ -28,4 +28,5 @@ templates:
   - 30-nicconfigurationtemplate.yaml
   - 60-cidrpool.yaml
   - 80-spectrumxrailpoolconfig.yaml
+  - 85-resourceclaimtemplate.yaml
   - 90-example-daemonset.yaml


### PR DESCRIPTION
## Summary
- Add `profile.spectrumX.useDRA`, defaulting to false, for the RA2.2 Spectrum-X profile only.
- In non-DRA mode, render `draEnabled: false`, skip the SR-IOV DRA feature gate and ResourceClaimTemplates, and keep legacy `nvidia.com/rail_*` example workload resources.
- In DRA mode, enable `dynamicResourceAllocation`, render `draEnabled: true`, generate per-rail ResourceClaimTemplates, and switch the example workload to DRA resource claims.
- Persist discovered connected GPU PCI addresses for future GPU PCI-root selectors; fall back cleanly when older configs only have `connectedGPU`.

## Compatibility note
Spectrum-X itself is not an established l8k use case yet. This change intentionally defines the first supported Spectrum-X DRA path as explicit opt-in via `profile.spectrumX.useDRA: true`, while keeping generated configs non-DRA by default. I am not trying to preserve compatibility with earlier experimental Spectrum-X output shapes.

## Validation
- `git diff --check`
- `GOCACHE=/private/tmp/l8k-spectrum-x-dra-go-cache go test ./pkg/config ./pkg/networkoperatorplugin/... -count=1`
- `GOCACHE=/private/tmp/l8k-spectrum-x-dra-go-cache go test ./... -count=1 -skip 'TestGetPresetsDir_(NotFound|SkipsFiles)'`
- Generated `/Users/amaslennikov/workspace/k8s-launch-kit/rtx-cluster/cluster-config.yaml` both with and without DRA:
  - non-DRA: no ResourceClaimTemplate, no `dynamicResourceAllocation`, `draEnabled: false`, legacy rail resources preserved
  - DRA: 4 ResourceClaimTemplate docs, `dynamicResourceAllocation: true`, `draEnabled: true`, example workload uses resource claims

## Scope
- Updated `profiles/spectrum-x` only; `profiles/spectrum-x-ra2.1` is unchanged.
