### PR TITLE
release: add Network Operator 26.7 beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Common Flags:
       --image-pull-secrets strings          Image pull secret names for NicClusterPolicy (comma-separated)
       --kubeconfig string                   Path to kubeconfig file for cluster deployment (required when using --deploy; falls back to $KUBECONFIG, then ~/.kube/config)
       --network-operator-namespace string   Override the network operator namespace from the config file
-      --network-operator-release string     Network Operator release line to deploy (MAJOR.MINOR). Selects component image tags + repository from a built-in catalog and drives version-gated template sections. Supported: 25.10, 26.1, 26.4
+      --network-operator-release string     Network Operator release line to deploy (MAJOR.MINOR). Selects component image tags + repository from a built-in catalog and drives version-gated template sections. Supported: 25.10, 26.1, 26.4, 26.7
       --node-selector string                Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe (default "feature.node.kubernetes.io/pci-15b3.present=true")
       --user-config string                  Use provided cluster configuration file (as base config for discovery or as full config without discovery)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -551,7 +551,7 @@ var SupportedNumberOfPlanes = []int{1, 2, 4}
 // hardware-defaulting (pkg/resolve).
 var SPCXVersionAllowedReleases = map[string][]string{
 	"RA2.1": {"26.1"},
-	"RA2.2": {"26.4"},
+	"RA2.2": {"26.4", "26.7"},
 }
 
 // DefaultSPCXReleaseFor returns the canonical (first-listed) Network

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -4,7 +4,7 @@ networkOperator:
   # version/componentVersion/repository/operatorRepository/helmRepoURL (below)
   # and docaDriver.version are populated from the embedded catalog;
   # explicit values here are overridden.
-  # Supported: 25.10, 26.1, 26.4. Leave empty to use the explicit values
+  # Supported: 25.10, 26.1, 26.4, 26.7. Leave empty to use the explicit values
   # below as-is.
   # selectedRelease: "26.4"
   version: v26.4.0

--- a/pkg/networkoperatorplugin/deploy.go
+++ b/pkg/networkoperatorplugin/deploy.go
@@ -421,7 +421,7 @@ func applyAndWait(ctx context.Context, c client.Client, registry *crstate.Regist
 		return nil
 	}
 
-	// applyUnstructured does an SSA Patch that returns the
+	// applyUnstructured does a server-side apply that returns the
 	// server-decided object on `obj`. Its current resourceVersion
 	// is "the version right after our apply". If the spec changed
 	// AND this Kind's validator reads .status from the CR itself

--- a/pkg/networkoperatorplugin/releases/releases.yaml
+++ b/pkg/networkoperatorplugin/releases/releases.yaml
@@ -40,3 +40,12 @@ releases:
       helmRepoURL: https://helm.ngc.nvidia.com/nvidia
     docaDriver:
       version: doca3.4.0-26.04-0.8.6.0-0
+  "26.7":
+    networkOperator:
+      version: v26.7.0-beta.2
+      componentVersion: network-operator-v26.7.0-beta.2
+      repository: nvcr.io/nvstaging/mellanox
+      operatorRepository: nvcr.io/nvstaging/mellanox
+      helmRepoURL: https://helm.ngc.nvidia.com/nvstaging/mellanox
+    docaDriver:
+      version: doca3.5.0-26.07-0.3.4.0-0

--- a/pkg/networkoperatorplugin/releases/releases_test.go
+++ b/pkg/networkoperatorplugin/releases/releases_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestLookupRelease_Known(t *testing.T) {
-	for _, key := range []string{"26.1", "26.4"} {
+	for _, key := range []string{"26.1", "26.4", "26.7"} {
 		r, ok := LookupRelease(key)
 		require.True(t, ok, "expected catalog entry for %q", key)
 		assert.NotEmpty(t, r.NetworkOperator.Version, "key %s: networkOperator.version", key)
@@ -32,6 +32,18 @@ func TestLookupRelease_Known(t *testing.T) {
 		assert.NotEmpty(t, r.NetworkOperator.Repository, "key %s: networkOperator.repository", key)
 		assert.NotEmpty(t, r.DOCADriver.Version, "key %s: docaDriver.version", key)
 	}
+}
+
+func TestLookupRelease_267BetaUsesStagingArtifacts(t *testing.T) {
+	r, ok := LookupRelease("26.7")
+	require.True(t, ok)
+
+	assert.Equal(t, "v26.7.0-beta.2", r.NetworkOperator.Version)
+	assert.Equal(t, "network-operator-v26.7.0-beta.2", r.NetworkOperator.ComponentVersion)
+	assert.Equal(t, "nvcr.io/nvstaging/mellanox", r.NetworkOperator.Repository)
+	assert.Equal(t, "nvcr.io/nvstaging/mellanox", r.NetworkOperator.OperatorRepository)
+	assert.Equal(t, "https://helm.ngc.nvidia.com/nvstaging/mellanox", r.NetworkOperator.HelmRepoURL)
+	assert.Equal(t, "doca3.5.0-26.07-0.3.4.0-0", r.DOCADriver.Version)
 }
 
 func TestLookupRelease_Unknown(t *testing.T) {
@@ -47,6 +59,7 @@ func TestSupportedReleases_SortedAndContainsKnownKeys(t *testing.T) {
 	require.NotEmpty(t, got)
 	assert.Contains(t, got, "26.1")
 	assert.Contains(t, got, "26.4")
+	assert.Contains(t, got, "26.7")
 
 	// Ensure ascending order.
 	for i := 1; i < len(got); i++ {


### PR DESCRIPTION
## Summary
- add the 26.7 release-line catalog entry for Network Operator v26.7.0-beta.2
- use nvstaging repositories and Helm repo for the pre-release artifacts
- set DOCA driver to doca3.5.0-26.07-0.3.4.0-0
- allow Spectrum-X RA2.2 validation with the 26.7 release line

## Testing
- GOCACHE=/private/tmp/l8k-release-267-go-cache go test ./pkg/networkoperatorplugin/releases ./pkg/cmd ./pkg/config ./pkg/networkoperatorplugin -run 'Release|SPCX|Spectrum|NetworkOperator|version' -count=1
- git diff --check