### PR TITLE
Generate Spectrum-X CIDRPools from topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,23 @@ feature gate, sets `SpectrumXRailPoolConfig.spec.draEnabled: true`, emits
 `ResourceClaimTemplate` manifests, and renders the example workload with DRA
 claims instead of `nvidia.com/rail_*` device-plugin resource requests.
 
+Spectrum-X CIDRPools are generated from a `topology.json` in the reference
+generator format plus the resolved l8k discovery data. Pass the topology scheme
+and file on the CLI, or set the same values under `profile.spectrumX`:
+
+```bash
+l8k generate --user-config cluster-config.yaml \
+  --spectrum-x RA2.3 \
+  --topology-scheme 2-tier \
+  --ip-version ipv4 \
+  --topology-file ./topology.json
+```
+
+`profile.spectrumX.hostFirstOctet` is config-only. When omitted, l8k uses `172`
+for 2-tier IPv4 allocation and `10` for 3-tier IPv4 allocation. `ipVersion:
+ipv6` is accepted in the config and CLI, but Spectrum-X CIDRPool rendering
+currently supports IPv4 static allocations only.
+
 For non-Spectrum-X profiles, leaving both the flag and `selectedRelease` empty
 continues to render the newest gates (treated as "latest").
 
@@ -947,6 +964,9 @@ profile:
     spcxVersion: RA2.3
     multiplaneMode: hwplb
     numberOfPlanes: 4
+    topologyType: 2-tier
+    ipVersion: ipv4
+    topologyFile: ./topology.json
     configMapName: site-ra23-profile
     profile: |
       useSoftwareCCAlgorithm: true

--- a/pkg/app/discover_profile_test.go
+++ b/pkg/app/discover_profile_test.go
@@ -171,6 +171,7 @@ func TestDiscoverPersistsSpectrumXHardwareDefaults(t *testing.T) {
 		SaveClusterConfig: outputConfig,
 		SpectrumX:         true,
 		SPCXVersion:       "RA2.2",
+		TopologyScheme:    config.SpectrumXTopology2Tier,
 	}, []config.ClusterConfig{{
 		Identifier: "group-a",
 		LinkType:   "Ethernet",

--- a/pkg/app/generate.go
+++ b/pkg/app/generate.go
@@ -79,6 +79,7 @@ func (l *Launcher) executeGeneration(configPath string) error {
 	if err := l.resolveProfileSettings(fullConfig); err != nil {
 		return err
 	}
+	resolveSpectrumXTopologyFile(configPath, fullConfig)
 
 	// Now that fullConfig.NetworkOperator is fully resolved (catalog
 	// values + CLI overrides + l8k-config.yaml), expose it to the plugin
@@ -186,6 +187,28 @@ func (l *Launcher) executeGeneration(configPath string) error {
 	warnStorageModules(fullConfig, "generate", l.ui)
 
 	return nil
+}
+
+func resolveSpectrumXTopologyFile(configPath string, fullConfig *config.LaunchKitConfig) {
+	if fullConfig == nil || fullConfig.Profile == nil || fullConfig.Profile.SpectrumX == nil {
+		return
+	}
+	spcx := fullConfig.Profile.SpectrumX
+	if spcx.TopologyFile == "" {
+		return
+	}
+	if spcx.ResolvedTopologyFile != "" {
+		return
+	}
+	if filepath.IsAbs(spcx.TopologyFile) {
+		spcx.ResolvedTopologyFile = spcx.TopologyFile
+		return
+	}
+	if configPath == "" {
+		spcx.ResolvedTopologyFile = spcx.TopologyFile
+		return
+	}
+	spcx.ResolvedTopologyFile = filepath.Join(filepath.Dir(configPath), spcx.TopologyFile)
 }
 
 func (l *Launcher) saveResolvedConfig(

--- a/pkg/app/generate_profile_test.go
+++ b/pkg/app/generate_profile_test.go
@@ -89,3 +89,35 @@ func TestGeneratePersistsResolvedProfileToOriginalConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, string(updated), string(secondUpdate), "repeated generation must produce stable config YAML")
 }
+
+func TestResolveSpectrumXTopologyFile(t *testing.T) {
+	t.Run("config relative path resolves from config directory", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "configs", "cluster-config.yaml")
+		cfg := &config.LaunchKitConfig{
+			Profile: &config.Profile{SpectrumX: &config.ProfileSpectrumX{
+				TopologyFile: "../topology.json",
+			}},
+		}
+
+		resolveSpectrumXTopologyFile(configPath, cfg)
+
+		assert.Equal(t,
+			filepath.Join(filepath.Dir(configPath), "../topology.json"),
+			cfg.Profile.SpectrumX.ResolvedTopologyFile)
+	})
+
+	t.Run("pre-resolved CLI path is preserved", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "configs", "cluster-config.yaml")
+		resolvedCLIPath := filepath.Join(t.TempDir(), "topology.json")
+		cfg := &config.LaunchKitConfig{
+			Profile: &config.Profile{SpectrumX: &config.ProfileSpectrumX{
+				TopologyFile:         "topology.json",
+				ResolvedTopologyFile: resolvedCLIPath,
+			}},
+		}
+
+		resolveSpectrumXTopologyFile(configPath, cfg)
+
+		assert.Equal(t, resolvedCLIPath, cfg.Profile.SpectrumX.ResolvedTopologyFile)
+	})
+}

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -99,6 +99,9 @@ and writes the final profile back to cluster-config.yaml.`,
 			SPCXVersion:              spectrumXVersion,
 			MultiplaneMode:           multiplaneMode,
 			NumberOfPlanes:           numberOfPlanes,
+			TopologyScheme:           topologyScheme,
+			IPVersion:                ipVersion,
+			TopologyFile:             topologyFile,
 			SpectrumXConfig:          spectrumXConfig,
 			SpectrumXConfigMapName:   spectrumXConfigMapName,
 			KeepNamespace:            keepNamespace,
@@ -155,6 +158,9 @@ func init() {
 			config.SupportedSPCXVersions))
 	discoverCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Spectrum-X multiplane mode override: none, swplb, hwplb, uniplane (requires --spectrum-x)")
 	discoverCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Spectrum-X plane count override: 1, 2, or 4 (requires --spectrum-x)")
+	discoverCmd.Flags().StringVar(&topologyScheme, "topology-scheme", "", "Spectrum-X topology scheme for guide-based IP allocation: 2-tier or 3-tier (requires --spectrum-x)")
+	discoverCmd.Flags().StringVar(&ipVersion, "ip-version", "", "Spectrum-X IP version for guide-based allocation: ipv4 or ipv6 (requires --spectrum-x)")
+	discoverCmd.Flags().StringVar(&topologyFile, "topology-file", "", "Path to spcx-gen-format topology.json for Spectrum-X CIDRPool generation (requires --spectrum-x)")
 	discoverCmd.Flags().StringVar(&spectrumXConfig, "spectrum-x-config", "", "Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML (required for SPC-X RA versions newer than RA2.2)")
 	discoverCmd.Flags().StringVar(&spectrumXConfigMapName, "spectrum-x-configmap-name", "", "Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML")
 
@@ -176,6 +182,9 @@ func init() {
 	setFlagGroup(discoverCmd, "spectrum-x", GroupProfile)
 	setFlagGroup(discoverCmd, "multiplane-mode", GroupSpectrumX)
 	setFlagGroup(discoverCmd, "number-of-planes", GroupSpectrumX)
+	setFlagGroup(discoverCmd, "topology-scheme", GroupSpectrumX)
+	setFlagGroup(discoverCmd, "ip-version", GroupSpectrumX)
+	setFlagGroup(discoverCmd, "topology-file", GroupSpectrumX)
 	setFlagGroup(discoverCmd, "spectrum-x-config", GroupSpectrumX)
 	setFlagGroup(discoverCmd, "spectrum-x-configmap-name", GroupSpectrumX)
 }

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -115,6 +115,9 @@ Optionally deploy the generated manifests with --deploy.`,
 			SPCXVersion:              spectrumXVersion,
 			MultiplaneMode:           multiplaneMode,
 			NumberOfPlanes:           numberOfPlanes,
+			TopologyScheme:           topologyScheme,
+			IPVersion:                ipVersion,
+			TopologyFile:             topologyFile,
 			SpectrumXConfig:          spectrumXConfig,
 			SpectrumXConfigMapName:   spectrumXConfigMapName,
 			Groups:                   groups,
@@ -197,6 +200,9 @@ func init() {
 			config.SupportedSPCXVersions))
 	generateCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Multiplane mode: none, swplb, hwplb, uniplane (requires --spectrum-x)")
 	generateCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes (requires --spectrum-x)")
+	generateCmd.Flags().StringVar(&topologyScheme, "topology-scheme", "", "Spectrum-X topology scheme for guide-based IP allocation: 2-tier or 3-tier (requires --spectrum-x)")
+	generateCmd.Flags().StringVar(&ipVersion, "ip-version", "", "Spectrum-X IP version for guide-based allocation: ipv4 or ipv6 (requires --spectrum-x)")
+	generateCmd.Flags().StringVar(&topologyFile, "topology-file", "", "Path to spcx-gen-format topology.json for Spectrum-X CIDRPool generation (requires --spectrum-x)")
 	generateCmd.Flags().StringVar(&spectrumXConfig, "spectrum-x-config", "", "Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML (required for SPC-X RA versions newer than RA2.2)")
 	generateCmd.Flags().StringVar(&spectrumXConfigMapName, "spectrum-x-configmap-name", "", "Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML")
 	generateCmd.Flags().StringSliceVar(&groups, "groups", nil, "Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.")
@@ -243,6 +249,9 @@ func init() {
 
 	setFlagGroup(generateCmd, "multiplane-mode", GroupSpectrumX)
 	setFlagGroup(generateCmd, "number-of-planes", GroupSpectrumX)
+	setFlagGroup(generateCmd, "topology-scheme", GroupSpectrumX)
+	setFlagGroup(generateCmd, "ip-version", GroupSpectrumX)
+	setFlagGroup(generateCmd, "topology-file", GroupSpectrumX)
 	setFlagGroup(generateCmd, "spectrum-x-config", GroupSpectrumX)
 	setFlagGroup(generateCmd, "spectrum-x-configmap-name", GroupSpectrumX)
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -56,6 +56,9 @@ var (
 	spectrumXVersion         string
 	multiplaneMode           string
 	numberOfPlanes           int
+	topologyScheme           string
+	ipVersion                string
+	topologyFile             string
 	spectrumXConfig          string
 	spectrumXConfigMapName   string
 	saveDeploymentFiles      string
@@ -174,6 +177,9 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
 			SPCXVersion:              spectrumXVersion,
 			MultiplaneMode:           multiplaneMode,
 			NumberOfPlanes:           numberOfPlanes,
+			TopologyScheme:           topologyScheme,
+			IPVersion:                ipVersion,
+			TopologyFile:             topologyFile,
 			SpectrumXConfig:          spectrumXConfig,
 			SpectrumXConfigMapName:   spectrumXConfigMapName,
 			Groups:                   groups,
@@ -261,6 +267,9 @@ func init() {
 			config.SupportedSPCXVersions))
 	rootCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Spectrum-X multiplane mode: none, swplb, hwplb, uniplane (requires --spectrum-x)")
 	rootCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes for Spectrum-X (requires --spectrum-x)")
+	rootCmd.Flags().StringVar(&topologyScheme, "topology-scheme", "", "Spectrum-X topology scheme for guide-based IP allocation: 2-tier or 3-tier (requires --spectrum-x)")
+	rootCmd.Flags().StringVar(&ipVersion, "ip-version", "", "Spectrum-X IP version for guide-based allocation: ipv4 or ipv6 (requires --spectrum-x)")
+	rootCmd.Flags().StringVar(&topologyFile, "topology-file", "", "Path to spcx-gen-format topology.json for Spectrum-X CIDRPool generation (requires --spectrum-x)")
 	rootCmd.Flags().StringVar(&spectrumXConfig, "spectrum-x-config", "", "Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML (required for SPC-X RA versions newer than RA2.2)")
 	rootCmd.Flags().StringVar(&spectrumXConfigMapName, "spectrum-x-configmap-name", "", "Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML")
 	rootCmd.Flags().StringSliceVar(&groups, "groups", nil, "Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.")
@@ -319,6 +328,9 @@ func init() {
 
 	setFlagGroup(rootCmd, "multiplane-mode", GroupSpectrumX)
 	setFlagGroup(rootCmd, "number-of-planes", GroupSpectrumX)
+	setFlagGroup(rootCmd, "topology-scheme", GroupSpectrumX)
+	setFlagGroup(rootCmd, "ip-version", GroupSpectrumX)
+	setFlagGroup(rootCmd, "topology-file", GroupSpectrumX)
 	setFlagGroup(rootCmd, "spectrum-x-config", GroupSpectrumX)
 	setFlagGroup(rootCmd, "spectrum-x-configmap-name", GroupSpectrumX)
 
@@ -473,6 +485,15 @@ func applySpectrumXSyntaxChecks(opts *options.Options) error {
 		if opts.NumberOfPlanes != 0 {
 			return fmt.Errorf("--number-of-planes can only be used with --spectrum-x")
 		}
+		if opts.TopologyScheme != "" {
+			return fmt.Errorf("--topology-scheme can only be used with --spectrum-x")
+		}
+		if opts.IPVersion != "" {
+			return fmt.Errorf("--ip-version can only be used with --spectrum-x")
+		}
+		if opts.TopologyFile != "" {
+			return fmt.Errorf("--topology-file can only be used with --spectrum-x")
+		}
 		if opts.SpectrumXConfig != "" {
 			return fmt.Errorf("--spectrum-x-config can only be used with --spectrum-x")
 		}
@@ -502,6 +523,14 @@ func applySpectrumXSyntaxChecks(opts *options.Options) error {
 	if opts.NumberOfPlanes != 0 && !slices.Contains(config.SupportedNumberOfPlanes, opts.NumberOfPlanes) {
 		return fmt.Errorf("invalid --number-of-planes %d; supported: %v",
 			opts.NumberOfPlanes, config.SupportedNumberOfPlanes)
+	}
+	if opts.TopologyScheme != "" && !slices.Contains(config.SupportedSpectrumXTopologyTypes, opts.TopologyScheme) {
+		return fmt.Errorf("invalid --topology-scheme %q; supported: %v",
+			opts.TopologyScheme, config.SupportedSpectrumXTopologyTypes)
+	}
+	if opts.IPVersion != "" && !slices.Contains(config.SupportedSpectrumXIPVersions, opts.IPVersion) {
+		return fmt.Errorf("invalid --ip-version %q; supported: %v",
+			opts.IPVersion, config.SupportedSpectrumXIPVersions)
 	}
 
 	// --network-operator-release enum check (when supplied). The

--- a/pkg/cmd/root_options_test.go
+++ b/pkg/cmd/root_options_test.go
@@ -94,14 +94,14 @@ var (
 )
 
 // resolveProfile simulates the full Unit-8 CLI→config→validate chain:
-// 1. Phase 1 syntax checks on CLI options.
-// 2. Build cfg with config profile (or empty when no source).
-// 3. ApplyHardwareDefaults — fills empty profile fields from cluster
-//    hardware (always-on defaults + Spectrum-X-implied defaults).
-// 4. ApplyOptionsToConfig — CLI overlay; non-zero CLI values override
-//    HW defaults; bool override gated by MultirailSet.
-// 5. Phase 2 cohort validation.
-// 6. Validate against the target profile definition.
+//  1. Phase 1 syntax checks on CLI options.
+//  2. Build cfg with config profile (or empty when no source).
+//  3. ApplyHardwareDefaults — fills empty profile fields from cluster
+//     hardware (always-on defaults + Spectrum-X-implied defaults).
+//  4. ApplyOptionsToConfig — CLI overlay; non-zero CLI values override
+//     HW defaults; bool override gated by MultirailSet.
+//  5. Phase 2 cohort validation.
+//  6. Validate against the target profile definition.
 func resolveProfile(
 	t *testing.T,
 	opts options.Options,
@@ -110,6 +110,10 @@ func resolveProfile(
 	capabilities *config.ClusterCapabilities,
 ) (bool, string) {
 	t.Helper()
+
+	if opts.SpectrumX && opts.TopologyScheme == "" {
+		opts.TopologyScheme = config.SpectrumXTopology2Tier
+	}
 
 	// Step 1: Phase 1 syntax checks
 	err := applySpectrumXSyntaxChecks(&opts)
@@ -123,6 +127,9 @@ func resolveProfile(
 		profileCopy := *configProfile
 		if configProfile.SpectrumX != nil {
 			sxCopy := *configProfile.SpectrumX
+			if sxCopy.TopologyType == "" {
+				sxCopy.TopologyType = config.SpectrumXTopology2Tier
+			}
 			profileCopy.SpectrumX = &sxCopy
 		}
 		fullConfig.Profile = &profileCopy
@@ -332,6 +339,7 @@ func TestMixedCLIConfigProfileResolution(t *testing.T) {
 			SPCXVersion:            "RA2.2",
 			MultiplaneMode:         "hwplb",
 			NumberOfPlanes:         4, // CLI overrides planes
+			TopologyScheme:         config.SpectrumXTopology2Tier,
 			NetworkOperatorRelease: "26.4",
 		}
 

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -60,6 +60,8 @@ func applySpectrumXDefaults(opts *options.Options) error {
 			SPCXVersion:    opts.SPCXVersion,
 			MultiplaneMode: opts.MultiplaneMode,
 			NumberOfPlanes: opts.NumberOfPlanes,
+			TopologyType:   opts.TopologyScheme,
+			IPVersion:      opts.IPVersion,
 		}
 	}
 	if opts.NetworkOperatorRelease != "" {
@@ -92,6 +94,7 @@ func minSpectrumXOpts() *options.Options {
 		SPCXVersion:            "RA2.2",
 		MultiplaneMode:         "hwplb",
 		NumberOfPlanes:         4,
+		TopologyScheme:         config.SpectrumXTopology2Tier,
 		NetworkOperatorRelease: "26.4",
 	}
 }
@@ -210,6 +213,9 @@ func TestApplySpectrumXDefaults_RejectsCohortFlagsWithoutSpectrumX(t *testing.T)
 	cases := map[string]*options.Options{
 		"multiplane-mode":  {MultiplaneMode: "hwplb"},
 		"number-of-planes": {NumberOfPlanes: 4},
+		"topology-scheme":  {TopologyScheme: config.SpectrumXTopology2Tier},
+		"ip-version":       {IPVersion: config.SpectrumXIPVersionIPv4},
+		"topology-file":    {TopologyFile: "topology.json"},
 	}
 	for flag, opts := range cases {
 		t.Run(flag, func(t *testing.T) {
@@ -327,14 +333,14 @@ func TestValidateConfig_DryRunRequiresDeploy(t *testing.T) {
 
 func TestValidateConfig_DryRunWithDeployPasses(t *testing.T) {
 	opts := options.Options{
-		UserConfig:     "config.yaml",
-		EnabledPlugins: []string{"network-operator"},
-		OutputFormat:   "text",
-		DryRun:         true,
-		Deploy:         true,
-		Kubeconfig:     "/path/to/kubeconfig",
-		Fabric:         "ethernet",
-		DeploymentType: "sriov",
+		UserConfig:          "config.yaml",
+		EnabledPlugins:      []string{"network-operator"},
+		OutputFormat:        "text",
+		DryRun:              true,
+		Deploy:              true,
+		Kubeconfig:          "/path/to/kubeconfig",
+		Fabric:              "ethernet",
+		DeploymentType:      "sriov",
 		SaveDeploymentFiles: "/tmp/test",
 	}
 	err := validateConfig(&opts)

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -153,6 +153,19 @@ var schemaCmd = &cobra.Command{
 					Type:        "int",
 					Description: "Spectrum-X plane count override: 1, 2, or 4. Auto-derived from NIC device ID when omitted.",
 				},
+				"--topology-scheme": {
+					Type:        "string",
+					Description: "Spectrum-X topology scheme for guide-based IP allocation: 2-tier or 3-tier.",
+				},
+				"--ip-version": {
+					Type:        "string",
+					Default:     config.SpectrumXIPVersionIPv4,
+					Description: "Spectrum-X host-to-leaf IP version for guide-based allocation: ipv4 or ipv6. IPv6 is accepted in config but CIDRPool rendering currently supports IPv4 only.",
+				},
+				"--topology-file": {
+					Type:        "string",
+					Description: "Path to a spcx-gen-format topology.json used to generate Spectrum-X CIDRPool host static allocations.",
+				},
 				"--spectrum-x-config": {
 					Type:        "string",
 					Description: "Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML. Required for SPC-X RA versions newer than RA2.2.",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,6 +96,13 @@ const (
 	RoutingSourceBased      = "source-based"
 )
 
+const (
+	SpectrumXTopology2Tier = "2-tier"
+	SpectrumXTopology3Tier = "3-tier"
+	SpectrumXIPVersionIPv4 = "ipv4"
+	SpectrumXIPVersionIPv6 = "ipv6"
+)
+
 // MachineLabelValue returns the per-source-group machine label value:
 // `<machineType>-<gpuType>` literal when it fits Kubernetes' 63-char
 // label-value limit, or a deterministic shortened form for long names
@@ -513,13 +520,18 @@ func (p Profile) MarshalYAML() (interface{}, error) {
 }
 
 type ProfileSpectrumX struct {
-	Enable         bool   `yaml:"enable"`         // must be true for Spectrum-X profiles to match
-	SPCXVersion    string `yaml:"spcxVersion"`    // e.g., "RA2.2"
-	MultiplaneMode string `yaml:"multiplaneMode"` // swplb, hwplb, uniplane
-	NumberOfPlanes int    `yaml:"numberOfPlanes"` // 2 or 4
-	UseDRA         bool   `yaml:"useDRA"`         // enable DRA ResourceClaimTemplate-based workload allocation
-	ConfigMapName  string `yaml:"configMapName,omitempty"`
-	Profile        string `yaml:"profile,omitempty"`
+	Enable               bool   `yaml:"enable"`         // must be true for Spectrum-X profiles to match
+	SPCXVersion          string `yaml:"spcxVersion"`    // e.g., "RA2.2"
+	MultiplaneMode       string `yaml:"multiplaneMode"` // swplb, hwplb, uniplane
+	NumberOfPlanes       int    `yaml:"numberOfPlanes"` // 2 or 4
+	TopologyType         string `yaml:"topologyType,omitempty"`
+	IPVersion            string `yaml:"ipVersion,omitempty"`
+	HostFirstOctet       int    `yaml:"hostFirstOctet,omitempty"`
+	TopologyFile         string `yaml:"topologyFile,omitempty"`
+	ResolvedTopologyFile string `yaml:"-"`
+	UseDRA               bool   `yaml:"useDRA"` // enable DRA ResourceClaimTemplate-based workload allocation
+	ConfigMapName        string `yaml:"configMapName,omitempty"`
+	Profile              string `yaml:"profile,omitempty"`
 }
 
 type ClusterConfig struct {
@@ -794,6 +806,10 @@ var SupportedMultiplaneModes = []string{"none", "swplb", "hwplb", "uniplane"}
 
 // SupportedNumberOfPlanes lists the values numberOfPlanes can take.
 var SupportedNumberOfPlanes = []int{1, 2, 4}
+
+var SupportedSpectrumXTopologyTypes = []string{SpectrumXTopology2Tier, SpectrumXTopology3Tier}
+
+var SupportedSpectrumXIPVersions = []string{SpectrumXIPVersionIPv4, SpectrumXIPVersionIPv6}
 
 // SPCXVersionAllowedReleases is the authoritative mapping from SPC-X RA
 // version to the Network Operator releases that ship that version's CRD

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -155,6 +155,10 @@ profile:
     # spcxVersion: "RA2.3" # CLI parameter (overrides this value): --spectrum-x
     # multiplaneMode: swplb # CLI parameter (overrides this value): --multiplane-mode (swplb, hwplb, uniplane)
     # numberOfPlanes: 4 # CLI parameter (overrides this value): --number-of-planes, also used as pfsPerNic
+    # topologyType: 2-tier # CLI parameter (overrides this value): --topology-scheme (2-tier, 3-tier)
+    # ipVersion: ipv4 # CLI parameter (overrides this value): --ip-version (ipv4, ipv6); CIDRPool rendering currently supports ipv4
+    # hostFirstOctet: 172 # Config-only IPv4 first octet override; defaults to 172 for 2-tier, 10 for 3-tier
+    # topologyFile: ./topology.json # CLI parameter (overrides this value): --topology-file; spcx-gen-format topology.json
     # configMapName: "site-ra23-profile" # Required for RA2.3 when profile is raw data.profile YAML; CLI: --spectrum-x-configmap-name
     # profile: | # Required for RA2.3; accepts raw data.profile YAML or a full ConfigMap YAML. CLI: --spectrum-x-config
     #   useSoftwareCCAlgorithm: true

--- a/pkg/config/spectrumx_profile.go
+++ b/pkg/config/spectrumx_profile.go
@@ -44,7 +44,26 @@ func SpectrumXProfileConfigRequired(ra string) bool {
 // metadata.name; rendered manifests always supply the canonical namespace and
 // label themselves.
 func NormalizeSpectrumXProfileConfig(spcx *ProfileSpectrumX) error {
-	if spcx == nil || strings.TrimSpace(spcx.Profile) == "" {
+	if spcx == nil {
+		return nil
+	}
+
+	if topologyType := strings.TrimSpace(spcx.TopologyType); topologyType != "" {
+		normalized, err := NormalizeSpectrumXTopologyType(topologyType)
+		if err != nil {
+			return err
+		}
+		spcx.TopologyType = normalized
+	}
+	if ipVersion := strings.TrimSpace(spcx.IPVersion); ipVersion != "" {
+		normalized, err := NormalizeSpectrumXIPVersion(ipVersion)
+		if err != nil {
+			return err
+		}
+		spcx.IPVersion = normalized
+	}
+
+	if strings.TrimSpace(spcx.Profile) == "" {
 		return nil
 	}
 
@@ -71,6 +90,37 @@ func NormalizeSpectrumXProfileConfig(spcx *ProfileSpectrumX) error {
 	spcx.ConfigMapName = cm.Metadata.Name
 	spcx.Profile = cm.Data[SpectrumXProfileConfigMapDataKey]
 	return nil
+}
+
+func NormalizeSpectrumXTopologyType(topologyType string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(topologyType)) {
+	case SpectrumXTopology2Tier, "2-tier-poc":
+		return SpectrumXTopology2Tier, nil
+	case SpectrumXTopology3Tier:
+		return SpectrumXTopology3Tier, nil
+	default:
+		return "", fmt.Errorf("topologyType must be one of: %s, %s",
+			SpectrumXTopology2Tier, SpectrumXTopology3Tier)
+	}
+}
+
+func NormalizeSpectrumXIPVersion(ipVersion string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(ipVersion)) {
+	case SpectrumXIPVersionIPv4:
+		return SpectrumXIPVersionIPv4, nil
+	case SpectrumXIPVersionIPv6:
+		return SpectrumXIPVersionIPv6, nil
+	default:
+		return "", fmt.Errorf("ipVersion must be one of: %s, %s",
+			SpectrumXIPVersionIPv4, SpectrumXIPVersionIPv6)
+	}
+}
+
+func SpectrumXDefaultHostFirstOctet(topologyType string) int {
+	if topologyType == SpectrumXTopology3Tier {
+		return 10
+	}
+	return 172
 }
 
 type spectrumXProfileConfigMap struct {

--- a/pkg/networkoperatorplugin/grouping_test.go
+++ b/pkg/networkoperatorplugin/grouping_test.go
@@ -17,6 +17,9 @@
 package networkoperatorplugin
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -79,6 +82,7 @@ func renderSpectrumXWithDRA(t *testing.T, configName, multiplaneMode string, num
 		ctrllog.Log,
 	)
 	require.NoError(t, err)
+	topologyFile := writeSpectrumXTopology(t, cfg, numberOfPlanes)
 
 	// Attach the profile metadata that the CLI would normally inject.
 	cfg.Profile = &config.Profile{
@@ -90,6 +94,8 @@ func renderSpectrumXWithDRA(t *testing.T, configName, multiplaneMode string, num
 			SPCXVersion:    "RA2.2",
 			MultiplaneMode: multiplaneMode,
 			NumberOfPlanes: numberOfPlanes,
+			TopologyType:   config.SpectrumXTopology2Tier,
+			TopologyFile:   topologyFile,
 			UseDRA:         useDRA,
 		},
 	}
@@ -98,6 +104,108 @@ func renderSpectrumXWithDRA(t *testing.T, configName, multiplaneMode string, num
 	rendered, err := plugin.GenerateProfileDeploymentFiles(loadSpectrumXProfile(t), cfg)
 	require.NoError(t, err)
 	return rendered
+}
+
+func writeSpectrumXTopology(t *testing.T, cfg *config.LaunchKitConfig, planes int) string {
+	t.Helper()
+	type endpoint struct {
+		Node      string         `json:"node"`
+		Interface string         `json:"interface"`
+		Attrs     map[string]any `json:"attributes"`
+	}
+	type node struct {
+		Name string `json:"name"`
+		Role string `json:"role"`
+		Type string `json:"type"`
+	}
+	if planes < 1 {
+		planes = 1
+	}
+	nodesByName := map[string]node{}
+	var links [][]endpoint
+	for groupIdx, group := range cfg.ClusterConfig {
+		rails := railsForTest(group.PFs, planes)
+		for _, workerNode := range group.WorkerNodes {
+			nodesByName[workerNode] = node{Name: workerNode, Role: "host", Type: "default"}
+		}
+		for plane := 0; plane < planes; plane++ {
+			for _, rail := range rails {
+				leafName := fmt.Sprintf("leaf-g%d-p%d-r%d", groupIdx, plane, rail)
+				nodesByName[leafName] = node{Name: leafName, Role: "leaf", Type: "cumulus"}
+				for nodeIdx, workerNode := range group.WorkerNodes {
+					links = append(links, []endpoint{
+						{
+							Node:      leafName,
+							Interface: fmt.Sprintf("swp%d", nodeIdx+1),
+							Attrs: map[string]any{
+								"role":       "leaf",
+								"plane":      plane,
+								"pod":        0,
+								"su":         groupIdx,
+								"rail_group": []int{rail},
+							},
+						},
+						{
+							Node:      workerNode,
+							Interface: fmt.Sprintf("eth_p%d_r%d", plane, rail),
+							Attrs: map[string]any{
+								"role": "host",
+								"rail": rail,
+								"pod":  0,
+								"su":   groupIdx,
+							},
+						},
+					})
+				}
+			}
+		}
+	}
+	nodes := make([]node, 0, len(nodesByName))
+	for _, node := range nodesByName {
+		nodes = append(nodes, node)
+	}
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Name < nodes[j].Name })
+	data, err := json.Marshal(map[string]any{
+		"nodes": nodes,
+		"links": links,
+	})
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "topology.json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func railsForTest(pfs []config.PFConfig, planes int) []int {
+	seen := map[int]struct{}{}
+	for _, pf := range pfs {
+		if pf.Traffic != "east-west" {
+			continue
+		}
+		if pf.Rail != nil {
+			seen[*pf.Rail] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		count := len(pfs)
+		if planes > 0 {
+			count = len(pfs) / planes
+		}
+		if count < 1 {
+			count = 1
+		}
+		for rail := 0; rail < count; rail++ {
+			seen[rail] = struct{}{}
+		}
+	}
+	rails := make([]int, 0, len(seen))
+	for rail := range seen {
+		rails = append(rails, rail)
+	}
+	sort.Ints(rails)
+	if len(rails) > 8 {
+		rails = rails[:8]
+	}
+	return rails
 }
 
 // fileNamesMatching returns the sorted file names whose basenames contain the
@@ -234,6 +342,7 @@ func TestSpectrumXRA23RendersProfileConfigMap(t *testing.T) {
 		ctrllog.Log,
 	)
 	require.NoError(t, err)
+	topologyFile := writeSpectrumXTopology(t, cfg, 4)
 
 	cfg.NetworkOperator.SelectedRelease = "26.7"
 	cfg.NetworkOperator.Namespace = "nvidia-network-operator"
@@ -246,6 +355,8 @@ func TestSpectrumXRA23RendersProfileConfigMap(t *testing.T) {
 			SPCXVersion:    "RA2.3",
 			MultiplaneMode: "hwplb",
 			NumberOfPlanes: 4,
+			TopologyType:   config.SpectrumXTopology2Tier,
+			TopologyFile:   topologyFile,
 			ConfigMapName:  "site-ra23-profile",
 			Profile:        "useSoftwareCCAlgorithm: true\r\ndocaCCVersion: \"example\"\r\n",
 		},
@@ -415,6 +526,7 @@ func TestSpectrumXModeBSubsetFilter(t *testing.T) {
 		ctrllog.Log,
 	)
 	require.NoError(t, err)
+	topologyFile := writeSpectrumXTopology(t, cfg, 1)
 	cfg.Profile = &config.Profile{
 		Fabric:     "ethernet",
 		Deployment: "sriov",
@@ -424,6 +536,8 @@ func TestSpectrumXModeBSubsetFilter(t *testing.T) {
 			SPCXVersion:    "RA2.2",
 			MultiplaneMode: "none",
 			NumberOfPlanes: 1,
+			TopologyType:   config.SpectrumXTopology2Tier,
+			TopologyFile:   topologyFile,
 		},
 	}
 
@@ -514,6 +628,7 @@ func renderSpectrumXRA21(t *testing.T, configName, multiplaneMode string, number
 		ctrllog.Log,
 	)
 	require.NoError(t, err)
+	topologyFile := writeSpectrumXTopology(t, cfg, numberOfPlanes)
 
 	cfg.Profile = &config.Profile{
 		Fabric:     "ethernet",
@@ -524,6 +639,8 @@ func renderSpectrumXRA21(t *testing.T, configName, multiplaneMode string, number
 			SPCXVersion:    "RA2.1",
 			MultiplaneMode: multiplaneMode,
 			NumberOfPlanes: numberOfPlanes,
+			TopologyType:   config.SpectrumXTopology2Tier,
+			TopologyFile:   topologyFile,
 		},
 	}
 

--- a/pkg/networkoperatorplugin/networkoperator.go
+++ b/pkg/networkoperatorplugin/networkoperator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/discovery"
@@ -94,7 +95,9 @@ func (p *NetworkOperatorPlugin) GetVersion() string {
 
 func (p *NetworkOperatorPlugin) ProfileConfiguredInCmd(options options.Options) bool {
 	return options.Fabric != "" || options.DeploymentType != "" ||
-		options.Routing != "" || options.IgnoreARPSet
+		options.Routing != "" || options.IgnoreARPSet ||
+		options.SpectrumX || options.TopologyScheme != "" ||
+		options.IPVersion != "" || options.TopologyFile != ""
 }
 
 func (p *NetworkOperatorPlugin) BuildProfileFromOptions(options options.Options, profile *config.Profile) error {
@@ -113,6 +116,9 @@ func (p *NetworkOperatorPlugin) BuildProfileFromOptions(options options.Options,
 			SPCXVersion:    options.SPCXVersion,
 			MultiplaneMode: options.MultiplaneMode,
 			NumberOfPlanes: options.NumberOfPlanes,
+			TopologyType:   options.TopologyScheme,
+			IPVersion:      options.IPVersion,
+			TopologyFile:   options.TopologyFile,
 		}
 	}
 
@@ -281,6 +287,20 @@ func (p *NetworkOperatorPlugin) ApplyOptionsToConfig(options options.Options, fu
 		}
 		if options.NumberOfPlanes != 0 {
 			fullConfig.Profile.SpectrumX.NumberOfPlanes = options.NumberOfPlanes
+		}
+		if options.TopologyScheme != "" {
+			fullConfig.Profile.SpectrumX.TopologyType = options.TopologyScheme
+		}
+		if options.IPVersion != "" {
+			fullConfig.Profile.SpectrumX.IPVersion = options.IPVersion
+		}
+		if options.TopologyFile != "" {
+			fullConfig.Profile.SpectrumX.TopologyFile = options.TopologyFile
+			resolvedTopologyFile, err := filepath.Abs(options.TopologyFile)
+			if err != nil {
+				return fmt.Errorf("failed to resolve --topology-file %s: %w", options.TopologyFile, err)
+			}
+			fullConfig.Profile.SpectrumX.ResolvedTopologyFile = resolvedTopologyFile
 		}
 		if options.SpectrumXConfigMapName != "" {
 			fullConfig.Profile.SpectrumX.ConfigMapName = options.SpectrumXConfigMapName

--- a/pkg/networkoperatorplugin/networkoperator_test.go
+++ b/pkg/networkoperatorplugin/networkoperator_test.go
@@ -17,6 +17,7 @@
 package networkoperatorplugin
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
@@ -304,6 +305,28 @@ func TestApplyOptionsToConfig(t *testing.T) {
 		err := p.ApplyOptionsToConfig(opts, cfg)
 		require.NoError(t, err)
 		assert.Equal(t, 4, cfg.Profile.SpectrumX.NumberOfPlanes)
+	})
+
+	t.Run("relative CLI topology file resolves from working directory", func(t *testing.T) {
+		wd := t.TempDir()
+		t.Chdir(wd)
+		cfg := &config.LaunchKitConfig{
+			Profile: &config.Profile{
+				SpectrumX: &config.ProfileSpectrumX{
+					TopologyFile: "config-dir/topology.json",
+				},
+			},
+		}
+		opts := options.Options{
+			SpectrumX:    true,
+			TopologyFile: "cli-dir/topology.json",
+		}
+		err := p.ApplyOptionsToConfig(opts, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "cli-dir/topology.json", cfg.Profile.SpectrumX.TopologyFile)
+		assert.Equal(t,
+			filepath.Join(wd, "cli-dir", "topology.json"),
+			cfg.Profile.SpectrumX.ResolvedTopologyFile)
 	})
 
 	t.Run("full spectrum-x overlay merges all fields", func(t *testing.T) {

--- a/pkg/networkoperatorplugin/spectrumx/addressing.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing.go
@@ -1,0 +1,512 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spectrumx
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+type CIDRPool struct {
+	Name              string
+	CIDR              string
+	Routes            []string
+	StaticAllocations []StaticAllocation
+}
+
+type StaticAllocation struct {
+	Gateway  string
+	NodeName string
+	Prefix   string
+}
+
+type topologyFile struct {
+	Nodes []topologyNode `json:"nodes"`
+	Links []topologyLink `json:"links"`
+}
+
+type topologyNode struct {
+	Name string `json:"name"`
+	Role string `json:"role"`
+	Type string `json:"type"`
+}
+
+type topologyLink []topologyEndpoint
+
+func (l *topologyLink) UnmarshalJSON(data []byte) error {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	endpoints := make([]topologyEndpoint, 0, len(raw))
+	for _, item := range raw {
+		var disconnected string
+		if err := json.Unmarshal(item, &disconnected); err == nil && disconnected == "unconnected" {
+			continue
+		}
+		var endpoint topologyEndpoint
+		if err := json.Unmarshal(item, &endpoint); err != nil {
+			return err
+		}
+		endpoints = append(endpoints, endpoint)
+	}
+	*l = endpoints
+	return nil
+}
+
+type topologyEndpoint struct {
+	Node      string             `json:"node"`
+	Interface string             `json:"interface"`
+	Attrs     topologyAttributes `json:"attributes"`
+}
+
+type topologyAttributes struct {
+	Role     string `json:"role"`
+	Plane    int    `json:"plane"`
+	Pod      int    `json:"pod"`
+	SU       int    `json:"su"`
+	Rail     int    `json:"rail"`
+	HasPlane bool
+	HasPod   bool
+	HasSU    bool
+	HasRail  bool
+}
+
+func (a *topologyAttributes) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["role"]; ok {
+		if err := json.Unmarshal(v, &a.Role); err != nil {
+			return fmt.Errorf("role: %w", err)
+		}
+	}
+	if err := decodeOptionalInt(raw, "plane", &a.Plane, &a.HasPlane); err != nil {
+		return err
+	}
+	if err := decodeOptionalInt(raw, "pod", &a.Pod, &a.HasPod); err != nil {
+		return err
+	}
+	if err := decodeOptionalInt(raw, "su", &a.SU, &a.HasSU); err != nil {
+		return err
+	}
+	if err := decodeOptionalInt(raw, "rail", &a.Rail, &a.HasRail); err != nil {
+		return err
+	}
+	return nil
+}
+
+func decodeOptionalInt(raw map[string]json.RawMessage, key string, out *int, present *bool) error {
+	v, ok := raw[key]
+	if !ok || string(v) == "null" {
+		return nil
+	}
+	if err := json.Unmarshal(v, out); err != nil {
+		return fmt.Errorf("%s: %w", key, err)
+	}
+	*present = true
+	return nil
+}
+
+type hostLink struct {
+	node      string
+	plane     int
+	pod       int
+	su        int
+	rail      int
+	hostIndex int
+	hostIP    net.IP
+	leafIP    net.IP
+}
+
+type poolKey struct {
+	rail  int
+	plane int
+}
+
+// BuildCIDRPools builds nv-ipam CIDRPool data for the Spectrum-X profiles from
+// a topology.json that follows the reference generator schema.
+func BuildCIDRPools(cfg *config.LaunchKitConfig, group config.ClusterConfig) ([]CIDRPool, error) {
+	if cfg == nil || cfg.Profile == nil || cfg.Profile.SpectrumX == nil || !cfg.Profile.SpectrumX.Enable {
+		return nil, nil
+	}
+	spcx := cfg.Profile.SpectrumX
+	if spcx.IPVersion == config.SpectrumXIPVersionIPv6 {
+		return nil, fmt.Errorf("Spectrum-X CIDRPool generation currently supports ipVersion=%s only; got %s",
+			config.SpectrumXIPVersionIPv4, spcx.IPVersion)
+	}
+	if spcx.TopologyFile == "" {
+		return nil, fmt.Errorf("profile.spectrumX.topologyFile or --topology-file is required for Spectrum-X CIDRPool generation")
+	}
+	topologyPath := spcx.ResolvedTopologyFile
+	if topologyPath == "" {
+		topologyPath = spcx.TopologyFile
+	}
+	topology, err := loadTopology(topologyPath)
+	if err != nil {
+		return nil, err
+	}
+	links, err := hostLinks(topology, spcx)
+	if err != nil {
+		return nil, err
+	}
+
+	allowedNodes := nodeSet(group.WorkerNodes)
+	allocations := allocationsByPool(links, allowedNodes, spcx)
+	poolKeys := sortedPoolKeys(allocations)
+	if len(poolKeys) == 0 {
+		return nil, fmt.Errorf("no Spectrum-X topology allocations matched clusterConfig group %q", group.Identifier)
+	}
+	pools := make([]CIDRPool, 0, len(poolKeys))
+	for _, key := range poolKeys {
+		staticAllocations := allocations[key]
+		if len(staticAllocations) == 0 {
+			return nil, fmt.Errorf("CIDR pool %s has no host static allocations in topology file %s",
+				poolName(key, group.MergedIdentifier, spcx), topologyPath)
+		}
+		if len(allowedNodes) > 0 {
+			if missing := missingNodes(allowedNodes, staticAllocations); len(missing) > 0 {
+				return nil, fmt.Errorf("CIDR pool %s is missing topology allocations for worker nodes: %s",
+					poolName(key, group.MergedIdentifier, spcx), strings.Join(missing, ", "))
+			}
+		}
+		cidr := poolCIDR(staticAllocations[0].Prefix, spcx)
+		planeCIDR := planeCIDR(staticAllocations[0].Prefix, spcx)
+		routes := []string{cidr}
+		if planeCIDR != "" && planeCIDR != cidr {
+			routes = append(routes, planeCIDR)
+		}
+		pools = append(pools, CIDRPool{
+			Name:              poolName(key, group.MergedIdentifier, spcx),
+			CIDR:              cidr,
+			Routes:            routes,
+			StaticAllocations: staticAllocations,
+		})
+	}
+	return pools, nil
+}
+
+func loadTopology(path string) (*topologyFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Spectrum-X topology file %s: %w", path, err)
+	}
+	var topology topologyFile
+	if err := json.Unmarshal(data, &topology); err != nil {
+		return nil, fmt.Errorf("failed to parse Spectrum-X topology file %s: %w", path, err)
+	}
+	if len(topology.Links) == 0 {
+		return nil, fmt.Errorf("Spectrum-X topology file %s has no links", path)
+	}
+	return &topology, nil
+}
+
+func hostLinks(topology *topologyFile, spcx *config.ProfileSpectrumX) ([]hostLink, error) {
+	var links []hostLink
+	hostIndexes := map[string]int{}
+	for linkIdx, link := range topology.Links {
+		if len(link) == 0 {
+			continue
+		}
+		if len(link) != 2 {
+			return nil, fmt.Errorf("topology link %d must contain exactly two endpoints", linkIdx)
+		}
+		hostIdx := -1
+		leafIdx := -1
+		for i := range link {
+			switch link[i].Attrs.Role {
+			case "host":
+				hostIdx = i
+			case "leaf":
+				leafIdx = i
+			}
+		}
+		if hostIdx == -1 {
+			continue
+		}
+		if leafIdx == -1 {
+			return nil, fmt.Errorf("topology host link %d has no leaf endpoint", linkIdx)
+		}
+		host := link[hostIdx]
+		leaf := link[leafIdx]
+		if !host.Attrs.HasRail {
+			return nil, fmt.Errorf("topology host link %d endpoint %s/%s is missing attributes.rail",
+				linkIdx, host.Node, host.Interface)
+		}
+		if !leaf.Attrs.HasPlane {
+			return nil, fmt.Errorf("topology host link %d endpoint %s/%s is missing leaf attributes.plane",
+				linkIdx, leaf.Node, leaf.Interface)
+		}
+		if spcx.TopologyType == config.SpectrumXTopology3Tier && !host.Attrs.HasPod {
+			return nil, fmt.Errorf("topology host link %d endpoint %s/%s is missing attributes.pod for 3-tier allocation",
+				linkIdx, host.Node, host.Interface)
+		}
+		key := hostIndexKey(host.Attrs)
+		index, ok := hostIndexes[key+"|"+host.Node]
+		if !ok {
+			index = countHostIndex(hostIndexes, key)
+			hostIndexes[key+"|"+host.Node] = index
+		}
+		addressPlane := leaf.Attrs.Plane
+		if spcx.MultiplaneMode == "hwplb" {
+			addressPlane = 0
+		}
+		hostIP, leafIP, err := allocateIPv4HostLeaf(spcx, addressPlane, host.Attrs.Rail, host.Attrs.Pod, host.Attrs.SU, index)
+		if err != nil {
+			return nil, fmt.Errorf("topology host link %d endpoint %s/%s: %w", linkIdx, host.Node, host.Interface, err)
+		}
+		links = append(links, hostLink{
+			node:      host.Node,
+			plane:     leaf.Attrs.Plane,
+			pod:       host.Attrs.Pod,
+			su:        host.Attrs.SU,
+			rail:      host.Attrs.Rail,
+			hostIndex: index,
+			hostIP:    hostIP,
+			leafIP:    leafIP,
+		})
+	}
+	if len(links) == 0 {
+		return nil, fmt.Errorf("Spectrum-X topology file has no host-to-leaf links")
+	}
+	return links, nil
+}
+
+func hostIndexKey(attrs topologyAttributes) string {
+	plane := "nil"
+	if attrs.HasPlane {
+		plane = fmt.Sprintf("%d", attrs.Plane)
+	}
+	pod := "nil"
+	if attrs.HasPod {
+		pod = fmt.Sprintf("%d", attrs.Pod)
+	}
+	su := "nil"
+	if attrs.HasSU {
+		su = fmt.Sprintf("%d", attrs.SU)
+	}
+	return fmt.Sprintf("%s/%s/%s", plane, pod, su)
+}
+
+func countHostIndex(indexes map[string]int, key string) int {
+	prefix := key + "|"
+	count := 0
+	for k := range indexes {
+		if strings.HasPrefix(k, prefix) {
+			count++
+		}
+	}
+	return count
+}
+
+func allocateIPv4HostLeaf(spcx *config.ProfileSpectrumX, plane, rail, pod, su, hostIndex int) (net.IP, net.IP, error) {
+	if rail < 0 || rail > 7 {
+		return nil, nil, fmt.Errorf("rail %d exceeds the supported 3-bit rail field", rail)
+	}
+	if hostIndex < 0 || hostIndex > 127 {
+		return nil, nil, fmt.Errorf("host index %d exceeds the supported 7-bit host field", hostIndex)
+	}
+	firstOctet := spcx.HostFirstOctet
+	if firstOctet == 0 {
+		firstOctet = config.SpectrumXDefaultHostFirstOctet(spcx.TopologyType)
+	}
+	if firstOctet < 1 || firstOctet > 255 {
+		return nil, nil, fmt.Errorf("hostFirstOctet %d must fit in one IPv4 octet", firstOctet)
+	}
+	second, third, err := ipv4HostLeafMiddleOctets(spcx, plane, rail, pod, su)
+	if err != nil {
+		return nil, nil, err
+	}
+	host := net.IPv4(byte(firstOctet), byte(second), byte(third), byte(hostIndex<<1))
+	leaf := net.IPv4(byte(firstOctet), byte(second), byte(third), byte(hostIndex<<1|1))
+	return host, leaf, nil
+}
+
+func ipv4HostLeafMiddleOctets(spcx *config.ProfileSpectrumX, plane, rail, pod, su int) (int, int, error) {
+	planeAware := planeAwareAddressing(spcx)
+	switch spcx.TopologyType {
+	case config.SpectrumXTopology2Tier:
+		if su < 0 || su > 63 {
+			return 0, 0, fmt.Errorf("su %d exceeds the supported 6-bit SU field", su)
+		}
+		if planeAware {
+			if plane < 0 || plane > 3 {
+				return 0, 0, fmt.Errorf("plane %d exceeds the supported 2-bit plane field", plane)
+			}
+			second := 16 | (plane << 2) | ((rail >> 2) & 1)
+			third := ((rail & 3) << 6) | su
+			return second, third, nil
+		}
+		return 16 | (rail << 1), su, nil
+	case config.SpectrumXTopology3Tier:
+		if pod < 0 || pod > 31 {
+			return 0, 0, fmt.Errorf("pod %d exceeds the supported 5-bit POD field", pod)
+		}
+		if planeAware {
+			if su < 0 || su > 63 {
+				return 0, 0, fmt.Errorf("su %d exceeds the supported 6-bit SU field", su)
+			}
+			if plane < 0 || plane > 3 {
+				return 0, 0, fmt.Errorf("plane %d exceeds the supported 2-bit plane field", plane)
+			}
+			second := (plane << 6) | (rail << 3) | ((pod >> 2) & 7)
+			third := ((pod & 3) << 6) | su
+			return second, third, nil
+		}
+		if su < 0 || su > 255 {
+			return 0, 0, fmt.Errorf("su %d exceeds the supported 8-bit SU field", su)
+		}
+		return (rail << 5) | pod, su, nil
+	default:
+		return 0, 0, fmt.Errorf("unsupported Spectrum-X topologyType %q", spcx.TopologyType)
+	}
+}
+
+func planeAwareAddressing(spcx *config.ProfileSpectrumX) bool {
+	return spcx.MultiplaneMode == "swplb" || spcx.MultiplaneMode == "hwplb"
+}
+
+func allocationsByPool(links []hostLink, allowedNodes map[string]struct{}, spcx *config.ProfileSpectrumX) map[poolKey][]StaticAllocation {
+	result := map[poolKey][]StaticAllocation{}
+	seen := map[poolKey]map[string]struct{}{}
+	for _, link := range links {
+		if len(allowedNodes) > 0 {
+			if _, ok := allowedNodes[link.node]; !ok {
+				continue
+			}
+		}
+		key := poolKey{rail: link.rail}
+		if spcx.MultiplaneMode == "swplb" {
+			key.plane = link.plane
+		}
+		if seen[key] == nil {
+			seen[key] = map[string]struct{}{}
+		}
+		if _, ok := seen[key][link.node]; ok {
+			continue
+		}
+		seen[key][link.node] = struct{}{}
+		result[key] = append(result[key], StaticAllocation{
+			Gateway:  link.leafIP.String(),
+			NodeName: link.node,
+			Prefix:   link.hostIP.String() + "/31",
+		})
+	}
+	return result
+}
+
+func sortedPoolKeys(allocations map[poolKey][]StaticAllocation) []poolKey {
+	keys := make([]poolKey, 0, len(allocations))
+	for key := range allocations {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].rail != keys[j].rail {
+			return keys[i].rail < keys[j].rail
+		}
+		return keys[i].plane < keys[j].plane
+	})
+	return keys
+}
+
+func poolName(key poolKey, suffix string, spcx *config.ProfileSpectrumX) string {
+	name := fmt.Sprintf("rail-%d", key.rail)
+	if spcx.MultiplaneMode == "swplb" {
+		name = fmt.Sprintf("%s-plane-%d", name, key.plane)
+	}
+	if suffix != "" {
+		name += "-" + suffix
+	}
+	return name
+}
+
+func poolCIDR(prefix string, spcx *config.ProfileSpectrumX) string {
+	return supernet(prefix, railPrefixLength(spcx))
+}
+
+func planeCIDR(prefix string, spcx *config.ProfileSpectrumX) string {
+	return supernet(prefix, planePrefixLength(spcx))
+}
+
+func railPrefixLength(spcx *config.ProfileSpectrumX) int {
+	if spcx.TopologyType == config.SpectrumXTopology3Tier {
+		if planeAwareAddressing(spcx) {
+			return 13
+		}
+		return 11
+	}
+	if planeAwareAddressing(spcx) {
+		return 18
+	}
+	return 15
+}
+
+func planePrefixLength(spcx *config.ProfileSpectrumX) int {
+	if spcx.TopologyType == config.SpectrumXTopology3Tier {
+		if planeAwareAddressing(spcx) {
+			return 10
+		}
+		return 8
+	}
+	if planeAwareAddressing(spcx) {
+		return 14
+	}
+	return 12
+}
+
+func supernet(prefix string, prefixLength int) string {
+	ip, _, err := net.ParseCIDR(prefix)
+	if err != nil {
+		return ""
+	}
+	mask := net.CIDRMask(prefixLength, 32)
+	network := ip.Mask(mask)
+	return (&net.IPNet{IP: network, Mask: mask}).String()
+}
+
+func nodeSet(nodes []string) map[string]struct{} {
+	if len(nodes) == 0 {
+		return nil
+	}
+	result := make(map[string]struct{}, len(nodes))
+	for _, node := range nodes {
+		result[node] = struct{}{}
+	}
+	return result
+}
+
+func missingNodes(nodes map[string]struct{}, allocations []StaticAllocation) []string {
+	seen := map[string]struct{}{}
+	for _, allocation := range allocations {
+		seen[allocation.NodeName] = struct{}{}
+	}
+	missing := make([]string, 0)
+	for node := range nodes {
+		if _, ok := seen[node]; !ok {
+			missing = append(missing, node)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}

--- a/pkg/networkoperatorplugin/spectrumx/addressing_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spectrumx
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+func TestBuildCIDRPools2TierSWPLB(t *testing.T) {
+	topologyPath := writeTopology(t, `{
+  "nodes": [
+    {"name": "compute-a", "role": "host", "type": "default"},
+    {"name": "compute-b", "role": "host", "type": "default"},
+    {"name": "leaf-p0-r0", "role": "leaf", "type": "cumulus"},
+    {"name": "leaf-p0-r1", "role": "leaf", "type": "cumulus"},
+    {"name": "leaf-p1-r0", "role": "leaf", "type": "cumulus"},
+    {"name": "leaf-p1-r1", "role": "leaf", "type": "cumulus"}
+  ],
+  "links": [
+    [
+      {"node": "leaf-p0-r0", "interface": "swp1s0", "attributes": {"role": "leaf", "plane": 0, "pod": 0, "su": 0, "rail_group": [0]}},
+      {"node": "compute-a", "interface": "eth_p0_r0", "attributes": {"role": "host", "rail": 0, "pod": 0, "su": 0}}
+    ],
+    [
+      {"node": "leaf-p0-r0", "interface": "swp2s0", "attributes": {"role": "leaf", "plane": 0, "pod": 0, "su": 0, "rail_group": [0]}},
+      {"node": "compute-b", "interface": "eth_p0_r0", "attributes": {"role": "host", "rail": 0, "pod": 0, "su": 0}}
+    ],
+    [
+      {"node": "leaf-p0-r1", "interface": "swp1s0", "attributes": {"role": "leaf", "plane": 0, "pod": 0, "su": 0, "rail_group": [1]}},
+      {"node": "compute-a", "interface": "eth_p0_r1", "attributes": {"role": "host", "rail": 1, "pod": 0, "su": 0}}
+    ],
+    [
+      {"node": "leaf-p0-r1", "interface": "swp2s0", "attributes": {"role": "leaf", "plane": 0, "pod": 0, "su": 0, "rail_group": [1]}},
+      {"node": "compute-b", "interface": "eth_p0_r1", "attributes": {"role": "host", "rail": 1, "pod": 0, "su": 0}}
+    ],
+    [
+      {"node": "leaf-p1-r0", "interface": "swp1s0", "attributes": {"role": "leaf", "plane": 1, "pod": 0, "su": 0, "rail_group": [0]}},
+      {"node": "compute-a", "interface": "eth_p1_r0", "attributes": {"role": "host", "rail": 0, "pod": 0, "su": 0}}
+    ],
+    [
+      {"node": "leaf-p1-r0", "interface": "swp2s0", "attributes": {"role": "leaf", "plane": 1, "pod": 0, "su": 0, "rail_group": [0]}},
+      {"node": "compute-b", "interface": "eth_p1_r0", "attributes": {"role": "host", "rail": 0, "pod": 0, "su": 0}}
+    ],
+    [
+      {"node": "leaf-p1-r1", "interface": "swp1s0", "attributes": {"role": "leaf", "plane": 1, "pod": 0, "su": 0, "rail_group": [1]}},
+      {"node": "compute-a", "interface": "eth_p1_r1", "attributes": {"role": "host", "rail": 1, "pod": 0, "su": 0}}
+    ],
+    [
+      {"node": "leaf-p1-r1", "interface": "swp2s0", "attributes": {"role": "leaf", "plane": 1, "pod": 0, "su": 0, "rail_group": [1]}},
+      {"node": "compute-b", "interface": "eth_p1_r1", "attributes": {"role": "host", "rail": 1, "pod": 0, "su": 0}}
+    ]
+  ]
+}`)
+	rail0 := 0
+	rail1 := 1
+	cfg := &config.LaunchKitConfig{
+		Profile: &config.Profile{SpectrumX: &config.ProfileSpectrumX{
+			Enable:         true,
+			TopologyType:   config.SpectrumXTopology2Tier,
+			IPVersion:      config.SpectrumXIPVersionIPv4,
+			TopologyFile:   topologyPath,
+			MultiplaneMode: "swplb",
+			NumberOfPlanes: 2,
+		}},
+	}
+	pools, err := BuildCIDRPools(cfg, config.ClusterConfig{
+		MergedIdentifier: "gpu-model",
+		WorkerNodes:      []string{"compute-a", "compute-b"},
+		PFs: []config.PFConfig{
+			{Traffic: "east-west", Rail: &rail0},
+			{Traffic: "east-west", Rail: &rail0},
+			{Traffic: "east-west", Rail: &rail1},
+			{Traffic: "east-west", Rail: &rail1},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, pools, 4)
+	require.Equal(t, "rail-0-plane-0-gpu-model", pools[0].Name)
+	require.Equal(t, "172.16.0.0/18", pools[0].CIDR)
+	require.Equal(t, []string{"172.16.0.0/18", "172.16.0.0/14"}, pools[0].Routes)
+	require.Equal(t, []StaticAllocation{
+		{Gateway: "172.16.0.1", NodeName: "compute-a", Prefix: "172.16.0.0/31"},
+		{Gateway: "172.16.0.3", NodeName: "compute-b", Prefix: "172.16.0.2/31"},
+	}, pools[0].StaticAllocations)
+	require.Equal(t, "rail-1-plane-1-gpu-model", pools[3].Name)
+	require.Equal(t, "172.20.64.0/18", pools[3].CIDR)
+}
+
+func TestBuildCIDRPools3Tier(t *testing.T) {
+	topologyPath := writeTopology(t, `{
+  "nodes": [
+    {"name": "compute-a", "role": "host", "type": "default"},
+    {"name": "leaf-a", "role": "leaf", "type": "cumulus"}
+  ],
+  "links": [
+    [
+      {"node": "leaf-a", "interface": "swp1s0", "attributes": {"role": "leaf", "plane": 0, "pod": 2, "su": 3, "rail_group": [0]}},
+      {"node": "compute-a", "interface": "eth_p0_r0", "attributes": {"role": "host", "rail": 0, "pod": 2, "su": 3}}
+    ]
+  ]
+}`)
+	rail := 0
+	cfg := &config.LaunchKitConfig{
+		Profile: &config.Profile{SpectrumX: &config.ProfileSpectrumX{
+			Enable:         true,
+			TopologyType:   config.SpectrumXTopology3Tier,
+			IPVersion:      config.SpectrumXIPVersionIPv4,
+			TopologyFile:   topologyPath,
+			MultiplaneMode: "hwplb",
+			NumberOfPlanes: 4,
+		}},
+	}
+	pools, err := BuildCIDRPools(cfg, config.ClusterConfig{
+		WorkerNodes: []string{"compute-a"},
+		PFs:         []config.PFConfig{{Traffic: "east-west", Rail: &rail}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []CIDRPool{{
+		Name: "rail-0",
+		CIDR: "10.0.0.0/13",
+		Routes: []string{
+			"10.0.0.0/13",
+			"10.0.0.0/10",
+		},
+		StaticAllocations: []StaticAllocation{{
+			Gateway:  "10.0.131.1",
+			NodeName: "compute-a",
+			Prefix:   "10.0.131.0/31",
+		}},
+	}}, pools)
+}
+
+func TestBuildCIDRPoolsRejectsIPv6UntilRenderable(t *testing.T) {
+	cfg := &config.LaunchKitConfig{
+		Profile: &config.Profile{SpectrumX: &config.ProfileSpectrumX{
+			Enable:       true,
+			TopologyType: config.SpectrumXTopology2Tier,
+			IPVersion:    config.SpectrumXIPVersionIPv6,
+			TopologyFile: "topology.json",
+		}},
+	}
+	_, err := BuildCIDRPools(cfg, config.ClusterConfig{})
+	require.ErrorContains(t, err, "currently supports ipVersion=ipv4 only")
+}
+
+func writeTopology(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "topology.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/internal/pfutil"
+	spectrumxaddressing "github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/spectrumx"
 	"github.com/nvidia/k8s-launch-kit/pkg/profiles"
 )
 
@@ -116,6 +117,21 @@ var templateFuncs = template.FuncMap{
 		return profile != nil && profile.SpectrumX != nil && profile.SpectrumX.UseDRA
 	},
 	"spectrumXProfileConfigRequired": config.SpectrumXProfileConfigRequired,
+	"spectrumXCIDRPools": func(root any, clusterConfig *config.ClusterConfig) ([]spectrumxaddressing.CIDRPool, error) {
+		var cfg *config.LaunchKitConfig
+		switch v := root.(type) {
+		case *config.LaunchKitConfig:
+			cfg = v
+		case *templateContext:
+			cfg = v.LaunchKitConfig
+		default:
+			return nil, fmt.Errorf("Spectrum-X CIDRPool template requires launch-kit config root, got %T", root)
+		}
+		if clusterConfig == nil {
+			return nil, fmt.Errorf("Spectrum-X CIDRPool template requires a clusterConfig group")
+		}
+		return spectrumxaddressing.BuildCIDRPools(cfg, *clusterConfig)
+	},
 	"spectrumXVersionRef": func(spcx *config.ProfileSpectrumX) string {
 		if spcx == nil {
 			return ""

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -74,6 +74,9 @@ type Options struct {
 	SPCXVersion    string // Spectrum-X RA version (the value of --spectrum-x; empty = disabled)
 	MultiplaneMode string // Spectrum-X multiplane mode (default: swplb)
 	NumberOfPlanes int    // Number of planes for Spectrum-X (default: 4)
+	TopologyScheme string // Spectrum-X topology scheme: 2-tier or 3-tier
+	IPVersion      string // Spectrum-X address family: ipv4 or ipv6
+	TopologyFile   string // Path to spcx-gen-format topology.json for Spectrum-X CIDRPool generation
 	// SpectrumXConfig is a path to either a full Spectrum-X profile ConfigMap
 	// YAML or the raw data.profile YAML body. SpectrumXConfigMapName is required
 	// only when SpectrumXConfig contains the raw profile body.

--- a/pkg/resolve/defaults.go
+++ b/pkg/resolve/defaults.go
@@ -158,6 +158,14 @@ func applySpectrumXHardwareDefaults(cfg *config.LaunchKitConfig, opts options.Op
 		cfg.Profile.SpectrumX = &config.ProfileSpectrumX{}
 	}
 	cfg.Profile.SpectrumX.Enable = true
+	if cfg.Profile.SpectrumX.IPVersion == "" && opts.IPVersion == "" {
+		cfg.Profile.SpectrumX.IPVersion = config.SpectrumXIPVersionIPv4
+		*decisions = append(*decisions, DefaultDecision{
+			Flag:   "--ip-version",
+			Value:  config.SpectrumXIPVersionIPv4,
+			Reason: "Spectrum-X default",
+		})
+	}
 
 	// Implicit defaults: --spectrum-x forces ethernet fabric and sriov
 	// deployment. Multirail is handled by ApplyHardwareDefaults so its

--- a/pkg/resolve/validate.go
+++ b/pkg/resolve/validate.go
@@ -52,6 +52,15 @@ func ValidateResolvedConfig(cfg *config.LaunchKitConfig) error {
 		if cfg.Profile.SpectrumX.NumberOfPlanes != 0 {
 			return fmt.Errorf("numberOfPlanes is set but spectrumX.enable=false; remove the field or set --spectrum-x")
 		}
+		if cfg.Profile.SpectrumX.TopologyType != "" {
+			return fmt.Errorf("topologyType is set but spectrumX.enable=false; remove the field or set --spectrum-x")
+		}
+		if cfg.Profile.SpectrumX.IPVersion != "" {
+			return fmt.Errorf("ipVersion is set but spectrumX.enable=false; remove the field or set --spectrum-x")
+		}
+		if cfg.Profile.SpectrumX.TopologyFile != "" {
+			return fmt.Errorf("topologyFile is set but spectrumX.enable=false; remove the field or set --spectrum-x")
+		}
 	}
 
 	return nil
@@ -130,6 +139,21 @@ func validateSpectrumXCohort(cfg *config.LaunchKitConfig) error {
 	if !slices.Contains(config.SupportedNumberOfPlanes, spcx.NumberOfPlanes) {
 		return fmt.Errorf("invalid --number-of-planes %d; supported: %v",
 			spcx.NumberOfPlanes, config.SupportedNumberOfPlanes)
+	}
+	if spcx.TopologyType == "" {
+		return fmt.Errorf("--topology-scheme is required when --spectrum-x is set; supported: %v",
+			config.SupportedSpectrumXTopologyTypes)
+	}
+	if !slices.Contains(config.SupportedSpectrumXTopologyTypes, spcx.TopologyType) {
+		return fmt.Errorf("invalid --topology-scheme %q; supported: %v",
+			spcx.TopologyType, config.SupportedSpectrumXTopologyTypes)
+	}
+	if spcx.IPVersion == "" {
+		spcx.IPVersion = config.SpectrumXIPVersionIPv4
+	}
+	if !slices.Contains(config.SupportedSpectrumXIPVersions, spcx.IPVersion) {
+		return fmt.Errorf("invalid --ip-version %q; supported: %v",
+			spcx.IPVersion, config.SupportedSpectrumXIPVersions)
 	}
 
 	// Cross-validate mode ↔ planes. "none" (and "uniplane") collapse

--- a/pkg/resolve/validate_test.go
+++ b/pkg/resolve/validate_test.go
@@ -120,6 +120,7 @@ func TestValidateResolvedConfigAcceptsConfigMapProfileForRA23(t *testing.T) {
 				SPCXVersion:    "RA2.3",
 				MultiplaneMode: "hwplb",
 				NumberOfPlanes: 4,
+				TopologyType:   config.SpectrumXTopology2Tier,
 				ConfigMapName:  "site-ra23",
 				Profile:        "useSoftwareCCAlgorithm: true\n",
 			},

--- a/profiles/spectrum-x-ra2.1/60-cidrpool.yaml
+++ b/profiles/spectrum-x-ra2.1/60-cidrpool.yaml
@@ -1,62 +1,28 @@
-{{- /* One CIDRPool per rail (non-swplb) or per rail-plane (swplb).
-       All IP ranges are placeholders; the cluster operator must replace the
-       TODO_* values before applying. */ -}}
-{{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
-{{- $railCount := railCount .ClusterConfig.PFs $planes }}
-{{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
-{{- $first := true }}
-{{- range $railIdx := untilStep 0 $railCount 1 }}
-{{- if $swplb }}
-{{- range $planeIdx := untilStep 0 $planes 1 }}
-{{- if not $first }}---
-{{ end }}{{- $first = false -}}
+{{- /* .ClusterConfig.PFs keeps this template in per-group render mode. */ -}}
+{{- $pools := spectrumXCIDRPools . .ClusterConfig }}
+{{- range $idx, $pool := $pools }}
+{{- if $idx }}---
+{{ end -}}
 apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: CIDRPool
 metadata:
-  name: rail-{{$railIdx}}-plane-{{$planeIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
+  name: {{$pool.Name}}
   namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
-  # TODO: rail subnet for this plane (/15 for 2-tier, /11 for 3-tier topology)
-  cidr: TODO_RAIL_{{$railIdx}}_PLANE_{{$planeIdx}}_CIDR
+  cidr: {{$pool.CIDR}}
   gatewayIndex: 0
   perNodeNetworkPrefix: 31
   perNodeExclusions:
     - startIndex: 1
       endIndex: 1
   routes:
-    # TODO: rail subnet (same as cidr) + full east-west subnet
-    - dst: TODO_RAIL_SUBNET
-    - dst: TODO_EAST_WEST_SUBNET
-  # TODO: populate one entry per worker node
-  #   - gateway: <host ip on pod network>
-  #     nodeName: <node name>
-  #     prefix: <point-to-point /31 subnet>
-  staticAllocations: []
-{{ end }}
-{{- else }}
-{{- if not $first }}---
-{{ end }}{{- $first = false -}}
-apiVersion: nv-ipam.nvidia.com/v1alpha1
-kind: CIDRPool
-metadata:
-  name: rail-{{$railIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
-  namespace: "{{$.NetworkOperator.Namespace}}"
-spec:
-  # TODO: rail subnet (/15 for 2-tier, /11 for 3-tier topology)
-  cidr: TODO_RAIL_{{$railIdx}}_CIDR
-  gatewayIndex: 0
-  perNodeNetworkPrefix: 31
-  perNodeExclusions:
-    - startIndex: 1
-      endIndex: 1
-  routes:
-    # TODO: rail subnet (same as cidr) + full east-west subnet
-    - dst: TODO_RAIL_SUBNET
-    - dst: TODO_EAST_WEST_SUBNET
-  # TODO: populate one entry per worker node
-  #   - gateway: <host ip on pod network>
-  #     nodeName: <node name>
-  #     prefix: <point-to-point /31 subnet>
-  staticAllocations: []
-{{ end }}
+  {{- range $route := $pool.Routes }}
+    - dst: {{$route}}
+  {{- end }}
+  staticAllocations:
+  {{- range $allocation := $pool.StaticAllocations }}
+    - gateway: {{$allocation.Gateway}}
+      nodeName: {{$allocation.NodeName}}
+      prefix: {{$allocation.Prefix}}
+  {{- end }}
 {{- end }}

--- a/profiles/spectrum-x-ra2.2/60-cidrpool.yaml
+++ b/profiles/spectrum-x-ra2.2/60-cidrpool.yaml
@@ -1,62 +1,28 @@
-{{- /* One CIDRPool per rail (non-swplb) or per rail-plane (swplb).
-       All IP ranges are placeholders; the cluster operator must replace the
-       TODO_* values before applying. */ -}}
-{{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
-{{- $railCount := railCount .ClusterConfig.PFs $planes }}
-{{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
-{{- $first := true }}
-{{- range $railIdx := untilStep 0 $railCount 1 }}
-{{- if $swplb }}
-{{- range $planeIdx := untilStep 0 $planes 1 }}
-{{- if not $first }}---
-{{ end }}{{- $first = false -}}
+{{- /* .ClusterConfig.PFs keeps this template in per-group render mode. */ -}}
+{{- $pools := spectrumXCIDRPools . .ClusterConfig }}
+{{- range $idx, $pool := $pools }}
+{{- if $idx }}---
+{{ end -}}
 apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: CIDRPool
 metadata:
-  name: rail-{{$railIdx}}-plane-{{$planeIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
+  name: {{$pool.Name}}
   namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
-  # TODO: rail subnet for this plane (/15 for 2-tier, /11 for 3-tier topology)
-  cidr: TODO_RAIL_{{$railIdx}}_PLANE_{{$planeIdx}}_CIDR
+  cidr: {{$pool.CIDR}}
   gatewayIndex: 0
   perNodeNetworkPrefix: 31
   perNodeExclusions:
     - startIndex: 1
       endIndex: 1
   routes:
-    # TODO: rail subnet (same as cidr) + full east-west subnet
-    - dst: TODO_RAIL_SUBNET
-    - dst: TODO_EAST_WEST_SUBNET
-  # TODO: populate one entry per worker node
-  #   - gateway: <host ip on pod network>
-  #     nodeName: <node name>
-  #     prefix: <point-to-point /31 subnet>
-  staticAllocations: []
-{{ end }}
-{{- else }}
-{{- if not $first }}---
-{{ end }}{{- $first = false -}}
-apiVersion: nv-ipam.nvidia.com/v1alpha1
-kind: CIDRPool
-metadata:
-  name: rail-{{$railIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
-  namespace: "{{$.NetworkOperator.Namespace}}"
-spec:
-  # TODO: rail subnet (/15 for 2-tier, /11 for 3-tier topology)
-  cidr: TODO_RAIL_{{$railIdx}}_CIDR
-  gatewayIndex: 0
-  perNodeNetworkPrefix: 31
-  perNodeExclusions:
-    - startIndex: 1
-      endIndex: 1
-  routes:
-    # TODO: rail subnet (same as cidr) + full east-west subnet
-    - dst: TODO_RAIL_SUBNET
-    - dst: TODO_EAST_WEST_SUBNET
-  # TODO: populate one entry per worker node
-  #   - gateway: <host ip on pod network>
-  #     nodeName: <node name>
-  #     prefix: <point-to-point /31 subnet>
-  staticAllocations: []
-{{ end }}
+  {{- range $route := $pool.Routes }}
+    - dst: {{$route}}
+  {{- end }}
+  staticAllocations:
+  {{- range $allocation := $pool.StaticAllocations }}
+    - gateway: {{$allocation.Gateway}}
+      nodeName: {{$allocation.NodeName}}
+      prefix: {{$allocation.Prefix}}
+  {{- end }}
 {{- end }}

--- a/profiles/spectrum-x/60-cidrpool.yaml
+++ b/profiles/spectrum-x/60-cidrpool.yaml
@@ -1,62 +1,28 @@
-{{- /* One CIDRPool per rail (non-swplb) or per rail-plane (swplb).
-       All IP ranges are placeholders; the cluster operator must replace the
-       TODO_* values before applying. */ -}}
-{{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
-{{- $railCount := railCount .ClusterConfig.PFs $planes }}
-{{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
-{{- $first := true }}
-{{- range $railIdx := untilStep 0 $railCount 1 }}
-{{- if $swplb }}
-{{- range $planeIdx := untilStep 0 $planes 1 }}
-{{- if not $first }}---
-{{ end }}{{- $first = false -}}
+{{- /* .ClusterConfig.PFs keeps this template in per-group render mode. */ -}}
+{{- $pools := spectrumXCIDRPools . .ClusterConfig }}
+{{- range $idx, $pool := $pools }}
+{{- if $idx }}---
+{{ end -}}
 apiVersion: nv-ipam.nvidia.com/v1alpha1
 kind: CIDRPool
 metadata:
-  name: rail-{{$railIdx}}-plane-{{$planeIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
+  name: {{$pool.Name}}
   namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
-  # TODO: rail subnet for this plane (/15 for 2-tier, /11 for 3-tier topology)
-  cidr: TODO_RAIL_{{$railIdx}}_PLANE_{{$planeIdx}}_CIDR
+  cidr: {{$pool.CIDR}}
   gatewayIndex: 0
   perNodeNetworkPrefix: 31
   perNodeExclusions:
     - startIndex: 1
       endIndex: 1
   routes:
-    # TODO: rail subnet (same as cidr) + full east-west subnet
-    - dst: TODO_RAIL_SUBNET
-    - dst: TODO_EAST_WEST_SUBNET
-  # TODO: populate one entry per worker node
-  #   - gateway: <host ip on pod network>
-  #     nodeName: <node name>
-  #     prefix: <point-to-point /31 subnet>
-  staticAllocations: []
-{{ end }}
-{{- else }}
-{{- if not $first }}---
-{{ end }}{{- $first = false -}}
-apiVersion: nv-ipam.nvidia.com/v1alpha1
-kind: CIDRPool
-metadata:
-  name: rail-{{$railIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
-  namespace: "{{$.NetworkOperator.Namespace}}"
-spec:
-  # TODO: rail subnet (/15 for 2-tier, /11 for 3-tier topology)
-  cidr: TODO_RAIL_{{$railIdx}}_CIDR
-  gatewayIndex: 0
-  perNodeNetworkPrefix: 31
-  perNodeExclusions:
-    - startIndex: 1
-      endIndex: 1
-  routes:
-    # TODO: rail subnet (same as cidr) + full east-west subnet
-    - dst: TODO_RAIL_SUBNET
-    - dst: TODO_EAST_WEST_SUBNET
-  # TODO: populate one entry per worker node
-  #   - gateway: <host ip on pod network>
-  #     nodeName: <node name>
-  #     prefix: <point-to-point /31 subnet>
-  staticAllocations: []
-{{ end }}
+  {{- range $route := $pool.Routes }}
+    - dst: {{$route}}
+  {{- end }}
+  staticAllocations:
+  {{- range $allocation := $pool.StaticAllocations }}
+    - gateway: {{$allocation.Gateway}}
+      nodeName: {{$allocation.NodeName}}
+      prefix: {{$allocation.Prefix}}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary
- add Spectrum-X topology/IP inputs in config and CLI: `--topology-scheme`, `--ip-version`, and `--topology-file`
- generate nv-ipam CIDRPool manifests from spcx-gen-format `topology.json` and discovery-resolved worker groups
- implement guide-based IPv4 host/leaf allocation for 2-tier and 3-tier, including SWPLB and HWPLB plane-aware layouts
- keep `hostFirstOctet` config-only with topology-aware defaults; accept IPv6 input but fail CIDRPool rendering clearly until static IPv6 rendering is supported

## Testing
- `TMPDIR=$PWD/.tmp GOCACHE=$PWD/.gocache go test ./pkg/...`
- `git diff --check`
- `golangci-lint run ./...` not run: `golangci-lint` is not installed and there is no repo-local pinned binary
