### PR TITLE
fix: bound ICMP validation execs

### DIFF
--- a/pkg/networkoperatorplugin/connectivity/daemonset.go
+++ b/pkg/networkoperatorplugin/connectivity/daemonset.go
@@ -38,6 +38,7 @@ const (
 	rdmaTestContainerName = "test-container"
 	icmpTestContainerName = "netshoot"
 	icmpTestImage         = "nicolaka/netshoot:latest"
+	icmpTestCommand       = `trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done`
 )
 
 // DaemonSetRef identifies an applied test DaemonSet so the orchestrator
@@ -302,7 +303,7 @@ func ensureICMPContainer(ds *unstructured.Unstructured) {
 	containers = append(containers, map[string]interface{}{
 		"name":    icmpTestContainerName,
 		"image":   icmpTestImage,
-		"command": []interface{}{"/bin/sh", "-c", "sleep infinity"},
+		"command": []interface{}{"/bin/bash", "-c", icmpTestCommand},
 		"securityContext": map[string]interface{}{
 			"capabilities": map[string]interface{}{
 				"add": []interface{}{"NET_RAW"},

--- a/pkg/networkoperatorplugin/connectivity/daemonset_test.go
+++ b/pkg/networkoperatorplugin/connectivity/daemonset_test.go
@@ -74,6 +74,9 @@ func TestLoadExampleDaemonSetsUsesManifestNamespace(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Len(t, containers, 2)
+	sidecar, ok := containers[1].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, []interface{}{"/bin/bash", "-c", icmpTestCommand}, sidecar["command"])
 }
 
 func TestLoadExampleDaemonSetsSkipsICMPSidecarWhenDisabled(t *testing.T) {

--- a/pkg/networkoperatorplugin/connectivity/source.go
+++ b/pkg/networkoperatorplugin/connectivity/source.go
@@ -50,7 +50,10 @@ func shellWithTimeout(command string, timeout time.Duration) string {
 		seconds = 1
 	}
 	return fmt.Sprintf(
-		`%s & pid=$!; (`+
+		`if command -v timeout >/dev/null 2>&1; then `+
+			`timeout -s TERM -k 2 %d sh -c %s; `+
+			`else `+
+			`%s & pid=$!; (`+
 			`sleep %d; `+
 			`kill -TERM "$pid" 2>/dev/null; `+
 			`sleep 2; `+
@@ -59,8 +62,9 @@ func shellWithTimeout(command string, timeout time.Duration) string {
 			`wait "$pid"; rc=$?; `+
 			`kill "$watchdog" 2>/dev/null; `+
 			`wait "$watchdog" 2>/dev/null; `+
-			`exit "$rc"`,
-		command, seconds)
+			`exit "$rc"; `+
+			`fi`,
+		seconds, shellArg(command), command, seconds)
 }
 
 func commandTimeoutFor(test PingTest, defaultTimeout time.Duration) time.Duration {

--- a/pkg/networkoperatorplugin/connectivity/source_test.go
+++ b/pkg/networkoperatorplugin/connectivity/source_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connectivity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShellWithTimeoutPrefersNativeTimeout(t *testing.T) {
+	cmd := shellWithTimeout(`ping -c 1 -W 1 -I "192.168.0.10" "192.168.0.11"`, 5*time.Second)
+
+	assert.Contains(t, cmd, `command -v timeout`)
+	assert.Contains(t, cmd, `timeout -s TERM -k 2 5 sh -c`)
+	assert.Contains(t, cmd, `ping -c 1 -W 1 -I \"192.168.0.10\" \"192.168.0.11\"`)
+	assert.Contains(t, cmd, `else ping -c 1 -W 1 -I "192.168.0.10" "192.168.0.11" & pid=$!`)
+}
+
+func TestShellWithTimeoutUsesMinimumOneSecond(t *testing.T) {
+	cmd := shellWithTimeout(`true`, 0)
+
+	assert.Contains(t, cmd, `timeout -s TERM -k 2 1 sh -c "true"`)
+	assert.Contains(t, cmd, `sleep 1;`)
+}


### PR DESCRIPTION
## Summary
- prefer container-native `timeout` for ICMP command execution, with the existing shell watchdog kept as fallback
- start the injected netshoot sidecar under a small bash reaper loop instead of plain `sleep infinity`
- add focused unit coverage for timeout command generation and the injected ICMP sidecar command

## Live validation
- rebuilt `build/l8k` from this branch
- ran strict ICMP validation on the RTX cluster with source-based routing:
  - `--validation-mode strict --validation-checks icmp --connectivity-timeout 5m`
  - report: `/Users/amaslennikov/workspace/k8s-launch-kit/rtx-cluster/validation-strict-source-128-icmp-reaper.html`
  - result: 32/32 ICMP tests passed, including 24 cross-rail checks
- manually verified live pod pings from the netshoot sidecar:
  - same rail: `192.168.128.54 -> 192.168.128.13`, route `dev net1`, 0% packet loss
  - cross rail: `192.168.128.54 -> 192.168.129.13`, route `via 192.168.128.1 dev net1`, 0% packet loss
- checked `ps aux` after the run: the netshoot sidecar reaped completed exec children; no accumulated `[sleep]` or `[timeout]` zombies remained

## Tests
- `GOCACHE=/private/tmp/k8s-launch-kit-gocache go test ./pkg/networkoperatorplugin/connectivity`
- `GOCACHE=/private/tmp/k8s-launch-kit-gocache go build ./...`
- `GOCACHE=/private/tmp/k8s-launch-kit-gocache go test ./...`
