### PR TITLE
Automate Network Operator release synchronization

### DIFF
--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
 jobs:
   image-build-push:
     name: Image build and push

--- a/.github/workflows/sync-network-operator-releases.yml
+++ b/.github/workflows/sync-network-operator-releases.yml
@@ -1,0 +1,212 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Sync Network Operator releases
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "pkg/networkoperatorplugin/releases/releases.yaml"
+
+concurrency:
+  group: sync-network-operator-releases
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  sync:
+    if: github.event_name != 'push'
+    name: Sync release catalog
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Sync release catalog
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: make sync-network-operator-releases
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if git diff --quiet -- pkg/networkoperatorplugin/releases/releases.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify synchronized catalog
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          make build
+          go test -race -count=1 ./...
+
+      - name: Create or update pull request
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="automation/network-operator-release-sync"
+          remote_sha=""
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            git fetch origin "refs/heads/${branch}:refs/remotes/origin/${branch}"
+            remote_sha="$(git rev-parse "refs/remotes/origin/${branch}")"
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -C "$branch"
+          git add -- pkg/networkoperatorplugin/releases/releases.yaml
+          git commit -s -m "chore: sync Network Operator release versions"
+
+          if [ -n "$remote_sha" ]; then
+            git push \
+              --force-with-lease="refs/heads/${branch}:${remote_sha}" \
+              origin "HEAD:refs/heads/${branch}"
+          else
+            git push origin "HEAD:refs/heads/${branch}"
+          fi
+
+          body="Automated nightly synchronization from Mellanox/network-operator release branches.
+
+          The newest catalog release falls back to master only while its release branch is absent.
+
+          Source workflow: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          title="chore: sync Network Operator release versions"
+          pr_number="$(gh api \
+            --method GET \
+            "repos/${GITHUB_REPOSITORY}/pulls" \
+            -f state=open \
+            -f head="${GITHUB_REPOSITORY_OWNER}:${branch}" \
+            -f base=main \
+            --jq '.[0].number')"
+
+          if [ -n "$pr_number" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" \
+              -f title="$title" \
+              -f body="$body"
+          else
+            gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/pulls" \
+              -f head="$branch" \
+              -f base=main \
+              -f title="$title" \
+              -f body="$body"
+          fi
+
+  tag:
+    if: github.event_name == 'push'
+    name: Tag synchronized release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Detect a newer latest release
+        id: release
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          catalog="pkg/networkoperatorplugin/releases/releases.yaml"
+          previous_tag="$(git show "${BEFORE_SHA}:${catalog}" |
+            go run ./hack/sync-network-operator-releases \
+              --catalog - \
+              --print-latest-tag)"
+          current_tag="$(go run ./hack/sync-network-operator-releases \
+            --print-latest-tag)"
+
+          if [ "$current_tag" = "$previous_tag" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          go run ./hack/sync-network-operator-releases \
+            --print-latest-tag \
+            --newer-than "$previous_tag" >/dev/null
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$current_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Check upstream and local tags
+        if: steps.release.outputs.changed == 'true'
+        id: tag
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          if ! git ls-remote --exit-code --tags \
+            https://github.com/Mellanox/network-operator.git \
+            "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "The upstream tag ${RELEASE_TAG} does not exist; skipping"
+            echo "create=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin \
+            "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "The k8s-launch-kit tag ${RELEASE_TAG} already exists; skipping"
+            echo "create=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "create=true" >> "$GITHUB_OUTPUT"
+
+      - name: Cut release tag
+        if: steps.tag.outputs.create == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          git tag "$RELEASE_TAG" "$GITHUB_SHA"
+          git push origin "refs/tags/${RELEASE_TAG}"
+          gh workflow run image-push-release.yml --ref "$RELEASE_TAG"

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ PCI_IDS_NVIDIA=pkg/networkoperatorplugin/internal/pciids/nvidia.ids
 NIC_CONFIG_CRDS_DIR=pkg/nicconfigdaemon/assets/crds
 NIC_CONFIG_OPERATOR_MODULE=github.com/Mellanox/nic-configuration-operator
 
-.PHONY: all build clean test coverage deps lint docker-build docker-build-local docker-run update-readme download-sosreport update-pci-ids sync-nic-config-crds release release-snapshot help
+.PHONY: all build clean test coverage deps lint docker-build docker-build-local docker-run update-readme download-sosreport update-pci-ids sync-network-operator-releases sync-nic-config-crds release release-snapshot help
 
 ## Build the binary
 build:
@@ -179,6 +179,10 @@ sync-nic-config-crds:
 	mkdir -p $(NIC_CONFIG_CRDS_DIR); \
 	cp "$$mod_dir"/config/crd/bases/*.yaml $(NIC_CONFIG_CRDS_DIR)/; \
 	chmod u+w $(NIC_CONFIG_CRDS_DIR)/*.yaml
+
+## Sync managed release catalog entries from Network Operator release branches.
+sync-network-operator-releases:
+	$(GOCMD) run ./hack/sync-network-operator-releases
 
 ## Download sosreport script
 download-sosreport:

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Common Flags:
       --image-pull-secrets strings          Image pull secret names for NicClusterPolicy (comma-separated)
       --kubeconfig string                   Path to kubeconfig file for cluster deployment (required when using --deploy; falls back to $KUBECONFIG, then ~/.kube/config)
       --network-operator-namespace string   Override the network operator namespace from the config file
-      --network-operator-release string     Network Operator release line to deploy (MAJOR.MINOR). Selects component image tags + repository from a built-in catalog and drives version-gated template sections. Supported: 25.10, 26.1, 26.4, 26.7
+      --network-operator-release string     Network Operator release line to deploy (MAJOR.MINOR). Selects component image tags + repository from a built-in catalog and drives version-gated template sections. Supported: 26.1, 26.4, 26.7
       --node-selector string                Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe (default "feature.node.kubernetes.io/pci-15b3.present=true")
       --user-config string                  Use provided cluster configuration file (as base config for discovery or as full config without discovery)
 
@@ -715,7 +715,24 @@ currently supports IPv4 static allocations only.
 For non-Spectrum-X profiles, leaving both the flag and `selectedRelease` empty
 continues to render the newest gates (treated as "latest").
 
-Adding a new release is a YAML-only change in `releases.yaml` — patch bumps update an existing entry in place; new minor lines add a new top-level key.
+Every catalog entry is synchronized nightly from
+`Mellanox/network-operator`'s `v<MAJOR.MINOR>.x` branch. When the release
+branch for the highest catalog key has not been created yet, the synchronizer
+uses `master` and verifies that its Network Operator version still belongs to
+that release line. The workflow opens or refreshes a PR only when values
+change. Run the same update locally with
+`GITHUB_TOKEN=<token> make sync-network-operator-releases` (authentication
+avoids GitHub's low anonymous API rate limit).
+
+After a catalog update reaches `main`, the workflow compares the previous and
+new highest catalog versions. If the new version is newer and the exact tag
+exists in `Mellanox/network-operator`, it cuts the matching lightweight tag on
+the updated k8s-launch-kit commit and dispatches the existing release-image
+workflow for that tag.
+
+Adding a new release remains a YAML-only catalog change: add its top-level
+entry under `releases:`. It automatically becomes part of the nightly sync and,
+while it is the highest key, can use `master` until its release branch exists.
 
 ### Maintenance and node upgrade concurrency
 
@@ -880,7 +897,7 @@ networkOperator:
   imagePullSecrets: []
 docaDriver:
   enable: true
-  version: doca3.2.0-25.10-1.2.8.0-2
+  version: doca3.3.0-26.01-1.0.0.0-6
   unloadStorageModules: false
   enableNFSRDMA: false
   unloadThirdPartyRDMAModules: false

--- a/hack/sync-network-operator-releases/main.go
+++ b/hack/sync-network-operator-releases/main.go
@@ -1,0 +1,129 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	defaultCatalogPath = "pkg/networkoperatorplugin/releases/releases.yaml"
+	defaultAPIBaseURL  = "https://api.github.com"
+	commandTimeout     = 2 * time.Minute
+	httpTimeout        = 30 * time.Second
+)
+
+func main() {
+	catalogPath := flag.String(
+		"catalog",
+		defaultCatalogPath,
+		"path to the k8s-launch-kit Network Operator release catalog",
+	)
+	apiBaseURL := flag.String(
+		"api-base-url",
+		defaultAPIBaseURL,
+		"GitHub API base URL",
+	)
+	printLatestTag := flag.Bool(
+		"print-latest-tag",
+		false,
+		"print the Network Operator tag from the highest catalog release and exit",
+	)
+	newerThan := flag.String(
+		"newer-than",
+		"",
+		"require the tag printed by --print-latest-tag to be newer than this tag",
+	)
+	flag.Parse()
+
+	if *printLatestTag {
+		catalog, err := readCatalog(*catalogPath)
+		if err != nil {
+			exitWithError(err)
+		}
+		tag, err := latestCatalogTag(catalog)
+		if err != nil {
+			exitWithError(err)
+		}
+		if *newerThan != "" {
+			if err := requireNewerTag(tag, *newerThan); err != nil {
+				exitWithError(err)
+			}
+		}
+		fmt.Println(tag)
+		return
+	}
+	if *newerThan != "" {
+		exitWithError(errors.New("--newer-than requires --print-latest-tag"))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	result, err := syncCatalog(ctx, syncOptions{
+		CatalogPath: *catalogPath,
+		APIBaseURL:  *apiBaseURL,
+		Token:       os.Getenv("GITHUB_TOKEN"),
+		HTTPClient:  &http.Client{Timeout: httpTimeout},
+	})
+	if err != nil {
+		exitWithError(fmt.Errorf("sync Network Operator releases: %w", err))
+	}
+
+	if !result.Changed {
+		fmt.Println("Network Operator release catalog is already current")
+		return
+	}
+
+	for _, update := range result.Updates {
+		fmt.Printf(
+			"updated %s from %s: Network Operator %s, DOCA driver %s\n",
+			update.Release,
+			update.Ref,
+			update.NetworkOperatorVersion,
+			update.DOCADriverVersion,
+		)
+	}
+}
+
+func readCatalog(path string) ([]byte, error) {
+	if path == "-" {
+		catalog, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("read catalog from stdin: %w", err)
+		}
+		return catalog, nil
+	}
+
+	catalog, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read catalog %q: %w", path, err)
+	}
+	return catalog, nil
+}
+
+func exitWithError(err error) {
+	_, _ = fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/hack/sync-network-operator-releases/sync.go
+++ b/hack/sync-network-operator-releases/sync.go
@@ -1,0 +1,663 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	releaseBranchPrefix = "v"
+	releaseBranchSuffix = ".x"
+	fallbackBranch      = "master"
+	upstreamRepository  = "Mellanox/network-operator"
+
+	stableOperatorRepository  = "nvcr.io/nvidia/cloud-native"
+	stableComponentRepository = "nvcr.io/nvidia/mellanox"
+	stableHelmRepoURL         = "https://helm.ngc.nvidia.com/nvidia"
+
+	stagingOperatorRepository  = "nvcr.io/nvstaging/mellanox"
+	stagingComponentRepository = "nvcr.io/nvstaging/mellanox"
+	stagingHelmRepoURL         = "https://helm.ngc.nvidia.com/nvstaging/mellanox"
+)
+
+type syncOptions struct {
+	CatalogPath string
+	APIBaseURL  string
+	Token       string
+	HTTPClient  *http.Client
+}
+
+type syncResult struct {
+	Changed bool
+	Updates []releaseUpdate
+}
+
+type releaseUpdate struct {
+	Release                string
+	Ref                    string
+	NetworkOperatorVersion string
+	DOCADriverVersion      string
+}
+
+type upstreamReleaseFile struct {
+	NetworkOperator              upstreamImage `yaml:"NetworkOperator"`
+	NetworkOperatorInitContainer upstreamImage `yaml:"NetworkOperatorInitContainer"`
+	Mofed                        upstreamImage `yaml:"Mofed"`
+}
+
+type upstreamImage struct {
+	Repository string `yaml:"repository"`
+	Version    string `yaml:"version"`
+}
+
+type desiredRelease struct {
+	NetworkOperatorVersion string
+	ComponentVersion       string
+	ComponentRepository    string
+	OperatorRepository     string
+	HelmRepoURL            string
+	DOCADriverVersion      string
+}
+
+type desiredReleaseWithSource struct {
+	Release string
+	Ref     string
+	Desired desiredRelease
+}
+
+type catalogRelease struct {
+	Key     string
+	Version *semver.Version
+}
+
+type githubClient struct {
+	baseURL    string
+	repository string
+	token      string
+	httpClient *http.Client
+}
+
+func syncCatalog(ctx context.Context, opts syncOptions) (syncResult, error) {
+	if opts.CatalogPath == "" {
+		return syncResult{}, errors.New("catalog path must not be empty")
+	}
+	if opts.APIBaseURL == "" {
+		return syncResult{}, errors.New("GitHub API base URL must not be empty")
+	}
+	if opts.HTTPClient == nil {
+		return syncResult{}, errors.New("HTTP client must not be nil")
+	}
+
+	original, err := os.ReadFile(opts.CatalogPath)
+	if err != nil {
+		return syncResult{}, fmt.Errorf("read catalog %q: %w", opts.CatalogPath, err)
+	}
+
+	managed, err := catalogReleases(original)
+	if err != nil {
+		return syncResult{}, err
+	}
+
+	client, err := newGitHubClient(
+		opts.APIBaseURL,
+		upstreamRepository,
+		opts.Token,
+		opts.HTTPClient,
+	)
+	if err != nil {
+		return syncResult{}, err
+	}
+
+	desired := make([]desiredReleaseWithSource, 0, len(managed))
+	latestRelease := managed[len(managed)-1].Key
+	for _, catalogEntry := range managed {
+		release := catalogEntry.Key
+		ref, err := client.resolveRef(ctx, release, release == latestRelease)
+		if err != nil {
+			return syncResult{}, fmt.Errorf("resolve source for release %s: %w", release, err)
+		}
+
+		upstreamYAML, err := client.fetchReleaseFile(ctx, ref)
+		if err != nil {
+			return syncResult{}, fmt.Errorf("fetch release %s from %s: %w", release, ref, err)
+		}
+
+		releaseValues, err := desiredFromUpstream(release, upstreamYAML)
+		if err != nil {
+			return syncResult{}, fmt.Errorf("validate release %s from %s: %w", release, ref, err)
+		}
+
+		desired = append(desired, desiredReleaseWithSource{
+			Release: release,
+			Ref:     ref,
+			Desired: releaseValues,
+		})
+	}
+
+	var document yaml.Node
+	if err := yaml.Unmarshal(original, &document); err != nil {
+		return syncResult{}, fmt.Errorf("parse catalog document: %w", err)
+	}
+
+	changedItems := make([]desiredReleaseWithSource, 0, len(desired))
+	for _, item := range desired {
+		itemChanged, err := applyDesiredRelease(&document, item.Release, item.Desired)
+		if err != nil {
+			return syncResult{}, err
+		}
+		if itemChanged {
+			changedItems = append(changedItems, item)
+		}
+	}
+	if len(changedItems) == 0 {
+		return syncResult{Changed: false}, nil
+	}
+
+	var updated bytes.Buffer
+	encoder := yaml.NewEncoder(&updated)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&document); err != nil {
+		return syncResult{}, fmt.Errorf("encode updated catalog: %w", err)
+	}
+	if err := encoder.Close(); err != nil {
+		return syncResult{}, fmt.Errorf("close catalog encoder: %w", err)
+	}
+
+	if err := writeFileAtomically(opts.CatalogPath, updated.Bytes()); err != nil {
+		return syncResult{}, err
+	}
+
+	result := syncResult{
+		Changed: true,
+		Updates: make([]releaseUpdate, 0, len(changedItems)),
+	}
+	for _, item := range changedItems {
+		result.Updates = append(result.Updates, releaseUpdate{
+			Release:                item.Release,
+			Ref:                    item.Ref,
+			NetworkOperatorVersion: item.Desired.NetworkOperatorVersion,
+			DOCADriverVersion:      item.Desired.DOCADriverVersion,
+		})
+	}
+	return result, nil
+}
+
+func catalogReleases(catalogYAML []byte) ([]catalogRelease, error) {
+	var document struct {
+		Releases map[string]yaml.Node `yaml:"releases"`
+	}
+	if err := yaml.Unmarshal(catalogYAML, &document); err != nil {
+		return nil, fmt.Errorf("parse catalog releases: %w", err)
+	}
+	if len(document.Releases) == 0 {
+		return nil, errors.New("catalog releases must not be empty")
+	}
+
+	releases := make([]catalogRelease, 0, len(document.Releases))
+	for release := range document.Releases {
+		version, err := semver.NewVersion(release + ".0")
+		if err != nil {
+			return nil, fmt.Errorf("catalog release %q is not MAJOR.MINOR: %w", release, err)
+		}
+		if fmt.Sprintf("%d.%d", version.Major(), version.Minor()) != release {
+			return nil, fmt.Errorf("catalog release %q must use MAJOR.MINOR format", release)
+		}
+		releases = append(releases, catalogRelease{
+			Key:     release,
+			Version: version,
+		})
+	}
+
+	sort.Slice(releases, func(i, j int) bool {
+		return releases[i].Version.LessThan(releases[j].Version)
+	})
+	return releases, nil
+}
+
+func latestCatalogTag(catalogYAML []byte) (string, error) {
+	releases, err := catalogReleases(catalogYAML)
+	if err != nil {
+		return "", err
+	}
+	latest := releases[len(releases)-1]
+
+	var document struct {
+		Releases map[string]struct {
+			NetworkOperator struct {
+				Version string `yaml:"version"`
+			} `yaml:"networkOperator"`
+		} `yaml:"releases"`
+	}
+	if err := yaml.Unmarshal(catalogYAML, &document); err != nil {
+		return "", fmt.Errorf("parse catalog versions: %w", err)
+	}
+
+	entry, ok := document.Releases[latest.Key]
+	if !ok {
+		return "", fmt.Errorf("latest catalog release %q is missing", latest.Key)
+	}
+	if entry.NetworkOperator.Version == "" {
+		return "", fmt.Errorf(
+			"latest catalog release %q has no networkOperator.version",
+			latest.Key,
+		)
+	}
+
+	tagVersion, err := semver.NewVersion(entry.NetworkOperator.Version)
+	if err != nil {
+		return "", fmt.Errorf(
+			"latest catalog tag %q is invalid: %w",
+			entry.NetworkOperator.Version,
+			err,
+		)
+	}
+	if tagVersion.Major() != latest.Version.Major() ||
+		tagVersion.Minor() != latest.Version.Minor() {
+		return "", fmt.Errorf(
+			"latest catalog tag %q does not belong to release line %s",
+			entry.NetworkOperator.Version,
+			latest.Key,
+		)
+	}
+	return entry.NetworkOperator.Version, nil
+}
+
+func requireNewerTag(candidate string, previous string) error {
+	candidateVersion, err := semver.NewVersion(candidate)
+	if err != nil {
+		return fmt.Errorf("candidate tag %q is invalid: %w", candidate, err)
+	}
+	previousVersion, err := semver.NewVersion(previous)
+	if err != nil {
+		return fmt.Errorf("previous tag %q is invalid: %w", previous, err)
+	}
+	if !candidateVersion.GreaterThan(previousVersion) {
+		return fmt.Errorf(
+			"candidate tag %q is not newer than %q",
+			candidate,
+			previous,
+		)
+	}
+	return nil
+}
+
+func newGitHubClient(
+	baseURL string,
+	repository string,
+	token string,
+	httpClient *http.Client,
+) (*githubClient, error) {
+	parts := strings.Split(repository, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("upstream repository %q must be OWNER/REPO", repository)
+	}
+
+	escapedRepository := url.PathEscape(parts[0]) + "/" + url.PathEscape(parts[1])
+	return &githubClient{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		repository: escapedRepository,
+		token:      token,
+		httpClient: httpClient,
+	}, nil
+}
+
+func (c *githubClient) resolveRef(
+	ctx context.Context,
+	release string,
+	allowMasterFallback bool,
+) (string, error) {
+	branch := releaseBranchPrefix + release + releaseBranchSuffix
+	exists, err := c.branchExists(ctx, branch)
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		return branch, nil
+	}
+	if !allowMasterFallback {
+		return "", fmt.Errorf("release branch %q does not exist", branch)
+	}
+
+	masterExists, err := c.branchExists(ctx, fallbackBranch)
+	if err != nil {
+		return "", err
+	}
+	if !masterExists {
+		return "", fmt.Errorf(
+			"release branch %q and fallback branch %q do not exist",
+			branch,
+			fallbackBranch,
+		)
+	}
+	return fallbackBranch, nil
+}
+
+func (c *githubClient) branchExists(ctx context.Context, branch string) (bool, error) {
+	endpoint := fmt.Sprintf(
+		"%s/repos/%s/branches/%s",
+		c.baseURL,
+		c.repository,
+		url.PathEscape(branch),
+	)
+	resp, err := c.get(ctx, endpoint, "application/vnd.github+json")
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return true, nil
+	case http.StatusNotFound:
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return false, nil
+	default:
+		return false, githubStatusError(resp, endpoint)
+	}
+}
+
+func (c *githubClient) fetchReleaseFile(ctx context.Context, ref string) ([]byte, error) {
+	endpoint := fmt.Sprintf(
+		"%s/repos/%s/contents/hack/release.yaml?ref=%s",
+		c.baseURL,
+		c.repository,
+		url.QueryEscape(ref),
+	)
+	resp, err := c.get(ctx, endpoint, "application/vnd.github.raw+json")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, githubStatusError(resp, endpoint)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read GitHub response for %s: %w", endpoint, err)
+	}
+	return body, nil
+}
+
+func (c *githubClient) get(
+	ctx context.Context,
+	endpoint string,
+	accept string,
+) (*http.Response, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create GitHub request: %w", err)
+	}
+	request.Header.Set("Accept", accept)
+	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if c.token != "" {
+		request.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("request %s: %w", endpoint, err)
+	}
+	return response, nil
+}
+
+func githubStatusError(response *http.Response, endpoint string) error {
+	body, readErr := io.ReadAll(io.LimitReader(response.Body, 4096))
+	if readErr != nil {
+		return fmt.Errorf(
+			"GitHub API returned %s for %s and the response body could not be read: %v",
+			response.Status,
+			endpoint,
+			readErr,
+		)
+	}
+	return fmt.Errorf(
+		"GitHub API returned %s for %s: %s",
+		response.Status,
+		endpoint,
+		strings.TrimSpace(string(body)),
+	)
+}
+
+func desiredFromUpstream(release string, upstreamYAML []byte) (desiredRelease, error) {
+	var upstream upstreamReleaseFile
+	if err := yaml.Unmarshal(upstreamYAML, &upstream); err != nil {
+		return desiredRelease{}, fmt.Errorf("parse hack/release.yaml: %w", err)
+	}
+
+	required := map[string]string{
+		"NetworkOperator.version":                 upstream.NetworkOperator.Version,
+		"NetworkOperator.repository":              upstream.NetworkOperator.Repository,
+		"NetworkOperatorInitContainer.version":    upstream.NetworkOperatorInitContainer.Version,
+		"NetworkOperatorInitContainer.repository": upstream.NetworkOperatorInitContainer.Repository,
+		"Mofed.version":                           upstream.Mofed.Version,
+		"Mofed.repository":                        upstream.Mofed.Repository,
+	}
+	for field, value := range required {
+		if value == "" {
+			return desiredRelease{}, fmt.Errorf("%s must not be empty", field)
+		}
+	}
+
+	operatorVersion, err := semver.NewVersion(upstream.NetworkOperator.Version)
+	if err != nil {
+		return desiredRelease{}, fmt.Errorf(
+			"upstream NetworkOperator.version %q is invalid: %w",
+			upstream.NetworkOperator.Version,
+			err,
+		)
+	}
+	releaseVersion, err := semver.NewVersion(release + ".0")
+	if err != nil {
+		return desiredRelease{}, fmt.Errorf("release key %q is invalid: %w", release, err)
+	}
+	if operatorVersion.Major() != releaseVersion.Major() ||
+		operatorVersion.Minor() != releaseVersion.Minor() {
+		return desiredRelease{}, fmt.Errorf(
+			"upstream NetworkOperator.version %q does not belong to release line %s",
+			upstream.NetworkOperator.Version,
+			release,
+		)
+	}
+
+	expectedComponentVersion := "network-operator-" + upstream.NetworkOperator.Version
+	if upstream.NetworkOperatorInitContainer.Version != expectedComponentVersion {
+		return desiredRelease{}, fmt.Errorf(
+			"upstream NetworkOperatorInitContainer.version %q does not match expected %q",
+			upstream.NetworkOperatorInitContainer.Version,
+			expectedComponentVersion,
+		)
+	}
+
+	destination, err := artifactDestinationFor(upstream.NetworkOperator.Repository)
+	if err != nil {
+		return desiredRelease{}, err
+	}
+	if upstream.NetworkOperatorInitContainer.Repository != destination.ComponentRepository {
+		return desiredRelease{}, fmt.Errorf(
+			"upstream NetworkOperatorInitContainer.repository %q does not match expected %q",
+			upstream.NetworkOperatorInitContainer.Repository,
+			destination.ComponentRepository,
+		)
+	}
+	if upstream.Mofed.Repository != destination.ComponentRepository {
+		return desiredRelease{}, fmt.Errorf(
+			"upstream Mofed.repository %q does not match expected %q",
+			upstream.Mofed.Repository,
+			destination.ComponentRepository,
+		)
+	}
+
+	return desiredRelease{
+		NetworkOperatorVersion: upstream.NetworkOperator.Version,
+		ComponentVersion:       upstream.NetworkOperatorInitContainer.Version,
+		ComponentRepository:    upstream.NetworkOperatorInitContainer.Repository,
+		OperatorRepository:     upstream.NetworkOperator.Repository,
+		HelmRepoURL:            destination.HelmRepoURL,
+		DOCADriverVersion:      upstream.Mofed.Version,
+	}, nil
+}
+
+type artifactDestination struct {
+	ComponentRepository string
+	HelmRepoURL         string
+}
+
+func artifactDestinationFor(operatorRepository string) (artifactDestination, error) {
+	switch operatorRepository {
+	case stableOperatorRepository:
+		return artifactDestination{
+			ComponentRepository: stableComponentRepository,
+			HelmRepoURL:         stableHelmRepoURL,
+		}, nil
+	case stagingOperatorRepository:
+		return artifactDestination{
+			ComponentRepository: stagingComponentRepository,
+			HelmRepoURL:         stagingHelmRepoURL,
+		}, nil
+	default:
+		return artifactDestination{}, fmt.Errorf(
+			"unsupported NetworkOperator.repository %q",
+			operatorRepository,
+		)
+	}
+}
+
+func applyDesiredRelease(
+	document *yaml.Node,
+	release string,
+	desired desiredRelease,
+) (bool, error) {
+	if document == nil || document.Kind != yaml.DocumentNode || len(document.Content) == 0 {
+		return false, errors.New("catalog YAML has no document")
+	}
+
+	root := document.Content[0]
+	releasesNode, err := mappingValue(root, "releases")
+	if err != nil {
+		return false, err
+	}
+	releaseNode, err := mappingValue(releasesNode, release)
+	if err != nil {
+		return false, fmt.Errorf("catalog release %s: %w", release, err)
+	}
+	networkOperatorNode, err := mappingValue(releaseNode, "networkOperator")
+	if err != nil {
+		return false, fmt.Errorf("catalog release %s: %w", release, err)
+	}
+	docaDriverNode, err := mappingValue(releaseNode, "docaDriver")
+	if err != nil {
+		return false, fmt.Errorf("catalog release %s: %w", release, err)
+	}
+
+	updates := []struct {
+		parent *yaml.Node
+		key    string
+		value  string
+	}{
+		{networkOperatorNode, "version", desired.NetworkOperatorVersion},
+		{networkOperatorNode, "componentVersion", desired.ComponentVersion},
+		{networkOperatorNode, "repository", desired.ComponentRepository},
+		{networkOperatorNode, "operatorRepository", desired.OperatorRepository},
+		{networkOperatorNode, "helmRepoURL", desired.HelmRepoURL},
+		{docaDriverNode, "version", desired.DOCADriverVersion},
+	}
+
+	changed := false
+	for _, update := range updates {
+		valueNode, err := mappingValue(update.parent, update.key)
+		if err != nil {
+			return false, fmt.Errorf("catalog release %s: %w", release, err)
+		}
+		if valueNode.Kind != yaml.ScalarNode {
+			return false, fmt.Errorf(
+				"catalog release %s field %s must be a scalar",
+				release,
+				update.key,
+			)
+		}
+		if valueNode.Value != update.value {
+			valueNode.Value = update.value
+			changed = true
+		}
+	}
+	return changed, nil
+}
+
+func mappingValue(mapping *yaml.Node, key string) (*yaml.Node, error) {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("expected YAML mapping while looking for %q", key)
+	}
+	for index := 0; index+1 < len(mapping.Content); index += 2 {
+		if mapping.Content[index].Value == key {
+			return mapping.Content[index+1], nil
+		}
+	}
+	return nil, fmt.Errorf("missing YAML key %q", key)
+}
+
+func writeFileAtomically(path string, data []byte) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat catalog %q: %w", path, err)
+	}
+
+	directory := filepath.Dir(path)
+	temporary, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary catalog: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	removeTemporary := true
+	defer func() {
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+
+	if err := temporary.Chmod(info.Mode().Perm()); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("set temporary catalog permissions: %w", err)
+	}
+	if _, err := temporary.Write(data); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write temporary catalog: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary catalog: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("replace catalog %q: %w", path, err)
+	}
+	removeTemporary = false
+	return nil
+}

--- a/hack/sync-network-operator-releases/sync_test.go
+++ b/hack/sync-network-operator-releases/sync_test.go
@@ -1,0 +1,366 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type fakeGitHub struct {
+	branches map[string]bool
+	files    map[string]string
+	requests []string
+}
+
+func (f *fakeGitHub) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	f.requests = append(f.requests, request.URL.RequestURI())
+
+	const branchPrefix = "/repos/Mellanox/network-operator/branches/"
+	if strings.HasPrefix(request.URL.Path, branchPrefix) {
+		branch, err := url.PathUnescape(strings.TrimPrefix(request.URL.Path, branchPrefix))
+		if err != nil {
+			http.Error(response, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if !f.branches[branch] {
+			http.NotFound(response, request)
+			return
+		}
+		response.WriteHeader(http.StatusOK)
+		_, _ = response.Write([]byte(`{}`))
+		return
+	}
+
+	const contentsPath = "/repos/Mellanox/network-operator/contents/hack/release.yaml"
+	if request.URL.Path == contentsPath {
+		ref := request.URL.Query().Get("ref")
+		releaseFile, ok := f.files[ref]
+		if !ok {
+			http.NotFound(response, request)
+			return
+		}
+		response.WriteHeader(http.StatusOK)
+		_, _ = response.Write([]byte(releaseFile))
+		return
+	}
+
+	http.NotFound(response, request)
+}
+
+type catalogReleaseValues struct {
+	NetworkOperator struct {
+		Version            string `yaml:"version"`
+		ComponentVersion   string `yaml:"componentVersion"`
+		Repository         string `yaml:"repository"`
+		OperatorRepository string `yaml:"operatorRepository"`
+		HelmRepoURL        string `yaml:"helmRepoURL"`
+	} `yaml:"networkOperator"`
+	DOCADriver struct {
+		Version string `yaml:"version"`
+	} `yaml:"docaDriver"`
+}
+
+func TestSyncCatalogUpdatesAllReleasesAndFallsBackForLatest(t *testing.T) {
+	catalogPath := writeTestCatalog(t, testCatalogYAML())
+	fake := &fakeGitHub{
+		branches: map[string]bool{
+			"v26.1.x": true,
+			"v26.7.x": false,
+			"master":  true,
+		},
+		files: map[string]string{
+			"v26.1.x": upstreamReleaseYAML(
+				"v26.1.2",
+				stableOperatorRepository,
+				stableComponentRepository,
+				"doca3.3.0-26.01-1.0.0.0-6",
+			),
+			"master": upstreamReleaseYAML(
+				"v26.7.0-beta.5",
+				stagingOperatorRepository,
+				stagingComponentRepository,
+				"doca3.5.0-26.07-0.4.3.0-0",
+			),
+		},
+		requests: nil,
+	}
+	server := httptest.NewServer(fake)
+	t.Cleanup(server.Close)
+
+	result, err := syncCatalog(context.Background(), syncOptions{
+		CatalogPath: catalogPath,
+		APIBaseURL:  server.URL,
+		Token:       "test-token",
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+	require.True(t, result.Changed)
+	require.Len(t, result.Updates, 2)
+	assert.Equal(t, "v26.1.x", result.Updates[0].Ref)
+	assert.Equal(t, fallbackBranch, result.Updates[1].Ref)
+
+	updated := readTestCatalog(t, catalogPath)
+	assert.Contains(t, string(updated), "# Test release catalog")
+
+	var catalog struct {
+		Releases map[string]catalogReleaseValues `yaml:"releases"`
+	}
+	require.NoError(t, yaml.Unmarshal(updated, &catalog))
+	require.Len(t, catalog.Releases, 2)
+
+	stable := catalog.Releases["26.1"]
+	assert.Equal(t, "v26.1.2", stable.NetworkOperator.Version)
+	assert.Equal(t, "network-operator-v26.1.2", stable.NetworkOperator.ComponentVersion)
+	assert.Equal(t, stableComponentRepository, stable.NetworkOperator.Repository)
+	assert.Equal(t, stableOperatorRepository, stable.NetworkOperator.OperatorRepository)
+	assert.Equal(t, stableHelmRepoURL, stable.NetworkOperator.HelmRepoURL)
+	assert.Equal(t, "doca3.3.0-26.01-1.0.0.0-6", stable.DOCADriver.Version)
+
+	latest := catalog.Releases["26.7"]
+	assert.Equal(t, "v26.7.0-beta.5", latest.NetworkOperator.Version)
+	assert.Equal(t, "network-operator-v26.7.0-beta.5", latest.NetworkOperator.ComponentVersion)
+	assert.Equal(t, stagingComponentRepository, latest.NetworkOperator.Repository)
+	assert.Equal(t, stagingOperatorRepository, latest.NetworkOperator.OperatorRepository)
+	assert.Equal(t, stagingHelmRepoURL, latest.NetworkOperator.HelmRepoURL)
+	assert.Equal(t, "doca3.5.0-26.07-0.4.3.0-0", latest.DOCADriver.Version)
+
+	beforeSecondRun := append([]byte(nil), updated...)
+	secondResult, err := syncCatalog(context.Background(), syncOptions{
+		CatalogPath: catalogPath,
+		APIBaseURL:  server.URL,
+		Token:       "test-token",
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+	assert.False(t, secondResult.Changed)
+	assert.Empty(t, secondResult.Updates)
+	assert.Equal(t, beforeSecondRun, readTestCatalog(t, catalogPath))
+}
+
+func TestSyncCatalogDoesNotFallbackForOlderRelease(t *testing.T) {
+	catalogPath := writeTestCatalog(t, testCatalogYAML())
+	fake := &fakeGitHub{
+		branches: map[string]bool{
+			"v26.1.x": false,
+			"v26.7.x": true,
+			"master":  true,
+		},
+		files:    map[string]string{},
+		requests: nil,
+	}
+	server := httptest.NewServer(fake)
+	t.Cleanup(server.Close)
+
+	_, err := syncCatalog(context.Background(), syncOptions{
+		CatalogPath: catalogPath,
+		APIBaseURL:  server.URL,
+		Token:       "",
+		HTTPClient:  server.Client(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `release branch "v26.1.x" does not exist`)
+	assert.NotContains(t, strings.Join(fake.requests, "\n"), "/branches/master")
+}
+
+func TestSyncCatalogRejectsMismatchedMasterWithoutWriting(t *testing.T) {
+	original := testCatalogYAML()
+	catalogPath := writeTestCatalog(t, original)
+	fake := &fakeGitHub{
+		branches: map[string]bool{
+			"v26.1.x": true,
+			"v26.7.x": false,
+			"master":  true,
+		},
+		files: map[string]string{
+			"v26.1.x": upstreamReleaseYAML(
+				"v26.1.2",
+				stableOperatorRepository,
+				stableComponentRepository,
+				"doca3.3.0-26.01-1.0.0.0-6",
+			),
+			"master": upstreamReleaseYAML(
+				"v26.10.0-beta.1",
+				stagingOperatorRepository,
+				stagingComponentRepository,
+				"doca3.6.0-26.10-0.1.0.0-0",
+			),
+		},
+		requests: nil,
+	}
+	server := httptest.NewServer(fake)
+	t.Cleanup(server.Close)
+
+	_, err := syncCatalog(context.Background(), syncOptions{
+		CatalogPath: catalogPath,
+		APIBaseURL:  server.URL,
+		Token:       "",
+		HTTPClient:  server.Client(),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not belong to release line 26.7")
+	assert.Equal(t, []byte(original), readTestCatalog(t, catalogPath))
+}
+
+func TestDesiredFromUpstreamRejectsInvalidArtifactMetadata(t *testing.T) {
+	tests := []struct {
+		name          string
+		operatorRepo  string
+		componentRepo string
+		version       string
+		expectedError string
+	}{
+		{
+			name:          "unsupported operator repository",
+			operatorRepo:  "registry.example.com/network-operator",
+			componentRepo: stableComponentRepository,
+			version:       "v26.4.1",
+			expectedError: "unsupported NetworkOperator.repository",
+		},
+		{
+			name:          "component version mismatch",
+			operatorRepo:  stableOperatorRepository,
+			componentRepo: stableComponentRepository,
+			version:       "v26.7.0",
+			expectedError: "does not belong to release line 26.4",
+		},
+		{
+			name:          "component repository mismatch",
+			operatorRepo:  stableOperatorRepository,
+			componentRepo: stagingComponentRepository,
+			version:       "v26.4.1",
+			expectedError: "NetworkOperatorInitContainer.repository",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := desiredFromUpstream(
+				"26.4",
+				[]byte(upstreamReleaseYAML(
+					test.version,
+					test.operatorRepo,
+					test.componentRepo,
+					"doca3.4.1-26.04-1.1.0.0-1",
+				)),
+			)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.expectedError)
+		})
+	}
+}
+
+func TestCatalogReleasesRequiresMajorMinorKeys(t *testing.T) {
+	_, err := catalogReleases([]byte(`
+releases:
+  "26.01":
+    networkOperator: {}
+    docaDriver: {}
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must use MAJOR.MINOR format")
+}
+
+func TestLatestCatalogTag(t *testing.T) {
+	tag, err := latestCatalogTag([]byte(testCatalogYAML()))
+	require.NoError(t, err)
+	assert.Equal(t, "v26.7.0-beta.4", tag)
+}
+
+func TestRequireNewerTag(t *testing.T) {
+	require.NoError(t, requireNewerTag("v26.7.0-beta.5", "v26.7.0-beta.4"))
+	require.NoError(t, requireNewerTag("v26.7.0", "v26.7.0-rc.1"))
+
+	err := requireNewerTag("v26.7.0-beta.4", "v26.7.0-beta.5")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not newer")
+}
+
+func writeTestCatalog(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "releases.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o644))
+	return path
+}
+
+func readTestCatalog(t *testing.T, path string) []byte {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return contents
+}
+
+func testCatalogYAML() string {
+	return `# Test release catalog
+releases:
+  "26.1":
+    networkOperator:
+      version: v26.1.1
+      componentVersion: network-operator-v26.1.1
+      repository: nvcr.io/nvidia/mellanox
+      operatorRepository: nvcr.io/nvidia/cloud-native
+      helmRepoURL: https://helm.ngc.nvidia.com/nvidia
+    docaDriver:
+      version: doca3.3.0-26.01-1.0.0.0-0
+  "26.7":
+    networkOperator:
+      version: v26.7.0-beta.4
+      componentVersion: network-operator-v26.7.0-beta.4
+      repository: nvcr.io/nvstaging/mellanox
+      operatorRepository: nvcr.io/nvstaging/mellanox
+      helmRepoURL: https://helm.ngc.nvidia.com/nvstaging/mellanox
+    docaDriver:
+      version: doca3.5.0-26.07-0.4.2.0-0
+`
+}
+
+func upstreamReleaseYAML(
+	version string,
+	operatorRepository string,
+	componentRepository string,
+	docaVersion string,
+) string {
+	return fmt.Sprintf(`
+NetworkOperator:
+  repository: %s
+  version: %s
+NetworkOperatorInitContainer:
+  repository: %s
+  version: network-operator-%s
+Mofed:
+  repository: %s
+  version: %s
+`,
+		operatorRepository,
+		version,
+		componentRepository,
+		version,
+		componentRepository,
+		docaVersion,
+	)
+}

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -4,7 +4,7 @@ networkOperator:
   # version/componentVersion/repository/operatorRepository/helmRepoURL (below)
   # and docaDriver.version are populated from the embedded catalog;
   # explicit values here are overridden.
-  # Supported: 25.10, 26.1, 26.4, 26.7. Leave empty to use the explicit values
+  # Supported: 26.1, 26.4, 26.7. Leave empty to use the explicit values
   # below as-is.
   # selectedRelease: "26.4"
   version: v26.4.0

--- a/pkg/networkoperatorplugin/releases/releases.go
+++ b/pkg/networkoperatorplugin/releases/releases.go
@@ -26,8 +26,8 @@
 //   - pkg/cmd (flag validation and help text).
 //
 // The catalog is the single source of truth for what "26.4" / "26.1" /
-// "25.10" actually resolve to. Bump entries here when a patch release
-// ships; add a new key for a new minor.
+// "26.7" actually resolve to. Entries are synchronized nightly from the
+// matching Network Operator release branches.
 package releases
 
 import (

--- a/pkg/networkoperatorplugin/releases/releases.yaml
+++ b/pkg/networkoperatorplugin/releases/releases.yaml
@@ -13,37 +13,28 @@
 #                          while components live at `nvcr.io/nvidia/mellanox`;
 #                          staging lumps both under `nvcr.io/nvstaging/mellanox`.
 releases:
-  "25.10":
-    networkOperator:
-      version: v25.10.0
-      componentVersion: network-operator-v25.10.0
-      repository: nvcr.io/nvidia/mellanox
-      operatorRepository: nvcr.io/nvidia/cloud-native
-      helmRepoURL: https://helm.ngc.nvidia.com/nvidia
-    docaDriver:
-      version: doca3.2.2-25.10-2.4.1.0-4
   "26.1":
     networkOperator:
-      version: v26.1.1
-      componentVersion: network-operator-v26.1.1
+      version: v26.1.2
+      componentVersion: network-operator-v26.1.2
       repository: nvcr.io/nvidia/mellanox
       operatorRepository: nvcr.io/nvidia/cloud-native
       helmRepoURL: https://helm.ngc.nvidia.com/nvidia
     docaDriver:
-      version: doca3.3.0-26.01-1.0.0.0-0
+      version: doca3.3.0-26.01-1.0.0.0-6
   "26.4":
     networkOperator:
-      version: v26.4.0
-      componentVersion: network-operator-v26.4.0
+      version: v26.4.1
+      componentVersion: network-operator-v26.4.1
       repository: nvcr.io/nvidia/mellanox
       operatorRepository: nvcr.io/nvidia/cloud-native
       helmRepoURL: https://helm.ngc.nvidia.com/nvidia
     docaDriver:
-      version: doca3.4.0-26.04-0.8.6.0-0
+      version: doca3.4.1-26.04-1.1.0.0-1
   "26.7":
     networkOperator:
-      version: v26.7.0-beta.4
-      componentVersion: network-operator-v26.7.0-beta.4
+      version: v26.7.0-beta.5
+      componentVersion: network-operator-v26.7.0-beta.5
       repository: nvcr.io/nvstaging/mellanox
       operatorRepository: nvcr.io/nvstaging/mellanox
       helmRepoURL: https://helm.ngc.nvidia.com/nvstaging/mellanox

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-config
-version: 1.2.0
+version: 1.2.1
 description: "Use this skill when the user needs help understanding, creating, or editing a k8s-launch-kit (l8k) configuration file (l8k-config.yaml or cluster-config.yaml). Activate for: config file questions, parameter tuning, subnet configuration, NV-IPAM setup, DOCA driver settings, maintenance concurrency, NIC configuration operator settings, changing MTU, VFs, resource names, or understanding what any config field does."
 metadata:
   requires:
@@ -124,7 +124,7 @@ sriov:
 
 # Set DOCA driver version
 docaDriver:
-  version: "doca3.2.0-25.10-1.2.8.0-2"
+  version: "doca3.3.0-26.01-1.0.0.0-6"
 
 # Allow four simultaneous maintenance operations. Network Operator 26.1+
 # uses the global Maintenance Operator limits; older releases use the legacy
@@ -159,6 +159,12 @@ networkNamespaces: ["my-namespace"]
 - Start by running discovery (`l8k discover`) to generate a baseline, then edit it.
 - A discovered config can be passed directly to `l8k generate` without
   repeating profile flags; use flags only for overrides.
+- Use `l8k schema` to discover the Network Operator release keys supported by
+  the installed l8k version. Catalog values are synchronized nightly from the
+  matching `Mellanox/network-operator` release branches; the newest entry uses
+  `master` only until its `v<MAJOR.MINOR>.x` branch exists. A newer highest
+  version is tagged in k8s-launch-kit after the synchronized catalog reaches
+  `main` and the exact Network Operator tag is present upstream.
 - `nvIpam` subnets are auto-generated if not specified — one per rail using non-routable ranges.
 - `docaDriver.unloadThirdPartyRDMAModules: true` auto-populates `UNLOAD_THIRD_PARTY_RDMA_MODULES` from discovered OFED-dependent modules.
 - For release 26.1+, SR-IOV requestor mode requires both the Network Operator drain requestor and the SR-IOV external drainer. l8k renders both; applying only CRs cannot enable their Deployment environment variables.


### PR DESCRIPTION
## Summary

- add a nightly release-catalog synchronizer that reads each Network Operator release line from its `v<MAJOR.MINOR>.x` branch
- fall back implicitly to `master` only for the highest catalog release while its release branch is absent
- validate release-line versions and artifact repositories before atomically updating the catalog
- remove the 25.10 catalog release and update 26.1, 26.4, and 26.7 from their current upstream release files
- open or refresh one automated PR when the nightly run finds changes
- after a newer highest release reaches `main`, cut the matching lightweight k8s-launch-kit tag when the exact Network Operator tag exists, then explicitly dispatch the existing release-image workflow for that tag

No separate synchronization metadata is added to `releases.yaml`; every release entry is managed automatically.

## Validation

- `go test -race -count=1 ./...`
- `CGO_ENABLED=0 make build`
- `CGO_ENABLED=0 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0 run ./...`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/sync-network-operator-releases.yml`
- authenticated live sync against `Mellanox/network-operator` (idempotent after applying the updates)
- tag replay: `v26.7.0-beta.4` -> `v26.7.0-beta.5`, with the exact upstream tag confirmed