### PR TITLE
Add validation modes and ICMP checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,16 +334,20 @@ condition-Reason classification, NicClusterPolicy appliedStates breakdown,
 etc.); and (3) a data-plane connectivity matrix — apply the example
 DaemonSet, wait for it to roll out completely (`numberReady ==
 desiredNumberScheduled > 0` — a single ContainerCreating-stuck pod fails),
-and run the configured RDMA checks (`rping` and/or `ib_write_bw`) across
-every same-rail pod pair plus a per-pair cross-rail canary. The matrix is on
-by default (`--connectivity=false` to skip) and cleans up the test DaemonSet
-unless `--keep` is set. Fresh `l8k discover` output includes the default
-validation block:
+and run the configured checks (`icmp`, `rping`, and/or `ib_write_bw`) with
+source-bound rail identity. ICMP uses `ping -I <src-iface>`, `rping` uses
+`-I <src-ip>`, and `ib_write_bw` uses `--bind_source_ip <src-ip>`; every test
+also records a source-qualified `ip route get <dst> from <src>` lookup. The
+matrix is on by default (`--connectivity=false` to skip) and cleans up the
+test DaemonSet unless `--keep` is set. Fresh `l8k discover` output includes
+the default validation block:
 
 ```yaml
 validation:
   connectivity: true
+  mode: strict
   checks:
+    - icmp
     - rping
     - ib_write_bw
   rdma:
@@ -352,9 +356,20 @@ validation:
     ibWriteMinBandwidthGbps: 100
 ```
 
+Validation modes control cross-rail coverage and gating:
+
+- `quick` runs all same-rail node pairs plus one non-gating cross-rail canary
+  for every source-rail/destination-rail mapping.
+- `full` runs every source rail × every destination rail × every ordered pod
+  pair; cross-rail results are reported but do not decide pass/fail.
+- `strict` is the default. It runs the full matrix and gates cross-rail by the
+  generated profile routing mode: `profile.routing: source-based` requires
+  cross-rail success, while `destination-based` requires cross-rail isolation.
+
 `l8k validate` can override that config for a single run:
+`--validation-mode quick|full|strict`, `--validation-checks icmp`,
 `--validation-checks rping`, `--validation-checks ib_write_bw`,
-`--validation-checks ""`, `--rdma-rping-iterations <N>`, and
+`--validation-checks ""`, `--rdma-rping-iterations <N>`,
 `--rdma-ib-write-size <BYTES>`, and
 `--rdma-ib-write-min-bandwidth-gbps <GBPS>` (`0` disables bandwidth gating).
 
@@ -365,7 +380,7 @@ profile, **Node groups** (per-`clusterConfig[]` entry with east-west / north-
 south PF tables — PCI, deviceID, rail, netdev, RDMA device, PSID, part #,
 NUMA, connected GPU), cluster nodes, Network Operator release, **Manifest
 state** (with expandable Details + **Live YAML** dropdowns per row),
-connectivity matrix (per-rail src×dst grids + cross-rail canary), and a
+connectivity matrix (per-rail src×dst grids + cross-rail results), and a
 warnings rollup. Styled after the NVIDIA AICR documentation light theme;
 no JS, no external assets.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -48,6 +48,23 @@ wrong HCA even though the IP destination is correct. These settings apply to
 SR-IOV, SR-IOV IB, host-device, Macvlan RDMA-shared, and IPoIB RDMA-shared
 profiles; they do not apply to Spectrum-X profiles.
 
+Validation
+----------
+
+``l8k validate`` verifies the generated deployment against the live cluster and
+runs a source-bound connectivity matrix by default. Fresh discovery writes
+``validation.mode: strict`` and enables ``icmp``, ``rping``, and
+``ib_write_bw`` checks. Use ``--validation-mode quick`` for a smoke test,
+``--validation-mode full`` for non-gating full cross-rail observation, or keep
+``strict`` to gate cross-rail behavior according to ``profile.routing``:
+``source-based`` must pass and ``destination-based`` must stay isolated.
+
+.. code-block:: bash
+
+   l8k validate --user-config ./cluster-config.yaml \
+     --deployment-files ./deployment \
+     --kubeconfig ~/.kube/config
+
 .. code-block:: bash
 
    l8k discover --user-config ./cluster-config.yaml \

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -75,7 +75,7 @@ var schemaCmd = &cobra.Command{
 					Example:     "l8k deploy --deployment-files ./deployment --kubeconfig ~/.kube/config",
 				},
 				"validate": {
-					Description: "Verify a deployment matches the selected Network Operator release (Helm chart version + manifest state + configurable RDMA connectivity checks)",
+					Description: "Verify a deployment matches the selected Network Operator release (Helm chart version + manifest state + configurable ICMP/RDMA connectivity checks)",
 					Example:     "l8k validate --user-config ./cluster-config.yaml --deployment-files ./deployment",
 				},
 				"sosreport": {
@@ -215,7 +215,12 @@ var schemaCmd = &cobra.Command{
 				"--validation-checks": {
 					Type:        "[]string",
 					Default:     "inherit from validation.checks",
-					Description: "Comma-separated RDMA checks to run during validate connectivity: rping, ib_write_bw.",
+					Description: "Comma-separated checks to run during validate connectivity: icmp, rping, ib_write_bw.",
+				},
+				"--validation-mode": {
+					Type:        "string",
+					Default:     "inherit from validation.mode",
+					Description: "Connectivity validation mode: quick, full, or strict.",
 				},
 				"--rdma-rping-iterations": {
 					Type:        "int",

--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -50,7 +50,7 @@ import (
 
 // Phase 2 connectivity-test flags. `--connectivity` defaults to ON —
 // every `l8k validate` verifies the data plane (apply example DS,
-// wait Ready, RDMA matrix, cleanup) unless the caller passes
+// wait Ready, source-bound connectivity matrix, cleanup) unless the caller passes
 // `--connectivity=false`. The other flags tune matrix behaviour
 // (--connectivity-timeout, --keep) or extend the validate semantics
 // (--wait blocks until in-progress manifests reach a terminal state).
@@ -65,6 +65,7 @@ var (
 	validateConnectivityTimeout time.Duration
 	validateWait                time.Duration
 	validateReportPath          string
+	validateMode                string
 	validateChecks              []string
 	validateRDMAIterations      int
 	validateRDMAIBWriteSize     int
@@ -96,9 +97,10 @@ Three checks are run:
   3. Connectivity (default ON, pass --connectivity=false to skip): the
      example DaemonSet is applied, the rollout is awaited until
      numberReady == desiredNumberScheduled > 0, and the configured
-     RDMA checks (rping and/or ib_write_bw) run between the test pods'
-     rail IPs (same-rail across every pod pair + one cross-rail canary
-     per pair). The DS is deleted on exit unless --keep is set. Skipped
+     source-bound checks (icmp, rping, and/or ib_write_bw) run between
+     the test pods' rail IPs. validation.mode controls coverage and
+     cross-rail gating: quick, full, or strict. The DS is deleted on exit
+     unless --keep is set. Skipped
      when any manifest from step 2 is IN-PROGRESS / ERROR / MISSING
      (running connectivity against an unready cluster would just
      produce noise).
@@ -108,11 +110,11 @@ connectivity-matrix failure.`,
 	Example: `  # Full validate (manifest state + connectivity matrix)
   l8k validate
 
-  # Manifest checks only (no DaemonSet apply, no RDMA matrix)
+  # Manifest checks only (no DaemonSet apply, no connectivity matrix)
   l8k validate --connectivity=false
 
-  # Only run rping, with more iterations
-  l8k validate --validation-checks rping --rdma-rping-iterations 100
+  # Only run rping, with more iterations, in full coverage mode
+  l8k validate --validation-mode full --validation-checks rping --rdma-rping-iterations 100
 
   # Block up to 10 minutes for in-progress manifests to finish reconciling
   l8k validate --wait 10m
@@ -206,6 +208,7 @@ connectivity-matrix failure.`,
 		// validate run against a namespace not recorded in cluster-config.yaml
 		// can still target the right Helm release / live CRs.
 		selectedRelease := ""
+		profileRouting := config.RoutingDestinationBased
 		validationCfg := config.DefaultValidationConfig()
 		cfg, cfgPath, cfgErr := loadUserConfig(options.Options{
 			ConfigDir:                configDir,
@@ -220,6 +223,9 @@ connectivity-matrix failure.`,
 			}
 			if cfg.NetworkOperator != nil {
 				selectedRelease = cfg.NetworkOperator.SelectedRelease
+			}
+			if cfg.Profile != nil && cfg.Profile.Routing != "" {
+				profileRouting = cfg.Profile.Routing
 			}
 			validationCfg = config.NormalizeValidationConfig(cfg.Validation)
 			for _, g := range cfg.ClusterConfig {
@@ -246,7 +252,7 @@ connectivity-matrix failure.`,
 			exitWithReport(apperrors.NewValidationError(
 				"invalid validation configuration",
 				err,
-				"Use --validation-checks rping,ib_write_bw and positive RDMA parameter values",
+				"Use --validation-mode quick|full|strict, --validation-checks icmp,rping,ib_write_bw, and positive RDMA parameter values",
 			))
 		}
 
@@ -397,6 +403,8 @@ connectivity-matrix failure.`,
 				ManifestDir:             manifestDir,
 				Timeout:                 validateConnectivityTimeout,
 				Keep:                    validateKeep,
+				Mode:                    connectivity.Mode(validationCfg.Mode),
+				Routing:                 profileRouting,
 				Checks:                  connectivityChecksFromConfig(validationCfg),
 				RPingIterations:         validationCfg.RDMA.RPingIterations,
 				IBWriteSize:             validationCfg.RDMA.IBWriteSize,
@@ -441,6 +449,9 @@ func applyValidateFlagOverrides(cmd *cobra.Command, validationCfg *config.Valida
 		v := validateConnectivity
 		validationCfg.Connectivity = &v
 	}
+	if cmd.Flags().Changed("validation-mode") {
+		validationCfg.Mode = strings.TrimSpace(validateMode)
+	}
 	if cmd.Flags().Changed("validation-checks") {
 		validationCfg.Checks = config.NormalizeValidationChecks(validateChecks)
 	}
@@ -483,6 +494,8 @@ func connectivityChecksFromConfig(validationCfg *config.ValidationConfig) []conn
 	checks := make([]connectivity.Check, 0, len(validationCfg.Checks))
 	for _, check := range validationCfg.Checks {
 		switch check {
+		case config.ValidationCheckICMP:
+			checks = append(checks, connectivity.CheckICMP)
 		case config.ValidationCheckRPing:
 			checks = append(checks, connectivity.CheckRPing)
 		case config.ValidationCheckIBWriteBW:
@@ -552,7 +565,7 @@ func computeOverallVerdict(
 	if matrix != nil {
 		if matrix.Summary.Failed > 0 {
 			out.Pass = false
-			out.Reasons = append(out.Reasons, fmt.Sprintf("%d RDMA test(s) failed in the connectivity matrix", matrix.Summary.Failed))
+			out.Reasons = append(out.Reasons, fmt.Sprintf("%d connectivity test(s) failed in the connectivity matrix", matrix.Summary.Failed))
 		}
 		if matrix.Skipped != nil {
 			out.Notes = append(out.Notes, "Connectivity matrix skipped: "+matrix.Skipped.Reason)
@@ -1566,10 +1579,11 @@ func init() {
 	// `l8k validate` exercises the data plane unless explicitly
 	// disabled. Pass `--connectivity=false` to limit validate to
 	// the static manifest-presence + Helm release-version checks.
-	validateCmd.Flags().BoolVar(&validateConnectivity, "connectivity", true, "Run an RDMA matrix (rping + ib_write_bw) between pods of the example DaemonSet to verify the data plane. Default true. Pass --connectivity=false to skip when only the static manifest checks are wanted.")
+	validateCmd.Flags().BoolVar(&validateConnectivity, "connectivity", true, "Run a source-bound connectivity matrix (icmp + rping + ib_write_bw) between pods of the example DaemonSet. Default true. Pass --connectivity=false to skip when only the static manifest checks are wanted.")
 	validateCmd.Flags().BoolVar(&validateKeep, "keep", false, "Leave the example DaemonSet running after --connectivity completes (useful for debugging).")
-	validateCmd.Flags().DurationVar(&validateConnectivityTimeout, "connectivity-timeout", 5*time.Minute, "Wall-clock budget for the connectivity matrix (DaemonSet rollout + rping + ib_write_bw execs).")
-	validateCmd.Flags().StringSliceVar(&validateChecks, "validation-checks", nil, "Comma-separated RDMA checks to run during connectivity validation. Supported: rping, ib_write_bw. Overrides validation.checks from cluster-config.yaml.")
+	validateCmd.Flags().DurationVar(&validateConnectivityTimeout, "connectivity-timeout", 5*time.Minute, "Wall-clock budget for the connectivity matrix (DaemonSet rollout + icmp + rping + ib_write_bw execs).")
+	validateCmd.Flags().StringVar(&validateMode, "validation-mode", "", "Connectivity validation mode: quick, full, or strict. Overrides validation.mode from cluster-config.yaml.")
+	validateCmd.Flags().StringSliceVar(&validateChecks, "validation-checks", nil, "Comma-separated checks to run during connectivity validation. Supported: icmp, rping, ib_write_bw. Overrides validation.checks from cluster-config.yaml.")
 	validateCmd.Flags().IntVar(&validateRDMAIterations, "rdma-rping-iterations", 0, "Number of rping client iterations. Overrides validation.rdma.rpingIterations from cluster-config.yaml.")
 	validateCmd.Flags().IntVar(&validateRDMAIBWriteSize, "rdma-ib-write-size", 0, "Message size for ib_write_bw -s. Overrides validation.rdma.ibWriteSize from cluster-config.yaml.")
 	validateCmd.Flags().Float64Var(&validateRDMAIBWriteMinGbps, "rdma-ib-write-min-bandwidth-gbps", 0, "Minimum observed ib_write_bw peak bandwidth in Gbps required for a test to pass. Use 0 to disable bandwidth gating. Overrides validation.rdma.ibWriteMinBandwidthGbps from cluster-config.yaml.")
@@ -1583,6 +1597,7 @@ func init() {
 	setFlagGroup(validateCmd, "connectivity", GroupValidation)
 	setFlagGroup(validateCmd, "connectivity-timeout", GroupValidation)
 	setFlagGroup(validateCmd, "keep", GroupValidation)
+	setFlagGroup(validateCmd, "validation-mode", GroupValidation)
 	setFlagGroup(validateCmd, "validation-checks", GroupValidation)
 	setFlagGroup(validateCmd, "rdma-rping-iterations", GroupValidation)
 	setFlagGroup(validateCmd, "rdma-ib-write-size", GroupValidation)

--- a/pkg/cmd/validate_config_test.go
+++ b/pkg/cmd/validate_config_test.go
@@ -29,6 +29,7 @@ import (
 func newValidateOverrideTestCmd() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Flags().BoolVar(&validateConnectivity, "connectivity", true, "")
+	cmd.Flags().StringVar(&validateMode, "validation-mode", "", "")
 	cmd.Flags().StringSliceVar(&validateChecks, "validation-checks", nil, "")
 	cmd.Flags().IntVar(&validateRDMAIterations, "rdma-rping-iterations", 0, "")
 	cmd.Flags().IntVar(&validateRDMAIBWriteSize, "rdma-ib-write-size", 0, "")
@@ -39,6 +40,7 @@ func newValidateOverrideTestCmd() *cobra.Command {
 func resetValidateOverrideGlobals(t *testing.T) {
 	t.Helper()
 	validateConnectivity = true
+	validateMode = ""
 	validateChecks = nil
 	validateRDMAIterations = 0
 	validateRDMAIBWriteSize = 0
@@ -54,6 +56,7 @@ func TestApplyValidateFlagOverrides(t *testing.T) {
 		minBandwidthGbps := 200.0
 		cfg := config.NormalizeValidationConfig(&config.ValidationConfig{
 			Checks: []string{config.ValidationCheckRPing},
+			Mode:   config.ValidationModeQuick,
 			RDMA: &config.ValidationRDMAConfig{
 				RPingIterations:         3,
 				IBWriteSize:             4096,
@@ -61,18 +64,32 @@ func TestApplyValidateFlagOverrides(t *testing.T) {
 			},
 		})
 
+		require.NoError(t, cmd.Flags().Set("validation-mode", "full"))
 		require.NoError(t, cmd.Flags().Set("validation-checks", "ib_write_bw"))
 		require.NoError(t, cmd.Flags().Set("rdma-rping-iterations", "11"))
 		require.NoError(t, cmd.Flags().Set("rdma-ib-write-size", "8192"))
 		require.NoError(t, cmd.Flags().Set("rdma-ib-write-min-bandwidth-gbps", "800"))
 		require.NoError(t, applyValidateFlagOverrides(cmd, cfg))
 
+		assert.Equal(t, config.ValidationModeFull, cfg.Mode)
 		assert.Equal(t, []string{config.ValidationCheckIBWriteBW}, cfg.Checks)
 		assert.Equal(t, 11, cfg.RDMA.RPingIterations)
 		assert.Equal(t, 8192, cfg.RDMA.IBWriteSize)
 		require.NotNil(t, cfg.RDMA.IBWriteMinBandwidthGbps)
 		assert.Equal(t, 800.0, *cfg.RDMA.IBWriteMinBandwidthGbps)
 		assert.Equal(t, []connectivity.Check{connectivity.CheckIBWriteBW}, connectivityChecksFromConfig(cfg))
+	})
+
+	t.Run("cli can select icmp check", func(t *testing.T) {
+		resetValidateOverrideGlobals(t)
+		cmd := newValidateOverrideTestCmd()
+		cfg := config.NormalizeValidationConfig(nil)
+
+		require.NoError(t, cmd.Flags().Set("validation-checks", "icmp"))
+		require.NoError(t, applyValidateFlagOverrides(cmd, cfg))
+
+		assert.Equal(t, []string{config.ValidationCheckICMP}, cfg.Checks)
+		assert.Equal(t, []connectivity.Check{connectivity.CheckICMP}, connectivityChecksFromConfig(cfg))
 	})
 
 	t.Run("zero minimum bandwidth override disables bandwidth gating", func(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -311,6 +311,11 @@ type WorkloadConfig struct {
 }
 
 const (
+	ValidationModeQuick  = "quick"
+	ValidationModeFull   = "full"
+	ValidationModeStrict = "strict"
+
+	ValidationCheckICMP      = "icmp"
 	ValidationCheckRPing     = "rping"
 	ValidationCheckIBWriteBW = "ib_write_bw"
 
@@ -324,6 +329,7 @@ const (
 // matrix. Checks selects which RDMA families to run.
 type ValidationConfig struct {
 	Connectivity *bool                 `yaml:"connectivity,omitempty"`
+	Mode         string                `yaml:"mode,omitempty"`
 	Checks       []string              `yaml:"checks,omitempty"`
 	RDMA         *ValidationRDMAConfig `yaml:"rdma,omitempty"`
 }
@@ -345,7 +351,8 @@ func defaultFloat64(v float64) *float64 {
 func DefaultValidationConfig() *ValidationConfig {
 	return &ValidationConfig{
 		Connectivity: defaultBool(true),
-		Checks:       []string{ValidationCheckRPing, ValidationCheckIBWriteBW},
+		Mode:         ValidationModeStrict,
+		Checks:       []string{ValidationCheckICMP, ValidationCheckRPing, ValidationCheckIBWriteBW},
 		RDMA: &ValidationRDMAConfig{
 			RPingIterations:         DefaultValidationRPingIterations,
 			IBWriteSize:             DefaultValidationIBWriteSize,
@@ -361,8 +368,12 @@ func NormalizeValidationConfig(v *ValidationConfig) *ValidationConfig {
 	if v.Connectivity == nil {
 		v.Connectivity = defaultBool(true)
 	}
+	v.Mode = strings.TrimSpace(v.Mode)
+	if v.Mode == "" {
+		v.Mode = ValidationModeStrict
+	}
 	if v.Checks == nil {
-		v.Checks = []string{ValidationCheckRPing, ValidationCheckIBWriteBW}
+		v.Checks = []string{ValidationCheckICMP, ValidationCheckRPing, ValidationCheckIBWriteBW}
 	} else {
 		v.Checks = NormalizeValidationChecks(v.Checks)
 	}
@@ -402,15 +413,21 @@ func ValidateValidationConfig(v *ValidationConfig) error {
 	if v == nil {
 		return nil
 	}
+	switch v.Mode {
+	case "", ValidationModeQuick, ValidationModeFull, ValidationModeStrict:
+	default:
+		return fmt.Errorf("validation.mode must be one of: %s, %s, %s",
+			ValidationModeQuick, ValidationModeFull, ValidationModeStrict)
+	}
 	if v.RDMA != nil && v.RDMA.IBWriteMinBandwidthGbps != nil && *v.RDMA.IBWriteMinBandwidthGbps < 0 {
 		return fmt.Errorf("validation.rdma.ibWriteMinBandwidthGbps must be greater than or equal to 0")
 	}
 	for _, check := range v.Checks {
 		switch check {
-		case ValidationCheckRPing, ValidationCheckIBWriteBW:
+		case ValidationCheckICMP, ValidationCheckRPing, ValidationCheckIBWriteBW:
 		default:
-			return fmt.Errorf("validation.checks contains unsupported check %q (supported: %s, %s)",
-				check, ValidationCheckRPing, ValidationCheckIBWriteBW)
+			return fmt.Errorf("validation.checks contains unsupported check %q (supported: %s, %s, %s)",
+				check, ValidationCheckICMP, ValidationCheckRPing, ValidationCheckIBWriteBW)
 		}
 	}
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -91,7 +91,8 @@ profile:
 		require.NotNil(t, config.Validation)
 		require.NotNil(t, config.Validation.Connectivity)
 		assert.True(t, *config.Validation.Connectivity)
-		assert.Equal(t, []string{ValidationCheckRPing, ValidationCheckIBWriteBW}, config.Validation.Checks)
+		assert.Equal(t, ValidationModeStrict, config.Validation.Mode)
+		assert.Equal(t, []string{ValidationCheckICMP, ValidationCheckRPing, ValidationCheckIBWriteBW}, config.Validation.Checks)
 		require.NotNil(t, config.Validation.RDMA)
 		assert.Equal(t, DefaultValidationRPingIterations, config.Validation.RDMA.RPingIterations)
 		assert.Equal(t, DefaultValidationIBWriteSize, config.Validation.RDMA.IBWriteSize)
@@ -150,7 +151,8 @@ func TestDefaultLaunchKitConfig(t *testing.T) {
 	require.NotNil(t, cfg.DOCADriver, "DefaultLaunchKitConfig must populate DOCADriver")
 	require.NotNil(t, cfg.NvIpam, "DefaultLaunchKitConfig must populate NvIpam")
 	require.NotNil(t, cfg.Validation, "DefaultLaunchKitConfig must populate Validation")
-	assert.Equal(t, []string{ValidationCheckRPing, ValidationCheckIBWriteBW}, cfg.Validation.Checks)
+	assert.Equal(t, ValidationModeStrict, cfg.Validation.Mode)
+	assert.Equal(t, []string{ValidationCheckICMP, ValidationCheckRPing, ValidationCheckIBWriteBW}, cfg.Validation.Checks)
 	require.NotNil(t, cfg.Validation.RDMA)
 	assert.Equal(t, DefaultValidationRPingIterations, cfg.Validation.RDMA.RPingIterations)
 	assert.Equal(t, DefaultValidationIBWriteSize, cfg.Validation.RDMA.IBWriteSize)
@@ -166,15 +168,22 @@ func TestValidationConfig(t *testing.T) {
 	})
 
 	t.Run("normalizes duplicates and blanks", func(t *testing.T) {
-		checks := NormalizeValidationChecks([]string{" rping ", "", "ib_write_bw", "rping"})
-		assert.Equal(t, []string{ValidationCheckRPing, ValidationCheckIBWriteBW}, checks)
+		checks := NormalizeValidationChecks([]string{" icmp ", " rping ", "", "ib_write_bw", "rping"})
+		assert.Equal(t, []string{ValidationCheckICMP, ValidationCheckRPing, ValidationCheckIBWriteBW}, checks)
 	})
 
 	t.Run("rejects unknown checks", func(t *testing.T) {
-		cfg := NormalizeValidationConfig(&ValidationConfig{Checks: []string{"rping", "icmp"}})
+		cfg := NormalizeValidationConfig(&ValidationConfig{Checks: []string{"rping", "tcp"}})
 		err := ValidateValidationConfig(cfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported check")
+	})
+
+	t.Run("rejects unknown mode", func(t *testing.T) {
+		cfg := NormalizeValidationConfig(&ValidationConfig{Mode: "deep"})
+		err := ValidateValidationConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "validation.mode")
 	})
 
 	t.Run("preserves explicit zero minimum bandwidth", func(t *testing.T) {

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -37,9 +37,15 @@ validation:
   # connectivity gates the data-plane validation stage. Static manifest,
   # Helm release, component-version, and preflight checks always run.
   connectivity: true
-  # checks selects which RDMA test families l8k validate runs.
-  # Supported: rping, ib_write_bw. Use [] to disable all connectivity checks.
+  # mode controls matrix coverage and gating.
+  # quick: same-rail all nodes plus one non-gating cross-rail canary per rail pair.
+  # full: every source rail x every destination rail per ordered pod pair; cross-rail is non-gating.
+  # strict: full matrix; cross-rail gates according to profile.routing.
+  mode: strict
+  # checks selects which data-plane test families l8k validate runs.
+  # Supported: icmp, rping, ib_write_bw. Use [] to disable all connectivity checks.
   checks:
+    - icmp
     - rping
     - ib_write_bw
   rdma:

--- a/pkg/networkoperatorplugin/connectivity/connectivity.go
+++ b/pkg/networkoperatorplugin/connectivity/connectivity.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -147,7 +148,11 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 	}
 	uiOutput.Info("Loading example DaemonSet manifests from %s", opts.ManifestDir)
 
-	objs, refs, err := LoadExampleDaemonSets(opts.ManifestDir)
+	hasICMP := checksContain(opts.Checks, CheckICMP)
+	hasRDMA := checksContain(opts.Checks, CheckRPing) || checksContain(opts.Checks, CheckIBWriteBW)
+	deferICMPSidecar := hasICMP && hasRDMA
+	includeICMP := hasICMP && !deferICMPSidecar
+	objs, refs, err := LoadExampleDaemonSets(opts.ManifestDir, includeICMP)
 	if err != nil {
 		return nil, err
 	}
@@ -177,69 +182,95 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 		}
 	}()
 
-	for i, obj := range objs {
-		ref := refs[i]
-		uiOutput.Info("Applying %s/%s (from %s)", ref.Namespace, ref.Name, ref.SourceFile)
-		if err := ApplyDaemonSet(ctx, c, obj); err != nil {
-			return result, fmt.Errorf("apply daemonset %s/%s: %w", ref.Namespace, ref.Name, err)
+	applyAndCollectPods := func(objs []*unstructured.Unstructured, refs []DaemonSetRef) ([]testPodWithDS, error) {
+		for i, obj := range objs {
+			ref := refs[i]
+			uiOutput.Info("Applying %s/%s (from %s)", ref.Namespace, ref.Name, ref.SourceFile)
+			if err := ApplyDaemonSet(ctx, c, obj); err != nil {
+				return nil, fmt.Errorf("apply daemonset %s/%s: %w", ref.Namespace, ref.Name, err)
+			}
 		}
+
+		// Wait for each DS to roll out, then enumerate its pods.
+		out := make([]testPodWithDS, 0)
+		for _, ref := range refs {
+			uiOutput.Info("Waiting for DaemonSet %s/%s to roll out", ref.Namespace, ref.Name)
+			rollout, err := WaitForRollout(ctx, c, ref, opts.Timeout)
+			if err != nil {
+				return out, err
+			}
+			uiOutput.Success("DaemonSet %s/%s ready (%d/%d pods)", ref.Namespace, ref.Name, rollout.Ready, rollout.Desired)
+			pods, err := ListPods(ctx, c, ref)
+			if err != nil {
+				return out, err
+			}
+			// Sanity check that every desired pod is also in the
+			// Running+Ready list. ListPods filters by phase+condition,
+			// so a mismatch here means we're racing — happen on rare
+			// occasions, surface as warning.
+			if int32(len(pods)) != rollout.Desired {
+				uiOutput.Warning("DaemonSet %s/%s reports %d ready but only %d pods are Running+Ready — racing reconciliation?",
+					ref.Namespace, ref.Name, rollout.Desired, len(pods))
+			}
+			result.DaemonSets = append(result.DaemonSets, DaemonSetReport{
+				Ref:      ref,
+				Rollout:  rollout,
+				PodCount: len(pods),
+			})
+			for i := range pods {
+				out = append(out, testPodWithDS{pod: &pods[i], ref: ref})
+			}
+		}
+		return out, nil
 	}
 
-	// Wait for each DS to roll out, then enumerate its pods.
-	allPods := make([]testPodWithDS, 0)
-	for _, ref := range refs {
-		uiOutput.Info("Waiting for DaemonSet %s/%s to roll out", ref.Namespace, ref.Name)
-		rollout, err := WaitForRollout(ctx, c, ref, opts.Timeout)
-		if err != nil {
-			return result, err
+	buildMatrixPods := func(allPods []testPodWithDS, discoverRDMA bool) []TestPod {
+		// Parse multus annotations and build the TestPod list. Each
+		// pod's RDMA-device-by-rail map is filled in from a single
+		// in-pod shell exec that reads
+		// /sys/class/net/<iface>/device/infiniband/ per multus iface,
+		// so the rping + ib_write_bw stages can pass `-d <dev>`.
+		testPods := make([]TestPod, 0, len(allPods))
+		for _, p := range allPods {
+			tp, ifaceByRail, err := buildTestPod(p.pod)
+			if err != nil {
+				uiOutput.Warning("Pod %s/%s: %v — excluded from matrix", p.pod.Namespace, p.pod.Name, err)
+				log.Log.V(1).Info("buildTestPod failed", "pod", p.pod.Name, "error", err.Error())
+				continue
+			}
+			if len(tp.RailOrder) == 0 {
+				uiOutput.Warning("Pod %s/%s has no secondary network IPs — excluded from matrix", p.pod.Namespace, p.pod.Name)
+				continue
+			}
+			if discoverRDMA {
+				tp.RDMADevsByRail = DiscoverRDMADevices(ctx, restConfig, p.pod.Namespace, p.pod.Name, p.ref.RDMAContainer, ifaceByRail)
+				log.Log.V(1).Info("RDMA device discovery",
+					"pod", p.pod.Name, "rails", tp.RailOrder,
+					"rdmaDevsByRail", tp.RDMADevsByRail)
+			}
+			tp.InterfacesByRail = ifaceByRail
+			testPods = append(testPods, tp)
 		}
-		uiOutput.Success("DaemonSet %s/%s ready (%d/%d pods)", ref.Namespace, ref.Name, rollout.Ready, rollout.Desired)
-		pods, err := ListPods(ctx, c, ref)
-		if err != nil {
-			return result, err
-		}
-		// Sanity check that every desired pod is also in the
-		// Running+Ready list. ListPods filters by phase+condition,
-		// so a mismatch here means we're racing — happen on rare
-		// occasions, surface as warning.
-		if int32(len(pods)) != rollout.Desired {
-			uiOutput.Warning("DaemonSet %s/%s reports %d ready but only %d pods are Running+Ready — racing reconciliation?",
-				ref.Namespace, ref.Name, rollout.Desired, len(pods))
-		}
-		result.DaemonSets = append(result.DaemonSets, DaemonSetReport{
-			Ref:      ref,
-			Rollout:  rollout,
-			PodCount: len(pods),
-		})
-		for i := range pods {
-			allPods = append(allPods, testPodWithDS{pod: &pods[i], ref: ref})
-		}
+		return testPods
 	}
 
-	// Parse multus annotations and build the TestPod list. Each
-	// pod's RDMA-device-by-rail map is filled in from a single
-	// in-pod shell exec that reads
-	// /sys/class/net/<iface>/device/infiniband/ per multus iface,
-	// so the rping + ib_write_bw stages can pass `-d <dev>`.
-	testPods := make([]TestPod, 0, len(allPods))
-	for _, p := range allPods {
-		tp, ifaceByRail, err := buildTestPod(p.pod)
-		if err != nil {
-			uiOutput.Warning("Pod %s/%s: %v — excluded from matrix", p.pod.Namespace, p.pod.Name, err)
-			log.Log.V(1).Info("buildTestPod failed", "pod", p.pod.Name, "error", err.Error())
-			continue
+	containerMaps := func(allPods []testPodWithDS) (map[string]string, map[string]string, map[string]string) {
+		rdmaContainerByPod := map[string]string{}
+		icmpContainerByPod := map[string]string{}
+		namespaceByPod := map[string]string{}
+		for _, p := range allPods {
+			rdmaContainerByPod[p.pod.Name] = p.ref.RDMAContainer
+			icmpContainerByPod[p.pod.Name] = p.ref.ICMPContainer
+			namespaceByPod[p.pod.Name] = p.pod.Namespace
 		}
-		if len(tp.RailOrder) == 0 {
-			uiOutput.Warning("Pod %s/%s has no secondary network IPs — excluded from matrix", p.pod.Namespace, p.pod.Name)
-			continue
-		}
-		tp.RDMADevsByRail = DiscoverRDMADevices(ctx, restConfig, p.pod.Namespace, p.pod.Name, p.ref.RDMAContainer, ifaceByRail)
-		tp.InterfacesByRail = ifaceByRail
-		log.Log.V(1).Info("RDMA device discovery",
-			"pod", p.pod.Name, "rails", tp.RailOrder,
-			"rdmaDevsByRail", tp.RDMADevsByRail)
-		testPods = append(testPods, tp)
+		return rdmaContainerByPod, icmpContainerByPod, namespaceByPod
 	}
+
+	allPods, err := applyAndCollectPods(objs, refs)
+	if err != nil {
+		return result, err
+	}
+	testPods := buildMatrixPods(allPods, hasRDMA)
 
 	plan := PlanWithOptions(testPods, opts.Mode, opts.Routing)
 	if plan.Skip != nil {
@@ -291,34 +322,18 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 
 	// Build pod-name → container maps so ICMP can run in netshoot while RDMA
 	// tooling stays in the DOCA container that owns the RDMA resources.
-	rdmaContainerByPod := map[string]string{}
-	icmpContainerByPod := map[string]string{}
-	namespaceByPod := map[string]string{}
-	for _, p := range allPods {
-		rdmaContainerByPod[p.pod.Name] = p.ref.RDMAContainer
-		icmpContainerByPod[p.pod.Name] = p.ref.ICMPContainer
-		namespaceByPod[p.pod.Name] = p.pod.Namespace
-	}
+	rdmaContainerByPod, icmpContainerByPod, namespaceByPod := containerMaps(allPods)
 
-	// Two stages, each running sequentially per the "spawn fresh
-	// server per test" decision: every test starts its own server,
-	// runs the client, kills the server. Concurrent runs would
-	// fight over the listener port.
+	// Stages run RDMA first when ICMP and RDMA are both enabled. In that case
+	// the initial DaemonSet rollout stays DOCA-only; the netshoot sidecar is
+	// patched in only before the ICMP stage so a restricted cluster can still
+	// produce RDMA results if the helper image cannot be pulled.
 	stages := []struct {
 		check Check
 		label string
 		tests []PingTest
 		run   func(t PingTest) PingResult
 	}{
-		{
-			check: CheckICMP,
-			label: "Layer 3 ping (ICMP)",
-			tests: append(append([]PingTest{}, plan.ICMPSameRail...), plan.ICMPCrossRail...),
-			run: func(t PingTest) PingResult {
-				return RunICMP(ctx, restConfig, namespaceByPod[t.SrcPod],
-					t.SrcPod, icmpContainerByPod[t.SrcPod], t)
-			},
-		},
 		{
 			check: CheckRPing,
 			label: "RDMA ping (rping)",
@@ -329,26 +344,56 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			label: "RDMA bandwidth (ib_write_bw)",
 			tests: append(append([]PingTest{}, plan.RDMABwSameRail...), plan.RDMABwCrossRail...),
 		},
+		{
+			check: CheckICMP,
+			label: "Layer 3 ping (ICMP)",
+			tests: append(append([]PingTest{}, plan.ICMPSameRail...), plan.ICMPCrossRail...),
+			run: func(t PingTest) PingResult {
+				return RunICMP(ctx, restConfig, namespaceByPod[t.SrcPod],
+					t.SrcPod, icmpContainerByPod[t.SrcPod], t)
+			},
+		},
 	}
 	for _, stage := range stages {
 		if !checksContain(opts.Checks, stage.check) {
 			continue
 		}
-		if len(stage.tests) == 0 {
+		tests := stage.tests
+		if stage.check == CheckICMP && deferICMPSidecar {
+			uiOutput.Info("Adding ICMP helper sidecar before ICMP stage")
+			icmpObjs, icmpRefs, err := LoadExampleDaemonSets(opts.ManifestDir, true)
+			if err != nil {
+				return result, err
+			}
+			icmpPods, err := applyAndCollectPods(icmpObjs, icmpRefs)
+			if err != nil {
+				uiOutput.Warning("ICMP helper rollout failed: %v — skipping ICMP stage", err)
+				log.Log.V(1).Info("skipping ICMP stage after helper rollout failure", "error", err.Error())
+				continue
+			}
+			_, icmpContainerByPod, namespaceByPod = containerMaps(icmpPods)
+			icmpPlan := PlanWithOptions(buildMatrixPods(icmpPods, false), opts.Mode, opts.Routing)
+			if icmpPlan.Skip != nil {
+				uiOutput.Warning("ICMP matrix skipped: %s", icmpPlan.Skip.Reason)
+				continue
+			}
+			tests = append(append([]PingTest{}, icmpPlan.ICMPSameRail...), icmpPlan.ICMPCrossRail...)
+		}
+		if len(tests) == 0 {
 			continue
 		}
-		uiOutput.Info("Stage: %s — %d test(s)", stage.label, len(stage.tests))
+		uiOutput.Info("Stage: %s — %d test(s)", stage.label, len(tests))
 		if stage.check == CheckRPing {
 			result.PingResults = append(result.PingResults,
-				RunRPingBatches(ctx, restConfig, namespaceByPod, rdmaContainerByPod, stage.tests, opts.RPingIterations)...)
+				RunRPingBatches(ctx, restConfig, namespaceByPod, rdmaContainerByPod, tests, opts.RPingIterations)...)
 			continue
 		}
 		if stage.check == CheckIBWriteBW {
 			result.PingResults = append(result.PingResults,
-				RunIbWriteBwBatches(ctx, restConfig, namespaceByPod, rdmaContainerByPod, stage.tests, opts.IBWriteSize, opts.IBWriteMinBandwidthGbps)...)
+				RunIbWriteBwBatches(ctx, restConfig, namespaceByPod, rdmaContainerByPod, tests, opts.IBWriteSize, opts.IBWriteMinBandwidthGbps)...)
 			continue
 		}
-		for _, t := range stage.tests {
+		for _, t := range tests {
 			if namespaceByPod[t.SrcPod] == "" || namespaceByPod[t.DstPod] == "" || icmpContainerByPod[t.SrcPod] == "" {
 				result.PingResults = append(result.PingResults, PingResult{
 					Test: t,

--- a/pkg/networkoperatorplugin/connectivity/connectivity.go
+++ b/pkg/networkoperatorplugin/connectivity/connectivity.go
@@ -33,6 +33,7 @@ import (
 type Check string
 
 const (
+	CheckICMP      Check = "icmp"
 	CheckRPing     Check = "rping"
 	CheckIBWriteBW Check = "ib_write_bw"
 )
@@ -45,13 +46,18 @@ type Options struct {
 	// validated).
 	ManifestDir string
 	// Timeout caps the whole connectivity phase: apply + DS rollout
-	// + RDMA test execs + cleanup. 0 falls back to 5 minutes.
+	// + connectivity test execs + cleanup. 0 falls back to 5 minutes.
 	Timeout time.Duration
 	// Keep leaves the test DaemonSets running after the matrix
 	// completes, for follow-up debugging. Default is to delete.
 	Keep bool
-	// Checks selects which RDMA test families to run. Nil means the
-	// default set (rping + ib_write_bw); an empty slice means skip all
+	// Mode controls rail-matrix coverage and cross-rail gating.
+	Mode Mode
+	// Routing is the profile routing mode used to decide strict
+	// cross-rail expectations.
+	Routing string
+	// Checks selects which connectivity test families to run. Nil means
+	// the default set (icmp + rping + ib_write_bw); an empty slice means skip all
 	// connectivity tests without applying the example DaemonSets.
 	Checks []Check
 	// RPingIterations maps to `rping -C`. 0 defaults to 5, matching the
@@ -71,8 +77,8 @@ type MatrixResult struct {
 	// DaemonSets is one entry per applied example DS — typically
 	// one per merged group.
 	DaemonSets []DaemonSetReport
-	// PingResults is the flat list of every executed RDMA test
-	// (rping + ib_write_bw, same-rail + cross-rail).
+	// PingResults is the flat list of every executed connectivity test
+	// (icmp + rping + ib_write_bw, same-rail + cross-rail).
 	PingResults []PingResult
 	// Skipped is non-nil when fewer than 2 schedulable test pods
 	// were available across all DaemonSets. The matrix is treated
@@ -107,11 +113,10 @@ type DaemonSetReport struct {
 //  4. Lists Running+Ready pods, parses each pod's multus annotation,
 //     filters to secondary networks, picks the first IPv4 per rail.
 //  5. Discovers the RDMA device backing each multus interface per pod.
-//  6. Builds a test plan via Plan() — same-rail plus per-pair cross-rail
-//     canaries; soft-skip if <2 schedulable pods.
-//  7. Runs the configured RDMA stages sequentially per the "spawn fresh
-//     server per test" lifecycle (concurrent runs would fight over the
-//     listener port).
+//  6. Builds a test plan via PlanWithOptions().
+//  7. Runs the configured connectivity stages sequentially. RDMA stages use the
+//     "spawn fresh server per test" lifecycle (concurrent runs would fight over
+//     the listener port).
 //  8. Deletes the DaemonSets unless opts.Keep.
 //
 // All UI output flows through `uiOutput` (caller passes
@@ -121,6 +126,9 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 		opts.Timeout = 5 * time.Minute
 	}
 	opts.Checks = normalizeChecks(opts.Checks)
+	if opts.Mode == "" {
+		opts.Mode = ModeStrict
+	}
 	if opts.RPingIterations <= 0 {
 		opts.RPingIterations = 5
 	}
@@ -225,14 +233,15 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			uiOutput.Warning("Pod %s/%s has no secondary network IPs — excluded from matrix", p.pod.Namespace, p.pod.Name)
 			continue
 		}
-		tp.RDMADevsByRail = DiscoverRDMADevices(ctx, restConfig, p.pod.Namespace, p.pod.Name, p.ref.Container, ifaceByRail)
+		tp.RDMADevsByRail = DiscoverRDMADevices(ctx, restConfig, p.pod.Namespace, p.pod.Name, p.ref.RDMAContainer, ifaceByRail)
+		tp.InterfacesByRail = ifaceByRail
 		log.Log.V(1).Info("RDMA device discovery",
 			"pod", p.pod.Name, "rails", tp.RailOrder,
 			"rdmaDevsByRail", tp.RDMADevsByRail)
 		testPods = append(testPods, tp)
 	}
 
-	plan := Plan(testPods)
+	plan := PlanWithOptions(testPods, opts.Mode, opts.Routing)
 	if plan.Skip != nil {
 		uiOutput.Warning("Matrix skipped: %s", plan.Skip.Reason)
 		result.Skipped = plan.Skip
@@ -242,6 +251,11 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 	totalSameRail := len(plan.RDMASameRail)
 	totalCrossRail := len(plan.RDMACrossRail)
 	plannedTests := 0
+	if checksContain(opts.Checks, CheckICMP) {
+		uiOutput.Info("Plan: %d same-rail ICMP + %d cross-rail ICMP",
+			len(plan.ICMPSameRail), len(plan.ICMPCrossRail))
+		plannedTests += len(plan.ICMPSameRail) + len(plan.ICMPCrossRail)
+	}
 	if checksContain(opts.Checks, CheckRPing) {
 		uiOutput.Info("Plan: %d same-rail rping + %d cross-rail rping",
 			totalSameRail, totalCrossRail)
@@ -275,13 +289,14 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			len(testPods))
 	}
 
-	// Build a pod-name → container name map so the test runners
-	// know which container to exec in (test DSes have a single
-	// container today, but the orchestrator stays general).
-	containerByPod := map[string]string{}
+	// Build pod-name → container maps so ICMP can run in netshoot while RDMA
+	// tooling stays in the DOCA container that owns the RDMA resources.
+	rdmaContainerByPod := map[string]string{}
+	icmpContainerByPod := map[string]string{}
 	namespaceByPod := map[string]string{}
 	for _, p := range allPods {
-		containerByPod[p.pod.Name] = p.ref.Container
+		rdmaContainerByPod[p.pod.Name] = p.ref.RDMAContainer
+		icmpContainerByPod[p.pod.Name] = p.ref.ICMPContainer
 		namespaceByPod[p.pod.Name] = p.pod.Namespace
 	}
 
@@ -296,26 +311,23 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 		run   func(t PingTest) PingResult
 	}{
 		{
+			check: CheckICMP,
+			label: "Layer 3 ping (ICMP)",
+			tests: append(append([]PingTest{}, plan.ICMPSameRail...), plan.ICMPCrossRail...),
+			run: func(t PingTest) PingResult {
+				return RunICMP(ctx, restConfig, namespaceByPod[t.SrcPod],
+					t.SrcPod, icmpContainerByPod[t.SrcPod], t)
+			},
+		},
+		{
 			check: CheckRPing,
 			label: "RDMA ping (rping)",
 			tests: append(append([]PingTest{}, plan.RDMASameRail...), plan.RDMACrossRail...),
-			run: func(t PingTest) PingResult {
-				return RunRPing(ctx, restConfig, namespaceByPod[t.DstPod],
-					t.DstPod, containerByPod[t.DstPod], // server side
-					t.SrcPod, containerByPod[t.SrcPod], // client side
-					t, opts.RPingIterations)
-			},
 		},
 		{
 			check: CheckIBWriteBW,
 			label: "RDMA bandwidth (ib_write_bw)",
 			tests: append(append([]PingTest{}, plan.RDMABwSameRail...), plan.RDMABwCrossRail...),
-			run: func(t PingTest) PingResult {
-				return RunIbWriteBw(ctx, restConfig, namespaceByPod[t.DstPod],
-					t.DstPod, containerByPod[t.DstPod],
-					t.SrcPod, containerByPod[t.SrcPod],
-					t, 0, opts.IBWriteSize, opts.IBWriteMinBandwidthGbps)
-			},
 		},
 	}
 	for _, stage := range stages {
@@ -326,11 +338,21 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			continue
 		}
 		uiOutput.Info("Stage: %s — %d test(s)", stage.label, len(stage.tests))
+		if stage.check == CheckRPing {
+			result.PingResults = append(result.PingResults,
+				RunRPingBatches(ctx, restConfig, namespaceByPod, rdmaContainerByPod, stage.tests, opts.RPingIterations)...)
+			continue
+		}
+		if stage.check == CheckIBWriteBW {
+			result.PingResults = append(result.PingResults,
+				RunIbWriteBwBatches(ctx, restConfig, namespaceByPod, rdmaContainerByPod, stage.tests, opts.IBWriteSize, opts.IBWriteMinBandwidthGbps)...)
+			continue
+		}
 		for _, t := range stage.tests {
-			if namespaceByPod[t.SrcPod] == "" || namespaceByPod[t.DstPod] == "" {
+			if namespaceByPod[t.SrcPod] == "" || namespaceByPod[t.DstPod] == "" || icmpContainerByPod[t.SrcPod] == "" {
 				result.PingResults = append(result.PingResults, PingResult{
 					Test: t,
-					Err:  fmt.Errorf("no namespace lookup for pod pair (%s, %s)", t.SrcPod, t.DstPod),
+					Err:  fmt.Errorf("no namespace/container lookup for pod pair (%s, %s)", t.SrcPod, t.DstPod),
 				})
 				continue
 			}
@@ -357,7 +379,7 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 
 func normalizeChecks(checks []Check) []Check {
 	if checks == nil {
-		return []Check{CheckRPing, CheckIBWriteBW}
+		return []Check{CheckICMP, CheckRPing, CheckIBWriteBW}
 	}
 	out := make([]Check, 0, len(checks))
 	seen := map[Check]bool{}
@@ -400,10 +422,11 @@ func buildTestPod(p *corev1.Pod) (TestPod, map[string]string, error) {
 		return TestPod{}, nil, err
 	}
 	tp := TestPod{
-		Name:      p.Name,
-		Namespace: p.Namespace,
-		Node:      p.Spec.NodeName,
-		IPsByRail: map[string]string{},
+		Name:             p.Name,
+		Namespace:        p.Namespace,
+		Node:             p.Spec.NodeName,
+		IPsByRail:        map[string]string{},
+		InterfacesByRail: map[string]string{},
 	}
 	ifaceByRail := map[string]string{}
 	for _, n := range SecondaryNetworks(nets) {
@@ -425,6 +448,7 @@ func buildTestPod(p *corev1.Pod) (TestPod, map[string]string, error) {
 		tp.RailOrder = append(tp.RailOrder, rail)
 		if n.Interface != "" {
 			ifaceByRail[rail] = n.Interface
+			tp.InterfacesByRail[rail] = n.Interface
 		}
 	}
 	sort.Strings(tp.RailOrder)
@@ -457,7 +481,7 @@ func emitSummary(uiOutput ui.Output, result *MatrixResult) {
 	uiOutput.Info("Matrix complete: %d/%d passed, %d failed",
 		s.Passed, s.TotalTests, s.Failed)
 	if s.Failed == 0 && s.TotalTests > 0 {
-		uiOutput.Success("All %d RDMA test(s) passed", s.TotalTests)
+		uiOutput.Success("All %d connectivity test(s) passed", s.TotalTests)
 		return
 	}
 	// Render up to 5 failures so operators see what broke without
@@ -488,8 +512,11 @@ func emitSummary(uiOutput ui.Output, result *MatrixResult) {
 }
 
 // stageLabelOf returns the human-friendly label for a test kind used
-// in failure-line prefixes ("rping", "ib_write_bw").
+// in failure-line prefixes ("icmp", "rping", "ib_write_bw").
 func stageLabelOf(k PingTestKind) string {
+	if k.IsICMP() {
+		return "icmp"
+	}
 	if k.IsRDMABw() {
 		return "ib_write_bw"
 	}

--- a/pkg/networkoperatorplugin/connectivity/daemonset.go
+++ b/pkg/networkoperatorplugin/connectivity/daemonset.go
@@ -56,7 +56,7 @@ type DaemonSetRef struct {
 // per file. Multi-doc YAMLs are walked; non-DaemonSet docs are skipped
 // (the file pattern is descriptive, not enforced, so we tolerate a
 // ConfigMap or two beside the DS).
-func LoadExampleDaemonSets(manifestDir string) ([]*unstructured.Unstructured, []DaemonSetRef, error) {
+func LoadExampleDaemonSets(manifestDir string, includeICMP bool) ([]*unstructured.Unstructured, []DaemonSetRef, error) {
 	entries, err := os.ReadDir(manifestDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("read manifest dir %s: %w", manifestDir, err)
@@ -95,7 +95,9 @@ func LoadExampleDaemonSets(manifestDir string) ([]*unstructured.Unstructured, []
 					obj.SetGroupVersionKind(gv.WithKind(obj.GetKind()))
 				}
 			}
-			ensureICMPContainer(obj)
+			if includeICMP {
+				ensureICMPContainer(obj)
+			}
 			rdmaContainer, icmpContainer := testContainerNames(obj)
 			objs = append(objs, obj)
 			refs = append(refs, DaemonSetRef{

--- a/pkg/networkoperatorplugin/connectivity/daemonset.go
+++ b/pkg/networkoperatorplugin/connectivity/daemonset.go
@@ -34,13 +34,21 @@ import (
 	yaml "sigs.k8s.io/yaml"
 )
 
+const (
+	rdmaTestContainerName = "test-container"
+	icmpTestContainerName = "netshoot"
+	icmpTestImage         = "nicolaka/netshoot:latest"
+)
+
 // DaemonSetRef identifies an applied test DaemonSet so the orchestrator
 // can later list its pods and (optionally) delete it.
 type DaemonSetRef struct {
-	Namespace  string
-	Name       string
-	Container  string // primary container name to ping from
-	SourceFile string // file the DS was loaded from (for log breadcrumbs)
+	Namespace     string
+	Name          string
+	Container     string // RDMA container, kept as the primary container for reports
+	RDMAContainer string // DOCA container used for rping and ib_write_bw
+	ICMPContainer string // netshoot container used for ping and route checks
+	SourceFile    string // file the DS was loaded from (for log breadcrumbs)
 }
 
 // LoadExampleDaemonSets reads every `*example*.yaml` manifest under
@@ -87,13 +95,16 @@ func LoadExampleDaemonSets(manifestDir string) ([]*unstructured.Unstructured, []
 					obj.SetGroupVersionKind(gv.WithKind(obj.GetKind()))
 				}
 			}
-			container := firstContainerName(obj)
+			ensureICMPContainer(obj)
+			rdmaContainer, icmpContainer := testContainerNames(obj)
 			objs = append(objs, obj)
 			refs = append(refs, DaemonSetRef{
-				Namespace:  obj.GetNamespace(),
-				Name:       obj.GetName(),
-				Container:  container,
-				SourceFile: e.Name(),
+				Namespace:     obj.GetNamespace(),
+				Name:          obj.GetName(),
+				Container:     rdmaContainer,
+				RDMAContainer: rdmaContainer,
+				ICMPContainer: icmpContainer,
+				SourceFile:    e.Name(),
 			})
 		}
 	}
@@ -125,6 +136,7 @@ func DeleteDaemonSet(ctx context.Context, c client.Client, ref DaemonSetRef) err
 // while it waits.
 type RolloutStatus struct {
 	Desired   int32
+	Updated   int32
 	Available int32
 	Ready     int32
 	NotReady  int32 // desired - ready, never negative
@@ -136,7 +148,7 @@ type RolloutStatus struct {
 // nodes — silently passing that as "ready" would let an empty matrix
 // claim success.
 func (s RolloutStatus) IsRolledOut() bool {
-	return s.Desired > 0 && s.Ready == s.Desired
+	return s.Desired > 0 && s.Updated == s.Desired && s.Ready == s.Desired
 }
 
 // WaitForRollout polls the DaemonSet's status until it satisfies
@@ -157,6 +169,7 @@ func WaitForRollout(ctx context.Context, c client.Client, ref DaemonSetRef, poll
 		if err == nil {
 			last = RolloutStatus{
 				Desired:   ds.Status.DesiredNumberScheduled,
+				Updated:   ds.Status.UpdatedNumberScheduled,
 				Available: ds.Status.NumberAvailable,
 				Ready:     ds.Status.NumberReady,
 			}
@@ -241,21 +254,60 @@ func podRunningReady(p corev1.Pod) bool {
 	return false
 }
 
-// firstContainerName returns the first container name from a
-// DaemonSet's pod template — that's the container the orchestrator
-// execs `ping` in. Returns "" if the spec is malformed (caller
-// surfaces a useful error).
-func firstContainerName(ds *unstructured.Unstructured) string {
+// testContainerNames returns the DOCA container used for RDMA checks and the
+// netshoot container used for ICMP checks.
+func testContainerNames(ds *unstructured.Unstructured) (rdmaContainer, icmpContainer string) {
 	containers, _, _ := unstructured.NestedSlice(ds.Object, "spec", "template", "spec", "containers")
-	if len(containers) == 0 {
-		return ""
+	for i, raw := range containers {
+		c, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(c, "name")
+		image, _, _ := unstructured.NestedString(c, "image")
+		if i == 0 && rdmaContainer == "" {
+			rdmaContainer = name
+		}
+		if rdmaContainer == "" || name == rdmaTestContainerName || strings.Contains(image, "/doca/") {
+			rdmaContainer = name
+		}
+		if icmpContainer == "" || name == icmpTestContainerName || strings.Contains(image, "netshoot") {
+			icmpContainer = name
+		}
 	}
-	c, ok := containers[0].(map[string]interface{})
-	if !ok {
-		return ""
+	if icmpContainer == "" {
+		icmpContainer = rdmaContainer
 	}
-	name, _, _ := unstructured.NestedString(c, "name")
-	return name
+	return rdmaContainer, icmpContainer
+}
+
+func ensureICMPContainer(ds *unstructured.Unstructured) {
+	containers, found, _ := unstructured.NestedSlice(ds.Object, "spec", "template", "spec", "containers")
+	if !found {
+		return
+	}
+	for _, raw := range containers {
+		c, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(c, "name")
+		image, _, _ := unstructured.NestedString(c, "image")
+		if name == icmpTestContainerName || strings.Contains(image, "netshoot") {
+			return
+		}
+	}
+	containers = append(containers, map[string]interface{}{
+		"name":    icmpTestContainerName,
+		"image":   icmpTestImage,
+		"command": []interface{}{"/bin/sh", "-c", "sleep infinity"},
+		"securityContext": map[string]interface{}{
+			"capabilities": map[string]interface{}{
+				"add": []interface{}{"NET_RAW"},
+			},
+		},
+	})
+	_ = unstructured.SetNestedSlice(ds.Object, containers, "spec", "template", "spec", "containers")
 }
 
 // splitYAMLDocs is a minimal local copy of the YAML doc splitter in

--- a/pkg/networkoperatorplugin/connectivity/daemonset_test.go
+++ b/pkg/networkoperatorplugin/connectivity/daemonset_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const exampleDaemonSetManifest = `apiVersion: apps/v1
@@ -67,4 +68,10 @@ func TestLoadExampleDaemonSetsUsesManifestNamespace(t *testing.T) {
 	require.Len(t, refs, 1)
 	require.Equal(t, "nvidia-network-operator", objs[0].GetNamespace())
 	require.Equal(t, "nvidia-network-operator", refs[0].Namespace)
+	require.Equal(t, "test-container", refs[0].RDMAContainer)
+	require.Equal(t, "netshoot", refs[0].ICMPContainer)
+	containers, ok, err := unstructured.NestedSlice(objs[0].Object, "spec", "template", "spec", "containers")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, containers, 2)
 }

--- a/pkg/networkoperatorplugin/connectivity/daemonset_test.go
+++ b/pkg/networkoperatorplugin/connectivity/daemonset_test.go
@@ -62,7 +62,7 @@ func writeExampleDS(t *testing.T) string {
 // its namespace baked in), so validate fans out across them automatically
 // without any namespace flag of its own.
 func TestLoadExampleDaemonSetsUsesManifestNamespace(t *testing.T) {
-	objs, refs, err := LoadExampleDaemonSets(writeExampleDS(t))
+	objs, refs, err := LoadExampleDaemonSets(writeExampleDS(t), true)
 	require.NoError(t, err)
 	require.Len(t, objs, 1)
 	require.Len(t, refs, 1)
@@ -74,4 +74,17 @@ func TestLoadExampleDaemonSetsUsesManifestNamespace(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Len(t, containers, 2)
+}
+
+func TestLoadExampleDaemonSetsSkipsICMPSidecarWhenDisabled(t *testing.T) {
+	objs, refs, err := LoadExampleDaemonSets(writeExampleDS(t), false)
+	require.NoError(t, err)
+	require.Len(t, objs, 1)
+	require.Len(t, refs, 1)
+	require.Equal(t, "test-container", refs[0].RDMAContainer)
+	require.Equal(t, "test-container", refs[0].ICMPContainer)
+	containers, ok, err := unstructured.NestedSlice(objs[0].Object, "spec", "template", "spec", "containers")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, containers, 1)
 }

--- a/pkg/networkoperatorplugin/connectivity/icmp.go
+++ b/pkg/networkoperatorplugin/connectivity/icmp.go
@@ -1,0 +1,50 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connectivity
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/kubeclient"
+	"k8s.io/client-go/rest"
+)
+
+func RunICMP(ctx context.Context, restConfig *rest.Config, namespace, pod, container string, test PingTest) PingResult {
+	r := initResult(test)
+	if test.SrcIface == "" {
+		r.Err = fmt.Errorf("icmp needs source interface for rail %q", test.SrcRail)
+		finalizeExpectedResult(&r, false, r.Err)
+		return r
+	}
+	if r.Expectation == ExpectRequired {
+		r.Route = checkRoute(ctx, restConfig, namespace, pod, container, test)
+		if routeMismatch(r.Route, test) {
+			r.Err = fmt.Errorf("source route selected dev %q, expected %q (route: %s)",
+				r.Route.Dev, test.SrcIface, r.Route.Output)
+			finalizeExpectedResult(&r, false, r.Err)
+			return r
+		}
+	}
+	cmd := shellWithTimeout(fmt.Sprintf("ping -c 1 -W 1 -I %s %s", shellArg(test.SrcIP), shellArg(test.DstIP)),
+		commandTimeoutFor(test, 5*time.Second))
+	res, err := kubeclient.ExecInPod(ctx, restConfig, namespace, pod, container, []string{"/bin/sh", "-c", cmd})
+	r.Stdout, r.Stderr = res.Stdout, res.Stderr
+	finalizeExpectedResult(&r, err == nil, err)
+	return r
+}

--- a/pkg/networkoperatorplugin/connectivity/matrix.go
+++ b/pkg/networkoperatorplugin/connectivity/matrix.go
@@ -19,6 +19,26 @@ package connectivity
 import (
 	"fmt"
 	"sort"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+// Mode controls matrix coverage and cross-rail gating.
+type Mode string
+
+const (
+	ModeQuick  Mode = "quick"
+	ModeFull   Mode = "full"
+	ModeStrict Mode = "strict"
+)
+
+// Expectation controls how a test result contributes to the verdict.
+type Expectation string
+
+const (
+	ExpectRequired  Expectation = "required"
+	ExpectForbidden Expectation = "forbidden"
+	ExpectObserve   Expectation = "observe"
 )
 
 // TestPod is one entry in the matrix's source set — a pod with its
@@ -40,6 +60,9 @@ type TestPod struct {
 	// RDMA-capable device or where the lookup failed are absent.
 	// Used by RunIbWriteBw / RunRPing to pass `-d <dev>`.
 	RDMADevsByRail map[string]string
+	// InterfacesByRail is "<rail>" → pod netdev name (e.g. "net1").
+	// Every runner uses this to pin or verify the source interface.
+	InterfacesByRail map[string]string
 	// RailOrder is the deterministic iteration order over IPsByRail
 	// — needed because Go map iteration is randomized and the cross
 	// -rail canary picks "rail 0" vs "rail 1" by position.
@@ -47,7 +70,7 @@ type TestPod struct {
 }
 
 // PingTest is one src→dst test the matrix will execute. Kind tags the
-// test bucket. Two RDMA test families are scheduled in stages by the
+// test bucket. ICMP and two RDMA test families are scheduled in stages by the
 // orchestrator:
 //
 //   - Kind = RDMAPingSameRail / RDMAPingCrossRail — `rping -c -a
@@ -67,18 +90,21 @@ type TestPod struct {
 // SrcRDMADev / DstRDMADev carry the per-pod RDMA device names so the
 // test runner can pass `-d <dev>` for ib_write_bw.
 type PingTest struct {
-	Kind       PingTestKind
-	SrcPod     string
-	DstPod     string
-	SrcNode    string
-	DstNode    string
-	Rail       string // for same-rail tests; "<srcRail>→<dstRail>" for cross
-	SrcIP      string
-	DstIP      string
-	SrcRail    string
-	DstRail    string
-	SrcRDMADev string
-	DstRDMADev string
+	Kind        PingTestKind
+	SrcPod      string
+	DstPod      string
+	SrcNode     string
+	DstNode     string
+	Rail        string // for same-rail tests; "<srcRail>→<dstRail>" for cross
+	SrcIP       string
+	DstIP       string
+	SrcRail     string
+	DstRail     string
+	SrcIface    string
+	DstIface    string
+	SrcRDMADev  string
+	DstRDMADev  string
+	Expectation Expectation
 }
 
 // PingTestKind enumerates the buckets the matrix renders into. Order
@@ -87,11 +113,17 @@ type PingTest struct {
 type PingTestKind int
 
 const (
-	RDMAPingSameRail PingTestKind = iota
+	ICMPSameRail PingTestKind = iota
+	ICMPCrossRail
+	RDMAPingSameRail
 	RDMAPingCrossRail
 	RDMABwSameRail
 	RDMABwCrossRail
 )
+
+func (k PingTestKind) IsICMP() bool {
+	return k == ICMPSameRail || k == ICMPCrossRail
+}
 
 // IsRDMAPing reports whether the test kind is an rping (RDMA-CM QP)
 // test.
@@ -108,7 +140,7 @@ func (k PingTestKind) IsRDMABw() bool {
 // IsCrossRail reports whether the test kind is one of the cross-rail
 // canary variants (regardless of family).
 func (k PingTestKind) IsCrossRail() bool {
-	return k == RDMAPingCrossRail || k == RDMABwCrossRail
+	return k == ICMPCrossRail || k == RDMAPingCrossRail || k == RDMABwCrossRail
 }
 
 // MatrixSkip captures the soft-skip case where fewer than 2 schedulable
@@ -127,6 +159,8 @@ type MatrixSkip struct {
 // silently dropped: there's no `-d <dev>` to pass and the test
 // would fail with a confusing error.
 type MatrixPlan struct {
+	ICMPSameRail    []PingTest
+	ICMPCrossRail   []PingTest
 	RDMASameRail    []PingTest
 	RDMACrossRail   []PingTest
 	RDMABwSameRail  []PingTest
@@ -150,6 +184,10 @@ type MatrixPlan struct {
 //     the caller can render "matrix skipped: only N schedulable test
 //     pod(s)".
 func Plan(pods []TestPod) MatrixPlan {
+	return PlanWithOptions(pods, ModeQuick, config.RoutingDestinationBased)
+}
+
+func PlanWithOptions(pods []TestPod, mode Mode, routing string) MatrixPlan {
 	if len(pods) < 2 {
 		return MatrixPlan{Skip: &MatrixSkip{
 			Reason: fmt.Sprintf("only %d schedulable test pod(s) — need ≥2 for a matrix", len(pods)),
@@ -162,6 +200,7 @@ func Plan(pods []TestPod) MatrixPlan {
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
 
 	var plan MatrixPlan
+	crossExpectation := crossRailExpectation(mode, routing)
 	for i, src := range sorted {
 		for j, dst := range sorted {
 			if i == j {
@@ -176,9 +215,9 @@ func Plan(pods []TestPod) MatrixPlan {
 				if !ok1 || !ok2 || srcIP == "" || dstIP == "" {
 					continue
 				}
-				srcDev, hasSrcDev := src.RDMADevsByRail[rail]
-				dstDev, hasDstDev := dst.RDMADevsByRail[rail]
-				if !hasSrcDev || !hasDstDev || srcDev == "" || dstDev == "" {
+				srcIface := src.InterfacesByRail[rail]
+				dstIface := dst.InterfacesByRail[rail]
+				if srcIface == "" || dstIface == "" {
 					continue
 				}
 				base := PingTest{
@@ -186,8 +225,19 @@ func Plan(pods []TestPod) MatrixPlan {
 					SrcNode: src.Node, DstNode: dst.Node,
 					Rail: rail, SrcIP: srcIP, DstIP: dstIP,
 					SrcRail: rail, DstRail: rail,
-					SrcRDMADev: srcDev, DstRDMADev: dstDev,
+					SrcIface: srcIface, DstIface: dstIface,
+					Expectation: ExpectRequired,
 				}
+				icmpT := base
+				icmpT.Kind = ICMPSameRail
+				plan.ICMPSameRail = append(plan.ICMPSameRail, icmpT)
+				srcDev, hasSrcDev := src.RDMADevsByRail[rail]
+				dstDev, hasDstDev := dst.RDMADevsByRail[rail]
+				if !hasSrcDev || !hasDstDev || srcDev == "" || dstDev == "" {
+					continue
+				}
+				base.SrcRDMADev = srcDev
+				base.DstRDMADev = dstDev
 				rpingT := base
 				rpingT.Kind = RDMAPingSameRail
 				plan.RDMASameRail = append(plan.RDMASameRail, rpingT)
@@ -195,25 +245,34 @@ func Plan(pods []TestPod) MatrixPlan {
 				bwT.Kind = RDMABwSameRail
 				plan.RDMABwSameRail = append(plan.RDMABwSameRail, bwT)
 			}
-			// Cross-rail canary: src.rail[0] → dst.rail[1] when
-			// both pods have ≥2 rails. Skipped otherwise.
-			if len(src.RailOrder) >= 2 && len(dst.RailOrder) >= 2 {
-				srcRail, dstRail := src.RailOrder[0], dst.RailOrder[1]
+			for _, pair := range crossRailPairs(src, dst, mode, i, j) {
+				srcRail, dstRail := pair.srcRail, pair.dstRail
 				srcIP, ok1 := src.IPsByRail[srcRail]
 				dstIP, ok2 := dst.IPsByRail[dstRail]
-				srcDev, hasSrcDev := src.RDMADevsByRail[srcRail]
-				dstDev, hasDstDev := dst.RDMADevsByRail[dstRail]
-				if !ok1 || !ok2 || srcIP == "" || dstIP == "" || !hasSrcDev || !hasDstDev {
+				srcIface := src.InterfacesByRail[srcRail]
+				dstIface := dst.InterfacesByRail[dstRail]
+				if !ok1 || !ok2 || srcIP == "" || dstIP == "" || srcIface == "" || dstIface == "" {
 					continue
 				}
 				base := PingTest{
 					SrcPod: src.Name, DstPod: dst.Name,
 					SrcNode: src.Node, DstNode: dst.Node,
-					Rail:    fmt.Sprintf("%s→%s", srcRail, dstRail),
-					SrcIP:   srcIP, DstIP: dstIP,
+					Rail:  fmt.Sprintf("%s→%s", srcRail, dstRail),
+					SrcIP: srcIP, DstIP: dstIP,
 					SrcRail: srcRail, DstRail: dstRail,
-					SrcRDMADev: srcDev, DstRDMADev: dstDev,
+					SrcIface: srcIface, DstIface: dstIface,
+					Expectation: crossExpectation,
 				}
+				icmpC := base
+				icmpC.Kind = ICMPCrossRail
+				plan.ICMPCrossRail = append(plan.ICMPCrossRail, icmpC)
+				srcDev, hasSrcDev := src.RDMADevsByRail[srcRail]
+				dstDev, hasDstDev := dst.RDMADevsByRail[dstRail]
+				if !hasSrcDev || !hasDstDev || srcDev == "" || dstDev == "" {
+					continue
+				}
+				base.SrcRDMADev = srcDev
+				base.DstRDMADev = dstDev
 				rpingC := base
 				rpingC.Kind = RDMAPingCrossRail
 				plan.RDMACrossRail = append(plan.RDMACrossRail, rpingC)
@@ -225,4 +284,54 @@ func Plan(pods []TestPod) MatrixPlan {
 	}
 
 	return plan
+}
+
+type railPair struct {
+	srcRail string
+	dstRail string
+}
+
+func crossRailPairs(src, dst TestPod, mode Mode, srcIdx, dstIdx int) []railPair {
+	if len(src.RailOrder) < 2 || len(dst.RailOrder) < 2 {
+		return nil
+	}
+	switch mode {
+	case ModeFull, ModeStrict:
+		var out []railPair
+		for _, srcRail := range src.RailOrder {
+			for _, dstRail := range dst.RailOrder {
+				if srcRail == dstRail {
+					continue
+				}
+				out = append(out, railPair{srcRail: srcRail, dstRail: dstRail})
+			}
+		}
+		return out
+	default:
+		// Quick mode runs one non-gating canary per rail mapping, not per
+		// pod pair. Deterministically use the first ordered pod pair.
+		if srcIdx != 0 || dstIdx != 1 {
+			return nil
+		}
+		var out []railPair
+		for _, srcRail := range src.RailOrder {
+			for _, dstRail := range dst.RailOrder {
+				if srcRail == dstRail {
+					continue
+				}
+				out = append(out, railPair{srcRail: srcRail, dstRail: dstRail})
+			}
+		}
+		return out
+	}
+}
+
+func crossRailExpectation(mode Mode, routing string) Expectation {
+	if mode != ModeStrict {
+		return ExpectObserve
+	}
+	if routing == config.RoutingSourceBased {
+		return ExpectRequired
+	}
+	return ExpectForbidden
 }

--- a/pkg/networkoperatorplugin/connectivity/matrix_test.go
+++ b/pkg/networkoperatorplugin/connectivity/matrix_test.go
@@ -17,6 +17,7 @@
 package connectivity
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,19 +25,20 @@ import (
 )
 
 // mkPod builds a TestPod fixture with synthetic IPs *and* an RDMA
-// device per rail. Plan() now requires both sides of a pair to have an
-// RDMA device for the rail in order to emit tests (since the matrix
-// is RDMA-only), so the test fixture must populate RDMADevsByRail to
-// produce non-empty plans.
+// device per rail. RDMA stages require both sides of a pair to have an RDMA
+// device for the rail, so the test fixture populates RDMADevsByRail alongside
+// IP/interface data.
 func mkPod(name string, rails ...string) TestPod {
 	tp := TestPod{
-		Name:           name,
-		IPsByRail:      map[string]string{},
-		RDMADevsByRail: map[string]string{},
+		Name:             name,
+		IPsByRail:        map[string]string{},
+		RDMADevsByRail:   map[string]string{},
+		InterfacesByRail: map[string]string{},
 	}
-	for _, rail := range rails {
+	for i, rail := range rails {
 		tp.IPsByRail[rail] = fakeIP(name, rail)
 		tp.RDMADevsByRail[rail] = fakeRDMADev(name, rail)
+		tp.InterfacesByRail[rail] = fakeIface(i)
 		tp.RailOrder = append(tp.RailOrder, rail)
 	}
 	return tp
@@ -81,6 +83,10 @@ func fakeRDMADev(pod, rail string) string {
 	return "mlx5_" + pod + "_" + rail
 }
 
+func fakeIface(idx int) string {
+	return fmt.Sprintf("net%d", idx+1)
+}
+
 func TestPlan_SoftSkipOnFewerThan2Pods(t *testing.T) {
 	t.Run("zero pods", func(t *testing.T) {
 		plan := Plan(nil)
@@ -96,7 +102,7 @@ func TestPlan_SoftSkipOnFewerThan2Pods(t *testing.T) {
 }
 
 func TestNormalizeChecks(t *testing.T) {
-	assert.Equal(t, []Check{CheckRPing, CheckIBWriteBW}, normalizeChecks(nil))
+	assert.Equal(t, []Check{CheckICMP, CheckRPing, CheckIBWriteBW}, normalizeChecks(nil))
 	assert.Empty(t, normalizeChecks([]Check{}))
 	assert.Equal(t, []Check{CheckIBWriteBW, CheckRPing},
 		normalizeChecks([]Check{CheckIBWriteBW, "", CheckRPing, CheckIBWriteBW}))
@@ -113,9 +119,11 @@ func TestPlan_TwoPodsOneRail(t *testing.T) {
 	// rping tests and 2 ib_write_bw tests.
 	assert.Len(t, plan.RDMASameRail, 2)
 	assert.Len(t, plan.RDMABwSameRail, 2)
+	assert.Len(t, plan.ICMPSameRail, 2)
 	// Cross-rail canary requires ≥2 rails per pod — skipped here.
 	assert.Empty(t, plan.RDMACrossRail)
 	assert.Empty(t, plan.RDMABwCrossRail)
+	assert.Empty(t, plan.ICMPCrossRail)
 
 	// Check direction coverage: both A→B and B→A appear in the rping
 	// slice.
@@ -130,6 +138,8 @@ func TestPlan_TwoPodsOneRail(t *testing.T) {
 	for _, tt := range plan.RDMABwSameRail {
 		assert.NotEmpty(t, tt.SrcRDMADev, "%+v", tt)
 		assert.NotEmpty(t, tt.DstRDMADev, "%+v", tt)
+		assert.NotEmpty(t, tt.SrcIface, "%+v", tt)
+		assert.NotEmpty(t, tt.DstIface, "%+v", tt)
 	}
 }
 
@@ -144,26 +154,28 @@ func TestPlan_TwoPodsTwoRails_IncludesCrossRailCanary(t *testing.T) {
 	// per family.
 	assert.Len(t, plan.RDMASameRail, 4)
 	assert.Len(t, plan.RDMABwSameRail, 4)
-	// Cross-rail canary: one per ordered pod pair = 2 per family.
+	assert.Len(t, plan.ICMPSameRail, 4)
+	// Quick cross-rail canary: one deterministic pod pair for every
+	// ordered rail mapping = 2 per family for two rails.
 	assert.Len(t, plan.RDMACrossRail, 2)
 	assert.Len(t, plan.RDMABwCrossRail, 2)
+	assert.Len(t, plan.ICMPCrossRail, 2)
 
 	// Each cross-rail test should ping rail-0 → rail-1 (the first two
 	// rails by sorted order). Concrete IP assertions catch
 	// off-by-one in railOrder indexing.
 	for _, c := range plan.RDMACrossRail {
-		assert.Equal(t, "rail-0", c.SrcRail)
-		assert.Equal(t, "rail-1", c.DstRail)
-		assert.Equal(t, "rail-0→rail-1", c.Rail)
+		assert.Equal(t, ExpectObserve, c.Expectation)
+		assert.NotEqual(t, c.SrcRail, c.DstRail)
 	}
 }
 
 func TestPlan_ThreePodsThreeRails_FullMatrix(t *testing.T) {
-	plan := Plan([]TestPod{
+	plan := PlanWithOptions([]TestPod{
 		mkPod("pod-a", "rail-0", "rail-1", "rail-2"),
 		mkPod("pod-b", "rail-0", "rail-1", "rail-2"),
 		mkPod("pod-c", "rail-0", "rail-1"), // shorter rail list — exercise asymmetric case
-	})
+	}, ModeFull, "")
 
 	require.Nil(t, plan.Skip)
 
@@ -175,12 +187,30 @@ func TestPlan_ThreePodsThreeRails_FullMatrix(t *testing.T) {
 	// Total = 14 per family (rping + ib_write_bw each).
 	assert.Len(t, plan.RDMASameRail, 14)
 	assert.Len(t, plan.RDMABwSameRail, 14)
+	assert.Len(t, plan.ICMPSameRail, 14)
 
-	// Cross-rail canary requires ≥2 rails on both endpoints. All
-	// three pods qualify (pod-c has 2), so every ordered pair gets
-	// one canary: 3 × 2 = 6 per family.
-	assert.Len(t, plan.RDMACrossRail, 6)
-	assert.Len(t, plan.RDMABwCrossRail, 6)
+	// Full cross-rail: every ordered pod pair x every source rail x
+	// every destination rail, excluding same rail.
+	assert.Len(t, plan.RDMACrossRail, 28)
+	assert.Len(t, plan.RDMABwCrossRail, 28)
+	assert.Len(t, plan.ICMPCrossRail, 28)
+	for _, c := range plan.RDMACrossRail {
+		assert.Equal(t, ExpectObserve, c.Expectation)
+	}
+}
+
+func TestPlan_StrictCrossRailExpectationFollowsRouting(t *testing.T) {
+	pods := []TestPod{
+		mkPod("pod-a", "rail-0", "rail-1"),
+		mkPod("pod-b", "rail-0", "rail-1"),
+	}
+	source := PlanWithOptions(pods, ModeStrict, "source-based")
+	require.NotEmpty(t, source.RDMACrossRail)
+	assert.Equal(t, ExpectRequired, source.RDMACrossRail[0].Expectation)
+
+	destination := PlanWithOptions(pods, ModeStrict, "destination-based")
+	require.NotEmpty(t, destination.RDMACrossRail)
+	assert.Equal(t, ExpectForbidden, destination.RDMACrossRail[0].Expectation)
 }
 
 func TestPlan_StableOrderingAcrossRuns(t *testing.T) {
@@ -221,6 +251,7 @@ func TestPlan_SkipsPairsWithoutRDMADevices(t *testing.T) {
 	delete(b.RDMADevsByRail, "rail-0")
 	plan := Plan([]TestPod{a, b})
 	require.Nil(t, plan.Skip)
-	assert.Empty(t, plan.RDMASameRail, "no test should be emitted for the missing-device pair")
+	assert.Empty(t, plan.RDMASameRail, "no RDMA test should be emitted for the missing-device pair")
 	assert.Empty(t, plan.RDMABwSameRail)
+	assert.Len(t, plan.ICMPSameRail, 2, "ICMP still only needs IP and interface")
 }

--- a/pkg/networkoperatorplugin/connectivity/multus.go
+++ b/pkg/networkoperatorplugin/connectivity/multus.go
@@ -16,8 +16,8 @@
 
 // Package connectivity drives the Phase-2 data-plane verification flow:
 // apply the example DaemonSet, wait for it to reach Ready, parse each
-// pod's multus network-status annotation, and run an RDMA matrix between
-// the secondary-network IPs.
+// pod's multus network-status annotation, and run source-bound connectivity
+// checks between the secondary-network IPs.
 package connectivity
 
 import (
@@ -33,7 +33,7 @@ const MultusAnnotation = "k8s.v1.cni.cncf.io/network-status"
 // NetworkStatus mirrors the upstream multus
 // `k8s.v1.cni.cncf.io/network-status` annotation entry shape. We only
 // model the fields we read; the upstream struct carries a few more
-// (gateway, dns, mtu) that aren't relevant to the RDMA matrix.
+// (gateway, dns, mtu) that aren't relevant to the connectivity matrix.
 type NetworkStatus struct {
 	// Name is the NetworkAttachmentDefinition name in
 	// `<namespace>/<name>` form (or just the name when in the pod's
@@ -74,7 +74,7 @@ func ParseNetworkStatus(annotation string) ([]NetworkStatus, error) {
 
 // SecondaryNetworks filters out the cluster's default-CNI attachment
 // (e.g. Calico/Flannel/Cilium), leaving only the secondary networks
-// the deployment under test put on the pod. The RDMA matrix runs over
+// the deployment under test put on the pod. The connectivity matrix runs over
 // these.
 func SecondaryNetworks(all []NetworkStatus) []NetworkStatus {
 	out := make([]NetworkStatus, 0, len(all))

--- a/pkg/networkoperatorplugin/connectivity/rdma.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma.go
@@ -41,7 +41,12 @@ const rdmaServerSettleDelay = 2 * time.Second
 // Options.Timeout.
 const rdmaTestTimeout = 90 * time.Second
 
-const rpingBatchResultMarker = "__L8K_RPING_RESULT__"
+const (
+	rpingBatchResultMarker     = "__L8K_RPING_RESULT__"
+	rdmaBatchRouteResultMarker = "__L8K_ROUTE_RESULT__"
+	rdmaBatchRouteEndMarker    = "__L8K_ROUTE_END__"
+	rdmaBatchRouteFailCode     = 201
+)
 
 const (
 	ibWriteBwBatchResultMarker = "__L8K_IBWRITEBW_RESULT__"
@@ -288,9 +293,25 @@ func runRPingBatch(ctx context.Context, restConfig *rest.Config, namespaceByPod,
 	clientCmd := rpingBatchClientCommand(tests, iterations)
 	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, clientNamespace, first.SrcPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
 	rcByIndex := parseRPingBatchResults(cliRes.Stdout)
+	routeByIndex := parseRDMABatchRouteResults(cliRes.Stdout, tests)
 	for i := range results {
 		results[i].Stdout = cliRes.Stdout
 		results[i].Stderr = cliRes.Stderr
+		if results[i].Expectation == ExpectRequired {
+			route, ok := routeByIndex[i]
+			if !ok {
+				err := fmt.Errorf("rping batch missing source-route check for test %d", i)
+				finalizeExpectedResult(&results[i], false, err)
+				continue
+			}
+			results[i].Route = route
+			if routeMismatch(route, tests[i]) {
+				err := fmt.Errorf("source route selected dev %q, expected %q (route: %s)",
+					route.Dev, tests[i].SrcIface, route.Output)
+				finalizeExpectedResult(&results[i], false, err)
+				continue
+			}
+		}
 		rc, ok := rcByIndex[i]
 		if !ok {
 			err := cliErr
@@ -355,8 +376,12 @@ func rpingBatchClientCommand(tests []PingTest, iterations int) string {
 		if timeoutSeconds <= 0 {
 			timeoutSeconds = 1
 		}
+		appendRDMABatchRouteGuard(&b, i, test,
+			fmt.Sprintf("echo %s %d %d", rpingBatchResultMarker, i, rdmaBatchRouteFailCode))
 		fmt.Fprintf(&b,
-			"run_with_timeout %d rping -c -I %s -a %s -p 9999 -C %d -v >/tmp/l8k-rping-client-%d.out 2>/tmp/l8k-rping-client-%d.err; rc=$?; echo %s %d $rc; ",
+			`if [ "$route_ok" = "1" ]; then `+
+				"run_with_timeout %d rping -c -I %s -a %s -p 9999 -C %d -v >/tmp/l8k-rping-client-%d.out 2>/tmp/l8k-rping-client-%d.err; rc=$?; echo %s %d $rc; "+
+				`fi; `,
 			timeoutSeconds, shellArg(test.SrcIP), shellArg(test.DstIP), iterations, i, i, rpingBatchResultMarker, i)
 	}
 	b.WriteString("exit 0")
@@ -376,6 +401,80 @@ func parseRPingBatchResults(stdout string) map[int]int {
 			continue
 		}
 		out[idx] = rc
+	}
+	return out
+}
+
+func appendRDMABatchRouteGuard(b *strings.Builder, index int, test PingTest, failCommand string) {
+	b.WriteString("route_ok=1; ")
+	if test.Expectation != ExpectRequired {
+		return
+	}
+	routeFile := fmt.Sprintf("/tmp/l8k-route-%d.out", index)
+	fmt.Fprintf(b,
+		`route_file=%s; ipcmd=""; for p in ip /sbin/ip /usr/sbin/ip /bin/ip /usr/bin/ip; do `+
+			`if command -v "$p" >/dev/null 2>&1 || [ -x "$p" ]; then ipcmd="$p"; break; fi; `+
+			`done; `+
+			`if [ -z "$ipcmd" ]; then echo %s >"$route_file"; route_rc=127; `+
+			`else "$ipcmd" -o route get %s from %s >"$route_file" 2>&1; route_rc=$?; fi; `+
+			`route_dev=$(sed -n 's/.* dev \([^ ]*\).*/\1/p' "$route_file" | head -n1); `+
+			`echo %s %d $route_rc; cat "$route_file" 2>/dev/null; echo %s %d; `+
+			`if [ "$route_rc" != "0" ] || [ "$route_dev" != %s ]; then route_ok=0; %s; fi; `,
+		shellArg(routeFile), shellArg(routeSkipMarker), shellArg(test.DstIP), shellArg(test.SrcIP),
+		rdmaBatchRouteResultMarker, index, rdmaBatchRouteEndMarker, index, shellArg(test.SrcIface), failCommand)
+}
+
+func parseRDMABatchRouteResults(stdout string, tests []PingTest) map[int]RouteCheck {
+	out := map[int]RouteCheck{}
+	var current *int
+	var b strings.Builder
+	rcByIndex := map[int]int{}
+	for _, line := range strings.Split(stdout, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) == 3 && fields[0] == rdmaBatchRouteResultMarker {
+			idx, idxErr := strconv.Atoi(fields[1])
+			rc, rcErr := strconv.Atoi(fields[2])
+			if idxErr != nil || rcErr != nil {
+				current = nil
+				b.Reset()
+				continue
+			}
+			current = &idx
+			rcByIndex[idx] = rc
+			b.Reset()
+			continue
+		}
+		if len(fields) == 2 && fields[0] == rdmaBatchRouteEndMarker {
+			idx, err := strconv.Atoi(fields[1])
+			if err == nil && current != nil && idx == *current {
+				output := strings.TrimSpace(b.String())
+				route := RouteCheck{
+					Output: output,
+					OK:     rcByIndex[idx] == 0,
+				}
+				if idx >= 0 && idx < len(tests) {
+					route.Command = fmt.Sprintf("ip -o route get %s from %s", tests[idx].DstIP, tests[idx].SrcIP)
+				}
+				if strings.Contains(output, routeSkipMarker) {
+					route.Err = "ip command not found in validation container"
+					route.OK = false
+				}
+				if m := routeDevRe.FindStringSubmatch(output); len(m) == 2 {
+					route.Dev = m[1]
+				}
+				if route.Dev == "" {
+					route.OK = false
+				}
+				out[idx] = route
+			}
+			current = nil
+			b.Reset()
+			continue
+		}
+		if current != nil {
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
 	}
 	return out
 }
@@ -541,10 +640,26 @@ func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceBy
 	clientCmd := ibWriteBwBatchClientCommand(tests, size)
 	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, clientNamespace, first.SrcPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
 	parsed := parseIbWriteBwBatchResults(cliRes.Stdout)
+	routeByIndex := parseRDMABatchRouteResults(cliRes.Stdout, tests)
 	for i := range results {
 		results[i].Stderr = cliRes.Stderr
 		if results[i].Err != nil {
 			continue
+		}
+		if results[i].Expectation == ExpectRequired {
+			route, ok := routeByIndex[i]
+			if !ok {
+				err := fmt.Errorf("ib_write_bw batch missing source-route check for test %d", i)
+				finalizeExpectedResult(&results[i], false, err)
+				continue
+			}
+			results[i].Route = route
+			if routeMismatch(route, tests[i]) {
+				err := fmt.Errorf("source route selected dev %q, expected %q (route: %s)",
+					route.Dev, tests[i].SrcIface, route.Output)
+				finalizeExpectedResult(&results[i], false, err)
+				continue
+			}
 		}
 		cell, ok := parsed[i]
 		if !ok {
@@ -598,8 +713,12 @@ func ibWriteBwBatchClientCommand(tests []PingTest, size int) string {
 		}
 		outFile := fmt.Sprintf("/tmp/l8k-ibwritebw-client-%d.out", i)
 		errFile := fmt.Sprintf("/tmp/l8k-ibwritebw-client-%d.err", i)
+		appendRDMABatchRouteGuard(&b, i, test,
+			fmt.Sprintf("echo %s %d %d; echo %s %d", ibWriteBwBatchResultMarker, i, rdmaBatchRouteFailCode, ibWriteBwBatchEndMarker, i))
 		fmt.Fprintf(&b,
-			"run_with_timeout %d ib_write_bw -d %s -R -s %d --report_gbits -p %d --bind_source_ip %s %s >%s 2>%s; rc=$?; echo %s %d $rc; cat %s 2>/dev/null; echo %s %d; ",
+			`if [ "$route_ok" = "1" ]; then `+
+				"run_with_timeout %d ib_write_bw -d %s -R -s %d --report_gbits -p %d --bind_source_ip %s %s >%s 2>%s; rc=$?; echo %s %d $rc; cat %s 2>/dev/null; echo %s %d; "+
+				`fi; `,
 			timeoutSeconds, shellArg(test.SrcRDMADev), size, ibWriteBwBatchPort(i), shellArg(test.SrcIP), shellArg(test.DstIP),
 			outFile, errFile, ibWriteBwBatchResultMarker, i, outFile, ibWriteBwBatchEndMarker, i)
 	}

--- a/pkg/networkoperatorplugin/connectivity/rdma.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma.go
@@ -41,6 +41,13 @@ const rdmaServerSettleDelay = 2 * time.Second
 // Options.Timeout.
 const rdmaTestTimeout = 90 * time.Second
 
+const rpingBatchResultMarker = "__L8K_RPING_RESULT__"
+
+const (
+	ibWriteBwBatchResultMarker = "__L8K_IBWRITEBW_RESULT__"
+	ibWriteBwBatchEndMarker    = "__L8K_IBWRITEBW_END__"
+)
+
 // railNameIndex extracts the numeric rail index from a rail key like
 // "macvlan-network-rail-3-some-suffix" → 3. Matches the rendered
 // NetworkAttachmentDefinition / MacvlanNetwork names every l8k profile
@@ -174,40 +181,220 @@ func DiscoverRDMADevices(ctx context.Context, restConfig *rest.Config, namespace
 // output for any structured value — the binary OK is enough for
 // matrix display. rping verifies the QP pair establishes
 // end-to-end; ib_write_bw additionally measures throughput.
-func RunRPing(ctx context.Context, restConfig *rest.Config, namespace string, serverPod, serverContainer string, clientPod, clientContainer string, test PingTest, iterations int) PingResult {
+func RunRPing(ctx context.Context, restConfig *rest.Config, serverNamespace string, serverPod, serverContainer string, clientNamespace string, clientPod, clientContainer string, test PingTest, iterations int) PingResult {
 	if iterations <= 0 {
 		iterations = 5
 	}
-	r := PingResult{Test: test}
+	r := initResult(test)
 
 	tctx, cancel := context.WithTimeout(ctx, rdmaTestTimeout)
 	defer cancel()
 
-	serverCmd := fmt.Sprintf("nohup rping -s -a %s -p 9999 -v >/tmp/rping-server.log 2>&1 & echo $!", test.DstIP)
-	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, namespace, serverPod, serverContainer, []string{"/bin/sh", "-c", serverCmd})
+	if r.Expectation == ExpectRequired {
+		r.Route = checkRoute(tctx, restConfig, clientNamespace, clientPod, clientContainer, test)
+		if routeMismatch(r.Route, test) {
+			r.Err = fmt.Errorf("source route selected dev %q, expected %q (route: %s)",
+				r.Route.Dev, test.SrcIface, r.Route.Output)
+			finalizeExpectedResult(&r, false, r.Err)
+			return r
+		}
+	}
+
+	serverCmd := fmt.Sprintf("nohup rping -s -a %s -p 9999 -v >/tmp/rping-server.log 2>&1 & echo $!", shellArg(test.DstIP))
+	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, serverNamespace, serverPod, serverContainer, []string{"/bin/sh", "-c", serverCmd})
 	if err != nil {
 		r.Err = fmt.Errorf("rping server start: %w (stderr: %s)", err, srvRes.Stderr)
 		return r
 	}
 	serverPID := strings.TrimSpace(srvRes.Stdout)
-	defer killRDMAServer(restConfig, namespace, serverPod, serverContainer, "rping", serverPID)
+	defer killRDMAServer(restConfig, serverNamespace, serverPod, serverContainer, "rping", serverPID)
 
 	// Settle window — give the server time to bind.
 	select {
 	case <-tctx.Done():
 		r.Err = fmt.Errorf("rping settle wait: %w", tctx.Err())
 		return r
-	case <-time.After(rdmaServerSettleDelay):
+	case <-time.After(rdmaSettleDelayFor(test)):
 	}
 
-	clientCmd := fmt.Sprintf("rping -c -a %s -p 9999 -C %d -v", test.DstIP, iterations)
-	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, namespace, clientPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
+	clientCmd := shellWithTimeout(
+		fmt.Sprintf("rping -c -I %s -a %s -p 9999 -C %d -v", shellArg(test.SrcIP), shellArg(test.DstIP), iterations),
+		commandTimeoutFor(test, 30*time.Second))
+	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, clientNamespace, clientPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
 	r.Stdout, r.Stderr = cliRes.Stdout, cliRes.Stderr
-	r.Err = cliErr
-	// rping exits 0 only on a clean run; non-zero exit propagates
-	// to cliErr.
-	r.OK = cliErr == nil
+	finalizeExpectedResult(&r, cliErr == nil, cliErr)
 	return r
+}
+
+// RunRPingBatches executes rping tests grouped by ordered pod pair. This keeps
+// the matrix result per test, but collapses the API exec traffic from
+// start/client/cleanup per cell to start/client/cleanup per pod pair.
+func RunRPingBatches(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, iterations int) []PingResult {
+	if iterations <= 0 {
+		iterations = 5
+	}
+	groups := groupRPingTests(tests)
+	out := make([]PingResult, 0, len(tests))
+	for _, group := range groups {
+		out = append(out, runRPingBatch(ctx, restConfig, namespaceByPod, containerByPod, group, iterations)...)
+	}
+	return out
+}
+
+func runRPingBatch(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, iterations int) []PingResult {
+	results := make([]PingResult, len(tests))
+	for i, test := range tests {
+		results[i] = initResult(test)
+	}
+	if len(tests) == 0 {
+		return results
+	}
+
+	first := tests[0]
+	serverNamespace, serverContainer := namespaceByPod[first.DstPod], containerByPod[first.DstPod]
+	clientNamespace, clientContainer := namespaceByPod[first.SrcPod], containerByPod[first.SrcPod]
+	if serverNamespace == "" || serverContainer == "" || clientNamespace == "" || clientContainer == "" {
+		err := fmt.Errorf("no namespace/container lookup for rping pod pair (%s, %s)", first.SrcPod, first.DstPod)
+		for i := range results {
+			results[i].Err = err
+		}
+		return results
+	}
+
+	tctx, cancel := context.WithTimeout(ctx, rdmaBatchTimeoutFor(tests))
+	defer cancel()
+
+	serverCmd := rpingBatchServerCommand(tests)
+	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, serverNamespace, first.DstPod, serverContainer, []string{"/bin/sh", "-c", serverCmd})
+	if err != nil {
+		batchErr := fmt.Errorf("rping batch server start: %w (stderr: %s)", err, srvRes.Stderr)
+		for i := range results {
+			results[i].Err = batchErr
+		}
+		return results
+	}
+	defer killRDMAServer(restConfig, serverNamespace, first.DstPod, serverContainer, "rping", "")
+
+	select {
+	case <-tctx.Done():
+		batchErr := fmt.Errorf("rping batch settle wait: %w", tctx.Err())
+		for i := range results {
+			results[i].Err = batchErr
+		}
+		return results
+	case <-time.After(rdmaBatchSettleDelayFor(tests)):
+	}
+
+	clientCmd := rpingBatchClientCommand(tests, iterations)
+	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, clientNamespace, first.SrcPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
+	rcByIndex := parseRPingBatchResults(cliRes.Stdout)
+	for i := range results {
+		results[i].Stdout = cliRes.Stdout
+		results[i].Stderr = cliRes.Stderr
+		rc, ok := rcByIndex[i]
+		if !ok {
+			err := cliErr
+			if err == nil {
+				err = fmt.Errorf("rping batch missing result for test %d", i)
+			}
+			finalizeExpectedResult(&results[i], false, err)
+			continue
+		}
+		if rc == 0 {
+			finalizeExpectedResult(&results[i], true, nil)
+			continue
+		}
+		finalizeExpectedResult(&results[i], false, fmt.Errorf("rping exited with code %d", rc))
+	}
+	return results
+}
+
+func groupRPingTests(tests []PingTest) [][]PingTest {
+	type key struct {
+		srcPod string
+		dstPod string
+	}
+	var order []key
+	byKey := map[key][]PingTest{}
+	for _, test := range tests {
+		k := key{srcPod: test.SrcPod, dstPod: test.DstPod}
+		if _, ok := byKey[k]; !ok {
+			order = append(order, k)
+		}
+		byKey[k] = append(byKey[k], test)
+	}
+	out := make([][]PingTest, 0, len(order))
+	for _, k := range order {
+		out = append(out, byKey[k])
+	}
+	return out
+}
+
+func rpingBatchServerCommand(tests []PingTest) string {
+	seen := map[string]bool{}
+	var b strings.Builder
+	b.WriteString("pkill rping 2>/dev/null || true; rm -f /tmp/l8k-rping-server-*.log; ")
+	idx := 0
+	for _, test := range tests {
+		if test.DstIP == "" || seen[test.DstIP] {
+			continue
+		}
+		seen[test.DstIP] = true
+		fmt.Fprintf(&b, "nohup rping -s -a %s -p 9999 -v >/tmp/l8k-rping-server-%d.log 2>&1 & ", shellArg(test.DstIP), idx)
+		idx++
+	}
+	b.WriteString("echo ready")
+	return b.String()
+}
+
+func rpingBatchClientCommand(tests []PingTest, iterations int) string {
+	var b strings.Builder
+	b.WriteString(`run_with_timeout() { seconds="$1"; shift; if command -v timeout >/dev/null 2>&1; then timeout --kill-after=2s "${seconds}s" "$@"; else "$@" & pid=$!; (sleep "$seconds"; kill -TERM "$pid" 2>/dev/null; sleep 2; kill -KILL "$pid" 2>/dev/null) & watchdog=$!; wait "$pid"; rc=$?; kill "$watchdog" 2>/dev/null; wait "$watchdog" 2>/dev/null; return "$rc"; fi; }; `)
+	for i, test := range tests {
+		timeoutSeconds := int(commandTimeoutFor(test, 30*time.Second).Seconds())
+		if timeoutSeconds <= 0 {
+			timeoutSeconds = 1
+		}
+		fmt.Fprintf(&b,
+			"run_with_timeout %d rping -c -I %s -a %s -p 9999 -C %d -v >/tmp/l8k-rping-client-%d.out 2>/tmp/l8k-rping-client-%d.err; rc=$?; echo %s %d $rc; ",
+			timeoutSeconds, shellArg(test.SrcIP), shellArg(test.DstIP), iterations, i, i, rpingBatchResultMarker, i)
+	}
+	b.WriteString("exit 0")
+	return b.String()
+}
+
+func parseRPingBatchResults(stdout string) map[int]int {
+	out := map[int]int{}
+	for _, line := range strings.Split(stdout, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) != 3 || fields[0] != rpingBatchResultMarker {
+			continue
+		}
+		idx, err1 := strconv.Atoi(fields[1])
+		rc, err2 := strconv.Atoi(fields[2])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		out[idx] = rc
+	}
+	return out
+}
+
+func rdmaBatchTimeoutFor(tests []PingTest) time.Duration {
+	timeout := 15 * time.Second
+	for _, test := range tests {
+		timeout += commandTimeoutFor(test, 30*time.Second) + rdmaBatchSettleDelayFor([]PingTest{test})
+	}
+	return timeout
+}
+
+func rdmaBatchSettleDelayFor(tests []PingTest) time.Duration {
+	for _, test := range tests {
+		if test.Expectation == ExpectRequired {
+			return rdmaServerSettleDelay
+		}
+	}
+	return rdmaSettleDelayFor(PingTest{Expectation: ExpectObserve})
 }
 
 // RunIbWriteBw runs an ib_write_bw bandwidth test for one src→dst pair.
@@ -217,14 +404,15 @@ func RunRPing(ctx context.Context, restConfig *rest.Config, namespace string, se
 // parse for a matrix cell. Each test allocates a fresh TCP listener
 // port (default 18515 + an orchestrator-supplied offset) to avoid
 // collisions with concurrent runs against unrelated rails.
-func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, namespace string, serverPod, serverContainer string, clientPod, clientContainer string, test PingTest, port, size int, minBandwidthGbps float64) PingResult {
+func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, serverNamespace string, serverPod, serverContainer string, clientNamespace string, clientPod, clientContainer string, test PingTest, port, size int, minBandwidthGbps float64) PingResult {
 	if port <= 0 {
 		port = 18515
 	}
 	if size <= 0 {
 		size = 65536
 	}
-	r := PingResult{Test: test, MinBandwidthGbps: minBandwidthGbps}
+	r := initResult(test)
+	r.MinBandwidthGbps = minBandwidthGbps
 	if test.SrcRDMADev == "" || test.DstRDMADev == "" {
 		r.Err = fmt.Errorf("ib_write_bw needs RDMA device names; got src=%q dst=%q", test.SrcRDMADev, test.DstRDMADev)
 		return r
@@ -233,31 +421,43 @@ func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, namespace string
 	tctx, cancel := context.WithTimeout(ctx, rdmaTestTimeout)
 	defer cancel()
 
+	if r.Expectation == ExpectRequired {
+		r.Route = checkRoute(tctx, restConfig, clientNamespace, clientPod, clientContainer, test)
+		if routeMismatch(r.Route, test) {
+			r.Err = fmt.Errorf("source route selected dev %q, expected %q (route: %s)",
+				r.Route.Dev, test.SrcIface, r.Route.Output)
+			finalizeExpectedResult(&r, false, r.Err)
+			return r
+		}
+	}
+
 	// `ib_write_bw -d <dev> -R -s <size> --report_gbits -p <port>`
 	// runs as the server when invoked without a peer IP, as the
 	// client when invoked with one. The server prints a banner and
 	// then waits; the client connects, runs the test, and both
 	// sides print the summary table.
-	serverCmd := fmt.Sprintf("nohup ib_write_bw -d %s -R -s %d --report_gbits -p %d >/tmp/ibwritebw-server.log 2>&1 & echo $!",
-		test.DstRDMADev, size, port)
-	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, namespace, serverPod, serverContainer, []string{"/bin/sh", "-c", serverCmd})
+	serverCmd := fmt.Sprintf("nohup ib_write_bw -d %s -R -s %d --report_gbits -p %d --bind_source_ip %s >/tmp/ibwritebw-server.log 2>&1 & echo $!",
+		shellArg(test.DstRDMADev), size, port, shellArg(test.DstIP))
+	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, serverNamespace, serverPod, serverContainer, []string{"/bin/sh", "-c", serverCmd})
 	if err != nil {
 		r.Err = fmt.Errorf("ib_write_bw server start: %w (stderr: %s)", err, srvRes.Stderr)
 		return r
 	}
 	serverPID := strings.TrimSpace(srvRes.Stdout)
-	defer killRDMAServer(restConfig, namespace, serverPod, serverContainer, "ib_write_bw", serverPID)
+	defer killRDMAServer(restConfig, serverNamespace, serverPod, serverContainer, "ib_write_bw", serverPID)
 
 	select {
 	case <-tctx.Done():
 		r.Err = fmt.Errorf("ib_write_bw settle wait: %w", tctx.Err())
 		return r
-	case <-time.After(rdmaServerSettleDelay):
+	case <-time.After(rdmaSettleDelayFor(test)):
 	}
 
-	clientCmd := fmt.Sprintf("ib_write_bw -d %s -R -s %d --report_gbits -p %d %s",
-		test.SrcRDMADev, size, port, test.DstIP)
-	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, namespace, clientPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
+	clientCmd := shellWithTimeout(
+		fmt.Sprintf("ib_write_bw -d %s -R -s %d --report_gbits -p %d --bind_source_ip %s %s",
+			shellArg(test.SrcRDMADev), size, port, shellArg(test.SrcIP), shellArg(test.DstIP)),
+		commandTimeoutFor(test, 45*time.Second))
+	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, clientNamespace, clientPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
 	r.Stdout, r.Stderr = cliRes.Stdout, cliRes.Stderr
 
 	bw, msgRate, parseOK := parseIbWriteBwOutput(cliRes.Stdout)
@@ -265,37 +465,223 @@ func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, namespace string
 	r.MsgRateMpps = msgRate
 	switch {
 	case cliErr != nil && !parseOK:
-		r.Err = cliErr
-		r.OK = false
+		finalizeExpectedResult(&r, false, cliErr)
 	case !parseOK:
-		r.Err = fmt.Errorf("ib_write_bw output missing summary row")
-		r.OK = false
+		finalizeExpectedResult(&r, false, fmt.Errorf("ib_write_bw output missing summary row"))
 	default:
-		switch {
-		case bw <= 0:
-			r.OK = false
-		case minBandwidthGbps > 0 && bw < minBandwidthGbps:
-			r.Err = fmt.Errorf("observed bandwidth %.1f Gbps below minimum %.1f Gbps", bw, minBandwidthGbps)
-			r.OK = false
-		default:
-			r.OK = true
-		}
+		observedOK, observedErr := bandwidthVerdict(bw, minBandwidthGbps)
+		finalizeExpectedResult(&r, observedOK, observedErr)
 	}
 	return r
 }
 
+// RunIbWriteBwBatches executes ib_write_bw tests grouped by ordered pod pair.
+// Each test in a group gets a unique TCP listener port so all destination
+// listeners can be started with one server-side exec before the client pod runs
+// the tests sequentially in one client-side exec.
+func RunIbWriteBwBatches(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, size int, minBandwidthGbps float64) []PingResult {
+	if size <= 0 {
+		size = 65536
+	}
+	groups := groupRPingTests(tests)
+	out := make([]PingResult, 0, len(tests))
+	for _, group := range groups {
+		out = append(out, runIbWriteBwBatch(ctx, restConfig, namespaceByPod, containerByPod, group, size, minBandwidthGbps)...)
+	}
+	return out
+}
+
+func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, size int, minBandwidthGbps float64) []PingResult {
+	results := make([]PingResult, len(tests))
+	for i, test := range tests {
+		results[i] = initResult(test)
+		results[i].MinBandwidthGbps = minBandwidthGbps
+		if test.SrcRDMADev == "" || test.DstRDMADev == "" {
+			results[i].Err = fmt.Errorf("ib_write_bw needs RDMA device names; got src=%q dst=%q", test.SrcRDMADev, test.DstRDMADev)
+		}
+	}
+	if len(tests) == 0 {
+		return results
+	}
+	first := tests[0]
+	serverNamespace, serverContainer := namespaceByPod[first.DstPod], containerByPod[first.DstPod]
+	clientNamespace, clientContainer := namespaceByPod[first.SrcPod], containerByPod[first.SrcPod]
+	if serverNamespace == "" || serverContainer == "" || clientNamespace == "" || clientContainer == "" {
+		err := fmt.Errorf("no namespace/container lookup for ib_write_bw pod pair (%s, %s)", first.SrcPod, first.DstPod)
+		for i := range results {
+			results[i].Err = err
+		}
+		return results
+	}
+
+	tctx, cancel := context.WithTimeout(ctx, ibWriteBwBatchTimeoutFor(tests))
+	defer cancel()
+
+	serverCmd := ibWriteBwBatchServerCommand(tests, size)
+	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, serverNamespace, first.DstPod, serverContainer, []string{"/bin/sh", "-c", serverCmd})
+	if err != nil {
+		batchErr := fmt.Errorf("ib_write_bw batch server start: %w (stderr: %s)", err, srvRes.Stderr)
+		for i := range results {
+			results[i].Err = batchErr
+		}
+		return results
+	}
+	defer killRDMAServer(restConfig, serverNamespace, first.DstPod, serverContainer, "ib_write_bw", "")
+
+	select {
+	case <-tctx.Done():
+		batchErr := fmt.Errorf("ib_write_bw batch settle wait: %w", tctx.Err())
+		for i := range results {
+			results[i].Err = batchErr
+		}
+		return results
+	case <-time.After(rdmaBatchSettleDelayFor(tests)):
+	}
+
+	clientCmd := ibWriteBwBatchClientCommand(tests, size)
+	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, clientNamespace, first.SrcPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
+	parsed := parseIbWriteBwBatchResults(cliRes.Stdout)
+	for i := range results {
+		results[i].Stderr = cliRes.Stderr
+		if results[i].Err != nil {
+			continue
+		}
+		cell, ok := parsed[i]
+		if !ok {
+			err := cliErr
+			if err == nil {
+				err = fmt.Errorf("ib_write_bw batch missing result for test %d", i)
+			}
+			finalizeExpectedResult(&results[i], false, err)
+			continue
+		}
+		results[i].Stdout = cell.stdout
+		bw, msgRate, parseOK := parseIbWriteBwOutput(cell.stdout)
+		results[i].BandwidthGbps = bw
+		results[i].MsgRateMpps = msgRate
+		switch {
+		case cell.rc != 0 && !parseOK:
+			finalizeExpectedResult(&results[i], false, fmt.Errorf("ib_write_bw exited with code %d", cell.rc))
+		case !parseOK:
+			finalizeExpectedResult(&results[i], false, fmt.Errorf("ib_write_bw output missing summary row"))
+		default:
+			observedOK, observedErr := bandwidthVerdict(bw, minBandwidthGbps)
+			finalizeExpectedResult(&results[i], observedOK, observedErr)
+		}
+	}
+	return results
+}
+
+func ibWriteBwBatchServerCommand(tests []PingTest, size int) string {
+	var b strings.Builder
+	b.WriteString("pkill ib_write_bw 2>/dev/null || true; rm -f /tmp/l8k-ibwritebw-server-*.log; ")
+	for i, test := range tests {
+		if test.DstRDMADev == "" || test.DstIP == "" {
+			continue
+		}
+		port := ibWriteBwBatchPort(i)
+		fmt.Fprintf(&b,
+			"nohup ib_write_bw -d %s -R -s %d --report_gbits -p %d --bind_source_ip %s >/tmp/l8k-ibwritebw-server-%d.log 2>&1 & ",
+			shellArg(test.DstRDMADev), size, port, shellArg(test.DstIP), i)
+	}
+	b.WriteString("echo ready")
+	return b.String()
+}
+
+func ibWriteBwBatchClientCommand(tests []PingTest, size int) string {
+	var b strings.Builder
+	b.WriteString(`run_with_timeout() { seconds="$1"; shift; if command -v timeout >/dev/null 2>&1; then timeout --kill-after=2s "${seconds}s" "$@"; else "$@" & pid=$!; (sleep "$seconds"; kill -TERM "$pid" 2>/dev/null; sleep 2; kill -KILL "$pid" 2>/dev/null) & watchdog=$!; wait "$pid"; rc=$?; kill "$watchdog" 2>/dev/null; wait "$watchdog" 2>/dev/null; return "$rc"; fi; }; `)
+	for i, test := range tests {
+		timeoutSeconds := int(commandTimeoutFor(test, 45*time.Second).Seconds())
+		if timeoutSeconds <= 0 {
+			timeoutSeconds = 1
+		}
+		outFile := fmt.Sprintf("/tmp/l8k-ibwritebw-client-%d.out", i)
+		errFile := fmt.Sprintf("/tmp/l8k-ibwritebw-client-%d.err", i)
+		fmt.Fprintf(&b,
+			"run_with_timeout %d ib_write_bw -d %s -R -s %d --report_gbits -p %d --bind_source_ip %s %s >%s 2>%s; rc=$?; echo %s %d $rc; cat %s 2>/dev/null; echo %s %d; ",
+			timeoutSeconds, shellArg(test.SrcRDMADev), size, ibWriteBwBatchPort(i), shellArg(test.SrcIP), shellArg(test.DstIP),
+			outFile, errFile, ibWriteBwBatchResultMarker, i, outFile, ibWriteBwBatchEndMarker, i)
+	}
+	b.WriteString("exit 0")
+	return b.String()
+}
+
+type ibWriteBwBatchCell struct {
+	rc     int
+	stdout string
+}
+
+func parseIbWriteBwBatchResults(stdout string) map[int]ibWriteBwBatchCell {
+	out := map[int]ibWriteBwBatchCell{}
+	var current *int
+	var b strings.Builder
+	for _, line := range strings.Split(stdout, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) == 3 && fields[0] == ibWriteBwBatchResultMarker {
+			idx, err1 := strconv.Atoi(fields[1])
+			rc, err2 := strconv.Atoi(fields[2])
+			if err1 == nil && err2 == nil {
+				out[idx] = ibWriteBwBatchCell{rc: rc}
+				current = &idx
+				b.Reset()
+			}
+			continue
+		}
+		if len(fields) == 2 && fields[0] == ibWriteBwBatchEndMarker {
+			idx, err := strconv.Atoi(fields[1])
+			if err == nil {
+				if cell, ok := out[idx]; ok {
+					cell.stdout = strings.TrimSpace(b.String())
+					out[idx] = cell
+				}
+			}
+			current = nil
+			b.Reset()
+			continue
+		}
+		if current != nil {
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	return out
+}
+
+func ibWriteBwBatchPort(index int) int {
+	return 18515 + index
+}
+
+func ibWriteBwBatchTimeoutFor(tests []PingTest) time.Duration {
+	timeout := 20 * time.Second
+	for _, test := range tests {
+		timeout += commandTimeoutFor(test, 45*time.Second) + rdmaBatchSettleDelayFor([]PingTest{test})
+	}
+	return timeout
+}
+
+func bandwidthVerdict(bw, minBandwidthGbps float64) (bool, error) {
+	switch {
+	case bw <= 0:
+		return false, fmt.Errorf("observed bandwidth %.1f Gbps is not positive", bw)
+	case minBandwidthGbps > 0 && bw < minBandwidthGbps:
+		return false, fmt.Errorf("observed bandwidth %.1f Gbps below minimum %.1f Gbps", bw, minBandwidthGbps)
+	default:
+		return true, nil
+	}
+}
+
 // killRDMAServer is best-effort cleanup. We try the captured PID
-// first (precise) and fall back to a wildcard `pkill -f <prog>` for
-// the cases where the PID didn't survive the exec round-trip.
+// first (precise) and fall back to an exact process-name `pkill`.
 // Errors are swallowed because by this point we've already recorded
 // the client's result — leaking a stale server is preferable to
 // failing the test on a cleanup hiccup.
 func killRDMAServer(restConfig *rest.Config, namespace, pod, container, prog, pid string) {
 	// Use a fresh background context so the cleanup runs even if
 	// the test's deadline already fired.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	cmd := fmt.Sprintf("kill %s 2>/dev/null; pkill -f %q 2>/dev/null; true", pid, prog)
+	cmd := fmt.Sprintf("kill %s 2>/dev/null; pkill %s 2>/dev/null; true", pid, shellArg(prog))
 	_, _ = kubeclient.ExecInPod(ctx, restConfig, namespace, pod, container, []string{"/bin/sh", "-c", cmd})
 }
 

--- a/pkg/networkoperatorplugin/connectivity/rdma_test.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma_test.go
@@ -112,6 +112,52 @@ timeout text
 	assert.Contains(t, got[1].stdout, "timeout text")
 }
 
+func TestParseRDMABatchRouteResults(t *testing.T) {
+	tests := []PingTest{
+		{SrcIP: "192.168.0.10", DstIP: "192.168.0.20"},
+		{SrcIP: "192.168.4.10", DstIP: "192.168.0.20"},
+	}
+	stdout := rdmaBatchRouteResultMarker + ` 0 0
+192.168.0.20 from 192.168.0.10 dev net1 src 192.168.0.10
+` + rdmaBatchRouteEndMarker + ` 0
+` + rdmaBatchRouteResultMarker + ` 1 127
+` + routeSkipMarker + `
+` + rdmaBatchRouteEndMarker + ` 1
+`
+	got := parseRDMABatchRouteResults(stdout, tests)
+	require.Len(t, got, 2)
+	assert.True(t, got[0].OK)
+	assert.Equal(t, "net1", got[0].Dev)
+	assert.Equal(t, "ip -o route get 192.168.0.20 from 192.168.0.10", got[0].Command)
+	assert.False(t, got[1].OK)
+	assert.Equal(t, "ip command not found in validation container", got[1].Err)
+}
+
+func TestRDMABatchClientCommandsIncludeSourceRouteGuard(t *testing.T) {
+	test := PingTest{
+		SrcIP:       "192.168.0.10",
+		DstIP:       "192.168.0.20",
+		SrcIface:    "net1",
+		SrcRDMADev:  "mlx5_1",
+		Expectation: ExpectRequired,
+	}
+
+	rpingCmd := rpingBatchClientCommand([]PingTest{test}, 5)
+	assert.Contains(t, rpingCmd, rdmaBatchRouteResultMarker)
+	assert.Contains(t, rpingCmd, "ipcmd")
+	assert.Contains(t, rpingCmd, "route get")
+	assert.Contains(t, rpingCmd, rpingBatchResultMarker+" 0 201")
+	assert.Contains(t, rpingCmd, `if [ "$route_ok" = "1" ]; then run_with_timeout`)
+	assert.NotContains(t, rpingCmd, "continue")
+
+	ibCmd := ibWriteBwBatchClientCommand([]PingTest{test}, 65536)
+	assert.Contains(t, ibCmd, rdmaBatchRouteResultMarker)
+	assert.Contains(t, ibCmd, "route get")
+	assert.Contains(t, ibCmd, ibWriteBwBatchResultMarker+" 0 201")
+	assert.Contains(t, ibCmd, `if [ "$route_ok" = "1" ]; then run_with_timeout`)
+	assert.NotContains(t, ibCmd, "continue")
+}
+
 func TestPingTestKind_Predicates(t *testing.T) {
 	assert.True(t, RDMAPingSameRail.IsRDMAPing())
 	assert.True(t, RDMAPingCrossRail.IsRDMAPing())

--- a/pkg/networkoperatorplugin/connectivity/rdma_test.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma_test.go
@@ -95,6 +95,23 @@ func TestParseIbWriteBwOutput(t *testing.T) {
 	})
 }
 
+func TestParseIbWriteBwBatchResults(t *testing.T) {
+	stdout := ibWriteBwBatchResultMarker + ` 0 0
+banner
+ 65536      5000             194.39             193.21		   0.368459
+` + ibWriteBwBatchEndMarker + ` 0
+` + ibWriteBwBatchResultMarker + ` 1 124
+timeout text
+` + ibWriteBwBatchEndMarker + ` 1
+`
+	got := parseIbWriteBwBatchResults(stdout)
+	require.Len(t, got, 2)
+	assert.Equal(t, 0, got[0].rc)
+	assert.Contains(t, got[0].stdout, "194.39")
+	assert.Equal(t, 124, got[1].rc)
+	assert.Contains(t, got[1].stdout, "timeout text")
+}
+
 func TestPingTestKind_Predicates(t *testing.T) {
 	assert.True(t, RDMAPingSameRail.IsRDMAPing())
 	assert.True(t, RDMAPingCrossRail.IsRDMAPing())

--- a/pkg/networkoperatorplugin/connectivity/report.go
+++ b/pkg/networkoperatorplugin/connectivity/report.go
@@ -330,9 +330,8 @@ func reportFuncMap() template.FuncMap {
 		},
 		// matrixByRail groups same-rail PingResults by (rail, kind
 		// family) so the template can render one sub-table per
-		// (rail, family) bucket. Families are RDMA-ping and
-		// RDMA-bandwidth — see PingTestKind.IsRDMAPing /
-		// IsRDMABw.
+		// (rail, family) bucket. Families are ICMP, RDMA-ping,
+		// and RDMA-bandwidth.
 		"matrixByRail": func(results []PingResult) []railSection {
 			type key struct {
 				rail string
@@ -351,7 +350,7 @@ func reportFuncMap() template.FuncMap {
 				byKey[k] = append(byKey[k], r)
 			}
 			// Sort deterministically: rail name, then a fixed
-			// family order so rping → ib_write_bw appear in
+			// family order so ICMP → rping → ib_write_bw appear in
 			// execution order in the rendered report.
 			sort.Slice(order, func(i, j int) bool {
 				if order[i].rail != order[j].rail {
@@ -403,6 +402,9 @@ func reportFuncMap() template.FuncMap {
 			if fam == "ibbw" {
 				return "RDMA bandwidth (ib_write_bw)"
 			}
+			if fam == "icmp" {
+				return "Layer 3 ping (ICMP)"
+			}
 			return "RDMA ping (rping)"
 		},
 		// cellClass returns the CSS class for a matrix cell based
@@ -412,7 +414,11 @@ func reportFuncMap() template.FuncMap {
 			if r == nil {
 				return "cell-missing"
 			}
-			if r.OK {
+			if r.Expectation == ExpectObserve {
+				return "cell-observe"
+			}
+			ok := r.OK
+			if ok {
 				return "cell-pass"
 			}
 			return "cell-fail"
@@ -423,8 +429,26 @@ func reportFuncMap() template.FuncMap {
 			if r == nil {
 				return "·"
 			}
+			if r.Expectation == ExpectObserve {
+				if observedOK(r) {
+					return "connected"
+				}
+				return "not connected"
+			}
+			if r.Expectation == ExpectForbidden {
+				if r.OK {
+					return "✓ blocked"
+				}
+				if !r.ObservedOK && r.Err != nil {
+					return "✗ ERR"
+				}
+				if !r.ObservedOK {
+					return "✗ unknown"
+				}
+				return "✗ connected"
+			}
 			if fam == "ibbw" {
-				if r.OK && r.BandwidthGbps > 0 {
+				if observedOK(r) && r.BandwidthGbps > 0 {
 					return fmt.Sprintf("✓ %.1f Gbps", r.BandwidthGbps)
 				}
 				if r.BandwidthGbps > 0 && r.MinBandwidthGbps > 0 {
@@ -435,7 +459,7 @@ func reportFuncMap() template.FuncMap {
 				}
 				return "✗ ERR"
 			}
-			if r.OK {
+			if observedOK(r) {
 				return "✓"
 			}
 			return "✗"
@@ -461,7 +485,7 @@ func reportFuncMap() template.FuncMap {
 // railSection feeds the per-(rail, kind family) sub-table in the
 // report. Nodes is the deterministic axis ordering; Table is a flat
 // node→node→*result map (the template indexes by string keys for
-// cells). Family is one of "rping" / "ibbw" — drives the section
+// cells). Family is one of "icmp" / "rping" / "ibbw" — drives the section
 // header and the cell-formatter dispatch.
 type railSection struct {
 	Rail   string
@@ -481,6 +505,9 @@ type crossRailSection struct {
 // the HTML template's funcs (kept as a separate string from
 // text_report.go's kindFamily enum to keep package boundaries clean).
 func htmlFamilyOf(k PingTestKind) string {
+	if k.IsICMP() {
+		return "icmp"
+	}
 	if k.IsRDMABw() {
 		return "ibbw"
 	}
@@ -488,12 +515,16 @@ func htmlFamilyOf(k PingTestKind) string {
 }
 
 // htmlFamilyRank gives a stable ordering of families in the rendered
-// report — rping (QP establishment) before ib_write_bw (bandwidth).
+// report — ICMP before rping (QP establishment) before ib_write_bw (bandwidth).
 func htmlFamilyRank(fam string) int {
-	if fam == "ibbw" {
+	switch fam {
+	case "icmp":
+		return 0
+	case "ibbw":
+		return 2
+	default:
 		return 1
 	}
-	return 0
 }
 
 // buildRailTable indexes a slice of same-rail PingResults by source

--- a/pkg/networkoperatorplugin/connectivity/report.html.tmpl
+++ b/pkg/networkoperatorplugin/connectivity/report.html.tmpl
@@ -343,6 +343,7 @@ details table th, details table td { padding: 6px 10px; }
 .matrix-table tr:hover td { background: transparent; }
 .cell-pass    { background: var(--success-bg); color: var(--success); }
 .cell-fail    { background: var(--error-bg);   color: var(--error); font-weight: 600; }
+.cell-observe { background: var(--bg-soft);    color: var(--text-muted); font-weight: 500; }
 .cell-missing { background: var(--bg-soft);    color: var(--text-faint); }
 .cell-self    { color: var(--text-faint); }
 
@@ -924,15 +925,17 @@ footer strong { color: var(--text-muted); }
         <div class="matrix-rail">Cross-rail canary — {{familyTitle $fam}}</div>
         <table class="matrix-table">
           <thead>
-            <tr><th>Source</th><th>Src rail</th><th>Destination</th><th>Dst rail</th><th>Result</th></tr>
+            <tr><th>Source</th><th>Src rail</th><th>Src iface</th><th>Destination</th><th>Dst rail</th><th>Dst iface</th><th>Result</th></tr>
           </thead>
           <tbody>
             {{- range .Results}}
             <tr>
               <td>{{srcLabel .Test}}</td>
               <td><code>{{.Test.SrcRail}}</code></td>
+              <td><code>{{.Test.SrcIface}}</code></td>
               <td>{{dstLabel .Test}}</td>
               <td><code>{{.Test.DstRail}}</code></td>
+              <td><code>{{.Test.DstIface}}</code></td>
               <td class="{{cellClass .}}">{{cellText . $fam}}</td>
             </tr>
             {{- end}}

--- a/pkg/networkoperatorplugin/connectivity/report_test.go
+++ b/pkg/networkoperatorplugin/connectivity/report_test.go
@@ -40,14 +40,14 @@ var updateGolden = flag.Bool("update-golden", false, "rewrite testdata/k8s-launc
 // fixtureData is the deterministic input the renderer is exercised
 // against. Includes one of every state badge, an IN-PROGRESS row with
 // expandable Details, a passing rail and a failing rail in the matrix,
-// and one cross-rail canary, so the golden covers the whole template
+// and one cross-rail result, so the golden covers the whole template
 // surface.
 func fixtureData() ReportData {
 	return ReportData{
 		Verdict: OverallVerdict{
 			Pass: false,
 			Reasons: []string{
-				"1 RDMA test(s) failed in the connectivity matrix",
+				"1 connectivity test(s) failed in the connectivity matrix",
 				`The detected platform topology does not match the certified topology for ACME-vendor-a-h200 server type (see Node groups section for the per-device diff)`,
 			},
 		},
@@ -206,12 +206,14 @@ func fixtureData() ReportData {
 						Rail: "rail-1", SrcRail: "rail-1", DstRail: "rail-1"},
 					OK: false,
 				},
-				// rping: cross-rail canary
+				// rping: cross-rail observation
 				{
 					Test: PingTest{Kind: RDMAPingCrossRail,
 						SrcNode: "node-a", DstNode: "node-b",
-						Rail: "rail-0→rail-1", SrcRail: "rail-0", DstRail: "rail-1"},
-					OK: true,
+						Rail: "rail-0→rail-1", SrcRail: "rail-0", DstRail: "rail-1",
+						SrcIface: "net1", DstIface: "net2",
+						Expectation: ExpectObserve},
+					OK: true, ObservedOK: true, Expectation: ExpectObserve,
 				},
 				// ib_write_bw: same-rail rail-0 both directions pass with bandwidth
 				{
@@ -226,12 +228,14 @@ func fixtureData() ReportData {
 						Rail: "rail-0", SrcRail: "rail-0", DstRail: "rail-0"},
 					OK: true, BandwidthGbps: 193.8,
 				},
-				// ib_write_bw: cross-rail canary passes with bandwidth
+				// ib_write_bw: cross-rail observation passes with bandwidth
 				{
 					Test: PingTest{Kind: RDMABwCrossRail,
 						SrcNode: "node-a", DstNode: "node-b",
-						Rail: "rail-0→rail-1", SrcRail: "rail-0", DstRail: "rail-1"},
-					OK: true, BandwidthGbps: 187.6,
+						Rail: "rail-0→rail-1", SrcRail: "rail-0", DstRail: "rail-1",
+						SrcIface: "net1", DstIface: "net2",
+						Expectation: ExpectObserve},
+					OK: true, ObservedOK: true, Expectation: ExpectObserve, BandwidthGbps: 187.6,
 				},
 			},
 			Summary: MatrixSummary{TotalTests: 8, Passed: 7, Failed: 1},

--- a/pkg/networkoperatorplugin/connectivity/result.go
+++ b/pkg/networkoperatorplugin/connectivity/result.go
@@ -16,6 +16,14 @@
 
 package connectivity
 
+type RouteCheck struct {
+	Command string
+	Output  string
+	Dev     string
+	OK      bool
+	Err     string
+}
+
 // PingResult carries the outcome of one src→dst matrix test. The
 // matrix currently runs rping and ib_write_bw — fields specific to a
 // kind stay zero for tests of the other kind:
@@ -26,11 +34,14 @@ package connectivity
 //     records the configured passing threshold when set.
 //
 // The struct name is kept for backwards compatibility with the
-// historical ICMP-first pipeline; the matrix is RDMA-only now but
-// callers and the JSON schema continue to reference PingResult.
+// historical ICMP-first pipeline; callers and the JSON schema continue
+// to reference PingResult.
 type PingResult struct {
 	Test             PingTest
 	OK               bool
+	ObservedOK       bool
+	Expectation      Expectation
+	Route            RouteCheck
 	BandwidthGbps    float64 // ib_write_bw only; 0 when n/a
 	MsgRateMpps      float64 // ib_write_bw only; 0 when n/a
 	MinBandwidthGbps float64 // ib_write_bw only; 0 when no threshold was applied

--- a/pkg/networkoperatorplugin/connectivity/source.go
+++ b/pkg/networkoperatorplugin/connectivity/source.go
@@ -1,0 +1,137 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connectivity
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/kubeclient"
+	"k8s.io/client-go/rest"
+)
+
+var routeDevRe = regexp.MustCompile(`(?:^|\s)dev\s+(\S+)`)
+
+const routeSkipMarker = "__L8K_ROUTE_SKIP__"
+
+func initResult(test PingTest) PingResult {
+	exp := test.Expectation
+	if exp == "" {
+		exp = ExpectRequired
+	}
+	return PingResult{Test: test, Expectation: exp}
+}
+
+func shellArg(s string) string {
+	return strconv.Quote(s)
+}
+
+func shellWithTimeout(command string, timeout time.Duration) string {
+	seconds := int(timeout.Seconds())
+	if seconds <= 0 {
+		seconds = 1
+	}
+	return fmt.Sprintf(
+		`%s & pid=$!; (`+
+			`sleep %d; `+
+			`kill -TERM "$pid" 2>/dev/null; `+
+			`sleep 2; `+
+			`kill -KILL "$pid" 2>/dev/null`+
+			`) & watchdog=$!; `+
+			`wait "$pid"; rc=$?; `+
+			`kill "$watchdog" 2>/dev/null; `+
+			`wait "$watchdog" 2>/dev/null; `+
+			`exit "$rc"`,
+		command, seconds)
+}
+
+func commandTimeoutFor(test PingTest, defaultTimeout time.Duration) time.Duration {
+	if test.Expectation == ExpectForbidden || test.Expectation == ExpectObserve {
+		return 5 * time.Second
+	}
+	return defaultTimeout
+}
+
+func rdmaSettleDelayFor(test PingTest) time.Duration {
+	if test.Expectation == ExpectForbidden {
+		return 1 * time.Second
+	}
+	return rdmaServerSettleDelay
+}
+
+func checkRoute(ctx context.Context, restConfig *rest.Config, namespace, pod, container string, test PingTest) RouteCheck {
+	cmd := fmt.Sprintf(
+		`ipcmd=""; for p in ip /sbin/ip /usr/sbin/ip /bin/ip /usr/bin/ip; do `+
+			`if command -v "$p" >/dev/null 2>&1 || [ -x "$p" ]; then ipcmd="$p"; break; fi; `+
+			`done; `+
+			`if [ -z "$ipcmd" ]; then echo %s; exit 0; fi; `+
+			`"$ipcmd" -o route get %s from %s`,
+		shellArg(routeSkipMarker), shellArg(test.DstIP), shellArg(test.SrcIP))
+	out := RouteCheck{Command: cmd}
+	if test.SrcIP == "" || test.DstIP == "" {
+		out.Err = "missing source or destination IP"
+		return out
+	}
+	tctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	res, err := kubeclient.ExecInPod(tctx, restConfig, namespace, pod, container, []string{"/bin/sh", "-c", cmd})
+	out.Output = strings.TrimSpace(strings.Join([]string{res.Stdout, res.Stderr}, "\n"))
+	if err != nil {
+		out.Err = err.Error()
+		return out
+	}
+	if strings.Contains(out.Output, routeSkipMarker) {
+		out.Err = "ip command not found in validation container"
+		return out
+	}
+	if m := routeDevRe.FindStringSubmatch(out.Output); len(m) == 2 {
+		out.Dev = m[1]
+	}
+	out.OK = out.Dev != ""
+	return out
+}
+
+func routeMatchesSourceInterface(route RouteCheck, test PingTest) bool {
+	return route.OK && route.Dev == test.SrcIface
+}
+
+func routeMismatch(route RouteCheck, test PingTest) bool {
+	return route.OK && !routeMatchesSourceInterface(route, test)
+}
+
+func finalizeExpectedResult(r *PingResult, observedOK bool, observedErr error) {
+	r.ObservedOK = observedOK
+	switch r.Expectation {
+	case ExpectObserve:
+		r.OK = true
+		r.Err = observedErr
+	case ExpectForbidden:
+		r.OK = !observedOK
+		if observedOK {
+			r.Err = fmt.Errorf("cross-rail traffic succeeded but profile routing expects isolation")
+		} else {
+			r.Err = nil
+		}
+	default:
+		r.OK = observedOK
+		r.Err = observedErr
+	}
+}

--- a/pkg/networkoperatorplugin/connectivity/source.go
+++ b/pkg/networkoperatorplugin/connectivity/source.go
@@ -114,7 +114,7 @@ func routeMatchesSourceInterface(route RouteCheck, test PingTest) bool {
 }
 
 func routeMismatch(route RouteCheck, test PingTest) bool {
-	return route.OK && !routeMatchesSourceInterface(route, test)
+	return !routeMatchesSourceInterface(route, test)
 }
 
 func finalizeExpectedResult(r *PingResult, observedOK bool, observedErr error) {

--- a/pkg/networkoperatorplugin/connectivity/testdata/k8s-launch-kit-validation-report.golden.html
+++ b/pkg/networkoperatorplugin/connectivity/testdata/k8s-launch-kit-validation-report.golden.html
@@ -316,6 +316,7 @@ details table th, details table td { padding: 6px 10px; }
 .matrix-table tr:hover td { background: transparent; }
 .cell-pass    { background: var(--success-bg); color: var(--success); }
 .cell-fail    { background: var(--error-bg);   color: var(--error); font-weight: 600; }
+.cell-observe { background: var(--bg-soft);    color: var(--text-muted); font-weight: 500; }
 .cell-missing { background: var(--bg-soft);    color: var(--text-faint); }
 .cell-self    { color: var(--text-faint); }
 
@@ -463,7 +464,7 @@ footer strong { color: var(--text-muted); }
     ✗ VALIDATION FAILED
   </div>
   <ul class="verdict-list verdict-reasons">
-    <li>1 RDMA test(s) failed in the connectivity matrix</li>
+    <li>1 connectivity test(s) failed in the connectivity matrix</li>
     <li>The detected platform topology does not match the certified topology for ACME-vendor-a-h200 server type (see Node groups section for the per-device diff)</li>
   </ul>
 </div>
@@ -831,30 +832,34 @@ status:
         <div class="matrix-rail">Cross-rail canary — RDMA ping (rping)</div>
         <table class="matrix-table">
           <thead>
-            <tr><th>Source</th><th>Src rail</th><th>Destination</th><th>Dst rail</th><th>Result</th></tr>
+            <tr><th>Source</th><th>Src rail</th><th>Src iface</th><th>Destination</th><th>Dst rail</th><th>Dst iface</th><th>Result</th></tr>
           </thead>
           <tbody>
             <tr>
               <td>node-a</td>
               <td><code>rail-0</code></td>
+              <td><code>net1</code></td>
               <td>node-b</td>
               <td><code>rail-1</code></td>
-              <td class="cell-pass">✓</td>
+              <td><code>net2</code></td>
+              <td class="cell-observe">connected</td>
             </tr>
           </tbody>
         </table>
         <div class="matrix-rail">Cross-rail canary — RDMA bandwidth (ib_write_bw)</div>
         <table class="matrix-table">
           <thead>
-            <tr><th>Source</th><th>Src rail</th><th>Destination</th><th>Dst rail</th><th>Result</th></tr>
+            <tr><th>Source</th><th>Src rail</th><th>Src iface</th><th>Destination</th><th>Dst rail</th><th>Dst iface</th><th>Result</th></tr>
           </thead>
           <tbody>
             <tr>
               <td>node-a</td>
               <td><code>rail-0</code></td>
+              <td><code>net1</code></td>
               <td>node-b</td>
               <td><code>rail-1</code></td>
-              <td class="cell-pass">✓ 187.6 Gbps</td>
+              <td><code>net2</code></td>
+              <td class="cell-observe">connected</td>
             </tr>
           </tbody>
         </table>

--- a/pkg/networkoperatorplugin/connectivity/text_report.go
+++ b/pkg/networkoperatorplugin/connectivity/text_report.go
@@ -52,11 +52,11 @@ func RenderMatrixText(uiOutput ui.Output, result *MatrixResult) {
 	tty := uiOutput.IsTTY()
 	// Group per (rail, kind family). One grid is rendered for
 	// every (rail, family) bucket that has at least one result, in
-	// the test-execution order so the reader sees rping
+	// the test-execution order so the reader sees ICMP, then rping
 	// (QP-establishment canary) before ib_write_bw (bandwidth).
 	byRail, byCross, nodes, rails := groupResultsByKind(result.PingResults)
 
-	families := []kindFamily{familyRPing, familyIbBw}
+	families := []kindFamily{familyICMP, familyRPing, familyIbBw}
 	for _, rail := range rails {
 		for _, fam := range families {
 			grid, ok := byRail[rail][fam]
@@ -91,11 +91,15 @@ func RenderMatrixText(uiOutput ui.Output, result *MatrixResult) {
 type kindFamily int
 
 const (
-	familyRPing kindFamily = iota
+	familyICMP kindFamily = iota
+	familyRPing
 	familyIbBw
 )
 
 func kindFamilyOf(k PingTestKind) kindFamily {
+	if k.IsICMP() {
+		return familyICMP
+	}
 	if k.IsRDMABw() {
 		return familyIbBw
 	}
@@ -105,6 +109,9 @@ func kindFamilyOf(k PingTestKind) kindFamily {
 func familyTitle(f kindFamily) string {
 	if f == familyIbBw {
 		return "RDMA bandwidth (ib_write_bw)"
+	}
+	if f == familyICMP {
+		return "Layer 3 ping (ICMP)"
 	}
 	return "RDMA ping (rping)"
 }
@@ -253,12 +260,16 @@ func cellFor(src, dst string, r *PingResult, fam kindFamily, tty bool) string {
 // + optional ANSI color when TTY. The body shape depends on the
 // kind family:
 //
-//   - rping:       ✓ / ✗
+//   - ICMP/rping:  ✓ / ✗
 //   - ib_write_bw: ✓ 194.4 Gbps / ✗ ERR
 func cellDetail(r *PingResult, fam kindFamily, tty bool) string {
 	body := cellBody(r, fam)
+	if r.Expectation == ExpectObserve {
+		return body
+	}
+	ok := r.OK
 	if tty {
-		if r.OK {
+		if ok {
 			return "\033[32m" + body + "\033[0m"
 		}
 		return "\033[31m" + body + "\033[0m"
@@ -267,8 +278,26 @@ func cellDetail(r *PingResult, fam kindFamily, tty bool) string {
 }
 
 func cellBody(r *PingResult, fam kindFamily) string {
+	if r.Expectation == ExpectObserve {
+		if observedOK(r) {
+			return "connected"
+		}
+		return "not connected"
+	}
+	if r.Expectation == ExpectForbidden {
+		if r.OK {
+			return "✓ blocked"
+		}
+		if !r.ObservedOK && r.Err != nil {
+			return "✗ ERR"
+		}
+		if !r.ObservedOK {
+			return "✗ unknown"
+		}
+		return "✗ connected"
+	}
 	if fam == familyIbBw {
-		if r.OK && r.BandwidthGbps > 0 {
+		if observedOK(r) && r.BandwidthGbps > 0 {
 			return fmt.Sprintf("✓ %.1f Gbps", r.BandwidthGbps)
 		}
 		if r.BandwidthGbps > 0 && r.MinBandwidthGbps > 0 {
@@ -279,11 +308,17 @@ func cellBody(r *PingResult, fam kindFamily) string {
 		}
 		return "✗ ERR"
 	}
-	// rping
-	if r.OK {
+	if observedOK(r) {
 		return "✓"
 	}
 	return "✗"
+}
+
+func observedOK(r *PingResult) bool {
+	if r.ObservedOK {
+		return true
+	}
+	return r.Expectation == "" && r.OK
 }
 
 // shortPodName trims a long pod name to keep grid columns from blowing

--- a/pkg/networkoperatorplugin/connectivity/text_report_test.go
+++ b/pkg/networkoperatorplugin/connectivity/text_report_test.go
@@ -111,6 +111,33 @@ func crossRpingResult(src, dst, srcRail, dstRail string, ok bool) PingResult {
 	}
 }
 
+func TestCellBodyExpectationLabels(t *testing.T) {
+	assert.Equal(t, "connected", cellBody(&PingResult{
+		Expectation: ExpectObserve,
+		ObservedOK:  true,
+	}, familyRPing))
+	assert.Equal(t, "not connected", cellBody(&PingResult{
+		Expectation: ExpectObserve,
+		ObservedOK:  false,
+	}, familyRPing))
+	assert.Equal(t, "✓ blocked", cellBody(&PingResult{
+		Expectation: ExpectForbidden,
+		OK:          true,
+		ObservedOK:  false,
+	}, familyRPing))
+	assert.Equal(t, "✗ connected", cellBody(&PingResult{
+		Expectation: ExpectForbidden,
+		OK:          false,
+		ObservedOK:  true,
+	}, familyRPing))
+	assert.Equal(t, "✗ ERR", cellBody(&PingResult{
+		Expectation: ExpectForbidden,
+		OK:          false,
+		ObservedOK:  false,
+		Err:         fmt.Errorf("api exec failed"),
+	}, familyRPing))
+}
+
 func TestRenderMatrixText_RailGridAndCrossRail(t *testing.T) {
 	result := &MatrixResult{
 		PingResults: []PingResult{

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -324,6 +324,38 @@ profile:
     numberOfPlanes: 4
 
 # ============================================================================
+# Validation Configuration
+# Controls l8k validate data-plane checks.
+# ============================================================================
+validation:
+  # bool | default: true
+  # Run the example DaemonSet connectivity matrix.
+  connectivity: true
+
+  # string | default: strict
+  # quick: same-rail all nodes + one non-gating cross-rail canary per rail pair.
+  # full: every source rail x every destination rail x every ordered pod pair;
+  #       cross-rail is non-gating.
+  # strict: full matrix; cross-rail gates according to profile.routing.
+  mode: strict
+
+  # list[string] | default: [icmp, rping, ib_write_bw]
+  # Supported checks. Use [] to disable all connectivity checks.
+  checks:
+    - icmp
+    - rping
+    - ib_write_bw
+
+  rdma:
+    # int | default: 5
+    rpingIterations: 5
+    # int | default: 65536
+    ibWriteSize: 65536
+    # float | default: 100
+    # 0 disables bandwidth threshold gating.
+    ibWriteMinBandwidthGbps: 100
+
+# ============================================================================
 # Cluster Configuration
 # Array of hardware groups. Typically populated by --discover-cluster-config.
 # ============================================================================

--- a/skills/k8s-launch-kit-validate/SKILL.md
+++ b/skills/k8s-launch-kit-validate/SKILL.md
@@ -27,10 +27,13 @@ Operator release.
    `--deployment-files` (skipping any file with "example" in its name)
    is fetched from the cluster via `client.Get`. Each manifest is
    reported `FOUND`, `MISSING`, or `ERROR`.
+3. **Connectivity matrix.** By default, `l8k validate` applies the generated
+   example DaemonSet, waits for ready pods, and runs source-bound `icmp`,
+   `rping`, and `ib_write_bw` tests. The default mode is `strict`.
 
-Exit code is non-zero (4) on any missing manifest or version mismatch.
-Both checks soft-skip when prerequisites are absent — no
-`cluster-config.yaml`, no Helm release Secret, etc.
+Exit code is non-zero (4) on any missing manifest, version mismatch, or
+gating connectivity failure. Version checks soft-skip when prerequisites are
+absent — no `cluster-config.yaml`, no Helm release Secret, etc.
 
 ## Usage
 
@@ -45,6 +48,23 @@ l8k validate [--user-config <PATH>] [--deployment-files <DIR>] [--kubeconfig <PA
 | `--kubeconfig` | `$KUBECONFIG` | Path to kubeconfig with read access to the cluster |
 | `--user-config` | `./cluster-config.yaml` | Cluster config YAML; used for `networkOperator.selectedRelease` and the operator namespace |
 | `--deployment-files` | `./deployment` | Directory containing the manifests to verify |
+| `--validation-mode` | `validation.mode` (`strict`) | Connectivity mode: `quick`, `full`, or `strict` |
+| `--validation-checks` | `validation.checks` (`icmp,rping,ib_write_bw`) | Comma-separated connectivity checks; `""` disables all |
+| `--rdma-rping-iterations` | `validation.rdma.rpingIterations` | rping client iteration count |
+| `--rdma-ib-write-size` | `validation.rdma.ibWriteSize` | ib_write_bw message size |
+| `--rdma-ib-write-min-bandwidth-gbps` | `validation.rdma.ibWriteMinBandwidthGbps` | Minimum peak Gbps; `0` disables bandwidth gating |
+
+## Connectivity Modes
+
+- `quick`: all same-rail node pairs plus one non-gating cross-rail canary per
+  source-rail/destination-rail mapping.
+- `full`: every source rail × every destination rail × every ordered pod pair;
+  cross-rail results are reported but do not gate pass/fail.
+- `strict`: full matrix. Cross-rail gates by `profile.routing`: `source-based`
+  must succeed, `destination-based` must stay isolated.
+
+All checks are source-bound. ICMP uses `ping -I <src-iface>`, `rping` uses
+`-I <src-ip>`, and `ib_write_bw` uses `--bind_source_ip <src-ip>`.
 
 ## Examples
 
@@ -58,7 +78,7 @@ l8k validate --user-config ./cluster-config.yaml \
   --kubeconfig ~/.kube/config
 
 # Agent mode (single JSON object on stdout, logs on stderr)
-l8k validate --output json --yes 2>/dev/null | jq '.summary'
+l8k validate --output json 2>/dev/null | jq '.summary'
 ```
 
 ## Output


### PR DESCRIPTION
## Summary

- adds validation config/mode/check plumbing for `strict`, `full`, and `quick`
- adds ICMP validation using a netshoot sidecar while keeping rping/ib_write_bw in the DOCA container
- source-binds ICMP/RDMA checks, batches rping and ib_write_bw by ordered pod pair, and keeps cross-rail expectations tied to routing mode
- updates validation reports/docs for ICMP, observed canaries, RDMA thresholds, and configurable checks

## Verification

- `GOCACHE=/private/tmp/l8k-validation-modes-go-cache go test ./... -count=1`
- `GOCACHE=/private/tmp/l8k-validation-modes-go-cache make build`
- live cluster: `l8k validate --validation-mode strict --validation-checks icmp --connectivity-timeout 4m --keep` against `/Users/amaslennikov/workspace/k8s-launch-kit/rtx-cluster/kubeconfig`: `32/32` ICMP checks passed on source-based routing
- live cluster triage: same-rail rping and ib_write_bw pass; cross-rail RDMA still times out even after cross-rail ICMP routing is confirmed, so that appears to be cluster/RDMA behavior rather than the ICMP validation path
