### PR TITLE
feat: make validation checks configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,14 +304,13 @@ and applies it in four phases: NicClusterPolicy first (await ready), per-group
 NicNodePolicy (await each), all remaining CRs in one batch (controllers
 reconcile concurrently), then verify every manifest reached a terminal state.
 Example workload manifests (`*example*`) are **not** applied by `l8k deploy` —
-they're fixtures consumed by `l8k validate --connectivity` or
-`l8k deploy --test-connectivity` for the data-plane phase. It auto-prefers
+they're fixtures consumed by `l8k validate --connectivity` for the data-plane
+phase. It auto-prefers
 `<dir>/network-operator/` (the layout `l8k generate` produces) and falls back
 to `<dir>` itself. `--dry-run` does a server-side dry run. `--deploy-timeout`
 caps the whole apply+reconcile phase end-to-end (e.g. `--deploy-timeout 90m`);
 without it, deploy polls indefinitely — right for SR-IOV on large clusters
-where reconciliation can take an hour. `--test-connectivity` chains the
-connectivity matrix straight after a successful apply.
+where reconciliation can take an hour.
 
 Verify the deployment end-to-end:
 
@@ -331,10 +330,29 @@ condition-Reason classification, NicClusterPolicy appliedStates breakdown,
 etc.); and (3) a data-plane connectivity matrix — apply the example
 DaemonSet, wait for it to roll out completely (`numberReady ==
 desiredNumberScheduled > 0` — a single ContainerCreating-stuck pod fails),
-and run `ping -c N -I <srcIP> <dstIP>` across every rail and pod pair plus
-a per-pair cross-rail canary. The matrix is on by default
-(`--connectivity=false` to skip), runs concurrent pings capped at 16, and
-cleans up the test DaemonSet unless `--keep` is set.
+and run the configured RDMA checks (`rping` and/or `ib_write_bw`) across
+every same-rail pod pair plus a per-pair cross-rail canary. The matrix is on
+by default (`--connectivity=false` to skip) and cleans up the test DaemonSet
+unless `--keep` is set. Fresh `l8k discover` output includes the default
+validation block:
+
+```yaml
+validation:
+  connectivity: true
+  checks:
+    - rping
+    - ib_write_bw
+  rdma:
+    rpingIterations: 5
+    ibWriteSize: 65536
+    ibWriteMinBandwidthGbps: 100
+```
+
+`l8k validate` can override that config for a single run:
+`--validation-checks rping`, `--validation-checks ib_write_bw`,
+`--validation-checks ""`, `--rdma-rping-iterations <N>`, and
+`--rdma-ib-write-size <BYTES>`, and
+`--rdma-ib-write-min-bandwidth-gbps <GBPS>` (`0` disables bandwidth gating).
 
 A self-contained HTML report lands at `<deployment-files>/k8s-launch-kit-validation-report.html`
 by default (override with `--report-path`, disable with `--report-path=-`).

--- a/pkg/cmd/deploy.go
+++ b/pkg/cmd/deploy.go
@@ -31,7 +31,6 @@ import (
 	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
 	"github.com/nvidia/k8s-launch-kit/pkg/kubeclient"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
-	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/connectivity"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 )
@@ -43,11 +42,6 @@ var (
 	// until every manifest reaches a terminal state or the user
 	// cancels.
 	deployTimeout time.Duration
-	// deployTestConnectivity chains the data-plane connectivity
-	// matrix (the same one `l8k validate --connectivity` runs)
-	// right after a successful deploy. Off by default; opt-in for
-	// pipelines that want end-to-end verification in one command.
-	deployTestConnectivity bool
 	// overwriteExistingFlag promotes Phase 0 helm install to
 	// `helm upgrade --install` when a release already exists with
 	// values that differ from the rendered values.yaml. Off by default
@@ -196,31 +190,6 @@ is used as the manifest directory.`,
 			uiOutput.Success("Deployment completed")
 		}
 
-		if deployTestConnectivity && !dryRunFlag {
-			// Pipeline the connectivity matrix straight after a
-			// successful apply. We deliberately do NOT re-run the
-			// version check here — deploy just landed manifests
-			// from this binary's catalog, the version is whatever
-			// we shipped. Connectivity is the value-add.
-			matrix, err := connectivity.RunMatrix(ctx, k8sClient, restConfig, uiOutput, connectivity.Options{
-				ManifestDir: manifestDir,
-				Timeout:     0, // RunMatrix defaults to 5m
-			})
-			if err != nil {
-				exitWithError(apperrors.NewClusterError(
-					"deploy succeeded but --test-connectivity failed",
-					err,
-					"Inspect the test DaemonSet via --keep + kubectl get pods",
-				), outputFormat)
-			}
-			if matrix != nil && matrix.Summary.Failed > 0 {
-				exitWithError(apperrors.NewDeploymentError(
-					fmt.Sprintf("connectivity matrix failed: %d/%d passed", matrix.Summary.Passed, matrix.Summary.TotalTests),
-					nil,
-					"Examine the failures above; re-run with --keep to keep the test DaemonSet for debugging",
-				), outputFormat)
-			}
-		}
 	},
 }
 
@@ -254,7 +223,6 @@ func init() {
 	deployCmd.Flags().StringVar(&userConfig, "user-config", "", "Cluster config file (auto-discovered from ./cluster-config.yaml or <deployment-files>/../cluster-config.yaml). Used to resolve the network-operator release for Phase 0 helm install and Phase 0.5 preflight checks.")
 	deployCmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "Preview the deployment via server-side dry-run without persisting changes")
 	deployCmd.Flags().DurationVar(&deployTimeout, "deploy-timeout", 0, "Maximum end-to-end wall-clock budget for the deploy phase (e.g. 45m, 2h). 0 (the default) means no deadline; the deploy polls until every manifest reaches a terminal state. Useful for matching a maintenance window when SR-IOV reconciliation on a large cluster can take an hour or more.")
-	deployCmd.Flags().BoolVar(&deployTestConnectivity, "test-connectivity", false, "After a successful deploy, run the connectivity matrix (apply example DaemonSet → wait Ready → RDMA matrix → cleanup) to verify the data plane end-to-end.")
 	deployCmd.Flags().BoolVar(&overwriteExistingFlag, "overwrite-existing", false, "Converge the cluster to the rendered manifests when preflight detects drift: helm upgrade the chart on chart-version/values mismatch, delete stray Network Operator CRs in the operator namespace, and rewrite NicClusterPolicy component versions via SSA. Off by default — preflight fails fast and lists what would change.")
 
 	setFlagGroup(deployCmd, "kubeconfig", GroupCommon)
@@ -262,7 +230,6 @@ func init() {
 	setFlagGroup(deployCmd, "network-operator-namespace", GroupCommon)
 	setFlagGroup(deployCmd, "deploy-timeout", GroupDeploy)
 	setFlagGroup(deployCmd, "dry-run", GroupDeploy)
-	setFlagGroup(deployCmd, "test-connectivity", GroupDeploy)
 	setFlagGroup(deployCmd, "overwrite-existing", GroupDeploy)
 }
 

--- a/pkg/cmd/flaggroups.go
+++ b/pkg/cmd/flaggroups.go
@@ -37,7 +37,8 @@ const (
 	GroupSpectrumX     = "4-spectrumx"
 	GroupGeneration    = "5-generation"
 	GroupDeploy        = "6-deploy"
-	GroupOutputLogging = "7-output-logging"
+	GroupValidation    = "7-validation"
+	GroupOutputLogging = "8-output-logging"
 )
 
 var groupOrder = []string{
@@ -47,6 +48,7 @@ var groupOrder = []string{
 	GroupSpectrumX,
 	GroupGeneration,
 	GroupDeploy,
+	GroupValidation,
 	GroupOutputLogging,
 }
 
@@ -57,6 +59,7 @@ var groupTitles = map[string]string{
 	GroupSpectrumX:     "Spectrum-X Flags",
 	GroupGeneration:    "Generation Output Flags",
 	GroupDeploy:        "Deploy Flags",
+	GroupValidation:    "Validation Flags",
 	GroupOutputLogging: "Output & Logging Flags",
 }
 

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -75,7 +75,7 @@ var schemaCmd = &cobra.Command{
 					Example:     "l8k deploy --deployment-files ./deployment --kubeconfig ~/.kube/config",
 				},
 				"validate": {
-					Description: "Verify a deployment matches the selected Network Operator release (Helm chart version + manifest presence in cluster)",
+					Description: "Verify a deployment matches the selected Network Operator release (Helm chart version + manifest state + configurable RDMA connectivity checks)",
 					Example:     "l8k validate --user-config ./cluster-config.yaml --deployment-files ./deployment",
 				},
 				"sosreport": {
@@ -203,6 +203,26 @@ var schemaCmd = &cobra.Command{
 				"--network-operator-release": {
 					Type:        "string",
 					Description: "Network Operator release line (MAJOR.MINOR). See supportedNetworkOperatorReleases for valid values; populates component versions and gates version-specific template sections.",
+				},
+				"--validation-checks": {
+					Type:        "[]string",
+					Default:     "inherit from validation.checks",
+					Description: "Comma-separated RDMA checks to run during validate connectivity: rping, ib_write_bw.",
+				},
+				"--rdma-rping-iterations": {
+					Type:        "int",
+					Default:     "0 (inherit from validation.rdma.rpingIterations)",
+					Description: "Number of rping client iterations during validate connectivity.",
+				},
+				"--rdma-ib-write-size": {
+					Type:        "int",
+					Default:     "0 (inherit from validation.rdma.ibWriteSize)",
+					Description: "Message size for ib_write_bw -s during validate connectivity.",
+				},
+				"--rdma-ib-write-min-bandwidth-gbps": {
+					Type:        "float",
+					Default:     "0 (inherit from validation.rdma.ibWriteMinBandwidthGbps)",
+					Description: "Minimum observed ib_write_bw peak bandwidth in Gbps required for a validate connectivity test to pass. Use 0 to disable bandwidth gating.",
 				},
 			},
 		}

--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -40,9 +40,9 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/kubeclient"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/connectivity"
+	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/crstate"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/preflight"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
-	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/crstate"
 	"github.com/nvidia/k8s-launch-kit/pkg/presetmatch"
 	"github.com/nvidia/k8s-launch-kit/pkg/presets"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
@@ -65,6 +65,10 @@ var (
 	validateConnectivityTimeout time.Duration
 	validateWait                time.Duration
 	validateReportPath          string
+	validateChecks              []string
+	validateRDMAIterations      int
+	validateRDMAIBWriteSize     int
+	validateRDMAIBWriteMinGbps  float64
 )
 
 // defaultOperatorNamespace is the default Network Operator namespace used
@@ -91,20 +95,24 @@ Three checks are run:
 
   3. Connectivity (default ON, pass --connectivity=false to skip): the
      example DaemonSet is applied, the rollout is awaited until
-     numberReady == desiredNumberScheduled > 0, and a ping matrix is
-     run between the test pods' rail IPs (same-rail across every pod
-     pair + one cross-rail canary per pair). The DS is deleted on exit
-     unless --keep is set. Skipped when any manifest from step 2 is
-     IN-PROGRESS / ERROR / MISSING (running connectivity against an
-     unready cluster would just produce noise).
+     numberReady == desiredNumberScheduled > 0, and the configured
+     RDMA checks (rping and/or ib_write_bw) run between the test pods'
+     rail IPs (same-rail across every pod pair + one cross-rail canary
+     per pair). The DS is deleted on exit unless --keep is set. Skipped
+     when any manifest from step 2 is IN-PROGRESS / ERROR / MISSING
+     (running connectivity against an unready cluster would just
+     produce noise).
 
 Exits non-zero on any missing manifest, version mismatch, or
 connectivity-matrix failure.`,
 	Example: `  # Full validate (manifest state + connectivity matrix)
   l8k validate
 
-  # Manifest checks only (no DaemonSet apply, no ping matrix)
+  # Manifest checks only (no DaemonSet apply, no RDMA matrix)
   l8k validate --connectivity=false
+
+  # Only run rping, with more iterations
+  l8k validate --validation-checks rping --rdma-rping-iterations 100
 
   # Block up to 10 minutes for in-progress manifests to finish reconciling
   l8k validate --wait 10m
@@ -113,7 +121,7 @@ connectivity-matrix failure.`,
   l8k validate --keep
 
   # Agent mode (JSON output)
-  l8k validate --output json --yes 2>/dev/null`,
+  l8k validate --output json 2>/dev/null`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// State accumulated during the run. Captured by reference
 		// in exitWithReport so that EVERY error path — including
@@ -122,17 +130,17 @@ connectivity-matrix failure.`,
 		// Go's defer doesn't run on os.Exit, so we can't rely on
 		// a deferred report write.
 		var (
-			versionCheck     *networkoperatorplugin.VersionCheck
-			componentCheck   *networkoperatorplugin.ComponentVersionCheck
-			helmValuesCheck  *networkoperatorplugin.HelmValuesCheck
-			strayCheck       *preflight.Result
-			results          []networkoperatorplugin.ValidationResult
-			matrix           *connectivity.MatrixResult
-			warnings         []string
-			presetDeviations []groupDeviationReport
-			presetResults    []presetmatch.Result
-			reportClient     ctrlclient.Client
-			reportRestConfig *rest.Config
+			versionCheck      *networkoperatorplugin.VersionCheck
+			componentCheck    *networkoperatorplugin.ComponentVersionCheck
+			helmValuesCheck   *networkoperatorplugin.HelmValuesCheck
+			strayCheck        *preflight.Result
+			results           []networkoperatorplugin.ValidationResult
+			matrix            *connectivity.MatrixResult
+			warnings          []string
+			presetDeviations  []groupDeviationReport
+			presetResults     []presetmatch.Result
+			reportClient      ctrlclient.Client
+			reportRestConfig  *rest.Config
 			reportManifestDir string
 			operatorNamespace = defaultOperatorNamespace
 		)
@@ -198,6 +206,7 @@ connectivity-matrix failure.`,
 		// validate run against a namespace not recorded in cluster-config.yaml
 		// can still target the right Helm release / live CRs.
 		selectedRelease := ""
+		validationCfg := config.DefaultValidationConfig()
 		cfg, cfgPath, cfgErr := loadUserConfig(options.Options{
 			ConfigDir:                configDir,
 			NetworkOperatorNamespace: networkOperatorNamespace,
@@ -212,6 +221,7 @@ connectivity-matrix failure.`,
 			if cfg.NetworkOperator != nil {
 				selectedRelease = cfg.NetworkOperator.SelectedRelease
 			}
+			validationCfg = config.NormalizeValidationConfig(cfg.Validation)
 			for _, g := range cfg.ClusterConfig {
 				if len(g.PresetDeviation) == 0 {
 					continue
@@ -231,6 +241,13 @@ connectivity-matrix failure.`,
 			// validate (matches the historical behaviour of
 			// presetDeviation), so the exit code is unchanged.
 			presetResults = presetmatch.MatchAllWithCatalog(cfg, presetCatalog)
+		}
+		if err := applyValidateFlagOverrides(cmd, validationCfg); err != nil {
+			exitWithReport(apperrors.NewValidationError(
+				"invalid validation configuration",
+				err,
+				"Use --validation-checks rping,ib_write_bw and positive RDMA parameter values",
+			))
 		}
 
 		log.Log.Info("Validating deployment",
@@ -362,7 +379,7 @@ connectivity-matrix failure.`,
 			if outputFormat != "json" {
 				fmt.Fprintln(os.Stderr, "\nNote: some manifests are still reconciling. Re-run later or use --wait to block.")
 			}
-			if validateConnectivity && outputFormat != "json" {
+			if validationConnectivityEnabled(validationCfg) && outputFormat != "json" {
 				fmt.Fprintln(os.Stderr, "Connectivity matrix skipped — cluster has in-progress manifests.")
 			}
 			warnings = append(warnings, "Connectivity matrix skipped — cluster has in-progress manifests.")
@@ -373,13 +390,17 @@ connectivity-matrix failure.`,
 			return
 		}
 
-		if validateConnectivity {
+		if validationConnectivityEnabled(validationCfg) {
 			uiOutput, _ := ui.NewOutputForFormat(outputFormat, yesFlag)
 			ctxWithUI := ui.WithOutput(ctx, uiOutput)
 			m, err := connectivity.RunMatrix(ctxWithUI, k8sClient, restConfig, uiOutput, connectivity.Options{
-				ManifestDir: manifestDir,
-				Timeout:     validateConnectivityTimeout,
-				Keep:        validateKeep,
+				ManifestDir:             manifestDir,
+				Timeout:                 validateConnectivityTimeout,
+				Keep:                    validateKeep,
+				Checks:                  connectivityChecksFromConfig(validationCfg),
+				RPingIterations:         validationCfg.RDMA.RPingIterations,
+				IBWriteSize:             validationCfg.RDMA.IBWriteSize,
+				IBWriteMinBandwidthGbps: *validationCfg.RDMA.IBWriteMinBandwidthGbps,
 			})
 			matrix = m
 			if err != nil {
@@ -410,6 +431,65 @@ connectivity-matrix failure.`,
 			os.Exit(apperrors.ExitDeployment)
 		}
 	},
+}
+
+func applyValidateFlagOverrides(cmd *cobra.Command, validationCfg *config.ValidationConfig) error {
+	if validationCfg == nil {
+		return fmt.Errorf("validation config must not be nil")
+	}
+	if cmd.Flags().Changed("connectivity") {
+		v := validateConnectivity
+		validationCfg.Connectivity = &v
+	}
+	if cmd.Flags().Changed("validation-checks") {
+		validationCfg.Checks = config.NormalizeValidationChecks(validateChecks)
+	}
+	if validationCfg.RDMA == nil {
+		validationCfg.RDMA = &config.ValidationRDMAConfig{}
+	}
+	if cmd.Flags().Changed("rdma-rping-iterations") {
+		if validateRDMAIterations <= 0 {
+			return fmt.Errorf("--rdma-rping-iterations must be greater than 0")
+		}
+		validationCfg.RDMA.RPingIterations = validateRDMAIterations
+	}
+	if cmd.Flags().Changed("rdma-ib-write-size") {
+		if validateRDMAIBWriteSize <= 0 {
+			return fmt.Errorf("--rdma-ib-write-size must be greater than 0")
+		}
+		validationCfg.RDMA.IBWriteSize = validateRDMAIBWriteSize
+	}
+	if cmd.Flags().Changed("rdma-ib-write-min-bandwidth-gbps") {
+		if validateRDMAIBWriteMinGbps < 0 {
+			return fmt.Errorf("--rdma-ib-write-min-bandwidth-gbps must be greater than or equal to 0")
+		}
+		validationCfg.RDMA.IBWriteMinBandwidthGbps = &validateRDMAIBWriteMinGbps
+	}
+	validationCfg = config.NormalizeValidationConfig(validationCfg)
+	return config.ValidateValidationConfig(validationCfg)
+}
+
+func validationConnectivityEnabled(validationCfg *config.ValidationConfig) bool {
+	if validationCfg == nil || validationCfg.Connectivity == nil {
+		return true
+	}
+	return *validationCfg.Connectivity
+}
+
+func connectivityChecksFromConfig(validationCfg *config.ValidationConfig) []connectivity.Check {
+	if validationCfg == nil {
+		return nil
+	}
+	checks := make([]connectivity.Check, 0, len(validationCfg.Checks))
+	for _, check := range validationCfg.Checks {
+		switch check {
+		case config.ValidationCheckRPing:
+			checks = append(checks, connectivity.CheckRPing)
+		case config.ValidationCheckIBWriteBW:
+			checks = append(checks, connectivity.CheckIBWriteBW)
+		}
+	}
+	return checks
 }
 
 // hasPresetDeviation reports whether any group deviated from its
@@ -523,7 +603,6 @@ func platformLabel(r presetmatch.Result) string {
 	}
 	return strings.Join(parts, "-")
 }
-
 
 // emitVerdictBanner prints the PASS/FAIL banner at the top of text
 // output (above the per-check details that follow). JSON mode skips
@@ -705,17 +784,17 @@ func writeHTMLReportIfWanted(
 			APIServerVersion:  probeAPIServerVersion(restConfig),
 			OperatorNamespace: operatorNamespace,
 		},
-		Profile:         loadProfileInfo(userCfgPath, manifestDir),
-		NodeGroups:      loadNodeGroups(userCfgPath, presetResults),
-		Nodes:           listNodesForReport(ctx, c),
-		Release:         versionCheck,
-		ComponentCheck:  componentCheck,
-		HelmValues:      helmValuesCheck,
-		StrayCRs:        strayCheck,
-		PresetMatches:   presetResults,
-		Manifests:       results,
-		Matrix:          *matrix,
-		Warnings:        *warnings,
+		Profile:        loadProfileInfo(userCfgPath, manifestDir),
+		NodeGroups:     loadNodeGroups(userCfgPath, presetResults),
+		Nodes:          listNodesForReport(ctx, c),
+		Release:        versionCheck,
+		ComponentCheck: componentCheck,
+		HelmValues:     helmValuesCheck,
+		StrayCRs:       strayCheck,
+		PresetMatches:  presetResults,
+		Manifests:      results,
+		Matrix:         *matrix,
+		Warnings:       *warnings,
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -1490,6 +1569,10 @@ func init() {
 	validateCmd.Flags().BoolVar(&validateConnectivity, "connectivity", true, "Run an RDMA matrix (rping + ib_write_bw) between pods of the example DaemonSet to verify the data plane. Default true. Pass --connectivity=false to skip when only the static manifest checks are wanted.")
 	validateCmd.Flags().BoolVar(&validateKeep, "keep", false, "Leave the example DaemonSet running after --connectivity completes (useful for debugging).")
 	validateCmd.Flags().DurationVar(&validateConnectivityTimeout, "connectivity-timeout", 5*time.Minute, "Wall-clock budget for the connectivity matrix (DaemonSet rollout + rping + ib_write_bw execs).")
+	validateCmd.Flags().StringSliceVar(&validateChecks, "validation-checks", nil, "Comma-separated RDMA checks to run during connectivity validation. Supported: rping, ib_write_bw. Overrides validation.checks from cluster-config.yaml.")
+	validateCmd.Flags().IntVar(&validateRDMAIterations, "rdma-rping-iterations", 0, "Number of rping client iterations. Overrides validation.rdma.rpingIterations from cluster-config.yaml.")
+	validateCmd.Flags().IntVar(&validateRDMAIBWriteSize, "rdma-ib-write-size", 0, "Message size for ib_write_bw -s. Overrides validation.rdma.ibWriteSize from cluster-config.yaml.")
+	validateCmd.Flags().Float64Var(&validateRDMAIBWriteMinGbps, "rdma-ib-write-min-bandwidth-gbps", 0, "Minimum observed ib_write_bw peak bandwidth in Gbps required for a test to pass. Use 0 to disable bandwidth gating. Overrides validation.rdma.ibWriteMinBandwidthGbps from cluster-config.yaml.")
 	validateCmd.Flags().DurationVar(&validateWait, "wait", 0, "Block validate up to this duration waiting for in-progress manifests to reach a terminal state. 0 (default) returns immediately on the first snapshot.")
 	validateCmd.Flags().StringVar(&validateReportPath, "report-path", "", "Write the HTML validation report to this path. When empty (default), writes to <deployment-files>/k8s-launch-kit-validation-report.html. Pass '-' to skip the report file entirely.")
 
@@ -1497,4 +1580,13 @@ func init() {
 	setFlagGroup(validateCmd, "user-config", GroupCommon)
 	setFlagGroup(validateCmd, "deployment-files", GroupGeneration)
 	setFlagGroup(validateCmd, "network-operator-namespace", GroupCommon)
+	setFlagGroup(validateCmd, "connectivity", GroupValidation)
+	setFlagGroup(validateCmd, "connectivity-timeout", GroupValidation)
+	setFlagGroup(validateCmd, "keep", GroupValidation)
+	setFlagGroup(validateCmd, "validation-checks", GroupValidation)
+	setFlagGroup(validateCmd, "rdma-rping-iterations", GroupValidation)
+	setFlagGroup(validateCmd, "rdma-ib-write-size", GroupValidation)
+	setFlagGroup(validateCmd, "rdma-ib-write-min-bandwidth-gbps", GroupValidation)
+	setFlagGroup(validateCmd, "wait", GroupValidation)
+	setFlagGroup(validateCmd, "report-path", GroupValidation)
 }

--- a/pkg/cmd/validate_config_test.go
+++ b/pkg/cmd/validate_config_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/connectivity"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newValidateOverrideTestCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().BoolVar(&validateConnectivity, "connectivity", true, "")
+	cmd.Flags().StringSliceVar(&validateChecks, "validation-checks", nil, "")
+	cmd.Flags().IntVar(&validateRDMAIterations, "rdma-rping-iterations", 0, "")
+	cmd.Flags().IntVar(&validateRDMAIBWriteSize, "rdma-ib-write-size", 0, "")
+	cmd.Flags().Float64Var(&validateRDMAIBWriteMinGbps, "rdma-ib-write-min-bandwidth-gbps", 0, "")
+	return cmd
+}
+
+func resetValidateOverrideGlobals(t *testing.T) {
+	t.Helper()
+	validateConnectivity = true
+	validateChecks = nil
+	validateRDMAIterations = 0
+	validateRDMAIBWriteSize = 0
+	validateRDMAIBWriteMinGbps = 0
+}
+
+func TestApplyValidateFlagOverrides(t *testing.T) {
+	t.Cleanup(func() { resetValidateOverrideGlobals(t) })
+
+	t.Run("cli overrides config checks and rdma parameters", func(t *testing.T) {
+		resetValidateOverrideGlobals(t)
+		cmd := newValidateOverrideTestCmd()
+		minBandwidthGbps := 200.0
+		cfg := config.NormalizeValidationConfig(&config.ValidationConfig{
+			Checks: []string{config.ValidationCheckRPing},
+			RDMA: &config.ValidationRDMAConfig{
+				RPingIterations:         3,
+				IBWriteSize:             4096,
+				IBWriteMinBandwidthGbps: &minBandwidthGbps,
+			},
+		})
+
+		require.NoError(t, cmd.Flags().Set("validation-checks", "ib_write_bw"))
+		require.NoError(t, cmd.Flags().Set("rdma-rping-iterations", "11"))
+		require.NoError(t, cmd.Flags().Set("rdma-ib-write-size", "8192"))
+		require.NoError(t, cmd.Flags().Set("rdma-ib-write-min-bandwidth-gbps", "800"))
+		require.NoError(t, applyValidateFlagOverrides(cmd, cfg))
+
+		assert.Equal(t, []string{config.ValidationCheckIBWriteBW}, cfg.Checks)
+		assert.Equal(t, 11, cfg.RDMA.RPingIterations)
+		assert.Equal(t, 8192, cfg.RDMA.IBWriteSize)
+		require.NotNil(t, cfg.RDMA.IBWriteMinBandwidthGbps)
+		assert.Equal(t, 800.0, *cfg.RDMA.IBWriteMinBandwidthGbps)
+		assert.Equal(t, []connectivity.Check{connectivity.CheckIBWriteBW}, connectivityChecksFromConfig(cfg))
+	})
+
+	t.Run("zero minimum bandwidth override disables bandwidth gating", func(t *testing.T) {
+		resetValidateOverrideGlobals(t)
+		cmd := newValidateOverrideTestCmd()
+		cfg := config.NormalizeValidationConfig(nil)
+
+		require.NoError(t, cmd.Flags().Set("rdma-ib-write-min-bandwidth-gbps", "0"))
+		require.NoError(t, applyValidateFlagOverrides(cmd, cfg))
+
+		require.NotNil(t, cfg.RDMA.IBWriteMinBandwidthGbps)
+		assert.Equal(t, 0.0, *cfg.RDMA.IBWriteMinBandwidthGbps)
+	})
+
+	t.Run("explicit empty check list disables connectivity tests", func(t *testing.T) {
+		resetValidateOverrideGlobals(t)
+		cmd := newValidateOverrideTestCmd()
+		cfg := config.NormalizeValidationConfig(nil)
+
+		require.NoError(t, cmd.Flags().Set("validation-checks", ""))
+		require.NoError(t, applyValidateFlagOverrides(cmd, cfg))
+
+		assert.Empty(t, cfg.Checks)
+		assert.Empty(t, connectivityChecksFromConfig(cfg))
+	})
+
+	t.Run("connectivity flag can override config false", func(t *testing.T) {
+		resetValidateOverrideGlobals(t)
+		cmd := newValidateOverrideTestCmd()
+		disabled := false
+		cfg := config.NormalizeValidationConfig(&config.ValidationConfig{Connectivity: &disabled})
+
+		require.NoError(t, cmd.Flags().Set("connectivity", "true"))
+		require.NoError(t, applyValidateFlagOverrides(cmd, cfg))
+
+		require.NotNil(t, cfg.Connectivity)
+		assert.True(t, *cfg.Connectivity)
+	})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,6 +61,10 @@ func DefaultLaunchKitConfig() (*LaunchKitConfig, error) {
 	if err := NormalizeMaintenance(&cfg); err != nil {
 		return nil, fmt.Errorf("invalid embedded maintenance config: %w", err)
 	}
+	cfg.Validation = NormalizeValidationConfig(cfg.Validation)
+	if err := ValidateValidationConfig(cfg.Validation); err != nil {
+		return nil, fmt.Errorf("invalid embedded validation config: %w", err)
+	}
 	return &cfg, nil
 }
 
@@ -169,10 +173,11 @@ type LaunchKitConfig struct {
 	// CurrentNetworkNamespace is transient render state. The renderer sets it
 	// to one NetworkNamespaces entry while producing that namespace's copy;
 	// it is never part of the persisted configuration schema.
-	CurrentNetworkNamespace string          `yaml:"-"`
-	Workload                *WorkloadConfig `yaml:"workload,omitempty"`
-	Profile                 *Profile        `yaml:"profile,omitempty"`
-	ClusterConfig           []ClusterConfig `yaml:"clusterConfig,omitempty"`
+	CurrentNetworkNamespace string            `yaml:"-"`
+	Workload                *WorkloadConfig   `yaml:"workload,omitempty"`
+	Validation              *ValidationConfig `yaml:"validation,omitempty"`
+	Profile                 *Profile          `yaml:"profile,omitempty"`
+	ClusterConfig           []ClusterConfig   `yaml:"clusterConfig,omitempty"`
 }
 
 type NetworkOperatorConfig struct {
@@ -298,6 +303,112 @@ type MacvlanConfig struct {
 
 type WorkloadConfig struct {
 	Manifest string `yaml:"manifest,omitempty"`
+}
+
+const (
+	ValidationCheckRPing     = "rping"
+	ValidationCheckIBWriteBW = "ib_write_bw"
+
+	DefaultValidationRPingIterations = 5
+	DefaultValidationIBWriteSize     = 65536
+	DefaultValidationIBWriteMinGbps  = 100
+)
+
+// ValidationConfig controls `l8k validate` data-plane checks. Static manifest
+// and version checks always run; Connectivity gates the example-DaemonSet RDMA
+// matrix. Checks selects which RDMA families to run.
+type ValidationConfig struct {
+	Connectivity *bool                 `yaml:"connectivity,omitempty"`
+	Checks       []string              `yaml:"checks,omitempty"`
+	RDMA         *ValidationRDMAConfig `yaml:"rdma,omitempty"`
+}
+
+type ValidationRDMAConfig struct {
+	RPingIterations         int      `yaml:"rpingIterations,omitempty"`
+	IBWriteSize             int      `yaml:"ibWriteSize,omitempty"`
+	IBWriteMinBandwidthGbps *float64 `yaml:"ibWriteMinBandwidthGbps,omitempty"`
+}
+
+func defaultBool(v bool) *bool {
+	return &v
+}
+
+func defaultFloat64(v float64) *float64 {
+	return &v
+}
+
+func DefaultValidationConfig() *ValidationConfig {
+	return &ValidationConfig{
+		Connectivity: defaultBool(true),
+		Checks:       []string{ValidationCheckRPing, ValidationCheckIBWriteBW},
+		RDMA: &ValidationRDMAConfig{
+			RPingIterations:         DefaultValidationRPingIterations,
+			IBWriteSize:             DefaultValidationIBWriteSize,
+			IBWriteMinBandwidthGbps: defaultFloat64(DefaultValidationIBWriteMinGbps),
+		},
+	}
+}
+
+func NormalizeValidationConfig(v *ValidationConfig) *ValidationConfig {
+	if v == nil {
+		return DefaultValidationConfig()
+	}
+	if v.Connectivity == nil {
+		v.Connectivity = defaultBool(true)
+	}
+	if v.Checks == nil {
+		v.Checks = []string{ValidationCheckRPing, ValidationCheckIBWriteBW}
+	} else {
+		v.Checks = NormalizeValidationChecks(v.Checks)
+	}
+	if v.RDMA == nil {
+		v.RDMA = &ValidationRDMAConfig{}
+	}
+	if v.RDMA.RPingIterations <= 0 {
+		v.RDMA.RPingIterations = DefaultValidationRPingIterations
+	}
+	if v.RDMA.IBWriteSize <= 0 {
+		v.RDMA.IBWriteSize = DefaultValidationIBWriteSize
+	}
+	if v.RDMA.IBWriteMinBandwidthGbps == nil {
+		v.RDMA.IBWriteMinBandwidthGbps = defaultFloat64(DefaultValidationIBWriteMinGbps)
+	}
+	return v
+}
+
+func NormalizeValidationChecks(checks []string) []string {
+	if checks == nil {
+		return nil
+	}
+	out := make([]string, 0, len(checks))
+	seen := map[string]bool{}
+	for _, check := range checks {
+		check = strings.TrimSpace(check)
+		if check == "" || seen[check] {
+			continue
+		}
+		seen[check] = true
+		out = append(out, check)
+	}
+	return out
+}
+
+func ValidateValidationConfig(v *ValidationConfig) error {
+	if v == nil {
+		return nil
+	}
+	if v.RDMA != nil && v.RDMA.IBWriteMinBandwidthGbps != nil && *v.RDMA.IBWriteMinBandwidthGbps < 0 {
+		return fmt.Errorf("validation.rdma.ibWriteMinBandwidthGbps must be greater than or equal to 0")
+	}
+	for _, check := range v.Checks {
+		switch check {
+		case ValidationCheckRPing, ValidationCheckIBWriteBW:
+		default:
+			return fmt.Errorf("validation.checks contains unsupported check %q (supported: %s, %s)",
+				check, ValidationCheckRPing, ValidationCheckIBWriteBW)
+		}
+	}
+	return nil
 }
 
 type Profile struct {
@@ -543,6 +654,10 @@ func LoadFullConfigWithSource(configPath string, logger logr.Logger) (*LaunchKit
 
 	if err := validateNvIpam(config.NvIpam); err != nil {
 		return nil, nil, fmt.Errorf("invalid nvIpam config in %s: %w", configPath, err)
+	}
+	config.Validation = NormalizeValidationConfig(config.Validation)
+	if err := ValidateValidationConfig(config.Validation); err != nil {
+		return nil, nil, fmt.Errorf("invalid validation config in %s: %w", configPath, err)
 	}
 
 	// Finalize exclusions for explicitly-listed (manual) subnets. Auto-generated

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -87,6 +87,16 @@ profile:
 		_, source, err := LoadFullConfigWithSource(configPath, logger)
 		require.NoError(t, err)
 		assert.Equal(t, configContent, string(source))
+
+		require.NotNil(t, config.Validation)
+		require.NotNil(t, config.Validation.Connectivity)
+		assert.True(t, *config.Validation.Connectivity)
+		assert.Equal(t, []string{ValidationCheckRPing, ValidationCheckIBWriteBW}, config.Validation.Checks)
+		require.NotNil(t, config.Validation.RDMA)
+		assert.Equal(t, DefaultValidationRPingIterations, config.Validation.RDMA.RPingIterations)
+		assert.Equal(t, DefaultValidationIBWriteSize, config.Validation.RDMA.IBWriteSize)
+		require.NotNil(t, config.Validation.RDMA.IBWriteMinBandwidthGbps)
+		assert.Equal(t, float64(DefaultValidationIBWriteMinGbps), *config.Validation.RDMA.IBWriteMinBandwidthGbps)
 	})
 
 	t.Run("load config file that does not exist", func(t *testing.T) {
@@ -139,6 +149,40 @@ func TestDefaultLaunchKitConfig(t *testing.T) {
 	assert.NotEmpty(t, cfg.NetworkOperator.Version, "default NetworkOperator must carry a version")
 	require.NotNil(t, cfg.DOCADriver, "DefaultLaunchKitConfig must populate DOCADriver")
 	require.NotNil(t, cfg.NvIpam, "DefaultLaunchKitConfig must populate NvIpam")
+	require.NotNil(t, cfg.Validation, "DefaultLaunchKitConfig must populate Validation")
+	assert.Equal(t, []string{ValidationCheckRPing, ValidationCheckIBWriteBW}, cfg.Validation.Checks)
+	require.NotNil(t, cfg.Validation.RDMA)
+	assert.Equal(t, DefaultValidationRPingIterations, cfg.Validation.RDMA.RPingIterations)
+	assert.Equal(t, DefaultValidationIBWriteSize, cfg.Validation.RDMA.IBWriteSize)
+	require.NotNil(t, cfg.Validation.RDMA.IBWriteMinBandwidthGbps)
+	assert.Equal(t, float64(DefaultValidationIBWriteMinGbps), *cfg.Validation.RDMA.IBWriteMinBandwidthGbps)
+}
+
+func TestValidationConfig(t *testing.T) {
+	t.Run("explicit empty checks stays empty", func(t *testing.T) {
+		cfg := NormalizeValidationConfig(&ValidationConfig{Checks: []string{}})
+		require.NotNil(t, cfg)
+		assert.Empty(t, cfg.Checks)
+	})
+
+	t.Run("normalizes duplicates and blanks", func(t *testing.T) {
+		checks := NormalizeValidationChecks([]string{" rping ", "", "ib_write_bw", "rping"})
+		assert.Equal(t, []string{ValidationCheckRPing, ValidationCheckIBWriteBW}, checks)
+	})
+
+	t.Run("rejects unknown checks", func(t *testing.T) {
+		cfg := NormalizeValidationConfig(&ValidationConfig{Checks: []string{"rping", "icmp"}})
+		err := ValidateValidationConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported check")
+	})
+
+	t.Run("preserves explicit zero minimum bandwidth", func(t *testing.T) {
+		zero := 0.0
+		cfg := NormalizeValidationConfig(&ValidationConfig{RDMA: &ValidationRDMAConfig{IBWriteMinBandwidthGbps: &zero}})
+		require.NotNil(t, cfg.RDMA.IBWriteMinBandwidthGbps)
+		assert.Equal(t, 0.0, *cfg.RDMA.IBWriteMinBandwidthGbps)
+	})
 }
 
 func TestDefaultLaunchKitConfig_FreshCopy(t *testing.T) {

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -33,6 +33,20 @@ networkNamespaces: [default]
 # workload:
 #   manifest: /path/to/my-deployment.yaml  # Custom workload manifest (replaces default example DaemonSet)
 
+validation:
+  # connectivity gates the data-plane validation stage. Static manifest,
+  # Helm release, component-version, and preflight checks always run.
+  connectivity: true
+  # checks selects which RDMA test families l8k validate runs.
+  # Supported: rping, ib_write_bw. Use [] to disable all connectivity checks.
+  checks:
+    - rping
+    - ib_write_bw
+  rdma:
+    rpingIterations: 5
+    ibWriteSize: 65536
+    ibWriteMinBandwidthGbps: 100
+
 docaDriver:
   enable: true
   version: doca3.4.0-26.04-0.8.6.0-0

--- a/pkg/kubeclient/exec.go
+++ b/pkg/kubeclient/exec.go
@@ -41,7 +41,7 @@ type ExecResult struct {
 // stdout/stderr.
 //
 // Used by both the discovery probes (sysfs reads, nvidia-smi parse) and
-// the Phase-2 connectivity ping matrix. The helper builds its own
+// the validate connectivity RDMA matrix. The helper builds its own
 // clientset from the supplied REST config so callers don't need to
 // thread two clients around — there's a one-time TLS/transport cost per
 // call that's negligible against the cost of an exec round-trip.

--- a/pkg/networkoperatorplugin/connectivity/connectivity.go
+++ b/pkg/networkoperatorplugin/connectivity/connectivity.go
@@ -30,6 +30,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+type Check string
+
+const (
+	CheckRPing     Check = "rping"
+	CheckIBWriteBW Check = "ib_write_bw"
+)
+
 // Options control the matrix run end-to-end. The l8k validate CLI
 // fills these from the corresponding flags.
 type Options struct {
@@ -43,6 +50,19 @@ type Options struct {
 	// Keep leaves the test DaemonSets running after the matrix
 	// completes, for follow-up debugging. Default is to delete.
 	Keep bool
+	// Checks selects which RDMA test families to run. Nil means the
+	// default set (rping + ib_write_bw); an empty slice means skip all
+	// connectivity tests without applying the example DaemonSets.
+	Checks []Check
+	// RPingIterations maps to `rping -C`. 0 defaults to 5, matching the
+	// historical hardcoded behavior.
+	RPingIterations int
+	// IBWriteSize maps to `ib_write_bw -s`. 0 defaults to 65536, matching
+	// the historical hardcoded behavior.
+	IBWriteSize int
+	// IBWriteMinBandwidthGbps is the minimum peak bandwidth that must be
+	// observed for an ib_write_bw test to pass. 0 disables threshold gating.
+	IBWriteMinBandwidthGbps float64
 }
 
 // MatrixResult is the aggregate output of one connectivity run. It's
@@ -87,12 +107,11 @@ type DaemonSetReport struct {
 //  4. Lists Running+Ready pods, parses each pod's multus annotation,
 //     filters to secondary networks, picks the first IPv4 per rail.
 //  5. Discovers the RDMA device backing each multus interface per pod.
-//  6. Builds a test plan via Plan() — same-rail rping + ib_write_bw
-//     across pods plus per-pair cross-rail canaries; soft-skip if <2
-//     schedulable pods.
-//  7. Runs rping then ib_write_bw stages sequentially per the
-//     "spawn fresh server per test" lifecycle (concurrent runs would
-//     fight over the listener port).
+//  6. Builds a test plan via Plan() — same-rail plus per-pair cross-rail
+//     canaries; soft-skip if <2 schedulable pods.
+//  7. Runs the configured RDMA stages sequentially per the "spawn fresh
+//     server per test" lifecycle (concurrent runs would fight over the
+//     listener port).
 //  8. Deletes the DaemonSets unless opts.Keep.
 //
 // All UI output flows through `uiOutput` (caller passes
@@ -101,11 +120,23 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 	if opts.Timeout <= 0 {
 		opts.Timeout = 5 * time.Minute
 	}
+	opts.Checks = normalizeChecks(opts.Checks)
+	if opts.RPingIterations <= 0 {
+		opts.RPingIterations = 5
+	}
+	if opts.IBWriteSize <= 0 {
+		opts.IBWriteSize = 65536
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 	defer cancel()
 
 	uiOutput.Section("Connectivity matrix")
+	if len(opts.Checks) == 0 {
+		return &MatrixResult{
+			Skipped: &MatrixSkip{Reason: "all connectivity checks are disabled"},
+		}, nil
+	}
 	uiOutput.Info("Loading example DaemonSet manifests from %s", opts.ManifestDir)
 
 	objs, refs, err := LoadExampleDaemonSets(opts.ManifestDir)
@@ -210,8 +241,17 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 
 	totalSameRail := len(plan.RDMASameRail)
 	totalCrossRail := len(plan.RDMACrossRail)
-	uiOutput.Info("Plan: %d same-rail rping + %d cross-rail rping; %d same-rail ib_write_bw + %d cross-rail ib_write_bw",
-		totalSameRail, totalCrossRail, len(plan.RDMABwSameRail), len(plan.RDMABwCrossRail))
+	plannedTests := 0
+	if checksContain(opts.Checks, CheckRPing) {
+		uiOutput.Info("Plan: %d same-rail rping + %d cross-rail rping",
+			totalSameRail, totalCrossRail)
+		plannedTests += totalSameRail + totalCrossRail
+	}
+	if checksContain(opts.Checks, CheckIBWriteBW) {
+		uiOutput.Info("Plan: %d same-rail ib_write_bw + %d cross-rail ib_write_bw",
+			len(plan.RDMABwSameRail), len(plan.RDMABwCrossRail))
+		plannedTests += len(plan.RDMABwSameRail) + len(plan.RDMABwCrossRail)
+	}
 	// Defensive: Plan() can return a zero-test plan without setting
 	// Skip (e.g. ≥2 schedulable pods but Plan's same-rail loop emits
 	// nothing). Two possible causes, both surface here:
@@ -227,7 +267,7 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 	//
 	// Without surfacing this, validate prints "Matrix complete: 0/0
 	// passed" and exits success, hiding a real coverage gap.
-	if totalSameRail+totalCrossRail+len(plan.RDMABwSameRail)+len(plan.RDMABwCrossRail) == 0 {
+	if plannedTests == 0 {
 		uiOutput.Warning(
 			"Matrix produced 0 tests despite %d schedulable pod(s) — either every rail had at least one endpoint with no resolvable RDMA device, or no rail key was shared across pods. "+
 				"Most common cause: macvlan or IPoIB secondary networks, where the in-pod iface has no PCI-direct mlx5 sysfs entry. "+
@@ -250,32 +290,38 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 	// runs the client, kills the server. Concurrent runs would
 	// fight over the listener port.
 	stages := []struct {
+		check Check
 		label string
 		tests []PingTest
 		run   func(t PingTest) PingResult
 	}{
 		{
+			check: CheckRPing,
 			label: "RDMA ping (rping)",
 			tests: append(append([]PingTest{}, plan.RDMASameRail...), plan.RDMACrossRail...),
 			run: func(t PingTest) PingResult {
 				return RunRPing(ctx, restConfig, namespaceByPod[t.DstPod],
 					t.DstPod, containerByPod[t.DstPod], // server side
 					t.SrcPod, containerByPod[t.SrcPod], // client side
-					t, 5)
+					t, opts.RPingIterations)
 			},
 		},
 		{
+			check: CheckIBWriteBW,
 			label: "RDMA bandwidth (ib_write_bw)",
 			tests: append(append([]PingTest{}, plan.RDMABwSameRail...), plan.RDMABwCrossRail...),
 			run: func(t PingTest) PingResult {
 				return RunIbWriteBw(ctx, restConfig, namespaceByPod[t.DstPod],
 					t.DstPod, containerByPod[t.DstPod],
 					t.SrcPod, containerByPod[t.SrcPod],
-					t, 0)
+					t, 0, opts.IBWriteSize, opts.IBWriteMinBandwidthGbps)
 			},
 		},
 	}
 	for _, stage := range stages {
+		if !checksContain(opts.Checks, stage.check) {
+			continue
+		}
 		if len(stage.tests) == 0 {
 			continue
 		}
@@ -307,6 +353,31 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 	RenderMatrixText(uiOutput, result)
 	emitSummary(uiOutput, result)
 	return result, nil
+}
+
+func normalizeChecks(checks []Check) []Check {
+	if checks == nil {
+		return []Check{CheckRPing, CheckIBWriteBW}
+	}
+	out := make([]Check, 0, len(checks))
+	seen := map[Check]bool{}
+	for _, check := range checks {
+		if check == "" || seen[check] {
+			continue
+		}
+		seen[check] = true
+		out = append(out, check)
+	}
+	return out
+}
+
+func checksContain(checks []Check, want Check) bool {
+	for _, check := range checks {
+		if check == want {
+			return true
+		}
+	}
+	return false
 }
 
 // testPodWithDS pairs a Running+Ready pod with the DaemonSetRef that

--- a/pkg/networkoperatorplugin/connectivity/matrix_test.go
+++ b/pkg/networkoperatorplugin/connectivity/matrix_test.go
@@ -95,6 +95,13 @@ func TestPlan_SoftSkipOnFewerThan2Pods(t *testing.T) {
 	})
 }
 
+func TestNormalizeChecks(t *testing.T) {
+	assert.Equal(t, []Check{CheckRPing, CheckIBWriteBW}, normalizeChecks(nil))
+	assert.Empty(t, normalizeChecks([]Check{}))
+	assert.Equal(t, []Check{CheckIBWriteBW, CheckRPing},
+		normalizeChecks([]Check{CheckIBWriteBW, "", CheckRPing, CheckIBWriteBW}))
+}
+
 func TestPlan_TwoPodsOneRail(t *testing.T) {
 	plan := Plan([]TestPod{
 		mkPod("pod-a", "rail-0"),

--- a/pkg/networkoperatorplugin/connectivity/multus.go
+++ b/pkg/networkoperatorplugin/connectivity/multus.go
@@ -16,7 +16,7 @@
 
 // Package connectivity drives the Phase-2 data-plane verification flow:
 // apply the example DaemonSet, wait for it to reach Ready, parse each
-// pod's multus network-status annotation, and run a ping matrix between
+// pod's multus network-status annotation, and run an RDMA matrix between
 // the secondary-network IPs.
 package connectivity
 
@@ -33,7 +33,7 @@ const MultusAnnotation = "k8s.v1.cni.cncf.io/network-status"
 // NetworkStatus mirrors the upstream multus
 // `k8s.v1.cni.cncf.io/network-status` annotation entry shape. We only
 // model the fields we read; the upstream struct carries a few more
-// (gateway, dns, mtu) that aren't relevant to the ping matrix.
+// (gateway, dns, mtu) that aren't relevant to the RDMA matrix.
 type NetworkStatus struct {
 	// Name is the NetworkAttachmentDefinition name in
 	// `<namespace>/<name>` form (or just the name when in the pod's
@@ -57,7 +57,7 @@ type NetworkStatus struct {
 // ParseNetworkStatus decodes the JSON payload from a pod's
 // `k8s.v1.cni.cncf.io/network-status` annotation. Returns an empty
 // slice (not an error) when the annotation is empty — pods without any
-// secondary networks simply have nothing to ping.
+// secondary networks simply have nothing to test.
 //
 // Malformed JSON returns a non-nil error so callers can decide whether
 // to skip the pod or fail the whole matrix.
@@ -74,7 +74,7 @@ func ParseNetworkStatus(annotation string) ([]NetworkStatus, error) {
 
 // SecondaryNetworks filters out the cluster's default-CNI attachment
 // (e.g. Calico/Flannel/Cilium), leaving only the secondary networks
-// the deployment under test put on the pod. The ping matrix runs over
+// the deployment under test put on the pod. The RDMA matrix runs over
 // these.
 func SecondaryNetworks(all []NetworkStatus) []NetworkStatus {
 	out := make([]NetworkStatus, 0, len(all))

--- a/pkg/networkoperatorplugin/connectivity/rdma.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma.go
@@ -217,11 +217,14 @@ func RunRPing(ctx context.Context, restConfig *rest.Config, namespace string, se
 // parse for a matrix cell. Each test allocates a fresh TCP listener
 // port (default 18515 + an orchestrator-supplied offset) to avoid
 // collisions with concurrent runs against unrelated rails.
-func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, namespace string, serverPod, serverContainer string, clientPod, clientContainer string, test PingTest, port int) PingResult {
+func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, namespace string, serverPod, serverContainer string, clientPod, clientContainer string, test PingTest, port, size int, minBandwidthGbps float64) PingResult {
 	if port <= 0 {
 		port = 18515
 	}
-	r := PingResult{Test: test}
+	if size <= 0 {
+		size = 65536
+	}
+	r := PingResult{Test: test, MinBandwidthGbps: minBandwidthGbps}
 	if test.SrcRDMADev == "" || test.DstRDMADev == "" {
 		r.Err = fmt.Errorf("ib_write_bw needs RDMA device names; got src=%q dst=%q", test.SrcRDMADev, test.DstRDMADev)
 		return r
@@ -230,13 +233,13 @@ func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, namespace string
 	tctx, cancel := context.WithTimeout(ctx, rdmaTestTimeout)
 	defer cancel()
 
-	// `ib_write_bw -d <dev> -R -s 65536 --report_gbits -p <port>`
+	// `ib_write_bw -d <dev> -R -s <size> --report_gbits -p <port>`
 	// runs as the server when invoked without a peer IP, as the
 	// client when invoked with one. The server prints a banner and
 	// then waits; the client connects, runs the test, and both
 	// sides print the summary table.
-	serverCmd := fmt.Sprintf("nohup ib_write_bw -d %s -R -s 65536 --report_gbits -p %d >/tmp/ibwritebw-server.log 2>&1 & echo $!",
-		test.DstRDMADev, port)
+	serverCmd := fmt.Sprintf("nohup ib_write_bw -d %s -R -s %d --report_gbits -p %d >/tmp/ibwritebw-server.log 2>&1 & echo $!",
+		test.DstRDMADev, size, port)
 	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, namespace, serverPod, serverContainer, []string{"/bin/sh", "-c", serverCmd})
 	if err != nil {
 		r.Err = fmt.Errorf("ib_write_bw server start: %w (stderr: %s)", err, srvRes.Stderr)
@@ -252,8 +255,8 @@ func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, namespace string
 	case <-time.After(rdmaServerSettleDelay):
 	}
 
-	clientCmd := fmt.Sprintf("ib_write_bw -d %s -R -s 65536 --report_gbits -p %d %s",
-		test.SrcRDMADev, port, test.DstIP)
+	clientCmd := fmt.Sprintf("ib_write_bw -d %s -R -s %d --report_gbits -p %d %s",
+		test.SrcRDMADev, size, port, test.DstIP)
 	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, namespace, clientPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
 	r.Stdout, r.Stderr = cliRes.Stdout, cliRes.Stderr
 
@@ -268,10 +271,15 @@ func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, namespace string
 		r.Err = fmt.Errorf("ib_write_bw output missing summary row")
 		r.OK = false
 	default:
-		// Treat any non-zero bandwidth as success — partial-bw
-		// numbers are still informative (slow rail, MTU
-		// mismatch, etc.) and the cell value tells the story.
-		r.OK = bw > 0
+		switch {
+		case bw <= 0:
+			r.OK = false
+		case minBandwidthGbps > 0 && bw < minBandwidthGbps:
+			r.Err = fmt.Errorf("observed bandwidth %.1f Gbps below minimum %.1f Gbps", bw, minBandwidthGbps)
+			r.OK = false
+		default:
+			r.OK = true
+		}
 	}
 	return r
 }

--- a/pkg/networkoperatorplugin/connectivity/report.go
+++ b/pkg/networkoperatorplugin/connectivity/report.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
-	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/preflight"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/crstate"
+	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/preflight"
 	"github.com/nvidia/k8s-launch-kit/pkg/presetmatch"
 )
 
@@ -66,12 +66,12 @@ type ReportData struct {
 	// Verdict is the overall pass/fail outcome rendered as a
 	// prominent banner at the top of the report. Computed by the
 	// caller (CLI) from the same inputs that drive the exit code.
-	Verdict OverallVerdict
-	Cluster        ClusterInfo
-	Profile        ProfileInfo
-	NodeGroups     []NodeGroupInfo
-	Nodes          []NodeInfo
-	Release        *networkoperatorplugin.VersionCheck
+	Verdict    OverallVerdict
+	Cluster    ClusterInfo
+	Profile    ProfileInfo
+	NodeGroups []NodeGroupInfo
+	Nodes      []NodeInfo
+	Release    *networkoperatorplugin.VersionCheck
 	// ComponentCheck cross-references the live NCP+NNP component
 	// versions against the embedded release catalog. Surfaced as a
 	// sub-table under "Network Operator release" in the HTML
@@ -426,6 +426,12 @@ func reportFuncMap() template.FuncMap {
 			if fam == "ibbw" {
 				if r.OK && r.BandwidthGbps > 0 {
 					return fmt.Sprintf("✓ %.1f Gbps", r.BandwidthGbps)
+				}
+				if r.BandwidthGbps > 0 && r.MinBandwidthGbps > 0 {
+					return fmt.Sprintf("✗ %.1f Gbps (< %.1f)", r.BandwidthGbps, r.MinBandwidthGbps)
+				}
+				if r.BandwidthGbps > 0 {
+					return fmt.Sprintf("✗ %.1f Gbps", r.BandwidthGbps)
 				}
 				return "✗ ERR"
 			}

--- a/pkg/networkoperatorplugin/connectivity/result.go
+++ b/pkg/networkoperatorplugin/connectivity/result.go
@@ -22,17 +22,19 @@ package connectivity
 //
 //   - rping: OK + Err + Stdout/Stderr; BandwidthGbps stays at 0.
 //   - ib_write_bw: OK + Err + Stdout/Stderr + BandwidthGbps +
-//     MsgRateMpps populated by parseIbWriteBwOutput.
+//     MsgRateMpps populated by parseIbWriteBwOutput. MinBandwidthGbps
+//     records the configured passing threshold when set.
 //
 // The struct name is kept for backwards compatibility with the
 // historical ICMP-first pipeline; the matrix is RDMA-only now but
 // callers and the JSON schema continue to reference PingResult.
 type PingResult struct {
-	Test          PingTest
-	OK            bool
-	BandwidthGbps float64 // ib_write_bw only; 0 when n/a
-	MsgRateMpps   float64 // ib_write_bw only; 0 when n/a
-	Stdout        string
-	Stderr        string
-	Err           error
+	Test             PingTest
+	OK               bool
+	BandwidthGbps    float64 // ib_write_bw only; 0 when n/a
+	MsgRateMpps      float64 // ib_write_bw only; 0 when n/a
+	MinBandwidthGbps float64 // ib_write_bw only; 0 when no threshold was applied
+	Stdout           string
+	Stderr           string
+	Err              error
 }

--- a/pkg/networkoperatorplugin/connectivity/text_report.go
+++ b/pkg/networkoperatorplugin/connectivity/text_report.go
@@ -271,6 +271,12 @@ func cellBody(r *PingResult, fam kindFamily) string {
 		if r.OK && r.BandwidthGbps > 0 {
 			return fmt.Sprintf("✓ %.1f Gbps", r.BandwidthGbps)
 		}
+		if r.BandwidthGbps > 0 && r.MinBandwidthGbps > 0 {
+			return fmt.Sprintf("✗ %.1f Gbps (< %.1f)", r.BandwidthGbps, r.MinBandwidthGbps)
+		}
+		if r.BandwidthGbps > 0 {
+			return fmt.Sprintf("✗ %.1f Gbps", r.BandwidthGbps)
+		}
 		return "✗ ERR"
 	}
 	// rping

--- a/pkg/networkoperatorplugin/connectivity/text_report_test.go
+++ b/pkg/networkoperatorplugin/connectivity/text_report_test.go
@@ -45,10 +45,10 @@ func (c *captureOutput) Error(format string, args ...interface{}) {
 func (c *captureOutput) StartProgress(message string) ui.Progress {
 	return &captureProgress{out: c, msg: message}
 }
-func (c *captureOutput) Header(text string)            {}
-func (c *captureOutput) Section(text string)           { c.lines = append(c.lines, "SECTION: "+text) }
-func (c *captureOutput) Confirm(string) (bool, error)  { return true, nil }
-func (c *captureOutput) IsTTY() bool                   { return false }
+func (c *captureOutput) Header(text string)           {}
+func (c *captureOutput) Section(text string)          { c.lines = append(c.lines, "SECTION: "+text) }
+func (c *captureOutput) Confirm(string) (bool, error) { return true, nil }
+func (c *captureOutput) IsTTY() bool                  { return false }
 
 type captureProgress struct {
 	out *captureOutput
@@ -211,6 +211,10 @@ func TestCellFor(t *testing.T) {
 	t.Run("ib_write_bw fail with no bandwidth is ERR", func(t *testing.T) {
 		r := PingResult{OK: false}
 		assert.Equal(t, "✗ ERR", cellFor("a", "b", &r, familyIbBw, false))
+	})
+	t.Run("ib_write_bw fail below threshold shows observed bandwidth", func(t *testing.T) {
+		r := PingResult{OK: false, BandwidthGbps: 194.39, MinBandwidthGbps: 800}
+		assert.Equal(t, "✗ 194.4 Gbps (< 800.0)", cellFor("a", "b", &r, familyIbBw, false))
 	})
 	t.Run("ib_write_bw OK but zero bandwidth is ERR", func(t *testing.T) {
 		// Defensive: OK=true with zero bandwidth shouldn't happen

--- a/pkg/networkoperatorplugin/validate.go
+++ b/pkg/networkoperatorplugin/validate.go
@@ -108,12 +108,12 @@ type HelmReleaseInfo struct {
 type VersionCheck struct {
 	// Skipped is true when the check could not be performed (no
 	// selectedRelease in user-config, or no Helm release Secret found).
-	Skipped       bool
-	Reason        string
+	Skipped         bool
+	Reason          string
 	SelectedRelease string // from user-config (e.g. "26.4")
 	ExpectedVersion string // from embedded release catalog (e.g. "v26.4.0-beta.6")
 	DeployedRelease *HelmReleaseInfo
-	Match         bool
+	Match           bool
 }
 
 const (
@@ -446,7 +446,7 @@ func fetchLiveYAML(ctx context.Context, c client.Client, manifest *unstructured.
 // IsExampleManifest reports whether the given filename matches the
 // example-workload naming pattern (case-insensitive substring
 // "example"). Files matching this pattern are deployed by
-// `l8k validate --connectivity` for the ping matrix and skipped by
+// `l8k validate --connectivity` for the RDMA matrix and skipped by
 // every other code path. Exported so the connectivity package can
 // find the example DS to apply.
 func IsExampleManifest(name string) bool {


### PR DESCRIPTION
## Summary
- add generated validation config with configurable RDMA checks and RDMA parameters
- route l8k validate through config plus CLI overrides for checks, rping iterations, ib_write_bw size, and minimum bandwidth
- remove l8k deploy --test-connectivity so only l8k validate runs data-plane tests

## Validation
- go test ./pkg/config ./pkg/cmd ./pkg/networkoperatorplugin/connectivity -count=1
- go test ./... -count=1 -skip 'TestGetPresetsDir_(NotFound|SkipsFiles)'
- make build
- live cluster: default validation passed 20/20
- live cluster: rping-only passed 10/10
- live cluster: ib_write_bw-only with size 4096 passed 10/10
- live cluster: empty validation-checks skipped connectivity
- live cluster: connectivity=false skipped connectivity
- live cluster: ib_write_bw min 800 Gbps failed 0/10 as expected
- live cluster: ib_write_bw min 300 Gbps failed overall with mixed result 6/10 passed, 4 failed