### PR TITLE
Add Spectrum-X RA2.3 ConfigMap profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ Examples:
 
   # Discover + deploy Spectrum-X with JSON output for automation
   l8k --kubeconfig ~/.kube/config --discover-cluster-config \
-    --spectrum-x RA2.2 --multiplane-mode hwplb --number-of-planes 4 --network-operator-release 26.4 --deploy --output json --yes
+    --spectrum-x RA2.3 --multiplane-mode hwplb --number-of-planes 4 \
+    --spectrum-x-config ./spectrum-x-profile-configmap.yaml \
+    --network-operator-release 26.7 --deploy --output json --yes
 
   # Dry-run: preview what would be deployed
   l8k --user-config cluster-config.yaml --spectrum-x --deploy \
@@ -240,11 +242,13 @@ Profile Selection Flags:
       --gpu-type string          Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.
       --groups strings           Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.
       --multirail                Override multirail deployment (defaults to true when absent; use --multirail=false to opt out)
-      --spectrum-x string        Enable Spectrum-X by passing the SPC-X RA version (folds in the legacy --spcx-version). Supported: [RA2.1 RA2.2]
+      --spectrum-x string        Enable Spectrum-X by passing the SPC-X RA version (folds in the legacy --spcx-version). Supported: [RA2.1 RA2.2 RA2.3]
 
 Spectrum-X Flags:
-      --multiplane-mode string   Spectrum-X multiplane mode: none, swplb, hwplb, uniplane (requires --spectrum-x)
-      --number-of-planes int     Number of planes for Spectrum-X (requires --spectrum-x)
+      --multiplane-mode string             Spectrum-X multiplane mode: none, swplb, hwplb, uniplane (requires --spectrum-x)
+      --number-of-planes int               Number of planes for Spectrum-X (requires --spectrum-x)
+      --spectrum-x-config string           Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML (required for SPC-X RA versions newer than RA2.2)
+      --spectrum-x-configmap-name string   Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML
 
 Generation Output Flags:
       --enable-doca-driver             Enable DOCA driver deployment (overrides config file docaDriver.enable)
@@ -612,19 +616,47 @@ l8k schema | jq '.supportedNetworkOperatorReleases'
 
 The release identifier is also used to gate version-specific template sections. **NicNodePolicy** is rendered only for `26.4+`; under older releases the OFED driver and the appropriate device plugin (`rdmaSharedDevicePlugin` for ipoib/macvlan, `sriovDevicePlugin` for host-device) are emitted in `NicClusterPolicy` instead, matching the legacy 26.1 model.
 
-There are two **Spectrum-X** profiles, picked by the value of `--spectrum-x`:
+There are three **Spectrum-X** profiles, picked by the value of `--spectrum-x`:
 
-- **`spectrum-x`** — RA2.2 on `26.4+`. Uses the v1alpha2 `SpectrumXRailPoolConfig` with `railTopology[]` to consolidate rail wiring. Selected for `--spectrum-x RA2.2`.
+- **`spectrum-x`** — RA2.3 on `26.7+`. Uses the v1alpha2 `SpectrumXRailPoolConfig` with `railTopology[]` and deploys the Spectrum-X profile through a ConfigMap consumed by NIC Configuration Operator. Selected for `--spectrum-x RA2.3`.
+- **`spectrum-x-ra2.2`** — RA2.2 on `26.4` only. Uses the v1alpha2 `SpectrumXRailPoolConfig` with `railTopology[]` to consolidate rail wiring. Selected for `--spectrum-x RA2.2`.
 - **`spectrum-x-ra2.1`** — RA2.1 on `26.1` only (pinned via `min`/`maxNetworkOperatorRelease: "26.1"`). Renders the full SR-IOV operator chain: per-group `SriovNetworkPoolConfig` + per-rail `SriovNetworkNodePolicy` + `OVSNetwork` + nv-ipam `CIDRPool` + a v1alpha1 glue `SpectrumXRailPoolConfig`. Selected for `--spectrum-x RA2.1`.
 
 When Spectrum-X is enabled and no release is already set, profile resolution
-selects its compatible default release (`RA2.1` → `26.1`, `RA2.2` → `26.4`).
+selects its compatible default release (`RA2.1` → `26.1`, `RA2.2` → `26.4`,
+`RA2.3` → `26.7`).
 An explicit CLI or config value is preserved and the pair is validated:
 `--spectrum-x RA2.1 --network-operator-release 26.4` errors with a specific
 "RA2.1 requires --network-operator-release in [26.1]" message rather than a
 generic "no applicable profile found".
 
-For the RA2.2 `spectrum-x` profile, `profile.spectrumX.useDRA` defaults to `false`.
+RA2.3 requires a Spectrum-X profile ConfigMap input. Pass either a full
+ConfigMap YAML:
+
+```bash
+l8k generate --user-config cluster-config.yaml \
+  --spectrum-x RA2.3 --network-operator-release 26.7 \
+  --spectrum-x-config ./spectrum-x-profile-configmap.yaml
+```
+
+or pass only the raw YAML that belongs under `data.profile` and provide the
+ConfigMap name:
+
+```bash
+l8k generate --user-config cluster-config.yaml \
+  --spectrum-x RA2.3 --network-operator-release 26.7 \
+  --spectrum-x-config ./profile.yaml \
+  --spectrum-x-configmap-name site-ra23-profile
+```
+
+l8k stores the raw Spectrum-X profile text in
+`profile.spectrumX.profile`, renders the deployed ConfigMap into the Network
+Operator namespace with the
+`network.nvidia.com/operator.nic-configuration.spectrum-x-profile` label, and
+sets `NicConfigurationTemplate.spec.template.spectrumXOptimized.version` to
+the rendered ConfigMap name.
+
+For the RA2.2 and RA2.3 Spectrum-X profiles, `profile.spectrumX.useDRA` defaults to `false`.
 When set to `true`, l8k enables the SR-IOV operator `dynamicResourceAllocation`
 feature gate, sets `SpectrumXRailPoolConfig.spec.draEnabled: true`, emits
 `ResourceClaimTemplate` manifests, and renders the example workload with DRA
@@ -878,6 +910,13 @@ profile:
   routing: destination-based
   ignoreARP: false
   spectrumX:
+    enable: true
+    spcxVersion: RA2.3
+    multiplaneMode: hwplb
+    numberOfPlanes: 4
+    configMapName: site-ra23-profile
+    profile: |
+      useSoftwareCCAlgorithm: true
     useDRA: false                       # Set true to generate Spectrum-X DRA ResourceClaimTemplates
 clusterConfig:
 - identifier: group-0

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -99,6 +99,8 @@ and writes the final profile back to cluster-config.yaml.`,
 			SPCXVersion:              spectrumXVersion,
 			MultiplaneMode:           multiplaneMode,
 			NumberOfPlanes:           numberOfPlanes,
+			SpectrumXConfig:          spectrumXConfig,
+			SpectrumXConfigMapName:   spectrumXConfigMapName,
 			KeepNamespace:            keepNamespace,
 			CollapseNicRails:         collapseNicRails,
 			NodeSelector:             nodeSelector,
@@ -153,6 +155,8 @@ func init() {
 			config.SupportedSPCXVersions))
 	discoverCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Spectrum-X multiplane mode override: none, swplb, hwplb, uniplane (requires --spectrum-x)")
 	discoverCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Spectrum-X plane count override: 1, 2, or 4 (requires --spectrum-x)")
+	discoverCmd.Flags().StringVar(&spectrumXConfig, "spectrum-x-config", "", "Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML (required for SPC-X RA versions newer than RA2.2)")
+	discoverCmd.Flags().StringVar(&spectrumXConfigMapName, "spectrum-x-configmap-name", "", "Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML")
 
 	setFlagGroup(discoverCmd, "kubeconfig", GroupCommon)
 	setFlagGroup(discoverCmd, "user-config", GroupCommon)
@@ -172,4 +176,6 @@ func init() {
 	setFlagGroup(discoverCmd, "spectrum-x", GroupProfile)
 	setFlagGroup(discoverCmd, "multiplane-mode", GroupSpectrumX)
 	setFlagGroup(discoverCmd, "number-of-planes", GroupSpectrumX)
+	setFlagGroup(discoverCmd, "spectrum-x-config", GroupSpectrumX)
+	setFlagGroup(discoverCmd, "spectrum-x-configmap-name", GroupSpectrumX)
 }

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -54,8 +54,9 @@ Optionally deploy the generated manifests with --deploy.`,
 
   # Spectrum-X with hardware plane load balancing
   l8k generate --user-config cluster-config.yaml \
-    --network-operator-release 26.4 \
-    --spectrum-x RA2.2 --multiplane-mode hwplb --number-of-planes 4 \
+    --network-operator-release 26.7 \
+    --spectrum-x RA2.3 --multiplane-mode hwplb --number-of-planes 4 \
+    --spectrum-x-config ./spectrum-x-profile-configmap.yaml \
     --save-deployment-files ./output
 
   # Generate and deploy in one step
@@ -114,6 +115,8 @@ Optionally deploy the generated manifests with --deploy.`,
 			SPCXVersion:              spectrumXVersion,
 			MultiplaneMode:           multiplaneMode,
 			NumberOfPlanes:           numberOfPlanes,
+			SpectrumXConfig:          spectrumXConfig,
+			SpectrumXConfigMapName:   spectrumXConfigMapName,
 			Groups:                   groups,
 			GpuType:                  gpuType,
 			NodeSelector:             generateNodeSelector,
@@ -194,6 +197,8 @@ func init() {
 			config.SupportedSPCXVersions))
 	generateCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Multiplane mode: none, swplb, hwplb, uniplane (requires --spectrum-x)")
 	generateCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes (requires --spectrum-x)")
+	generateCmd.Flags().StringVar(&spectrumXConfig, "spectrum-x-config", "", "Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML (required for SPC-X RA versions newer than RA2.2)")
+	generateCmd.Flags().StringVar(&spectrumXConfigMapName, "spectrum-x-configmap-name", "", "Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML")
 	generateCmd.Flags().StringSliceVar(&groups, "groups", nil, "Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.")
 	generateCmd.Flags().StringVar(&gpuType, "gpu-type", "", "Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.")
 	generateCmd.MarkFlagsMutuallyExclusive("groups", "gpu-type")
@@ -238,6 +243,8 @@ func init() {
 
 	setFlagGroup(generateCmd, "multiplane-mode", GroupSpectrumX)
 	setFlagGroup(generateCmd, "number-of-planes", GroupSpectrumX)
+	setFlagGroup(generateCmd, "spectrum-x-config", GroupSpectrumX)
+	setFlagGroup(generateCmd, "spectrum-x-configmap-name", GroupSpectrumX)
 
 	setFlagGroup(generateCmd, "save-deployment-files", GroupGeneration)
 	setFlagGroup(generateCmd, "network-namespaces", GroupGeneration)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -56,6 +56,8 @@ var (
 	spectrumXVersion         string
 	multiplaneMode           string
 	numberOfPlanes           int
+	spectrumXConfig          string
+	spectrumXConfigMapName   string
 	saveDeploymentFiles      string
 	deploy                   bool
 	kubeconfig               string
@@ -134,7 +136,9 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
 
   # Discover + deploy Spectrum-X with JSON output for automation
   l8k --kubeconfig ~/.kube/config --discover-cluster-config \
-    --spectrum-x RA2.2 --multiplane-mode hwplb --number-of-planes 4 --network-operator-release 26.4 --deploy --output json --yes
+    --spectrum-x RA2.3 --multiplane-mode hwplb --number-of-planes 4 \
+    --spectrum-x-config ./spectrum-x-profile-configmap.yaml \
+    --network-operator-release 26.7 --deploy --output json --yes
 
   # Dry-run: preview what would be deployed
   l8k --user-config cluster-config.yaml --spectrum-x --deploy \
@@ -170,6 +174,8 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
 			SPCXVersion:              spectrumXVersion,
 			MultiplaneMode:           multiplaneMode,
 			NumberOfPlanes:           numberOfPlanes,
+			SpectrumXConfig:          spectrumXConfig,
+			SpectrumXConfigMapName:   spectrumXConfigMapName,
 			Groups:                   groups,
 			GpuType:                  gpuType,
 			NodeSelector:             nodeSelector,
@@ -255,6 +261,8 @@ func init() {
 			config.SupportedSPCXVersions))
 	rootCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Spectrum-X multiplane mode: none, swplb, hwplb, uniplane (requires --spectrum-x)")
 	rootCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes for Spectrum-X (requires --spectrum-x)")
+	rootCmd.Flags().StringVar(&spectrumXConfig, "spectrum-x-config", "", "Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML (required for SPC-X RA versions newer than RA2.2)")
+	rootCmd.Flags().StringVar(&spectrumXConfigMapName, "spectrum-x-configmap-name", "", "Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML")
 	rootCmd.Flags().StringSliceVar(&groups, "groups", nil, "Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.")
 	rootCmd.Flags().StringVar(&gpuType, "gpu-type", "", "Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.")
 	rootCmd.MarkFlagsMutuallyExclusive("groups", "gpu-type")
@@ -311,6 +319,8 @@ func init() {
 
 	setFlagGroup(rootCmd, "multiplane-mode", GroupSpectrumX)
 	setFlagGroup(rootCmd, "number-of-planes", GroupSpectrumX)
+	setFlagGroup(rootCmd, "spectrum-x-config", GroupSpectrumX)
+	setFlagGroup(rootCmd, "spectrum-x-configmap-name", GroupSpectrumX)
 
 	setFlagGroup(rootCmd, "save-deployment-files", GroupGeneration)
 	setFlagGroup(rootCmd, "network-namespaces", GroupGeneration)
@@ -452,7 +462,8 @@ func validateProfileFlagValues(opts *options.Options) error {
 // Implicit defaulting (Spectrum-X → fabric=ethernet etc.) lives in
 // `pkg/resolve.ApplyHardwareDefaults`.
 func applySpectrumXSyntaxChecks(opts *options.Options) error {
-	// Inverse cohort: --multiplane-mode / --number-of-planes are only
+	// Inverse cohort: --multiplane-mode / --number-of-planes and
+	// ConfigMap-backed Spectrum-X profile inputs are only
 	// meaningful with --spectrum-x. Catch the CLI typo case here so
 	// the user doesn't get a confusing render-time failure.
 	if !opts.SpectrumX {
@@ -461,6 +472,12 @@ func applySpectrumXSyntaxChecks(opts *options.Options) error {
 		}
 		if opts.NumberOfPlanes != 0 {
 			return fmt.Errorf("--number-of-planes can only be used with --spectrum-x")
+		}
+		if opts.SpectrumXConfig != "" {
+			return fmt.Errorf("--spectrum-x-config can only be used with --spectrum-x")
+		}
+		if opts.SpectrumXConfigMapName != "" {
+			return fmt.Errorf("--spectrum-x-configmap-name can only be used with --spectrum-x")
 		}
 		return nil
 	}

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -143,7 +143,7 @@ var schemaCmd = &cobra.Command{
 				},
 				"--spectrum-x": {
 					Type:        "string",
-					Description: "Enable Spectrum-X by passing the SPC-X RA version (e.g. RA2.1, RA2.2). Implies ethernet, sriov, and multirail; hardware-derived mode and plane defaults are persisted by discover.",
+					Description: "Enable Spectrum-X by passing the SPC-X RA version (e.g. RA2.1, RA2.2, RA2.3). Implies ethernet, sriov, and multirail; hardware-derived mode and plane defaults are persisted by discover.",
 				},
 				"--multiplane-mode": {
 					Type:        "string",
@@ -152,6 +152,14 @@ var schemaCmd = &cobra.Command{
 				"--number-of-planes": {
 					Type:        "int",
 					Description: "Spectrum-X plane count override: 1, 2, or 4. Auto-derived from NIC device ID when omitted.",
+				},
+				"--spectrum-x-config": {
+					Type:        "string",
+					Description: "Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML. Required for SPC-X RA versions newer than RA2.2.",
+				},
+				"--spectrum-x-configmap-name": {
+					Type:        "string",
+					Description: "Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML.",
 				},
 				"--save-deployment-files": {
 					Type:        "string",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,11 @@ func DefaultLaunchKitConfig() (*LaunchKitConfig, error) {
 	if err := yaml.Unmarshal(defaultConfigYAML, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse embedded default l8k-config: %w", err)
 	}
+	if cfg.Profile != nil && cfg.Profile.SpectrumX != nil {
+		if err := NormalizeSpectrumXProfileConfig(cfg.Profile.SpectrumX); err != nil {
+			return nil, fmt.Errorf("invalid embedded spectrum-x profile config: %w", err)
+		}
+	}
 	if err := NormalizeMaintenance(&cfg); err != nil {
 		return nil, fmt.Errorf("invalid embedded maintenance config: %w", err)
 	}
@@ -385,6 +390,8 @@ type ProfileSpectrumX struct {
 	MultiplaneMode string `yaml:"multiplaneMode"` // swplb, hwplb, uniplane
 	NumberOfPlanes int    `yaml:"numberOfPlanes"` // 2 or 4
 	UseDRA         bool   `yaml:"useDRA"`         // enable DRA ResourceClaimTemplate-based workload allocation
+	ConfigMapName  string `yaml:"configMapName,omitempty"`
+	Profile        string `yaml:"profile,omitempty"`
 }
 
 type ClusterConfig struct {
@@ -533,6 +540,11 @@ func LoadFullConfigWithSource(configPath string, logger logr.Logger) (*LaunchKit
 	if err := yaml.Unmarshal(configData, &config); err != nil {
 		return nil, nil, fmt.Errorf("failed to parse cluster config YAML %s: %w", configPath, err)
 	}
+	if config.Profile != nil && config.Profile.SpectrumX != nil {
+		if err := NormalizeSpectrumXProfileConfig(config.Profile.SpectrumX); err != nil {
+			return nil, nil, fmt.Errorf("invalid spectrum-x profile config in %s: %w", configPath, err)
+		}
+	}
 	if err := NormalizeMaintenance(&config); err != nil {
 		return nil, nil, fmt.Errorf("invalid maintenance config in %s: %w", configPath, err)
 	}
@@ -641,7 +653,7 @@ func ValidateClusterConfig(config *LaunchKitConfig, profile string) error {
 // SupportedSPCXVersions lists the Spectrum-X RA versions for which l8k can
 // emit non-`none` multiplane configurations. RA2.1 ships on Network Operator
 // 26.1; RA2.2 on 26.4+. Order is preserved in error messages.
-var SupportedSPCXVersions = []string{"RA2.1", "RA2.2"}
+var SupportedSPCXVersions = []string{"RA2.1", "RA2.2", "RA2.3"}
 
 // SupportedMultiplaneModes lists the Spectrum-X multiplane modes the CLI
 // accepts. `none` and `uniplane` collapse to one plane; `swplb` and `hwplb`
@@ -661,7 +673,8 @@ var SupportedNumberOfPlanes = []int{1, 2, 4}
 // hardware-defaulting (pkg/resolve).
 var SPCXVersionAllowedReleases = map[string][]string{
 	"RA2.1": {"26.1"},
-	"RA2.2": {"26.4", "26.7"},
+	"RA2.2": {"26.4"},
+	"RA2.3": {"26.7"},
 }
 
 // DefaultSPCXReleaseFor returns the canonical (first-listed) Network

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -201,6 +201,20 @@ docaCCVersion: "example"
 	assert.Contains(t, spcx.Profile, `docaCCVersion: "example"`)
 }
 
+func TestNormalizeSpectrumXProfileConfigDoesNotMisclassifyRawDataProfile(t *testing.T) {
+	raw := `data:
+  profile: raw profile field owned by Spectrum-X
+`
+	spcx := &ProfileSpectrumX{
+		ConfigMapName: "site-ra23-profile",
+		Profile:       raw,
+	}
+
+	require.NoError(t, NormalizeSpectrumXProfileConfig(spcx))
+	assert.Equal(t, "site-ra23-profile", spcx.ConfigMapName)
+	assert.Equal(t, raw, spcx.Profile)
+}
+
 func TestValidateClusterConfig(t *testing.T) {
 	t.Run("validate config with missing network operator repository", func(t *testing.T) {
 		config := &LaunchKitConfig{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -167,6 +167,40 @@ func TestDefaultConfigYAMLReturnsFreshCopy(t *testing.T) {
 	assert.NotEqual(t, byte('X'), b[0])
 }
 
+func TestNormalizeSpectrumXProfileConfigFromFullConfigMap(t *testing.T) {
+	spcx := &ProfileSpectrumX{
+		Profile: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: site-ra23-profile
+  namespace: ignored
+data:
+  profile: |
+    useSoftwareCCAlgorithm: true
+    docaCCVersion: "example"
+`,
+	}
+
+	require.NoError(t, NormalizeSpectrumXProfileConfig(spcx))
+	assert.Equal(t, "site-ra23-profile", spcx.ConfigMapName)
+	assert.Contains(t, spcx.Profile, "useSoftwareCCAlgorithm: true")
+	assert.Contains(t, spcx.Profile, `docaCCVersion: "example"`)
+	assert.NotContains(t, spcx.Profile, "kind: ConfigMap")
+}
+
+func TestNormalizeSpectrumXProfileConfigPreservesRawProfile(t *testing.T) {
+	spcx := &ProfileSpectrumX{
+		ConfigMapName: "site-ra23-profile",
+		Profile: `useSoftwareCCAlgorithm: true
+docaCCVersion: "example"
+`,
+	}
+
+	require.NoError(t, NormalizeSpectrumXProfileConfig(spcx))
+	assert.Equal(t, "site-ra23-profile", spcx.ConfigMapName)
+	assert.Contains(t, spcx.Profile, `docaCCVersion: "example"`)
+}
+
 func TestValidateClusterConfig(t *testing.T) {
 	t.Run("validate config with missing network operator repository", func(t *testing.T) {
 		config := &LaunchKitConfig{

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -132,9 +132,12 @@ profile:
   ignoreARP: false # true chains tuning CNI sysctls to prevent ARP flux across pod rails. Not applied to Spectrum-X.
   spectrumX: # Spectrum-X configuration (set enable: true or use --spectrum-x CLI flag)
     enable: false # CLI parameter (overrides this value): --spectrum-x
-    # spcxVersion: "RA2.2" # CLI parameter (overrides this value): --spectrum-x
+    # spcxVersion: "RA2.3" # CLI parameter (overrides this value): --spectrum-x
     # multiplaneMode: swplb # CLI parameter (overrides this value): --multiplane-mode (swplb, hwplb, uniplane)
     # numberOfPlanes: 4 # CLI parameter (overrides this value): --number-of-planes, also used as pfsPerNic
+    # configMapName: "site-ra23-profile" # Required for RA2.3 when profile is raw data.profile YAML; CLI: --spectrum-x-configmap-name
+    # profile: | # Required for RA2.3; accepts raw data.profile YAML or a full ConfigMap YAML. CLI: --spectrum-x-config
+    #   useSoftwareCCAlgorithm: true
     useDRA: false # Enables DRA ResourceClaimTemplate-based Spectrum-X workload allocation
   ai: false
 

--- a/pkg/config/spectrumx_profile.go
+++ b/pkg/config/spectrumx_profile.go
@@ -1,0 +1,99 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	SpectrumXProfileLabel            = "network.nvidia.com/operator.nic-configuration.spectrum-x-profile"
+	SpectrumXProfileConfigMapDataKey = "profile"
+)
+
+// SpectrumXProfileConfigRequired reports whether the RA version must be
+// supplied to NIC Configuration Operator via a profile ConfigMap.
+func SpectrumXProfileConfigRequired(ra string) bool {
+	switch ra {
+	case "", "RA2.1", "RA2.2":
+		return false
+	default:
+		return true
+	}
+}
+
+// NormalizeSpectrumXProfileConfig accepts either a full Spectrum-X profile
+// ConfigMap YAML or the raw data.profile body. Full ConfigMaps contribute their
+// metadata.name; rendered manifests always supply the canonical namespace and
+// label themselves.
+func NormalizeSpectrumXProfileConfig(spcx *ProfileSpectrumX) error {
+	if spcx == nil || strings.TrimSpace(spcx.Profile) == "" {
+		return nil
+	}
+
+	raw := spcx.Profile
+	cm, ok, err := parseSpectrumXProfileConfigMap(raw)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	if strings.TrimSpace(cm.Metadata.Name) == "" {
+		return fmt.Errorf("spectrum-x profile ConfigMap input is missing metadata.name")
+	}
+	if strings.TrimSpace(cm.Data[SpectrumXProfileConfigMapDataKey]) == "" {
+		return fmt.Errorf("spectrum-x profile ConfigMap input is missing non-empty data.%s", SpectrumXProfileConfigMapDataKey)
+	}
+	if spcx.ConfigMapName != "" && spcx.ConfigMapName != cm.Metadata.Name {
+		return fmt.Errorf("profile.spectrumX.configMapName %q does not match input ConfigMap metadata.name %q",
+			spcx.ConfigMapName, cm.Metadata.Name)
+	}
+
+	spcx.ConfigMapName = cm.Metadata.Name
+	spcx.Profile = cm.Data[SpectrumXProfileConfigMapDataKey]
+	return nil
+}
+
+type spectrumXProfileConfigMap struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Data map[string]string `yaml:"data"`
+}
+
+func parseSpectrumXProfileConfigMap(raw string) (*spectrumXProfileConfigMap, bool, error) {
+	var cm spectrumXProfileConfigMap
+	if err := yaml.Unmarshal([]byte(raw), &cm); err != nil {
+		return nil, false, fmt.Errorf("failed to parse spectrum-x profile input: %w", err)
+	}
+
+	isConfigMap := strings.EqualFold(cm.Kind, "ConfigMap") || cm.Data[SpectrumXProfileConfigMapDataKey] != ""
+	if !isConfigMap {
+		return nil, false, nil
+	}
+	if cm.Kind != "" && !strings.EqualFold(cm.Kind, "ConfigMap") {
+		return nil, false, fmt.Errorf("spectrum-x profile input kind must be ConfigMap, got %q", cm.Kind)
+	}
+	return &cm, true, nil
+}

--- a/pkg/config/spectrumx_profile.go
+++ b/pkg/config/spectrumx_profile.go
@@ -88,11 +88,10 @@ func parseSpectrumXProfileConfigMap(raw string) (*spectrumXProfileConfigMap, boo
 		return nil, false, fmt.Errorf("failed to parse spectrum-x profile input: %w", err)
 	}
 
-	isConfigMap := strings.EqualFold(cm.Kind, "ConfigMap") || cm.Data[SpectrumXProfileConfigMapDataKey] != ""
-	if !isConfigMap {
+	if cm.Kind == "" {
 		return nil, false, nil
 	}
-	if cm.Kind != "" && !strings.EqualFold(cm.Kind, "ConfigMap") {
+	if !strings.EqualFold(cm.Kind, "ConfigMap") {
 		return nil, false, fmt.Errorf("spectrum-x profile input kind must be ConfigMap, got %q", cm.Kind)
 	}
 	return &cm, true, nil

--- a/pkg/networkoperatorplugin/grouping_test.go
+++ b/pkg/networkoperatorplugin/grouping_test.go
@@ -226,6 +226,70 @@ func TestSpectrumXGrouping(t *testing.T) {
 	}
 }
 
+func TestSpectrumXRA23RendersProfileConfigMap(t *testing.T) {
+	ctrllog.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	cfg, err := config.LoadFullConfig(
+		filepath.Join("testdata", "grouping", "mixed-same-type.yaml"),
+		ctrllog.Log,
+	)
+	require.NoError(t, err)
+
+	cfg.NetworkOperator.SelectedRelease = "26.7"
+	cfg.NetworkOperator.Namespace = "nvidia-network-operator"
+	cfg.Profile = &config.Profile{
+		Fabric:     "ethernet",
+		Deployment: "sriov",
+		Multirail:  true,
+		SpectrumX: &config.ProfileSpectrumX{
+			Enable:         true,
+			SPCXVersion:    "RA2.3",
+			MultiplaneMode: "hwplb",
+			NumberOfPlanes: 4,
+			ConfigMapName:  "site-ra23-profile",
+			Profile: `useSoftwareCCAlgorithm: true
+docaCCVersion: "example"
+`,
+		},
+	}
+
+	profileDir, err := filepath.Abs(filepath.Join("..", "..", "profiles", "spectrum-x"))
+	require.NoError(t, err)
+	p := &profiles.Profile{
+		Name:   "Spectrum-X Multi-Rail (RA2.3)",
+		Plugin: "network-operator",
+		Templates: []string{
+			"00-values.yaml",
+			"10-nicclusterpolicy.yaml",
+			"25-nicinterfacenametemplate.yaml",
+			"28-spectrumxprofile-configmap.yaml",
+			"30-nicconfigurationtemplate.yaml",
+			"60-cidrpool.yaml",
+			"80-spectrumxrailpoolconfig.yaml",
+			"85-resourceclaimtemplate.yaml",
+			"90-example-daemonset.yaml",
+		},
+	}
+	p.UpdateManifestsPaths(profileDir)
+
+	plugin := &NetworkOperatorPlugin{}
+	rendered, err := plugin.GenerateProfileDeploymentFiles(p, cfg)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"28-spectrumxprofile-configmap.yaml"},
+		fileNamesMatching(rendered, "28-spectrumxprofile-configmap"))
+
+	cm := rendered["28-spectrumxprofile-configmap.yaml"]
+	require.Contains(t, cm, "kind: ConfigMap")
+	require.Contains(t, cm, "name: \"site-ra23-profile\"")
+	require.Contains(t, cm, "namespace: \"nvidia-network-operator\"")
+	require.Contains(t, cm, config.SpectrumXProfileLabel+": \"\"")
+	require.Contains(t, cm, `docaCCVersion: "example"`)
+
+	nct := rendered["30-nicconfigurationtemplate-gpu-model-y.yaml"]
+	require.Contains(t, nct, `version: "site-ra23-profile"`)
+}
+
 func TestSpectrumXGrouping_MergedRailPoolContent(t *testing.T) {
 	// The merged y-model rail pool must select by gpuType (covers all y-model
 	// nodes across machine types) and reference renamed netdev names rather than

--- a/pkg/networkoperatorplugin/grouping_test.go
+++ b/pkg/networkoperatorplugin/grouping_test.go
@@ -247,9 +247,7 @@ func TestSpectrumXRA23RendersProfileConfigMap(t *testing.T) {
 			MultiplaneMode: "hwplb",
 			NumberOfPlanes: 4,
 			ConfigMapName:  "site-ra23-profile",
-			Profile: `useSoftwareCCAlgorithm: true
-docaCCVersion: "example"
-`,
+			Profile:        "useSoftwareCCAlgorithm: true\r\ndocaCCVersion: \"example\"\r\n",
 		},
 	}
 
@@ -285,6 +283,7 @@ docaCCVersion: "example"
 	require.Contains(t, cm, "namespace: \"nvidia-network-operator\"")
 	require.Contains(t, cm, config.SpectrumXProfileLabel+": \"\"")
 	require.Contains(t, cm, `docaCCVersion: "example"`)
+	require.NotContains(t, cm, "\r")
 
 	nct := rendered["30-nicconfigurationtemplate-gpu-model-y.yaml"]
 	require.Contains(t, nct, `version: "site-ra23-profile"`)

--- a/pkg/networkoperatorplugin/networkoperator.go
+++ b/pkg/networkoperatorplugin/networkoperator.go
@@ -19,6 +19,7 @@ package networkoperatorplugin
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/discovery"
@@ -280,6 +281,19 @@ func (p *NetworkOperatorPlugin) ApplyOptionsToConfig(options options.Options, fu
 		}
 		if options.NumberOfPlanes != 0 {
 			fullConfig.Profile.SpectrumX.NumberOfPlanes = options.NumberOfPlanes
+		}
+		if options.SpectrumXConfigMapName != "" {
+			fullConfig.Profile.SpectrumX.ConfigMapName = options.SpectrumXConfigMapName
+		}
+		if options.SpectrumXConfig != "" {
+			profileConfig, err := os.ReadFile(options.SpectrumXConfig)
+			if err != nil {
+				return fmt.Errorf("failed to read --spectrum-x-config %s: %w", options.SpectrumXConfig, err)
+			}
+			fullConfig.Profile.SpectrumX.Profile = string(profileConfig)
+		}
+		if err := config.NormalizeSpectrumXProfileConfig(fullConfig.Profile.SpectrumX); err != nil {
+			return fmt.Errorf("invalid Spectrum-X profile config: %w", err)
 		}
 	}
 

--- a/pkg/networkoperatorplugin/scopes.go
+++ b/pkg/networkoperatorplugin/scopes.go
@@ -86,6 +86,7 @@ var crScopeByKind = map[string]CRScope{
 	// Cluster-wide singleton — multus, CNI plugins, NV-IPAM, etc. live
 	// inside a single NicClusterPolicy.
 	"NicClusterPolicy": ScopeClusterWide,
+	"ConfigMap":        ScopeClusterWide,
 
 	// Aggregate (extended selector — `In: [machine-labels]` under Mode B)
 	"IPPool":    ScopeAggregate,

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -115,6 +115,20 @@ var templateFuncs = template.FuncMap{
 	"spectrumXUseDRA": func(profile *config.Profile) bool {
 		return profile != nil && profile.SpectrumX != nil && profile.SpectrumX.UseDRA
 	},
+	"spectrumXProfileConfigRequired": config.SpectrumXProfileConfigRequired,
+	"spectrumXVersionRef": func(spcx *config.ProfileSpectrumX) string {
+		if spcx == nil {
+			return ""
+		}
+		if config.SpectrumXProfileConfigRequired(spcx.SPCXVersion) {
+			return spcx.ConfigMapName
+		}
+		return spcx.SPCXVersion
+	},
+	"indent": func(s string, spaces int) string {
+		pad := strings.Repeat(" ", spaces)
+		return pad + strings.ReplaceAll(strings.TrimRight(s, "\n"), "\n", "\n"+pad)
+	},
 	"pcieRoot": pcieRoot,
 	// railCount returns how many rails are present in the east-west PFs.
 	// Authoritative source is the PFConfig.Rail field — a rail is a logical

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -126,6 +126,8 @@ var templateFuncs = template.FuncMap{
 		return spcx.SPCXVersion
 	},
 	"indent": func(s string, spaces int) string {
+		s = strings.ReplaceAll(s, "\r\n", "\n")
+		s = strings.ReplaceAll(s, "\r", "\n")
 		pad := strings.Repeat(" ", spaces)
 		return pad + strings.ReplaceAll(strings.TrimRight(s, "\n"), "\n", "\n"+pad)
 	},

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -74,6 +74,11 @@ type Options struct {
 	SPCXVersion    string // Spectrum-X RA version (the value of --spectrum-x; empty = disabled)
 	MultiplaneMode string // Spectrum-X multiplane mode (default: swplb)
 	NumberOfPlanes int    // Number of planes for Spectrum-X (default: 4)
+	// SpectrumXConfig is a path to either a full Spectrum-X profile ConfigMap
+	// YAML or the raw data.profile YAML body. SpectrumXConfigMapName is required
+	// only when SpectrumXConfig contains the raw profile body.
+	SpectrumXConfig        string
+	SpectrumXConfigMapName string
 	// Groups limits `l8k generate` to the named source groups (matched
 	// case-sensitively against `clusterConfig[].identifier`). Comma-separated
 	// on the CLI (`--groups a,b`). Mutually exclusive with GpuType.

--- a/pkg/resolve/validate.go
+++ b/pkg/resolve/validate.go
@@ -7,6 +7,7 @@ package resolve
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 )
@@ -98,6 +99,16 @@ func validateSpectrumXCohort(cfg *config.LaunchKitConfig) error {
 	}
 	if !slices.Contains(config.SupportedSPCXVersions, spcx.SPCXVersion) {
 		return fmt.Errorf("invalid SPC-X RA version %q; supported: %v", spcx.SPCXVersion, config.SupportedSPCXVersions)
+	}
+	if config.SpectrumXProfileConfigRequired(spcx.SPCXVersion) {
+		if strings.TrimSpace(spcx.Profile) == "" {
+			return fmt.Errorf("--spectrum-x %s requires a Spectrum-X profile ConfigMap input via --spectrum-x-config or profile.spectrumX.profile",
+				spcx.SPCXVersion)
+		}
+		if strings.TrimSpace(spcx.ConfigMapName) == "" {
+			return fmt.Errorf("--spectrum-x %s requires a Spectrum-X profile ConfigMap name via --spectrum-x-configmap-name or profile.spectrumX.configMapName when the input is raw data.profile YAML",
+				spcx.SPCXVersion)
+		}
 	}
 
 	// MultiplaneMode + NumberOfPlanes — these can come from

--- a/pkg/resolve/validate_test.go
+++ b/pkg/resolve/validate_test.go
@@ -87,3 +87,44 @@ func TestValidateResolvedConfigRejectsIgnoreARPForSpectrumX(t *testing.T) {
 	err := ValidateResolvedConfig(cfg)
 	require.ErrorContains(t, err, "--ignore-arp does not apply to Spectrum-X profiles")
 }
+
+func TestValidateResolvedConfigRequiresConfigMapProfileForRA23(t *testing.T) {
+	cfg := &config.LaunchKitConfig{
+		NetworkOperator: &config.NetworkOperatorConfig{SelectedRelease: "26.7"},
+		Profile: &config.Profile{
+			Fabric:     "ethernet",
+			Deployment: "sriov",
+			Multirail:  true,
+			SpectrumX: &config.ProfileSpectrumX{
+				Enable:         true,
+				SPCXVersion:    "RA2.3",
+				MultiplaneMode: "hwplb",
+				NumberOfPlanes: 4,
+			},
+		},
+	}
+
+	err := ValidateResolvedConfig(cfg)
+	require.ErrorContains(t, err, "requires a Spectrum-X profile ConfigMap input")
+}
+
+func TestValidateResolvedConfigAcceptsConfigMapProfileForRA23(t *testing.T) {
+	cfg := &config.LaunchKitConfig{
+		NetworkOperator: &config.NetworkOperatorConfig{SelectedRelease: "26.7"},
+		Profile: &config.Profile{
+			Fabric:     "ethernet",
+			Deployment: "sriov",
+			Multirail:  true,
+			SpectrumX: &config.ProfileSpectrumX{
+				Enable:         true,
+				SPCXVersion:    "RA2.3",
+				MultiplaneMode: "hwplb",
+				NumberOfPlanes: 4,
+				ConfigMapName:  "site-ra23",
+				Profile:        "useSoftwareCCAlgorithm: true\n",
+			},
+		},
+	}
+
+	require.NoError(t, ValidateResolvedConfig(cfg))
+}

--- a/profiles/spectrum-x-ra2.2/00-values.yaml
+++ b/profiles/spectrum-x-ra2.2/00-values.yaml
@@ -1,0 +1,87 @@
+{{- /*
+00-values.yaml — Helm values for the nvidia/network-operator chart.
+Rendered by `l8k generate` next to the post-install CR manifests.
+`l8k deploy` reads this file and invokes the Helm Go SDK to install
+or upgrade the network-operator release in the configured namespace
+(Phase 0) before applying the CRs (Phases 1-4).
+*/ -}}
+nfd:
+  enabled: true
+
+upgradeCRDs: true
+
+operator:
+  repository: {{ .NetworkOperator.OperatorRepository }}
+  image: network-operator
+{{- if .NetworkOperator.Version }}
+  tag: {{ .NetworkOperator.Version }}
+{{- end }}
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  maintenanceOperator:
+    useDrainControllerRequestor: true
+{{- end }}
+{{- if .NetworkOperator.ImagePullSecrets }}
+
+imagePullSecrets:
+{{- range .NetworkOperator.ImagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+
+maintenanceOperator:
+  enabled: {{ if or .NicConfigurationOperator (versionGE .NetworkOperator.SelectedRelease "26.1") }}true{{ else }}false{{ end }}
+
+maintenance-operator-chart:
+  operatorConfig:
+    deploy: true
+    # Keep scalar overrides quoted: upstream truthiness guards omit numeric 0.
+    maxParallelOperations: "{{ .Maintenance.MaxParallelOperations.String }}"
+    maxUnavailable: "{{ .Maintenance.MaxUnavailable.String }}"
+    maxNodeMaintenanceTimeSeconds: "{{ .Maintenance.MaxNodeMaintenanceTimeSeconds }}"
+
+sriovNetworkOperator:
+  enabled: true
+
+# Subchart overrides for sriov-network-operator. `sriovOperatorConfig.deploy`
+# defaults to FALSE in the upstream subchart — without this, the operator
+# logs `default SriovOperatorConfig object not found, cannot reconcile
+# SriovNetworkNodePolicies` and never reconciles any policies.
+#
+# Spectrum-X specifics:
+#   - manageSoftwareBridges: lets sriov-network-operator manage the OVS
+#     software bridges the Spectrum-X data path needs (sriov-network-operator
+#     watches OVSNetwork CRs and provisions per-rail bridges).
+#   - disablePlugins=[mellanox]: NicConfigurationOperator owns NIC firmware /
+#     NV config / SR-IOV enablement for Spectrum-X. Letting the operator's
+#     own mellanox plugin run too would mutate the same state twice and
+#     produce flapping configurations.
+#
+# When NicConfigurationOperator is also deployed, gate the daemon's
+# nodeSelector on `network.nvidia.com/operator.nic-configuration.wait=false`
+# so the sriov daemon waits for NCO to finish per-node firmware/NIC config
+# before mutating VFs.
+sriov-network-operator:
+{{- if versionGE .NetworkOperator.SelectedRelease "26.1" }}
+  operator:
+    externalDrainer:
+      enabled: true
+{{- end }}
+  sriovOperatorConfig:
+    deploy: true
+    # See sriov-ethernet-rdma's 00-values.yaml for the rationale: both
+    # optional helpers (auto-resource injector + validating webhook)
+    # depend on TLS secrets the subchart's post-install Job creates,
+    # which doesn't always re-run on cross-profile upgrades.
+    enableInjector: false
+    enableOperatorWebhook: false
+{{- if .NicConfigurationOperator }}
+    configDaemonNodeSelector:
+      network.nvidia.com/operator.nic-configuration.wait: "false"
+{{- end }}
+    featureGates:
+      manageSoftwareBridges: true
+{{- if spectrumXUseDRA .Profile }}
+      dynamicResourceAllocation: true
+{{- end }}
+    disablePlugins:
+      - mellanox

--- a/profiles/spectrum-x-ra2.2/10-nicclusterpolicy.yaml
+++ b/profiles/spectrum-x-ra2.2/10-nicclusterpolicy.yaml
@@ -1,0 +1,57 @@
+apiVersion: mellanox.com/v1alpha1
+kind: NicClusterPolicy
+metadata:
+  name: nic-cluster-policy
+spec:
+  {{- if .NetworkOperator.ImagePullSecrets }}
+  global:
+    imagePullSecrets:
+    {{- range .NetworkOperator.ImagePullSecrets }}
+      - {{ . }}
+    {{- end }}
+  {{- end }}
+  nicConfigurationOperator:
+    operator:
+      image: nic-configuration-operator
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
+    configurationDaemon:
+      image: nic-configuration-operator-daemon
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
+    {{- if .NicConfigurationOperator.UpdateFW }}
+    nicFirmwareStorage:
+      create: true
+      pvcName: nic-fw-storage-pvc
+      storageClassName: nic-fw-storage-class
+      availableStorageSize: 1Gi
+    {{- end }}
+    logLevel: info
+  nvIpam:
+    image: nvidia-k8s-ipam
+    repository: "{{.NetworkOperator.Repository}}"
+    version: "{{.NetworkOperator.ComponentVersion}}"
+    enableWebhook: false
+  spectrumXOperator:
+    image: spectrum-x-operator
+    repository: "{{.NetworkOperator.Repository}}"
+    version: "{{.NetworkOperator.ComponentVersion}}"
+    xPlane:
+      image: xplane
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
+      {{- if .NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+      {{- range .NetworkOperator.ImagePullSecrets }}
+        - {{ . }}
+      {{- end }}
+      {{- end }}
+  secondaryNetwork:
+    cniPlugins:
+      image: plugins
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"
+    multus:
+      image: multus-cni
+      repository: "{{.NetworkOperator.Repository}}"
+      version: "{{.NetworkOperator.ComponentVersion}}"

--- a/profiles/spectrum-x-ra2.2/25-nicinterfacenametemplate.yaml
+++ b/profiles/spectrum-x-ra2.2/25-nicinterfacenametemplate.yaml
@@ -1,0 +1,16 @@
+apiVersion: configuration.net.nvidia.com/v1alpha1
+kind: NicInterfaceNameTemplate
+metadata:
+  name: nic-rename-for-spectrum-x{{suffix .ClusterConfig.Identifier}}
+  namespace: "{{.NetworkOperator.Namespace}}"
+spec:
+  {{- if .ClusterConfig.NodeSelector }}
+  nodeSelector:
+    {{- range $key, $value := .ClusterConfig.NodeSelector }}
+    {{ $key }}: "{{ $value }}"
+    {{- end }}
+  {{- end }}
+  rdmaDevicePrefix: "{{.SpectrumX.RdmaPrefix}}"
+  netDevicePrefix: "{{.SpectrumX.NetdevPrefix}}"
+  pfsPerNic: {{spectrumXPfsPerNic .ClusterConfig.PFs .Profile.SpectrumX.NumberOfPlanes}}
+  railPciAddresses: [{{- $first := true }}{{- range $group := railPciGroups .ClusterConfig.PFs .Profile.SpectrumX.NumberOfPlanes }}{{- if not $first }}, {{ end }}{{- $first = false }}[{{- $firstInner := true }}{{- range $addr := $group }}{{- if not $firstInner }}, {{ end }}{{- $firstInner = false }}"{{$addr}}"{{- end }}]{{- end }}]

--- a/profiles/spectrum-x-ra2.2/30-nicconfigurationtemplate.yaml
+++ b/profiles/spectrum-x-ra2.2/30-nicconfigurationtemplate.yaml
@@ -17,7 +17,7 @@ spec:
     linkType: Ethernet
     spectrumXOptimized:
       enabled: true
-      version: "{{ spectrumXVersionRef .Profile.SpectrumX }}"
+      version: "{{.Profile.SpectrumX.SPCXVersion}}"
       multiplaneMode: "{{.Profile.SpectrumX.MultiplaneMode}}"  # swplb, hwplb, uniplane
       numberOfPlanes: {{.Profile.SpectrumX.NumberOfPlanes}}
       overlay: "{{.SpectrumX.Overlay}}"

--- a/profiles/spectrum-x-ra2.2/60-cidrpool.yaml
+++ b/profiles/spectrum-x-ra2.2/60-cidrpool.yaml
@@ -1,0 +1,62 @@
+{{- /* One CIDRPool per rail (non-swplb) or per rail-plane (swplb).
+       All IP ranges are placeholders; the cluster operator must replace the
+       TODO_* values before applying. */ -}}
+{{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
+{{- $railCount := railCount .ClusterConfig.PFs $planes }}
+{{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
+{{- $first := true }}
+{{- range $railIdx := untilStep 0 $railCount 1 }}
+{{- if $swplb }}
+{{- range $planeIdx := untilStep 0 $planes 1 }}
+{{- if not $first }}---
+{{ end }}{{- $first = false -}}
+apiVersion: nv-ipam.nvidia.com/v1alpha1
+kind: CIDRPool
+metadata:
+  name: rail-{{$railIdx}}-plane-{{$planeIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
+spec:
+  # TODO: rail subnet for this plane (/15 for 2-tier, /11 for 3-tier topology)
+  cidr: TODO_RAIL_{{$railIdx}}_PLANE_{{$planeIdx}}_CIDR
+  gatewayIndex: 0
+  perNodeNetworkPrefix: 31
+  perNodeExclusions:
+    - startIndex: 1
+      endIndex: 1
+  routes:
+    # TODO: rail subnet (same as cidr) + full east-west subnet
+    - dst: TODO_RAIL_SUBNET
+    - dst: TODO_EAST_WEST_SUBNET
+  # TODO: populate one entry per worker node
+  #   - gateway: <host ip on pod network>
+  #     nodeName: <node name>
+  #     prefix: <point-to-point /31 subnet>
+  staticAllocations: []
+{{ end }}
+{{- else }}
+{{- if not $first }}---
+{{ end }}{{- $first = false -}}
+apiVersion: nv-ipam.nvidia.com/v1alpha1
+kind: CIDRPool
+metadata:
+  name: rail-{{$railIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
+  namespace: "{{$.NetworkOperator.Namespace}}"
+spec:
+  # TODO: rail subnet (/15 for 2-tier, /11 for 3-tier topology)
+  cidr: TODO_RAIL_{{$railIdx}}_CIDR
+  gatewayIndex: 0
+  perNodeNetworkPrefix: 31
+  perNodeExclusions:
+    - startIndex: 1
+      endIndex: 1
+  routes:
+    # TODO: rail subnet (same as cidr) + full east-west subnet
+    - dst: TODO_RAIL_SUBNET
+    - dst: TODO_EAST_WEST_SUBNET
+  # TODO: populate one entry per worker node
+  #   - gateway: <host ip on pod network>
+  #     nodeName: <node name>
+  #     prefix: <point-to-point /31 subnet>
+  staticAllocations: []
+{{ end }}
+{{- end }}

--- a/profiles/spectrum-x-ra2.2/80-spectrumxrailpoolconfig.yaml
+++ b/profiles/spectrum-x-ra2.2/80-spectrumxrailpoolconfig.yaml
@@ -1,0 +1,37 @@
+{{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
+{{- $railCount := railCount .ClusterConfig.PFs $planes }}
+{{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
+apiVersion: spectrumx.nvidia.com/v1alpha2
+kind: SpectrumXRailPoolConfig
+metadata:
+  name: rails{{suffix .ClusterConfig.Identifier}}
+  namespace: "{{.NetworkOperator.Namespace}}"
+spec:
+  withBCM: false
+  draEnabled: {{ spectrumXUseDRA .Profile }}
+  {{- if .ClusterConfig.NodeSelector }}
+  nodeSelector:
+    {{- range $key, $value := .ClusterConfig.NodeSelector }}
+    {{ $key }}: "{{ $value }}"
+    {{- end }}
+  {{- end }}
+  networkNamespace: "{{.CurrentNetworkNamespace}}"
+  numVfs: 1
+  railTopology:
+  {{- range $railIdx := untilStep 0 $railCount 1 }}
+  {{- if $swplb }}
+    {{- range $planeIdx := untilStep 0 $planes 1 }}
+  - name: rail{{$railIdx}}p{{$planeIdx}}
+    nicSelector:
+      pfNames: ["{{ replaceVars $.SpectrumX.NetdevPrefix $railIdx $planeIdx $railIdx }}"]
+    cidrPoolRef: rail-{{$railIdx}}-plane-{{$planeIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
+    mtu: 9216
+    {{- end }}
+  {{- else }}
+  - name: rail{{$railIdx}}
+    nicSelector:
+      pfNames: [{{- $firstPF := true }}{{- range $planeIdx := untilStep 0 $planes 1 }}{{- if not $firstPF }}, {{ end }}{{- $firstPF = false }}"{{ replaceVars $.SpectrumX.NetdevPrefix $railIdx $planeIdx $railIdx }}"{{- end }}]
+    cidrPoolRef: rail-{{$railIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
+    mtu: 9216
+  {{- end }}
+  {{- end }}

--- a/profiles/spectrum-x-ra2.2/85-resourceclaimtemplate.yaml
+++ b/profiles/spectrum-x-ra2.2/85-resourceclaimtemplate.yaml
@@ -1,0 +1,87 @@
+{{- if spectrumXUseDRA .Profile }}
+{{- /* DRA ResourceClaimTemplates for Spectrum-X workloads.
+       The SR-IOV operator owns DeviceClass/SriovResourcePolicy/DeviceAttributes
+       generation when dynamicResourceAllocation is enabled. These templates
+       follow the Spectrum-X DRA guidance: each claim requests a GPU and the
+       matching SR-IOV VF(s), using resource.kubernetes.io/pcieRoot selectors
+       when launch-kit has discovered the corresponding PCI roots. */ -}}
+{{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
+{{- $railCount := railCount .ClusterConfig.PFs $planes }}
+{{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
+{{- $first := true }}
+{{- range $railIdx := untilStep 0 $railCount 1 }}
+{{- if $swplb }}
+{{- range $planeIdx := untilStep 0 $planes 1 }}
+{{- $pf := spectrumXPFForRailPlane $.ClusterConfig.PFs $railIdx $planeIdx $planes }}
+{{- $gpuRoot := pcieRoot $pf.ConnectedGPUPCIAddress }}
+{{- $vfRoot := pcieRoot $pf.PciAddress }}
+{{- if not $first }}---
+{{ end }}{{- $first = false -}}
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rail-{{$railIdx}}-plane-{{$planeIdx}}-template{{boundedSuffix 32 $.ClusterConfig.MergedIdentifier}}
+  namespace: "{{$.CurrentNetworkNamespace}}"
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 1
+          {{- if $gpuRoot }}
+          selectors:
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"].pcieRoot == "{{$gpuRoot}}"'
+          {{- end }}
+      - name: vf
+        exactly:
+          deviceClassName: sriovnetwork.k8snetworkplumbingwg.io
+          count: 1
+          selectors:
+          - cel:
+              expression: 'device.attributes["k8s.cni.cncf.io"].resourceName == "nvidia.com/rail_{{$railIdx}}_plane_{{$planeIdx}}"'
+          {{- if $vfRoot }}
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"].pcieRoot == "{{$vfRoot}}"'
+          {{- end }}
+{{ end }}
+{{- else }}
+{{- $pf := spectrumXPFForRailPlane $.ClusterConfig.PFs $railIdx 0 $planes }}
+{{- $gpuRoot := pcieRoot $pf.ConnectedGPUPCIAddress }}
+{{- $vfRoot := pcieRoot $pf.PciAddress }}
+{{- if not $first }}---
+{{ end }}{{- $first = false -}}
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: rail-{{$railIdx}}-template{{boundedSuffix 38 $.ClusterConfig.MergedIdentifier}}
+  namespace: "{{$.CurrentNetworkNamespace}}"
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          count: 1
+          {{- if $gpuRoot }}
+          selectors:
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"].pcieRoot == "{{$gpuRoot}}"'
+          {{- end }}
+      - name: vf
+        exactly:
+          deviceClassName: sriovnetwork.k8snetworkplumbingwg.io
+          count: {{$planes}}
+          selectors:
+          - cel:
+              expression: 'device.attributes["k8s.cni.cncf.io"].resourceName == "nvidia.com/rail_{{$railIdx}}"'
+          {{- if $vfRoot }}
+          - cel:
+              expression: 'device.attributes["resource.kubernetes.io"].pcieRoot == "{{$vfRoot}}"'
+          {{- end }}
+{{ end }}
+{{- end }}
+{{- end }}

--- a/profiles/spectrum-x-ra2.2/90-example-daemonset.yaml
+++ b/profiles/spectrum-x-ra2.2/90-example-daemonset.yaml
@@ -1,0 +1,115 @@
+# Example multi-rail DaemonSet with Spectrum-X networking
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: spectrum-x-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
+  namespace: "{{$.CurrentNetworkNamespace}}"
+spec:
+  selector:
+    matchLabels:
+      app: spectrum-x-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
+  template:
+    metadata:
+      labels:
+        app: spectrum-x-test{{boundedSuffix 48 .ClusterConfig.Identifier}}
+      annotations:
+        {{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
+        {{- $railCount := railCount .ClusterConfig.PFs $planes }}
+        {{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
+        k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $railIdx := untilStep 0 $railCount 1 }}{{- if $swplb }}{{- range $planeIdx := untilStep 0 $planes 1 }}{{- if not $first }},{{ end }}{{- $first = false }}rail-{{$railIdx}}-plane-{{$planeIdx}}{{- end }}{{- else }}{{- if not $first }},{{ end }}{{- $first = false }}rail-{{$railIdx}}{{- end }}{{- end }}
+    spec:
+      {{- if or .ClusterConfig.SourceMachineLabels .ClusterConfig.NodeSelector }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              {{- if .ClusterConfig.SourceMachineLabels }}
+              - key: nvidia.kubernetes-launch-kit.machine
+                operator: In
+                values:
+                {{- range .ClusterConfig.SourceMachineLabels }}
+                - "{{ . }}"
+                {{- end }}
+              {{- else }}
+              {{- range $key, $value := .ClusterConfig.NodeSelector }}
+              - key: {{ $key }}
+                {{- if ne $value "" }}
+                operator: In
+                values:
+                - "{{ printf "%v" $value }}"
+                {{- else }}
+                operator: Exists
+                {{- end }}
+              {{- end }}
+              {{- end }}
+      {{- end }}
+      containers:
+      - name: spectrum-x-test
+        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        command: ["/bin/bash", "-c", "sleep infinity"]
+        securityContext:
+          capabilities:
+            add: ["IPC_LOCK", "NET_RAW"]
+        {{- if spectrumXUseDRA .Profile }}
+        resources:
+          claims:
+            {{- range $railIdx := untilStep 0 $railCount 1 }}
+            {{- if $swplb }}
+            {{- range $planeIdx := untilStep 0 $planes 1 }}
+          - name: rail-{{$railIdx}}-plane-{{$planeIdx}}
+            {{- end }}
+            {{- else }}
+          - name: rail-{{$railIdx}}
+            {{- end }}
+            {{- end }}
+        {{- else }}
+        resources:
+          requests:
+            {{- range $railIdx := untilStep 0 $railCount 1 }}
+            {{- if $swplb }}
+            {{- range $planeIdx := untilStep 0 $planes 1 }}
+            nvidia.com/rail_{{$railIdx}}_plane_{{$planeIdx}}: "1"
+            {{- end }}
+            {{- else }}
+            nvidia.com/rail_{{$railIdx}}: "1"
+            {{- end }}
+            {{- end }}
+          limits:
+            {{- range $railIdx := untilStep 0 $railCount 1 }}
+            {{- if $swplb }}
+            {{- range $planeIdx := untilStep 0 $planes 1 }}
+            nvidia.com/rail_{{$railIdx}}_plane_{{$planeIdx}}: "1"
+            {{- end }}
+            {{- else }}
+            nvidia.com/rail_{{$railIdx}}: "1"
+            {{- end }}
+            {{- end }}
+        {{- end }}
+        command:
+        - sh
+        - -c
+        - |
+          echo "Spectrum-X Multi-Rail Test DaemonSet"
+          echo "Available network interfaces:"
+          ip addr show
+          echo ""
+          echo "RDMA devices:"
+          rdma link
+          echo ""
+          echo "Sleeping indefinitely for manual testing..."
+          sleep infinity
+      {{- if spectrumXUseDRA .Profile }}
+      resourceClaims:
+        {{- range $railIdx := untilStep 0 $railCount 1 }}
+        {{- if $swplb }}
+        {{- range $planeIdx := untilStep 0 $planes 1 }}
+      - name: rail-{{$railIdx}}-plane-{{$planeIdx}}
+        resourceClaimTemplateName: rail-{{$railIdx}}-plane-{{$planeIdx}}-template{{boundedSuffix 32 $.ClusterConfig.MergedIdentifier}}
+        {{- end }}
+        {{- else }}
+      - name: rail-{{$railIdx}}
+        resourceClaimTemplateName: rail-{{$railIdx}}-template{{boundedSuffix 38 $.ClusterConfig.MergedIdentifier}}
+        {{- end }}
+        {{- end }}
+      {{- end }}

--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-The Spectrum-X RA2.3 profile provides optimized multi-rail networking with OVS hardware offload, DOCA acceleration, and advanced NIC firmware configuration specifically designed for AI workloads.
+The Spectrum-X profile provides optimized multi-rail networking with OVS hardware offload, DOCA acceleration, and advanced NIC firmware configuration specifically designed for AI workloads.
 
 ## Features
 
 - **Multi-Rail Networking**: Supports multiple network rails for high-bandwidth AI workloads
 - **OVS Hardware Offload**: DOCA-accelerated Open vSwitch with hardware offloading
 - **RDMA Exclusive Mode**: Dedicated RDMA resources per workload
-- **Advanced Firmware Configuration**: Spectrum-X optimized firmware with RA2.3 support
+- **Advanced Firmware Configuration**: Spectrum-X optimized firmware with RA2.2 support
 - **Multiple Plane Modes**: Supports none, swplb, hwplb, and uniplane configurations
 - **Dynamic Interface Naming**: Automatic NIC interface naming based on plane and rail topology
 - **Optional DRA Workload Allocation**: `profile.spectrumX.useDRA` enables ResourceClaimTemplate-based GPU/VF allocation
@@ -35,7 +35,7 @@ nodeCapabilities:
   - `"1023"` for ConnectX-8
   - `"1025"` for ConnectX-9
   - `"a2dc"` for BlueField-3 SuperNIC
-- **firmwareVersion**: Spectrum-X firmware version (e.g., `"RA2.3"`)
+- **firmwareVersion**: Spectrum-X firmware version (e.g., `"RA2.2"`)
 - **multiplaneMode**: Multiplane configuration
   - `none`: Single plane
   - `swplb`: Software plane load balancing
@@ -49,14 +49,6 @@ nodeCapabilities:
   `dynamicResourceAllocation` feature gate, sets `SpectrumXRailPoolConfig.spec.draEnabled`
   to `true`, emits `ResourceClaimTemplate` manifests, and renders the example workload
   with DRA claims instead of device-plugin resource requests.
-- **configMapName**: Required for RA2.3 when `profile` contains only raw
-  `data.profile` YAML. When `profile` contains a full ConfigMap manifest, l8k
-  extracts `metadata.name`.
-- **profile**: Required for RA2.3. Accepts either the raw Spectrum-X profile
-  YAML that belongs under ConfigMap `data.profile`, or a full ConfigMap YAML.
-  l8k renders the deployed ConfigMap into the Network Operator namespace with
-  the required `network.nvidia.com/operator.nic-configuration.spectrum-x-profile`
-  label.
 
 ### OVS Configuration
 
@@ -101,28 +93,23 @@ The profile generates the following Kubernetes Custom Resources:
      NIC configuration template so the firmware/optimization template can refer to
      the renamed PFs.
 
-3. **Spectrum-X profile ConfigMap** (`28-spectrumxprofile-configmap.yaml`)
-   - Stores the RA2.3 Spectrum-X profile under `data.profile`, in the Network
-     Operator namespace, with the label watched by NIC Configuration Operator.
+3. **NicConfigurationTemplate** (`30-nicconfigurationtemplate.yaml`)
+   - Configures Spectrum-X optimized firmware settings (RA2.2).
 
-4. **NicConfigurationTemplate** (`30-nicconfigurationtemplate.yaml`)
-   - Configures Spectrum-X optimized firmware settings. For RA2.3,
-     `spectrumXOptimized.version` is the generated profile ConfigMap name.
-
-5. **CIDRPool** (`60-cidrpool.yaml`)
+4. **CIDRPool** (`60-cidrpool.yaml`)
    - One pool per rail (non-swplb) or per rail-plane (swplb), with IP placeholders
      the cluster operator must fill in.
 
-6. **SpectrumXRailPoolConfig** (`80-spectrumxrailpoolconfig.yaml`)
+5. **SpectrumXRailPoolConfig** (`80-spectrumxrailpoolconfig.yaml`)
    - Single `v1alpha2` resource with `railTopology[]`. In swplb, one entry per
      rail-plane; otherwise one entry per rail grouping all planes. `draEnabled`
      is rendered from `profile.spectrumX.useDRA`; the default is explicit `false`.
 
-7. **ResourceClaimTemplate** (`85-resourceclaimtemplate.yaml`)
+6. **ResourceClaimTemplate** (`85-resourceclaimtemplate.yaml`)
    - Rendered only when `profile.spectrumX.useDRA: true`. Each template requests
      a GPU and matching SR-IOV VF resources using DRA device classes.
 
-8. **Example DaemonSet** (`90-example-daemonset.yaml`)
+7. **Example DaemonSet** (`90-example-daemonset.yaml`)
    - Example workload requesting one VF per rail (non-swplb) or per rail-plane (swplb).
      In DRA mode, it references the generated `ResourceClaimTemplate` resources instead.
 
@@ -134,7 +121,7 @@ operator; l8k does not generate them.
 ```yaml
 spectrumX:
   nicType: "1023"
-  firmwareVersion: "RA2.3"
+  firmwareVersion: "RA2.2"
   multiplaneMode: hwplb
   numberOfPlanes: 4
   overlay: "none"
@@ -162,13 +149,9 @@ profile:
   multirail: true
   spectrumX:
     enable: true
-    spcxVersion: RA2.3
+    spcxVersion: RA2.2
     multiplaneMode: hwplb
     numberOfPlanes: 4
-    configMapName: site-ra23-profile
-    profile: |
-      useSoftwareCCAlgorithm: true
-      docaCCVersion: "example"
     useDRA: false
 ```
 
@@ -177,9 +160,9 @@ profile:
 ### Prerequisites
 
 1. Kubernetes cluster with SR-IOV capable nodes
-2. NVIDIA Network Operator v26.7.0 or later
+2. NVIDIA Network Operator v26.1.0 or later
 3. ConnectX-8, ConnectX-9, or BlueField-3 SuperNIC adapters
-4. Firmware compatible with Spectrum-X RA2.3
+4. Firmware compatible with Spectrum-X RA2.2
 
 ### Installation with Helm
 
@@ -192,7 +175,7 @@ helm repo update
 helm install network-operator nvidia/network-operator \
   --namespace nvidia-network-operator \
   --create-namespace \
-  --version v26.7.0 \
+  --version v26.1.0 \
   -f myValues.yaml \
   --wait
 ```

--- a/profiles/spectrum-x-ra2.2/profile.yaml
+++ b/profiles/spectrum-x-ra2.2/profile.yaml
@@ -1,32 +1,31 @@
-name: Spectrum-X Multi-Rail (RA2.3)
+name: Spectrum-X Multi-Rail (RA2.2)
 plugin: network-operator
 profileRequirements:
   fabric: ethernet
   deployment: sriov
   spectrumX:
-    spcxVersion: "RA2.3"
+    spcxVersion: "RA2.2"
     multiplaneMode: ["swplb", "hwplb", "uniplane", "none"]
   multirail: true
   # SpectrumXRailPoolConfig (spectrumx.net.nvidia.com/v1alpha2) is only
-  # available in Network Operator 26.4+. RA2.3 also requires the
-  # ConfigMap-backed Spectrum-X profile support shipped in 26.7+.
-  minNetworkOperatorRelease: "26.7"
+  # available in Network Operator 26.4+. Older releases must pick a
+  # different profile.
+  minNetworkOperatorRelease: "26.4"
+  maxNetworkOperatorRelease: "26.4"
 nodeCapabilities:
     sriov: true
     rdma: true
 description: |
-  Spectrum-X RA2.3 profile provides optimized multi-rail networking with the
+  Spectrum-X RA2.2 profile provides optimized multi-rail networking with the
   SpectrumXRailPoolConfig CRD, DOCA acceleration, and advanced NIC firmware
-  configuration supplied via a Spectrum-X profile ConfigMap. Supports swplb,
-  hwplb, uniplane, and none multiplane modes. In swplb the railTopology splits
-  each rail into per-plane entries; in other modes one entry per rail groups
-  all planes together.
+  configuration for AI workloads. Supports swplb, hwplb, uniplane, and none
+  multiplane modes. In swplb the railTopology splits each rail into per-plane
+  entries; in other modes one entry per rail groups all planes together.
 deploymentGuide: spectrum-x.rst
 templates:
   - 00-values.yaml
   - 10-nicclusterpolicy.yaml
   - 25-nicinterfacenametemplate.yaml
-  - 28-spectrumxprofile-configmap.yaml
   - 30-nicconfigurationtemplate.yaml
   - 60-cidrpool.yaml
   - 80-spectrumxrailpoolconfig.yaml

--- a/profiles/spectrum-x/28-spectrumxprofile-configmap.yaml
+++ b/profiles/spectrum-x/28-spectrumxprofile-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if spectrumXProfileConfigRequired .Profile.SpectrumX.SPCXVersion }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ .Profile.SpectrumX.ConfigMapName }}"
+  namespace: "{{ .NetworkOperator.Namespace }}"
+  labels:
+    network.nvidia.com/operator.nic-configuration.spectrum-x-profile: ""
+data:
+  profile: |
+{{ indent .Profile.SpectrumX.Profile 4 }}
+{{- end }}


### PR DESCRIPTION
## Summary
- make the existing spectrum-x profile target SPC-X RA2.3 and copy the previous implementation to spectrum-x-ra2.2
- accept Spectrum-X profile config as either a full ConfigMap YAML or raw data.profile YAML, with a required ConfigMap name for raw input
- render the profile ConfigMap with the Network Operator namespace and NIC Configuration Operator label, and point NicConfigurationTemplate spectrumXOptimized.version at the ConfigMap name for RA2.3
- document RA2.3 usage, CLI/config inputs, and the renamed RA2.2 profile

## Verification
- GOCACHE=/private/tmp/l8k-spcx-ra23-go-cache go test ./... -count=1
- GOCACHE=/private/tmp/l8k-spcx-ra23-go-cache go build ./...