### PR TITLE
Publish synchronized Network Operator releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 concurrency:
   group: release-${{ github.ref }}
@@ -88,8 +89,10 @@ jobs:
     steps:
       - name: Report job statuses
         run: |
-          echo "## Release Pipeline Summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Job | Status |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-----|--------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Test | ${{ needs.test.result }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| GoReleaser | ${{ needs.goreleaser.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Release Pipeline Summary"
+            echo "| Job | Status |"
+            echo "|-----|--------|"
+            echo "| Test | ${{ needs.test.result }} |"
+            echo "| GoReleaser | ${{ needs.goreleaser.result }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-network-operator-releases.yml
+++ b/.github/workflows/sync-network-operator-releases.yml
@@ -131,9 +131,9 @@ jobs:
               -f body="$body"
           fi
 
-  tag:
+  publish:
     if: github.event_name == 'push'
-    name: Tag synchronized release
+    name: Publish synchronized release
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -178,35 +178,73 @@ jobs:
           echo "changed=true" >> "$GITHUB_OUTPUT"
           echo "tag=$current_tag" >> "$GITHUB_OUTPUT"
 
-      - name: Check upstream and local tags
+      - name: Check upstream and publication state
         if: steps.release.outputs.changed == 'true'
-        id: tag
+        id: publication
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           if ! git ls-remote --exit-code --tags \
             https://github.com/Mellanox/network-operator.git \
             "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
             echo "The upstream tag ${RELEASE_TAG} does not exist; skipping"
-            echo "create=false" >> "$GITHUB_OUTPUT"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if git ls-remote --exit-code --tags origin \
-            "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
-            echo "The k8s-launch-kit tag ${RELEASE_TAG} already exists; skipping"
-            echo "create=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          tag_sha="$(git ls-remote --tags origin \
+            "refs/tags/${RELEASE_TAG}" | cut -f1)"
+          if [ -n "$tag_sha" ] && [ "$tag_sha" != "$GITHUB_SHA" ]; then
+            echo "::error::The k8s-launch-kit tag ${RELEASE_TAG} points to ${tag_sha}, not ${GITHUB_SHA}"
+            exit 1
           fi
 
-          echo "create=true" >> "$GITHUB_OUTPUT"
+          if gh release view "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if [ -z "$tag_sha" ]; then
+              echo "::error::Release ${RELEASE_TAG} exists without a matching tag"
+              exit 1
+            fi
+            echo "create_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "create_release=true" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Cut release tag
-        if: steps.tag.outputs.create == 'true'
+          if [ -n "$tag_sha" ]; then
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+
+      - name: Publish release and dispatch artifacts
+        if: steps.publication.outputs.publish == 'true'
         env:
+          CREATE_RELEASE: ${{ steps.publication.outputs.create_release }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          TAG_EXISTS: ${{ steps.publication.outputs.tag_exists }}
         run: |
-          git tag "$RELEASE_TAG" "$GITHUB_SHA"
-          git push origin "refs/tags/${RELEASE_TAG}"
-          gh workflow run image-push-release.yml --ref "$RELEASE_TAG"
+          if [ "$CREATE_RELEASE" = "true" ]; then
+            release_args=(
+              "$RELEASE_TAG"
+              --repo "$GITHUB_REPOSITORY"
+              --generate-notes
+              --title "$RELEASE_TAG"
+            )
+            if [ "$TAG_EXISTS" = "true" ]; then
+              release_args+=(--verify-tag)
+            else
+              release_args+=(--target "$GITHUB_SHA")
+            fi
+            gh release create "${release_args[@]}"
+          fi
+
+          gh workflow run release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$RELEASE_TAG"
+          gh workflow run image-push-release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$RELEASE_TAG"

--- a/README.md
+++ b/README.md
@@ -726,9 +726,11 @@ avoids GitHub's low anonymous API rate limit).
 
 After a catalog update reaches `main`, the workflow compares the previous and
 new highest catalog versions. If the new version is newer and the exact tag
-exists in `Mellanox/network-operator`, it cuts the matching lightweight tag on
-the updated k8s-launch-kit commit and dispatches the existing release-image
-workflow for that tag.
+exists in `Mellanox/network-operator`, it publishes a matching k8s-launch-kit
+GitHub Release with generated release notes. Publishing the release creates
+the tag on the catalog-update commit, then dispatches the existing GoReleaser
+and release-image workflows for that tag. No tag or release is created before
+the catalog update reaches `main`.
 
 Adding a new release remains a YAML-only catalog change: add its top-level
 entry under `releases:`. It automatically becomes part of the nightly sync and,

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -163,8 +163,10 @@ networkNamespaces: ["my-namespace"]
   the installed l8k version. Catalog values are synchronized nightly from the
   matching `Mellanox/network-operator` release branches; the newest entry uses
   `master` only until its `v<MAJOR.MINOR>.x` branch exists. A newer highest
-  version is tagged in k8s-launch-kit after the synchronized catalog reaches
-  `main` and the exact Network Operator tag is present upstream.
+  version is published as a generated-notes k8s-launch-kit GitHub Release
+  after the synchronized catalog reaches `main` and the exact Network Operator
+  tag is present upstream. Publishing creates the matching tag and dispatches
+  the binary and image artifact workflows.
 - `nvIpam` subnets are auto-generated if not specified — one per rail using non-routable ranges.
 - `docaDriver.unloadThirdPartyRDMAModules: true` auto-populates `UNLOAD_THIRD_PARTY_RDMA_MODULES` from discovered OFED-dependent modules.
 - For release 26.1+, SR-IOV requestor mode requires both the Network Operator drain requestor and the SR-IOV external drainer. l8k renders both; applying only CRs cannot enable their Deployment environment variables.


### PR DESCRIPTION
## Summary

- make an advancing highest version in `releases.yaml` on `main` the prerequisite for publication
- create the matching tag and published GitHub Release together with `gh release create --generate-notes`
- require the exact Network Operator tag upstream before publication
- reject an existing k8s-launch-kit tag that does not point to the catalog-update commit
- allow a same-commit tag or release to be reused only for retry recovery
- explicitly dispatch both `release.yml` and `image-push-release.yml` at the new tag so the `GITHUB_TOKEN` event suppression does not prevent binaries, SBOMs, or images from being built
- add `workflow_dispatch` support to the GoReleaser workflow

This PR does not modify `releases.yaml` and does not create or repair any release manually. The automation can be tested after merge.

## Validation

- `go test -race -count=1 ./...`
- `CGO_ENABLED=0 make build`
- `CGO_ENABLED=0 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0 run ./...`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/sync-network-operator-releases.yml .github/workflows/release.yml`
- workflow YAML parsing and `git diff --check`