### PR TITLE
fix: skip not ready nodes during discovery bootstrap

### DIFF
--- a/pkg/networkoperatorplugin/discovery/discover.go
+++ b/pkg/networkoperatorplugin/discovery/discover.go
@@ -133,6 +133,22 @@ func DiscoverClusterConfig(ctx context.Context, c client.Client, restConfig *res
 			nicconfigdaemon.Namespace, waitErr)
 	}
 
+	eligibleNodes, excluded, err := eligibleDiscoveryNodeNames(ctx, c)
+	if err != nil {
+		return fmt.Errorf("failed to determine nodes eligible for discovery daemon scheduling: %w", err)
+	}
+	if len(eligibleNodes) == 0 {
+		return fmt.Errorf("no Ready schedulable nodes available for discovery")
+	}
+	bootstrapOpts.NodeNames = eligibleNodes
+	uiOutput.Info("Restricting discovery daemon to %d Ready schedulable node(s)", len(eligibleNodes))
+	if excluded.notReady > 0 {
+		uiOutput.Warning("Excluding %d NotReady node(s) from discovery daemon scheduling", excluded.notReady)
+	}
+	if excluded.unschedulable > 0 {
+		uiOutput.Warning("Excluding %d Ready unschedulable node(s) from discovery daemon scheduling", excluded.unschedulable)
+	}
+
 	uiOutput.Info("Bootstrapping NIC configuration daemon in namespace %q", nicconfigdaemon.Namespace)
 	log.Log.Info("Bootstrapping NIC configuration daemon for discovery",
 		"namespace", nicconfigdaemon.Namespace, "image", bootstrapOpts.Image())
@@ -463,6 +479,49 @@ func patchNodeLabels(ctx context.Context, c client.Client, nodeName string, labe
 		strings.Join(parts, ",")))
 	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}
 	return c.Patch(ctx, node, client.RawPatch(k8stypes.StrategicMergePatchType, patch))
+}
+
+type excludedDiscoveryNodes struct {
+	notReady      int
+	unschedulable int
+}
+
+// eligibleDiscoveryNodeNames returns node names where the short-lived discovery
+// daemon can usefully run. Kubernetes has no spec.notready field: readiness is
+// reported as status.conditions[Ready]. Cordoned nodes are represented by
+// spec.unschedulable.
+func eligibleDiscoveryNodeNames(ctx context.Context, c client.Client) ([]string, excludedDiscoveryNodes, error) {
+	nodeList := &corev1.NodeList{}
+	if err := c.List(ctx, nodeList); err != nil {
+		return nil, excludedDiscoveryNodes{}, err
+	}
+
+	out := make([]string, 0, len(nodeList.Items))
+	excluded := excludedDiscoveryNodes{}
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		ready := nodeReady(node)
+		if !ready {
+			excluded.notReady++
+			continue
+		}
+		if node.Spec.Unschedulable {
+			excluded.unschedulable++
+			continue
+		}
+		out = append(out, node.Name)
+	}
+	slices.Sort(out)
+	return out, excluded, nil
+}
+
+func nodeReady(node *corev1.Node) bool {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // dsReadiness summarizes the readiness of a DaemonSet's pods.

--- a/pkg/networkoperatorplugin/discovery/discover_test.go
+++ b/pkg/networkoperatorplugin/discovery/discover_test.go
@@ -155,6 +155,60 @@ func TestCheckDaemonSetPodsReady_StuckPodCounted(t *testing.T) {
 	assert.Equal(t, []string{"node-ready"}, st.readyNodes)
 }
 
+func TestEligibleDiscoveryNodeNamesFiltersNotReadyAndUnschedulable(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		testNode("ready-b", corev1.ConditionTrue, false),
+		testNode("ready-a", corev1.ConditionTrue, false),
+		testNode("not-ready", corev1.ConditionFalse, false),
+		testNode("cordoned", corev1.ConditionTrue, true),
+		testNode("not-ready-cordoned", corev1.ConditionFalse, true),
+		testNodeWithoutReadyCondition("missing-ready-condition", false),
+	).Build()
+
+	got, excluded, err := eligibleDiscoveryNodeNames(context.Background(), c)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ready-a", "ready-b"}, got)
+	assert.Equal(t, 3, excluded.notReady)
+	assert.Equal(t, 1, excluded.unschedulable)
+}
+
+func TestEligibleDiscoveryNodeNamesNoEligibleNodes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		testNode("not-ready", corev1.ConditionFalse, false),
+		testNode("cordoned", corev1.ConditionTrue, true),
+	).Build()
+
+	got, excluded, err := eligibleDiscoveryNodeNames(context.Background(), c)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	assert.Equal(t, 1, excluded.notReady)
+	assert.Equal(t, 1, excluded.unschedulable)
+}
+
+func testNode(name string, ready corev1.ConditionStatus, unschedulable bool) *corev1.Node {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       corev1.NodeSpec{Unschedulable: unschedulable},
+	}
+	node.Status.Conditions = []corev1.NodeCondition{
+		{Type: corev1.NodeReady, Status: ready},
+	}
+	return node
+}
+
+func testNodeWithoutReadyCondition(name string, unschedulable bool) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       corev1.NodeSpec{Unschedulable: unschedulable},
+	}
+}
+
 func TestPodStuck(t *testing.T) {
 	stuck := &corev1.Pod{Status: corev1.PodStatus{
 		ContainerStatuses: []corev1.ContainerStatus{

--- a/pkg/nicconfigdaemon/assets/daemon.yaml.tmpl
+++ b/pkg/nicconfigdaemon/assets/daemon.yaml.tmpl
@@ -141,17 +141,34 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: {{ .SAName }}
       terminationGracePeriodSeconds: 10
-      # No nodeSelector: discovery runs on every node. The NFD label
-      # feature.node.kubernetes.io/pci-15b3.present may not exist yet at
-      # discover time (NFD not installed), so the daemon must not be pinned to
-      # it. The discovery flow probes each pod's sysfs for an NVIDIA NIC
-      # (PCI vendor 0x15b3) to decide which nodes to wait on instead.
+      # No NFD nodeSelector: feature.node.kubernetes.io/pci-15b3.present may
+      # not exist yet at discover time (NFD not installed), so the daemon must
+      # not be pinned to it. Discovery can still provide node-name affinity for
+      # the current Ready schedulable nodes, then probes each pod's sysfs for an
+      # NVIDIA NIC (PCI vendor 0x15b3) to decide which nodes to wait on.
       # Tolerate every taint so the daemon also lands on control-plane (and
       # other tainted) nodes — on small/single-node clusters the control-plane
       # node may carry the data-plane NICs. This is a short-lived, privileged
       # discovery daemon that is torn down afterwards.
       tolerations:
         - operator: Exists
+{{- if .NodeNames }}
+      # Restrict discovery to nodes that were Ready and schedulable when l8k
+      # bootstrapped the daemon. DaemonSet pods get Kubernetes-managed
+      # tolerations for NotReady/unschedulable nodes, so this node-name
+      # affinity is what prevents pods from being created for those nodes.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+{{- range .NodeNames }}
+              - matchFields:
+                  - key: metadata.name
+                    operator: In
+                    values:
+                      - {{ . }}
+{{- end }}
+{{- end }}
 {{- if .ImagePullSecrets }}
       imagePullSecrets:
 {{- range .ImagePullSecrets }}

--- a/pkg/nicconfigdaemon/bootstrap.go
+++ b/pkg/nicconfigdaemon/bootstrap.go
@@ -79,6 +79,10 @@ type Options struct {
 	// ImagePullSecrets is forwarded onto the DaemonSet pod spec.
 	ImagePullSecrets []string
 
+	// NodeNames restricts the DaemonSet to the named nodes via node affinity.
+	// Empty means the DaemonSet can run on every node.
+	NodeNames []string
+
 	// LogLevel sets the LOG_LEVEL env var on the daemon container. Defaults
 	// to DefaultLogLevel when empty.
 	LogLevel string
@@ -189,6 +193,7 @@ func renderDaemonManifests(opts Options) ([]*unstructured.Unstructured, error) {
 		"DaemonSetName":          DaemonSetName,
 		"Image":                  opts.Image(),
 		"ImagePullSecrets":       opts.ImagePullSecrets,
+		"NodeNames":              opts.NodeNames,
 		"LogLevel":               opts.LogLevel,
 	}
 

--- a/pkg/nicconfigdaemon/bootstrap_test.go
+++ b/pkg/nicconfigdaemon/bootstrap_test.go
@@ -216,6 +216,35 @@ func TestEnsure_AppliesDaemonSetWithExpectedImage(t *testing.T) {
 	assert.True(t, *container.SecurityContext.Privileged)
 }
 
+func TestEnsure_AppliesDaemonSetWithNodeNameAffinity(t *testing.T) {
+	c := newFakeClient(t)
+
+	require.NoError(t, Ensure(context.Background(), c, Options{
+		Repository: testRepo,
+		Version:    testVersion,
+		NodeNames:  []string{"node-a", "node-b"},
+	}))
+
+	ds := &appsv1.DaemonSet{}
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Namespace: Namespace, Name: DaemonSetName}, ds))
+
+	affinity := ds.Spec.Template.Spec.Affinity
+	require.NotNil(t, affinity)
+	require.NotNil(t, affinity.NodeAffinity)
+	required := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	require.NotNil(t, required)
+	require.Len(t, required.NodeSelectorTerms, 2)
+
+	for i, nodeName := range []string{"node-a", "node-b"} {
+		require.Len(t, required.NodeSelectorTerms[i].MatchFields, 1)
+		field := required.NodeSelectorTerms[i].MatchFields[0]
+		assert.Equal(t, "metadata.name", field.Key)
+		assert.Equal(t, corev1.NodeSelectorOpIn, field.Operator)
+		assert.Equal(t, []string{nodeName}, field.Values)
+	}
+}
+
 func TestEnsure_Idempotent(t *testing.T) {
 	c := newFakeClient(t)
 	opts := Options{Repository: testRepo, Version: testVersion}

--- a/skills/k8s-launch-kit-discover/SKILL.md
+++ b/skills/k8s-launch-kit-discover/SKILL.md
@@ -54,7 +54,7 @@ l8k discover --save-cluster-config <OUTPUT> [--kubeconfig <PATH>]
 | `--collapse-nic-rails` | — | `true` | Advertise one rail per NIC: collapse a NIC's multi-plane east-west PFs to its master PF, keeping a rail per port only for NICs whose VPD model is genuinely dual-port ("2-port"/"Dual-port"). Set `=false` to keep one rail per PF (dev setups). See "Rail collapsing" below. |
 | `--network-operator-namespace` | — | — | **Deprecated for `discover`**: accepted but ignored. The daemon always runs in `nvidia-k8s-launch-kit`. Still used by `l8k generate` / `l8k deploy`. |
 | `--user-config` | — | — | Base config to merge with discovered hardware |
-| `--node-selector` | — | `feature.node.kubernetes.io/pci-15b3.present=true` | Value written into the **saved** `cluster-config.yaml` `nodeSelector` (for deploy time). It does **not** gate discovery scheduling or the NicDevice wait set — the daemon runs on all nodes and NIC-bearing nodes are detected via a sysfs `0x15b3` probe. |
+| `--node-selector` | — | `feature.node.kubernetes.io/pci-15b3.present=true` | Value written into the **saved** `cluster-config.yaml` `nodeSelector` (for deploy time). It does **not** gate discovery scheduling or the NicDevice wait set — the daemon is restricted to Ready schedulable nodes and NIC-bearing nodes are detected via a sysfs `0x15b3` probe. |
 | `--image-pull-secrets` | — | — | Image pull secret names (comma-separated). Forwarded onto the bootstrapped DaemonSet pod spec. |
 | `--fabric` | — | discovered unanimous link type | Fabric override: `ethernet` or `infiniband`. |
 | `--deployment-type` | — | `sriov` | Deployment override: `sriov`, `rdma_shared`, or `host_device`. |
@@ -146,12 +146,13 @@ resolved.
 
 ## Prerequisites
 
-- Node Feature Discovery (NFD) is **not** required. The bootstrap daemon
-  runs on every node — no `nodeSelector`, and it tolerates all taints so it
-  also lands on control-plane nodes (small/single-node clusters may carry
-  NICs there). NIC-bearing nodes are detected by a sysfs probe for PCI vendor
-  `0x15b3` rather than the NFD `feature.node.kubernetes.io/pci-15b3.present`
-  label.
+- Node Feature Discovery (NFD) is **not** required. Before bootstrapping the
+  daemon, discovery lists Nodes and renders node-name affinity for nodes that
+  are `Ready=True` and not `spec.unschedulable`. The DaemonSet still has no
+  NFD `nodeSelector` and tolerates taints, so eligible control-plane/tainted
+  nodes are included. NIC-bearing nodes are detected by a sysfs probe for PCI
+  vendor `0x15b3` rather than the NFD
+  `feature.node.kubernetes.io/pci-15b3.present` label.
 - Image-pull access from every worker node to
   `<networkOperator.repository>/nic-configuration-operator-daemon:<networkOperator.componentVersion>`.
   Use `--image-pull-secrets <name>` (or `networkOperator.imagePullSecrets`

--- a/skills/k8s-launch-kit-discover/references/discovery-internals.md
+++ b/skills/k8s-launch-kit-discover/references/discovery-internals.md
@@ -23,7 +23,7 @@ The objects created by `Ensure(ctx, c, opts)` (`pkg/nicconfigdaemon/`) on every 
 | `ClusterRole` | `k8s-launch-kit-nic-config-daemon` | cluster | created on `Ensure`, deleted explicitly on `Cleanup` |
 | `ClusterRoleBinding` | `k8s-launch-kit-nic-config-daemon` | cluster | created on `Ensure`, deleted explicitly on `Cleanup` |
 | `ConfigMap` | `nic-configuration-operator-supported-nic-firmware` (empty `data: {}`) | namespaced | empty stand-in so the daemon's startup Get succeeds; deleted by namespace cascade |
-| `DaemonSet` | `nic-configuration-daemon` | namespaced | image = `<networkOperator.repository>/nic-configuration-operator-daemon:<networkOperator.componentVersion>`; **no `nodeSelector`** + tolerates all taints — runs on every node incl. control-plane (NFD-independent); deleted by namespace cascade |
+| `DaemonSet` | `nic-configuration-daemon` | namespaced | image = `<networkOperator.repository>/nic-configuration-operator-daemon:<networkOperator.componentVersion>`; **no NFD `nodeSelector`** + tolerates all taints + node-name affinity for nodes that are Ready and schedulable; deleted by namespace cascade |
 
 ### Why renamed RBAC
 
@@ -48,17 +48,19 @@ daemon pods don't go Ready (ImagePullBackOff, missing pull secret).
 
 ### Node scheduling + NIC wait set (NFD-independent)
 
-The DaemonSet has **no `nodeSelector`** and tolerates all taints
-(`tolerations: [{operator: Exists}]`), so it schedules on every node —
-including control-plane/tainted nodes, which on small or single-node clusters
-may carry the data-plane NICs. It does not depend on the NFD label
-`feature.node.kubernetes.io/pci-15b3.present` (often absent at discover time).
-Because the DaemonSet now runs everywhere, `waitForDaemonSetPods` no longer
-requires **every** pod Ready (that would let one wedged unrelated node block the
-whole 5-min window). It proceeds when all pods are Ready, or when every
-not-Ready pod is *stuck* (`ImagePullBackOff` / `CrashLoopBackOff` / etc., via
-`podStuck`) and at least one pod is Ready; on timeout it still proceeds with the
-Ready set, and only hard-fails when no pod ever became Ready.
+Before bootstrapping, discovery lists Nodes and builds a deterministic allow-list
+of nodes with `status.conditions[Ready] == True` and `spec.unschedulable ==
+false`. The DaemonSet has **no NFD `nodeSelector`** and tolerates all taints
+(`tolerations: [{operator: Exists}]`), but it also renders required node-name
+affinity with one `metadata.name In [node]` selector term per allowed node. This
+keeps discovery NFD-independent while avoiding DaemonSet pods on NotReady or
+cordoned nodes. Eligible control-plane/tainted nodes are still included, which
+matters on small or single-node clusters that carry data-plane NICs there.
+`waitForDaemonSetPods`
+proceeds when all targeted pods are Ready, or when every not-Ready targeted pod
+is *stuck* (`ImagePullBackOff` / `CrashLoopBackOff` / etc., via `podStuck`) and
+at least one pod is Ready; on timeout it still proceeds with the Ready set, and
+only hard-fails when no pod ever became Ready.
 
 To pick which nodes to wait on for `NicDevice` CRs, `filterNodesWithNICs` execs a
 sysfs probe (`sysfsMellanoxNICPresentCmd`) into each daemon pod that scans


### PR DESCRIPTION
## Summary
- restrict the l8k discovery bootstrap DaemonSet to nodes that are Ready and not spec.unschedulable
- render node-name affinity with one metadata.name selector term per eligible node
- warn when NotReady nodes or Ready-but-unschedulable nodes are excluded from daemon scheduling
- update discovery workflow docs for the new scheduling behavior

## Validation
- go test ./pkg/networkoperatorplugin/discovery -count=1
- go test ./pkg/nicconfigdaemon -count=1
- make build
- build/l8k discover --kubeconfig /Users/amaslennikov/workspace/k8s-launch-kit/rtx-cluster/kubeconfig --save-cluster-config /private/tmp/l8k-rtx-discover-cluster-config-pr.yaml --keep-namespace --output json
  - cluster had 3 Ready schedulable nodes and mdf-prod-2852-k8w-05 as Ready=Unknown/spec.unschedulable=true
  - discovery warned that 1 NotReady node was excluded
  - DaemonSet reported DESIRED=3 CURRENT=3 READY=3 and pods only on the three eligible nodes
  - discovery completed successfully without timing out