### PR TITLE
fix: keep RDMA validation running without route tooling

### DIFF
--- a/pkg/networkoperatorplugin/connectivity/rdma.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma.go
@@ -352,17 +352,14 @@ func groupRPingTests(tests []PingTest) [][]PingTest {
 }
 
 func rpingBatchServerCommand(tests []PingTest) string {
-	seen := map[string]bool{}
 	var b strings.Builder
 	b.WriteString("pkill rping 2>/dev/null || true; rm -f /tmp/l8k-rping-server-*.log; ")
-	idx := 0
-	for _, test := range tests {
-		if test.DstIP == "" || seen[test.DstIP] {
+	for i, test := range tests {
+		if test.DstIP == "" {
 			continue
 		}
-		seen[test.DstIP] = true
-		fmt.Fprintf(&b, "nohup rping -s -a %s -p 9999 -v >/tmp/l8k-rping-server-%d.log 2>&1 & ", shellArg(test.DstIP), idx)
-		idx++
+		fmt.Fprintf(&b, "nohup rping -s -a %s -p %d -v >/tmp/l8k-rping-server-%d.log 2>&1 & ",
+			shellArg(test.DstIP), rpingBatchPort(i), i)
 	}
 	b.WriteString("echo ready")
 	return b.String()
@@ -380,12 +377,16 @@ func rpingBatchClientCommand(tests []PingTest, iterations int) string {
 			fmt.Sprintf("echo %s %d %d", rpingBatchResultMarker, i, rdmaBatchRouteFailCode))
 		fmt.Fprintf(&b,
 			`if [ "$route_ok" = "1" ]; then `+
-				"run_with_timeout %d rping -c -I %s -a %s -p 9999 -C %d -v >/tmp/l8k-rping-client-%d.out 2>/tmp/l8k-rping-client-%d.err; rc=$?; echo %s %d $rc; "+
+				"run_with_timeout %d rping -c -I %s -a %s -p %d -C %d -v >/tmp/l8k-rping-client-%d.out 2>/tmp/l8k-rping-client-%d.err; rc=$?; echo %s %d $rc; "+
 				`fi; `,
-			timeoutSeconds, shellArg(test.SrcIP), shellArg(test.DstIP), iterations, i, i, rpingBatchResultMarker, i)
+			timeoutSeconds, shellArg(test.SrcIP), shellArg(test.DstIP), rpingBatchPort(i), iterations, i, i, rpingBatchResultMarker, i)
 	}
 	b.WriteString("exit 0")
 	return b.String()
+}
+
+func rpingBatchPort(index int) int {
+	return 9999 + index
 }
 
 func parseRPingBatchResults(stdout string) map[int]int {
@@ -415,11 +416,11 @@ func appendRDMABatchRouteGuard(b *strings.Builder, index int, test PingTest, fai
 		`route_file=%s; ipcmd=""; for p in ip /sbin/ip /usr/sbin/ip /bin/ip /usr/bin/ip; do `+
 			`if command -v "$p" >/dev/null 2>&1 || [ -x "$p" ]; then ipcmd="$p"; break; fi; `+
 			`done; `+
-			`if [ -z "$ipcmd" ]; then echo %s >"$route_file"; route_rc=127; `+
+			`route_missing=0; if [ -z "$ipcmd" ]; then echo %s >"$route_file"; route_rc=0; route_missing=1; `+
 			`else "$ipcmd" -o route get %s from %s >"$route_file" 2>&1; route_rc=$?; fi; `+
 			`route_dev=$(sed -n 's/.* dev \([^ ]*\).*/\1/p' "$route_file" | head -n1); `+
 			`echo %s %d $route_rc; cat "$route_file" 2>/dev/null; echo %s %d; `+
-			`if [ "$route_rc" != "0" ] || [ "$route_dev" != %s ]; then route_ok=0; %s; fi; `,
+			`if [ "$route_missing" != "1" ] && { [ "$route_rc" != "0" ] || [ "$route_dev" != %s ]; }; then route_ok=0; %s; fi; `,
 		shellArg(routeFile), shellArg(routeSkipMarker), shellArg(test.DstIP), shellArg(test.SrcIP),
 		rdmaBatchRouteResultMarker, index, rdmaBatchRouteEndMarker, index, shellArg(test.SrcIface), failCommand)
 }
@@ -456,7 +457,7 @@ func parseRDMABatchRouteResults(stdout string, tests []PingTest) map[int]RouteCh
 					route.Command = fmt.Sprintf("ip -o route get %s from %s", tests[idx].DstIP, tests[idx].SrcIP)
 				}
 				if strings.Contains(output, routeSkipMarker) {
-					route.Err = "ip command not found in validation container"
+					route.Err = routeSkipErr
 					route.OK = false
 				}
 				if m := routeDevRe.FindStringSubmatch(output); len(m) == 2 {

--- a/pkg/networkoperatorplugin/connectivity/rdma_test.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma_test.go
@@ -17,6 +17,7 @@
 package connectivity
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -131,6 +132,7 @@ func TestParseRDMABatchRouteResults(t *testing.T) {
 	assert.Equal(t, "ip -o route get 192.168.0.20 from 192.168.0.10", got[0].Command)
 	assert.False(t, got[1].OK)
 	assert.Equal(t, "ip command not found in validation container", got[1].Err)
+	assert.False(t, routeMismatch(got[1], PingTest{SrcIface: "net2"}))
 }
 
 func TestRDMABatchClientCommandsIncludeSourceRouteGuard(t *testing.T) {
@@ -148,6 +150,7 @@ func TestRDMABatchClientCommandsIncludeSourceRouteGuard(t *testing.T) {
 	assert.Contains(t, rpingCmd, "route get")
 	assert.Contains(t, rpingCmd, rpingBatchResultMarker+" 0 201")
 	assert.Contains(t, rpingCmd, `if [ "$route_ok" = "1" ]; then run_with_timeout`)
+	assert.Contains(t, rpingCmd, `-p 9999`)
 	assert.NotContains(t, rpingCmd, "continue")
 
 	ibCmd := ibWriteBwBatchClientCommand([]PingTest{test}, 65536)
@@ -156,6 +159,23 @@ func TestRDMABatchClientCommandsIncludeSourceRouteGuard(t *testing.T) {
 	assert.Contains(t, ibCmd, ibWriteBwBatchResultMarker+" 0 201")
 	assert.Contains(t, ibCmd, `if [ "$route_ok" = "1" ]; then run_with_timeout`)
 	assert.NotContains(t, ibCmd, "continue")
+}
+
+func TestRPingBatchServerCommandRunsOneListenerPerTest(t *testing.T) {
+	tests := []PingTest{
+		{DstIP: "192.168.0.20"},
+		{DstIP: "192.168.0.20"},
+		{DstIP: "192.168.4.20"},
+	}
+
+	cmd := rpingBatchServerCommand(tests)
+
+	assert.Contains(t, cmd, "pkill rping")
+	assert.Contains(t, cmd, "rping -s -a \"192.168.0.20\" -p 9999")
+	assert.Contains(t, cmd, "rping -s -a \"192.168.0.20\" -p 10000")
+	assert.Contains(t, cmd, "rping -s -a \"192.168.4.20\" -p 10001")
+	assert.Equal(t, 3, strings.Count(cmd, "rping -s -a "))
+	assert.Equal(t, 3, strings.Count(cmd, "nohup rping"))
 }
 
 func TestPingTestKind_Predicates(t *testing.T) {

--- a/pkg/networkoperatorplugin/connectivity/source.go
+++ b/pkg/networkoperatorplugin/connectivity/source.go
@@ -31,6 +31,7 @@ import (
 var routeDevRe = regexp.MustCompile(`(?:^|\s)dev\s+(\S+)`)
 
 const routeSkipMarker = "__L8K_ROUTE_SKIP__"
+const routeSkipErr = "ip command not found in validation container"
 
 func initResult(test PingTest) PingResult {
 	exp := test.Expectation
@@ -99,7 +100,7 @@ func checkRoute(ctx context.Context, restConfig *rest.Config, namespace, pod, co
 		return out
 	}
 	if strings.Contains(out.Output, routeSkipMarker) {
-		out.Err = "ip command not found in validation container"
+		out.Err = routeSkipErr
 		return out
 	}
 	if m := routeDevRe.FindStringSubmatch(out.Output); len(m) == 2 {
@@ -114,6 +115,9 @@ func routeMatchesSourceInterface(route RouteCheck, test PingTest) bool {
 }
 
 func routeMismatch(route RouteCheck, test PingTest) bool {
+	if route.Err == routeSkipErr {
+		return false
+	}
 	return !routeMatchesSourceInterface(route, test)
 }
 


### PR DESCRIPTION
## Summary
- allow RDMA validation to continue when the validation image lacks `ip`; source-bound `rping` and `ib_write_bw` still run and route metadata records the unavailable check
- run one `rping` server listener per test in batched validation so same-rail attempts do not consume listeners needed by cross-rail attempts
- add focused tests for route-check fallback and rping batch server lifecycle

## Notes
- `ib_write_bw` already starts one server per test on a unique port, so it did not need the rping listener lifecycle change. The shared route-guard fallback applies to `ib_write_bw` as well.

## Validation
- `GOCACHE=/private/tmp/k8s-launch-kit-gocache go build ./...`
- `GOCACHE=/private/tmp/k8s-launch-kit-gocache go test ./...`
- live RTX cluster strict rping validation: 32/32 passed after the fix (`validation-strict-source-128-rping-sequential.html`)
