### PR TITLE
fix: align Spectrum-X rail pool schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Profile Selection Flags:
       --spectrum-x string        Enable Spectrum-X by passing the SPC-X RA version (folds in the legacy --spcx-version). Supported: [RA2.1 RA2.2 RA2.3]
 
 Spectrum-X Flags:
-      --multiplane-mode string             Spectrum-X multiplane mode: none, swplb, hwplb, uniplane (requires --spectrum-x)
+      --multiplane-mode string             Spectrum-X multiplane mode: none, swplb, hwplb (requires --spectrum-x)
       --number-of-planes int               Number of planes for Spectrum-X (requires --spectrum-x)
       --spectrum-x-config string           Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML (required for SPC-X RA versions newer than RA2.2)
       --spectrum-x-configmap-name string   Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML
@@ -667,6 +667,10 @@ There are three **Spectrum-X** profiles, picked by the value of `--spectrum-x`:
 - **`spectrum-x`** — RA2.3 on `26.7+`. Uses the v1alpha2 `SpectrumXRailPoolConfig` with `railTopology[]` and deploys the Spectrum-X profile through a ConfigMap consumed by NIC Configuration Operator. Selected for `--spectrum-x RA2.3`.
 - **`spectrum-x-ra2.2`** — RA2.2 on `26.4` only. Uses the v1alpha2 `SpectrumXRailPoolConfig` with `railTopology[]` to consolidate rail wiring. Selected for `--spectrum-x RA2.2`.
 - **`spectrum-x-ra2.1`** — RA2.1 on `26.1` only (pinned via `min`/`maxNetworkOperatorRelease: "26.1"`). Renders the full SR-IOV operator chain: per-group `SriovNetworkPoolConfig` + per-rail `SriovNetworkNodePolicy` + `OVSNetwork` + nv-ipam `CIDRPool` + a v1alpha1 glue `SpectrumXRailPoolConfig`. Selected for `--spectrum-x RA2.1`.
+
+The v1alpha2 RA2.2 and RA2.3 manifests omit the removed `spec.withBCM`
+field. Current `SpectrumXRailPoolConfig` CRDs reject that field during strict
+decoding.
 
 When Spectrum-X is enabled and no release is already set, profile resolution
 selects its compatible default release (`RA2.1` → `26.1`, `RA2.2` → `26.4`,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -68,7 +68,7 @@ Discovery also accepts the profile and Spectrum-X flags below. Explicit flags ov
 | Flag | Description |
 | --- | --- |
 | `--spectrum-x` | Enable Spectrum-X and select RA version, such as `RA2.3`. |
-| `--multiplane-mode` | `none`, `swplb`, `hwplb`, or `uniplane`. |
+| `--multiplane-mode` | `none`, `swplb`, or `hwplb`. |
 | `--number-of-planes` | Plane count for Spectrum-X. |
 | `--topology-scheme` | `2-tier` or `3-tier` for topology-driven CIDRPool allocation. |
 | `--ip-version` | `ipv4` or `ipv6`. CIDRPool rendering currently supports IPv4. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -245,7 +245,7 @@ profile:
 | `ignoreARP` | Adds per-interface ARP tuning outside Spectrum-X. |
 | `spectrumX.enable` | Select a Spectrum-X profile. |
 | `spectrumX.spcxVersion` | `RA2.1`, `RA2.2`, or `RA2.3`. |
-| `spectrumX.multiplaneMode` | `none`, `swplb`, `hwplb`, or `uniplane`. |
+| `spectrumX.multiplaneMode` | `none`, `swplb`, or `hwplb`. |
 | `spectrumX.numberOfPlanes` | `1`, `2`, or `4`. |
 | `spectrumX.topologyType` | `2-tier` or `3-tier`. |
 | `spectrumX.ipVersion` | `ipv4` or `ipv6`; CIDRPool rendering currently supports IPv4. |

--- a/docs/user/spectrum-x.md
+++ b/docs/user/spectrum-x.md
@@ -15,6 +15,10 @@ Spectrum-X profiles render multi-rail AI interconnect manifests. The selected RA
 | RA2.2 | `26.4` | `spectrum-x-ra2.2` | Uses v1alpha2 `SpectrumXRailPoolConfig`. |
 | RA2.3 | `26.7` | `spectrum-x` | Uses v1alpha2 `SpectrumXRailPoolConfig` and a ConfigMap-backed Spectrum-X profile. |
 
+RA2.2 and RA2.3 output does not include the removed `spec.withBCM` field.
+Adding it causes the v1alpha2 CRD to reject the manifest during strict
+decoding.
+
 Select the release line explicitly:
 
 ```bash
@@ -27,10 +31,9 @@ l8k generate \
 
 | Mode | Use |
 | --- | --- |
-| `none` | No plane separation. Common for ConnectX-7 and BlueField-3 SuperNIC topologies. |
+| `none` | No plane separation. Used for ConnectX-7 and BlueField-3 SuperNIC topologies. |
 | `swplb` | Software plane load balancing. Renders per-rail, per-plane resources. |
 | `hwplb` | Hardware plane load balancing for larger topologies. |
-| `uniplane` | Single unified plane. |
 
 ```bash
 l8k discover \

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -156,7 +156,7 @@ func init() {
 	discoverCmd.Flags().StringVar(&spectrumXVersion, "spectrum-x", "",
 		fmt.Sprintf("Enable Spectrum-X by passing the SPC-X RA version. Supported: %v",
 			config.SupportedSPCXVersions))
-	discoverCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Spectrum-X multiplane mode override: none, swplb, hwplb, uniplane (requires --spectrum-x)")
+	discoverCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Spectrum-X multiplane mode override: none, swplb, hwplb (requires --spectrum-x)")
 	discoverCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Spectrum-X plane count override: 1, 2, or 4 (requires --spectrum-x)")
 	discoverCmd.Flags().StringVar(&topologyScheme, "topology-scheme", "", "Spectrum-X topology scheme for guide-based IP allocation: 2-tier or 3-tier (requires --spectrum-x)")
 	discoverCmd.Flags().StringVar(&ipVersion, "ip-version", "", "Spectrum-X IP version for guide-based allocation: ipv4 or ipv6 (requires --spectrum-x)")

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -198,7 +198,7 @@ func init() {
 	generateCmd.Flags().StringVar(&spectrumXVersion, "spectrum-x", "",
 		fmt.Sprintf("Enable Spectrum-X by passing the SPC-X RA version (e.g. RA2.1, RA2.2). Supported: %v",
 			config.SupportedSPCXVersions))
-	generateCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Multiplane mode: none, swplb, hwplb, uniplane (requires --spectrum-x)")
+	generateCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Multiplane mode: none, swplb, hwplb (requires --spectrum-x)")
 	generateCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes (requires --spectrum-x)")
 	generateCmd.Flags().StringVar(&topologyScheme, "topology-scheme", "", "Spectrum-X topology scheme for guide-based IP allocation: 2-tier or 3-tier (requires --spectrum-x)")
 	generateCmd.Flags().StringVar(&ipVersion, "ip-version", "", "Spectrum-X IP version for guide-based allocation: ipv4 or ipv6 (requires --spectrum-x)")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -265,7 +265,7 @@ func init() {
 	rootCmd.Flags().StringVar(&spectrumXVersion, "spectrum-x", "",
 		fmt.Sprintf("Enable Spectrum-X by passing the SPC-X RA version (folds in the legacy --spcx-version). Supported: %v",
 			config.SupportedSPCXVersions))
-	rootCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Spectrum-X multiplane mode: none, swplb, hwplb, uniplane (requires --spectrum-x)")
+	rootCmd.Flags().StringVar(&multiplaneMode, "multiplane-mode", "", "Spectrum-X multiplane mode: none, swplb, hwplb (requires --spectrum-x)")
 	rootCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes for Spectrum-X (requires --spectrum-x)")
 	rootCmd.Flags().StringVar(&topologyScheme, "topology-scheme", "", "Spectrum-X topology scheme for guide-based IP allocation: 2-tier or 3-tier (requires --spectrum-x)")
 	rootCmd.Flags().StringVar(&ipVersion, "ip-version", "", "Spectrum-X IP version for guide-based allocation: ipv4 or ipv6 (requires --spectrum-x)")

--- a/pkg/cmd/root_options_test.go
+++ b/pkg/cmd/root_options_test.go
@@ -42,7 +42,7 @@ var (
 			Multirail:  boolPtr(true),
 			SpectrumX: &profiles.ProfileRequirementsSpectrumX{
 				SPCXVersion:    "RA2.2",
-				MultiplaneMode: []string{"swplb", "hwplb", "uniplane", "none"},
+				MultiplaneMode: []string{"swplb", "hwplb", "none"},
 			},
 		},
 		NodeCapabilities: profiles.NodeCapabilities{

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -143,6 +143,18 @@ func TestApplySpectrumXDefaults_RejectsInvalidMultiplaneMode(t *testing.T) {
 	assert.Contains(t, err.Error(), `invalid --multiplane-mode "bogus"`)
 }
 
+func TestApplySpectrumXDefaults_RejectsRemovedUniplaneMode(t *testing.T) {
+	opts := minSpectrumXOpts()
+	opts.MultiplaneMode = "uniplane"
+	opts.NumberOfPlanes = 1
+
+	err := applySpectrumXDefaults(opts)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid --multiplane-mode "uniplane"`)
+	assert.Contains(t, err.Error(), "supported: [none swplb hwplb]")
+}
+
 func TestApplySpectrumXDefaults_RequiresNumberOfPlanes(t *testing.T) {
 	opts := minSpectrumXOpts()
 	opts.NumberOfPlanes = 0

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -147,7 +147,7 @@ var schemaCmd = &cobra.Command{
 				},
 				"--multiplane-mode": {
 					Type:        "string",
-					Description: "Spectrum-X multiplane mode override: none, swplb, hwplb, uniplane. Auto-derived from NIC device ID when omitted.",
+					Description: "Spectrum-X multiplane mode override: none, swplb, hwplb. Auto-derived from NIC device ID when omitted.",
 				},
 				"--number-of-planes": {
 					Type:        "int",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -522,7 +522,7 @@ func (p Profile) MarshalYAML() (interface{}, error) {
 type ProfileSpectrumX struct {
 	Enable               bool   `yaml:"enable"`         // must be true for Spectrum-X profiles to match
 	SPCXVersion          string `yaml:"spcxVersion"`    // e.g., "RA2.2"
-	MultiplaneMode       string `yaml:"multiplaneMode"` // swplb, hwplb, uniplane
+	MultiplaneMode       string `yaml:"multiplaneMode"` // none, swplb, hwplb
 	NumberOfPlanes       int    `yaml:"numberOfPlanes"` // 2 or 4
 	TopologyType         string `yaml:"topologyType,omitempty"`
 	IPVersion            string `yaml:"ipVersion,omitempty"`
@@ -800,9 +800,9 @@ func ValidateClusterConfig(config *LaunchKitConfig, profile string) error {
 var SupportedSPCXVersions = []string{"RA2.1", "RA2.2", "RA2.3"}
 
 // SupportedMultiplaneModes lists the Spectrum-X multiplane modes the CLI
-// accepts. `none` and `uniplane` collapse to one plane; `swplb` and `hwplb`
-// require numberOfPlanes > 1.
-var SupportedMultiplaneModes = []string{"none", "swplb", "hwplb", "uniplane"}
+// accepts. `none` collapses to one plane; `swplb` and `hwplb` require
+// numberOfPlanes > 1.
+var SupportedMultiplaneModes = []string{"none", "swplb", "hwplb"}
 
 // SupportedNumberOfPlanes lists the values numberOfPlanes can take.
 var SupportedNumberOfPlanes = []int{1, 2, 4}
@@ -843,7 +843,7 @@ func validateSpectrumXTemplates(config *LaunchKitConfig) error {
 	netdevPrefix := config.SpectrumX.NetdevPrefix
 	rdmaPrefix := config.SpectrumX.RdmaPrefix
 
-	// Non-`none` multiplane modes (swplb, hwplb, uniplane) require a supported
+	// Non-`none` multiplane modes (swplb, hwplb) require a supported
 	// RA version.
 	if config.Profile.SpectrumX.MultiplaneMode != "none" && config.Profile.SpectrumX.MultiplaneMode != "" {
 		got := config.Profile.SpectrumX.SPCXVersion

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -516,7 +516,7 @@ profile:
 	})
 
 	t.Run("verify different multiplane modes", func(t *testing.T) {
-		modes := []string{"swplb", "hwplb", "uniplane"}
+		modes := []string{"none", "swplb", "hwplb"}
 
 		for _, mode := range modes {
 			profileSpectrumX := &ProfileSpectrumX{
@@ -655,7 +655,7 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 				Multirail: true, // Multirail
 				SpectrumX: &ProfileSpectrumX{
 					SPCXVersion:    "RA2.2",
-					MultiplaneMode: "uniplane",
+					MultiplaneMode: "none",
 					NumberOfPlanes: 1,
 				},
 			},

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -153,7 +153,7 @@ profile:
   spectrumX: # Spectrum-X configuration (set enable: true or use --spectrum-x CLI flag)
     enable: false # CLI parameter (overrides this value): --spectrum-x
     # spcxVersion: "RA2.3" # CLI parameter (overrides this value): --spectrum-x
-    # multiplaneMode: swplb # CLI parameter (overrides this value): --multiplane-mode (swplb, hwplb, uniplane)
+    # multiplaneMode: swplb # CLI parameter (overrides this value): --multiplane-mode (none, swplb, hwplb)
     # numberOfPlanes: 4 # CLI parameter (overrides this value): --number-of-planes, also used as pfsPerNic
     # topologyType: 2-tier # CLI parameter (overrides this value): --topology-scheme (2-tier, 3-tier)
     # ipVersion: ipv4 # CLI parameter (overrides this value): --ip-version (ipv4, ipv6); CIDRPool rendering currently supports ipv4

--- a/pkg/networkoperatorplugin/grouping_test.go
+++ b/pkg/networkoperatorplugin/grouping_test.go
@@ -48,7 +48,7 @@ func loadSpectrumXProfile(t *testing.T) *profiles.Profile {
 			Deployment: "sriov",
 			SpectrumX: &profiles.ProfileRequirementsSpectrumX{
 				SPCXVersion:    "RA2.2",
-				MultiplaneMode: []string{"swplb", "hwplb", "uniplane", "none"},
+				MultiplaneMode: []string{"swplb", "hwplb", "none"},
 			},
 		},
 		Templates: []string{
@@ -597,7 +597,7 @@ func loadSpectrumXRA21Profile(t *testing.T) *profiles.Profile {
 			Deployment: "sriov",
 			SpectrumX: &profiles.ProfileRequirementsSpectrumX{
 				SPCXVersion:    "RA2.1",
-				MultiplaneMode: []string{"swplb", "hwplb", "uniplane", "none"},
+				MultiplaneMode: []string{"swplb", "hwplb", "none"},
 			},
 			MinNetworkOperatorRelease: "26.1",
 			MaxNetworkOperatorRelease: "26.1",

--- a/pkg/networkoperatorplugin/networkoperator_test.go
+++ b/pkg/networkoperatorplugin/networkoperator_test.go
@@ -337,7 +337,7 @@ func TestApplyOptionsToConfig(t *testing.T) {
 				Multirail:  false,
 				SpectrumX: &config.ProfileSpectrumX{
 					SPCXVersion:    "",
-					MultiplaneMode: "uniplane",
+					MultiplaneMode: "none",
 					NumberOfPlanes: 1,
 				},
 			},

--- a/pkg/networkoperatorplugin/spectrumx_railpool_test.go
+++ b/pkg/networkoperatorplugin/spectrumx_railpool_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkoperatorplugin
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+func TestSpectrumXRailPoolTemplatesOmitRemovedWithBCMField(t *testing.T) {
+	tests := []struct {
+		name       string
+		profileDir string
+	}{
+		{name: "RA2.3", profileDir: "spectrum-x"},
+		{name: "RA2.2", profileDir: "spectrum-x-ra2.2"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.LaunchKitConfig{
+				NetworkOperator: &config.NetworkOperatorConfig{
+					Namespace: "network-operator",
+				},
+				CurrentNetworkNamespace: "default",
+				SpectrumX: &config.SpectrumXConfig{
+					NetdevPrefix: "eth_p%plane_id%_r%rail_id%",
+				},
+				Profile: &config.Profile{
+					SpectrumX: &config.ProfileSpectrumX{
+						MultiplaneMode: "none",
+						NumberOfPlanes: 1,
+					},
+				},
+				ClusterConfig: []config.ClusterConfig{
+					{
+						Identifier:       "test",
+						MergedIdentifier: "test",
+						PFs: []config.PFConfig{
+							{
+								PciAddress: "0000:19:00.0",
+								Traffic:    "east-west",
+							},
+						},
+					},
+				},
+			}
+			templatePath := filepath.Join(
+				"..",
+				"..",
+				"profiles",
+				test.profileDir,
+				"80-spectrumxrailpoolconfig.yaml",
+			)
+
+			rendered, err := ProcessTemplate(templatePath, cfg, "")
+			require.NoError(t, err)
+			manifest := rendered["80-spectrumxrailpoolconfig-test.yaml"]
+			require.NotEmpty(t, manifest)
+
+			var object struct {
+				Spec map[string]any `yaml:"spec"`
+			}
+			require.NoError(t, yaml.Unmarshal([]byte(manifest), &object))
+			require.NotNil(t, object.Spec)
+			require.NotContains(t, object.Spec, "withBCM",
+				"v1alpha2 SpectrumXRailPoolConfig rejects the removed spec.withBCM field")
+			require.Equal(t, false, object.Spec["draEnabled"])
+		})
+	}
+}

--- a/pkg/networkoperatorplugin/workload_test.go
+++ b/pkg/networkoperatorplugin/workload_test.go
@@ -265,12 +265,12 @@ func TestBuildNetworkAnnotation(t *testing.T) {
 		assert.Equal(t, "rail-0-plane-0,rail-0-plane-1,rail-1-plane-0,rail-1-plane-1", got)
 	})
 
-	t.Run("spectrum-x uniplane", func(t *testing.T) {
+	t.Run("spectrum-x hwplb", func(t *testing.T) {
 		cfg := &config.LaunchKitConfig{
 			Profile: &config.Profile{
 				SpectrumX: &config.ProfileSpectrumX{
 					Enable:         true,
-					MultiplaneMode: "uniplane",
+					MultiplaneMode: "hwplb",
 				},
 			},
 		}
@@ -353,12 +353,12 @@ func TestBuildNetworkResources(t *testing.T) {
 		}, got)
 	})
 
-	t.Run("spectrum-x uniplane", func(t *testing.T) {
+	t.Run("spectrum-x hwplb", func(t *testing.T) {
 		cfg := &config.LaunchKitConfig{
 			Profile: &config.Profile{
 				SpectrumX: &config.ProfileSpectrumX{
 					Enable:         true,
-					MultiplaneMode: "uniplane",
+					MultiplaneMode: "hwplb",
 				},
 			},
 		}

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -51,7 +51,7 @@ type ProfileRequirements struct {
 
 type ProfileRequirementsSpectrumX struct {
 	SPCXVersion    string   `yaml:"spcxVersion"`              // Required version, e.g., "RA2.2"
-	MultiplaneMode []string `yaml:"multiplaneMode,omitempty"` // Allowed multiplane modes, e.g., ["hwplb", "uniplane", "none"]
+	MultiplaneMode []string `yaml:"multiplaneMode,omitempty"` // Allowed multiplane modes, e.g., ["hwplb", "none"]
 }
 
 type NodeCapabilities struct {
@@ -202,7 +202,7 @@ func (p *Profile) Validate(requirements *config.Profile, capabilities *config.Cl
 		if requirements.SpectrumX == nil || !requirements.SpectrumX.Enable {
 			return false, "profile requires Spectrum-X but it is not enabled"
 		}
-		
+
 		// Validate SPCX version if specified in profile requirements
 		if p.ProfileRequirements.SpectrumX.SPCXVersion != "" {
 			if requirements.SpectrumX.SPCXVersion != p.ProfileRequirements.SpectrumX.SPCXVersion {

--- a/pkg/profiles/profiles_test.go
+++ b/pkg/profiles/profiles_test.go
@@ -330,7 +330,7 @@ func TestProfileValidation(t *testing.T) {
 				Multirail:  boolPtr(true),
 				SpectrumX: &ProfileRequirementsSpectrumX{
 					SPCXVersion:    "RA2.2",
-					MultiplaneMode: []string{"hwplb", "uniplane", "none"},
+					MultiplaneMode: []string{"hwplb", "none"},
 				},
 			},
 			NodeCapabilities: NodeCapabilities{
@@ -373,7 +373,7 @@ func TestProfileValidation(t *testing.T) {
 				Multirail:  boolPtr(true),
 				SpectrumX: &ProfileRequirementsSpectrumX{
 					SPCXVersion:    "RA2.2",
-					MultiplaneMode: []string{"hwplb", "uniplane", "none"},
+					MultiplaneMode: []string{"hwplb", "none"},
 				},
 			},
 			NodeCapabilities: NodeCapabilities{
@@ -402,7 +402,7 @@ func TestProfileValidation(t *testing.T) {
 		}
 
 		valid, reason := profile.Validate(requirements, capabilities, "")
-		assert.False(t, valid, "Profile should reject swplb mode when only hwplb/uniplane/none are allowed")
+		assert.False(t, valid, "Profile should reject swplb mode when only hwplb/none are allowed")
 		assert.Contains(t, reason, "multiplane mode swplb not in profile's allowed modes")
 	})
 

--- a/pkg/resolve/defaults.go
+++ b/pkg/resolve/defaults.go
@@ -57,7 +57,7 @@ func (d DefaultDecision) String() string {
 //	--multirail           ← true (unless config or CLI explicitly sets it).
 //	--routing             ← "destination-based" (unless config or CLI sets it).
 //	--multiplane-mode     ← per east-west PF deviceID (only when --spectrum-x):
-//	                       1021 (CX7) / a2dc (BF3 SuperNIC) → "uniplane"
+//	                       1021 (CX7) / a2dc (BF3 SuperNIC) → "none"
 //	                       1023 (CX8) → "swplb"
 //	                       1025 (CX9) → "hwplb"
 //	                       Skipped+warned when groups have mixed deviceIDs.
@@ -301,13 +301,13 @@ func spectrumXDefaultsForDeviceID(groups []config.ClusterConfig) (mode string, p
 	}
 	switch seenID {
 	case "1021":
-		return "uniplane", 1, true, "ConnectX-7 (deviceID 1021)"
+		return "none", 1, true, "ConnectX-7 (deviceID 1021)"
 	case "1023":
 		return "swplb", 2, true, "ConnectX-8 (deviceID 1023)"
 	case "1025":
 		return "hwplb", 4, true, "ConnectX-9 (deviceID 1025)"
 	case "a2dc":
-		return "uniplane", 1, true, "BF3 SuperNIC (deviceID a2dc)"
+		return "none", 1, true, "BF3 SuperNIC (deviceID a2dc)"
 	}
 	return "", 0, false, fmt.Sprintf("east-west PF deviceID %q has no Spectrum-X default", seenID)
 }

--- a/pkg/resolve/defaults_test.go
+++ b/pkg/resolve/defaults_test.go
@@ -132,3 +132,33 @@ func TestApplyHardwareDefaultsRecordsSpectrumXMultirailReason(t *testing.T) {
 	require.Len(t, multirailDecisions, 1)
 	assert.Equal(t, "implied by --spectrum-x", multirailDecisions[0].Reason)
 }
+
+func TestDefaultSpectrumXModeForDeviceUsesSupportedModes(t *testing.T) {
+	tests := []struct {
+		deviceID string
+		wantMode string
+		wantN    int
+	}{
+		{deviceID: "1021", wantMode: "none", wantN: 1},
+		{deviceID: "a2dc", wantMode: "none", wantN: 1},
+		{deviceID: "1023", wantMode: "swplb", wantN: 2},
+		{deviceID: "1025", wantMode: "hwplb", wantN: 4},
+	}
+
+	for _, test := range tests {
+		t.Run(test.deviceID, func(t *testing.T) {
+			mode, planes, ok, _ := spectrumXDefaultsForDeviceID([]config.ClusterConfig{
+				{
+					PFs: []config.PFConfig{
+						{DeviceID: test.deviceID, Traffic: "east-west"},
+					},
+				},
+			})
+
+			require.True(t, ok)
+			assert.Equal(t, test.wantMode, mode)
+			assert.Equal(t, test.wantN, planes)
+			assert.Contains(t, config.SupportedMultiplaneModes, mode)
+		})
+	}
+}

--- a/pkg/resolve/validate.go
+++ b/pkg/resolve/validate.go
@@ -156,8 +156,8 @@ func validateSpectrumXCohort(cfg *config.LaunchKitConfig) error {
 			spcx.IPVersion, config.SupportedSpectrumXIPVersions)
 	}
 
-	// Cross-validate mode ↔ planes. "none" (and "uniplane") collapse
-	// to one plane; anything else is a contradiction.
+	// Cross-validate mode ↔ planes. "none" collapses to one plane; anything
+	// else is a contradiction.
 	if spcx.MultiplaneMode == "none" && spcx.NumberOfPlanes != 1 {
 		return fmt.Errorf("--multiplane-mode none requires --number-of-planes 1, got %d", spcx.NumberOfPlanes)
 	}

--- a/profiles/spectrum-x-ra2.1/30-nicconfigurationtemplate.yaml
+++ b/profiles/spectrum-x-ra2.1/30-nicconfigurationtemplate.yaml
@@ -18,6 +18,6 @@ spec:
     spectrumXOptimized:
       enabled: true
       version: "{{.Profile.SpectrumX.SPCXVersion}}"
-      multiplaneMode: "{{.Profile.SpectrumX.MultiplaneMode}}"  # swplb, hwplb, uniplane
+      multiplaneMode: "{{.Profile.SpectrumX.MultiplaneMode}}"  # none, swplb, hwplb
       numberOfPlanes: {{.Profile.SpectrumX.NumberOfPlanes}}
       overlay: "{{.SpectrumX.Overlay}}"

--- a/profiles/spectrum-x-ra2.1/50-sriovnetworknodepolicy.yaml
+++ b/profiles/spectrum-x-ra2.1/50-sriovnetworknodepolicy.yaml
@@ -1,4 +1,4 @@
-{{- /* One SriovNetworkNodePolicy per rail (hwplb/uniplane/none) or per
+{{- /* One SriovNetworkNodePolicy per rail (hwplb/none) or per
        rail-plane (swplb). SWPLB uses groupingPolicy=perPF and a single PF;
        other modes use groupingPolicy=all with all of a rail's PF netdevs
        grouped under one bridge plus devlinkParams.esw_multiport=true. */ -}}

--- a/profiles/spectrum-x-ra2.1/80-spectrumxrailpoolconfig.yaml
+++ b/profiles/spectrum-x-ra2.1/80-spectrumxrailpoolconfig.yaml
@@ -1,5 +1,5 @@
 {{- /* SpectrumXRailPoolConfig (v1alpha1, 26.1 form): one glue resource per
-       rail (hwplb/uniplane/none) or per rail-plane (swplb), referencing the
+       rail (hwplb/none) or per rail-plane (swplb), referencing the
        SriovNetworkNodePolicy from 50-… and the CIDRPool from 60-…. The
        v1alpha2 shape with railTopology[] used by the spectrum-x profile is
        NOT compatible with 26.1 — keep these templates separate. */ -}}

--- a/profiles/spectrum-x-ra2.1/README.md
+++ b/profiles/spectrum-x-ra2.1/README.md
@@ -36,14 +36,14 @@ gate will reject it.
 
 ## Multiplane modes
 
-Same set as the RA2.2 profile: `none`, `swplb`, `hwplb`, `uniplane`.
+Same set as the RA2.2 profile: `none`, `swplb`, `hwplb`.
 
 - `swplb` — each rail explodes into per-plane policies, with
   `bridge.groupingPolicy: perPF`. One PF per `SriovNetworkNodePolicy`,
   `metadata.name: rail-{i}-plane-{p}`,
   `resourceName: rail_{i}_plane_{p}`. No `devlinkParams` (each PF runs as
   an independent OVS bridge).
-- `hwplb` / `uniplane` / `none` — one policy per rail with
+- `hwplb` / `none` — one policy per rail with
   `bridge.groupingPolicy: all`, all of a rail's PF netdevs in `pfNames`,
   and `devlinkParams.params.esw_multiport: "true"` on the PF.
 

--- a/profiles/spectrum-x-ra2.1/profile.yaml
+++ b/profiles/spectrum-x-ra2.1/profile.yaml
@@ -5,7 +5,7 @@ profileRequirements:
   deployment: sriov
   spectrumX:
     spcxVersion: "RA2.1"
-    multiplaneMode: ["swplb", "hwplb", "uniplane", "none"]
+    multiplaneMode: ["swplb", "hwplb", "none"]
   multirail: true
   # SPC-X RA2.1 only ships on Network Operator 26.1. Pin both bounds to
   # 26.1 so this profile never matches a 26.4+ deployment (which uses
@@ -21,7 +21,7 @@ description: |
   SriovNetworkNodePolicy, OVSNetwork) plus an nv-ipam CIDRPool, and ties
   them together with the v1alpha1 SpectrumXRailPoolConfig glue resource.
   Supports the same multiplane modes as the 26.4+ profile (swplb, hwplb,
-  uniplane, none): in swplb the rail explodes into per-plane policies,
+  none): in swplb the rail explodes into per-plane policies,
   otherwise one policy per rail groups all planes together.
 deploymentGuide: spectrum-x-ra2.1.rst
 templates:

--- a/profiles/spectrum-x-ra2.2/30-nicconfigurationtemplate.yaml
+++ b/profiles/spectrum-x-ra2.2/30-nicconfigurationtemplate.yaml
@@ -18,6 +18,6 @@ spec:
     spectrumXOptimized:
       enabled: true
       version: "{{.Profile.SpectrumX.SPCXVersion}}"
-      multiplaneMode: "{{.Profile.SpectrumX.MultiplaneMode}}"  # swplb, hwplb, uniplane
+      multiplaneMode: "{{.Profile.SpectrumX.MultiplaneMode}}"  # none, swplb, hwplb
       numberOfPlanes: {{.Profile.SpectrumX.NumberOfPlanes}}
       overlay: "{{.SpectrumX.Overlay}}"

--- a/profiles/spectrum-x-ra2.2/80-spectrumxrailpoolconfig.yaml
+++ b/profiles/spectrum-x-ra2.2/80-spectrumxrailpoolconfig.yaml
@@ -7,7 +7,6 @@ metadata:
   name: rails{{suffix .ClusterConfig.Identifier}}
   namespace: "{{.NetworkOperator.Namespace}}"
 spec:
-  withBCM: false
   draEnabled: {{ spectrumXUseDRA .Profile }}
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:

--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -10,7 +10,7 @@ The Spectrum-X profile provides optimized multi-rail networking with OVS hardwar
 - **OVS Hardware Offload**: DOCA-accelerated Open vSwitch with hardware offloading
 - **RDMA Exclusive Mode**: Dedicated RDMA resources per workload
 - **Advanced Firmware Configuration**: Spectrum-X optimized firmware with RA2.2 support
-- **Multiple Plane Modes**: Supports none, swplb, hwplb, and uniplane configurations
+- **Multiple Plane Modes**: Supports none, swplb, and hwplb configurations
 - **Dynamic Interface Naming**: Automatic NIC interface naming based on plane and rail topology
 - **Optional DRA Workload Allocation**: `profile.spectrumX.useDRA` enables ResourceClaimTemplate-based GPU/VF allocation
 
@@ -40,7 +40,6 @@ nodeCapabilities:
   - `none`: Single plane
   - `swplb`: Software plane load balancing
   - `hwplb`: Hardware plane load balancing
-  - `uniplane`: Unified plane mode
 - **numberOfPlanes**: Number of planes (1, 2, or 4)
 
 ### Spectrum-X Profile Options
@@ -49,6 +48,8 @@ nodeCapabilities:
   `dynamicResourceAllocation` feature gate, sets `SpectrumXRailPoolConfig.spec.draEnabled`
   to `true`, emits `ResourceClaimTemplate` manifests, and renders the example workload
   with DRA claims instead of device-plugin resource requests.
+- Generated v1alpha2 `SpectrumXRailPoolConfig` resources omit the removed
+  `spec.withBCM` field because current CRDs reject it during strict decoding.
 
 ### OVS Configuration
 

--- a/profiles/spectrum-x-ra2.2/profile.yaml
+++ b/profiles/spectrum-x-ra2.2/profile.yaml
@@ -5,7 +5,7 @@ profileRequirements:
   deployment: sriov
   spectrumX:
     spcxVersion: "RA2.2"
-    multiplaneMode: ["swplb", "hwplb", "uniplane", "none"]
+    multiplaneMode: ["swplb", "hwplb", "none"]
   multirail: true
   # SpectrumXRailPoolConfig (spectrumx.net.nvidia.com/v1alpha2) is only
   # available in Network Operator 26.4+. Older releases must pick a
@@ -18,7 +18,7 @@ nodeCapabilities:
 description: |
   Spectrum-X RA2.2 profile provides optimized multi-rail networking with the
   SpectrumXRailPoolConfig CRD, DOCA acceleration, and advanced NIC firmware
-  configuration for AI workloads. Supports swplb, hwplb, uniplane, and none
+  configuration for AI workloads. Supports swplb, hwplb, and none
   multiplane modes. In swplb the railTopology splits each rail into per-plane
   entries; in other modes one entry per rail groups all planes together.
 deploymentGuide: spectrum-x.rst

--- a/profiles/spectrum-x/30-nicconfigurationtemplate.yaml
+++ b/profiles/spectrum-x/30-nicconfigurationtemplate.yaml
@@ -18,6 +18,6 @@ spec:
     spectrumXOptimized:
       enabled: true
       version: "{{ spectrumXVersionRef .Profile.SpectrumX }}"
-      multiplaneMode: "{{.Profile.SpectrumX.MultiplaneMode}}"  # swplb, hwplb, uniplane
+      multiplaneMode: "{{.Profile.SpectrumX.MultiplaneMode}}"  # none, swplb, hwplb
       numberOfPlanes: {{.Profile.SpectrumX.NumberOfPlanes}}
       overlay: "{{.SpectrumX.Overlay}}"

--- a/profiles/spectrum-x/80-spectrumxrailpoolconfig.yaml
+++ b/profiles/spectrum-x/80-spectrumxrailpoolconfig.yaml
@@ -7,7 +7,6 @@ metadata:
   name: rails{{suffix .ClusterConfig.Identifier}}
   namespace: "{{.NetworkOperator.Namespace}}"
 spec:
-  withBCM: false
   draEnabled: {{ spectrumXUseDRA .Profile }}
   {{- if .ClusterConfig.NodeSelector }}
   nodeSelector:

--- a/profiles/spectrum-x/README.md
+++ b/profiles/spectrum-x/README.md
@@ -10,7 +10,7 @@ The Spectrum-X RA2.3 profile provides optimized multi-rail networking with OVS h
 - **OVS Hardware Offload**: DOCA-accelerated Open vSwitch with hardware offloading
 - **RDMA Exclusive Mode**: Dedicated RDMA resources per workload
 - **Advanced Firmware Configuration**: Spectrum-X optimized firmware with RA2.3 support
-- **Multiple Plane Modes**: Supports none, swplb, hwplb, and uniplane configurations
+- **Multiple Plane Modes**: Supports none, swplb, and hwplb configurations
 - **Dynamic Interface Naming**: Automatic NIC interface naming based on plane and rail topology
 - **Optional DRA Workload Allocation**: `profile.spectrumX.useDRA` enables ResourceClaimTemplate-based GPU/VF allocation
 
@@ -40,7 +40,6 @@ nodeCapabilities:
   - `none`: Single plane
   - `swplb`: Software plane load balancing
   - `hwplb`: Hardware plane load balancing
-  - `uniplane`: Unified plane mode
 - **numberOfPlanes**: Number of planes (1, 2, or 4)
 
 ### Spectrum-X Profile Options
@@ -49,6 +48,8 @@ nodeCapabilities:
   `dynamicResourceAllocation` feature gate, sets `SpectrumXRailPoolConfig.spec.draEnabled`
   to `true`, emits `ResourceClaimTemplate` manifests, and renders the example workload
   with DRA claims instead of device-plugin resource requests.
+- Generated v1alpha2 `SpectrumXRailPoolConfig` resources omit the removed
+  `spec.withBCM` field because current CRDs reject it during strict decoding.
 - **configMapName**: Required for RA2.3 when `profile` contains only raw
   `data.profile` YAML. When `profile` contains a full ConfigMap manifest, l8k
   extracts `metadata.name`.

--- a/profiles/spectrum-x/profile.yaml
+++ b/profiles/spectrum-x/profile.yaml
@@ -5,7 +5,7 @@ profileRequirements:
   deployment: sriov
   spectrumX:
     spcxVersion: "RA2.3"
-    multiplaneMode: ["swplb", "hwplb", "uniplane", "none"]
+    multiplaneMode: ["swplb", "hwplb", "none"]
   multirail: true
   # SpectrumXRailPoolConfig (spectrumx.net.nvidia.com/v1alpha2) is only
   # available in Network Operator 26.4+. RA2.3 also requires the
@@ -18,7 +18,7 @@ description: |
   Spectrum-X RA2.3 profile provides optimized multi-rail networking with the
   SpectrumXRailPoolConfig CRD, DOCA acceleration, and advanced NIC firmware
   configuration supplied via a Spectrum-X profile ConfigMap. Supports swplb,
-  hwplb, uniplane, and none multiplane modes. In swplb the railTopology splits
+  hwplb, and none multiplane modes. In swplb the railTopology splits
   each rail into per-plane entries; in other modes one entry per rail groups
   all planes together.
 deploymentGuide: spectrum-x.rst

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-config
-version: 1.2.1
+version: 1.2.2
 description: "Use this skill when the user needs help understanding, creating, or editing a k8s-launch-kit (l8k) configuration file (l8k-config.yaml or cluster-config.yaml). Activate for: config file questions, parameter tuning, subnet configuration, NV-IPAM setup, DOCA driver settings, maintenance concurrency, NIC configuration operator settings, changing MTU, VFs, resource names, or understanding what any config field does."
 metadata:
   requires:

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -313,9 +313,9 @@ profile:
     spcxVersion: "RA2.2"
 
     # string | default: derived from east-west NIC device ID
-    # Multiplane mode: "none", "swplb" (software PLB), "hwplb" (hardware PLB),
-    # "uniplane". When Spectrum-X is enabled and this is absent, discovery
-    # derives it from the east-west NIC device ID.
+    # Multiplane mode: "none", "swplb" (software PLB), or "hwplb"
+    # (hardware PLB). When Spectrum-X is enabled and this is absent,
+    # discovery derives it from the east-west NIC device ID.
     multiplaneMode: swplb
 
     # int | default: derived from east-west NIC device ID

--- a/skills/k8s-launch-kit-discover/SKILL.md
+++ b/skills/k8s-launch-kit-discover/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-discover
-version: 1.2.0
+version: 1.2.1
 description: "Use this skill when the user wants to discover their Kubernetes cluster's network hardware capabilities using k8s-launch-kit (l8k). Activate for: cluster discovery, hardware detection, NIC detection, finding what GPUs or NICs are in a cluster, creating a cluster config file, or when the user says 'discover' in the context of l8k or NVIDIA networking."
 metadata:
   requires:
@@ -60,7 +60,7 @@ l8k discover --save-cluster-config <OUTPUT> [--kubeconfig <PATH>]
 | `--deployment-type` | — | `sriov` | Deployment override: `sriov`, `rdma_shared`, or `host_device`. |
 | `--multirail` | — | `true` | Multirail override. Use `--multirail=false` to opt out; explicit false is persisted. |
 | `--spectrum-x` | — | disabled | Enable Spectrum-X with an RA version (`RA2.1` or `RA2.2`). |
-| `--multiplane-mode` | — | derived with Spectrum-X | Spectrum-X mode override: `none`, `swplb`, `hwplb`, or `uniplane`. |
+| `--multiplane-mode` | — | derived with Spectrum-X | Spectrum-X mode override: `none`, `swplb`, or `hwplb`. |
 | `--number-of-planes` | — | derived with Spectrum-X | Spectrum-X plane-count override: `1`, `2`, or `4`. |
 
 ## Examples

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-generate
-version: 1.2.1
+version: 1.2.2
 description: "Use this skill when the user wants to generate Kubernetes YAML manifests for NVIDIA networking deployment using k8s-launch-kit (l8k). Activate for: manifest generation, profile selection, choosing between SR-IOV/host-device/RDMA-shared/IPoIB/MacVLAN/Spectrum-X, creating deployment files, or when the user asks 'which profile should I use' or needs help choosing a network configuration."
 metadata:
   requires:
@@ -32,7 +32,7 @@ to that source file; embedded `--for` generation does not write a config.
 | `--fabric` | Auto-defaulted | `ethernet`, `infiniband` | Network fabric. Auto-defaults from the cluster's unanimous `linkType` when omitted (Unit 5 fabric probe); skipped+warned when groups disagree or any has unverified linkType. |
 | `--deployment-type` | Auto-defaulted | `sriov`, `rdma_shared`, `host_device` | Deployment type. Auto-defaults to `sriov`. |
 | `--spectrum-x` | — | `RA2.1`, `RA2.2` | Enable Spectrum-X profile by passing the SPC-X RA version. Implies ethernet fabric, sriov deployment, and multirail. |
-| `--multiplane-mode` | Auto-defaulted with `--spectrum-x` | `none`, `swplb`, `hwplb`, `uniplane` | Auto-defaults from east-west PF deviceID: CX7 / BF3 SuperNIC → `uniplane`, CX8 → `swplb`, CX9 → `hwplb`. Skipped+warned when groups have mixed deviceIDs. |
+| `--multiplane-mode` | Auto-defaulted with `--spectrum-x` | `none`, `swplb`, `hwplb` | Auto-defaults from east-west PF deviceID: CX7 / BF3 SuperNIC → `none`, CX8 → `swplb`, CX9 → `hwplb`. Skipped+warned when groups have mixed deviceIDs. |
 | `--number-of-planes` | Auto-defaulted with `--spectrum-x` | `1`, `2`, `4` | Auto-defaults from deviceID: CX7 / BF3 → 1, CX8 → 2, CX9 → 4. |
 | `--multirail` | Auto-defaulted | — | Auto-defaults to `true`. Explicit `multirail: false` in YAML and `--multirail=false` on the CLI are both preserved. |
 | `--save-deployment-files` | Yes | — | Output directory for generated YAMLs |
@@ -150,6 +150,9 @@ win when a one-off override is needed.
 
 - Default to SR-IOV Ethernet for new GPU cluster deployments unless told otherwise.
 - For Spectrum-X, NIC type determines available multiplane modes — read `references/spectrum-x-guide.md`.
+- RA2.2 and RA2.3 v1alpha2 `SpectrumXRailPoolConfig` output intentionally
+  omits the removed `spec.withBCM` field; current CRDs reject it during strict
+  decoding.
 - Use `--groups <a,b,...>` (case-sensitive identifier list) or `--gpu-type <X>` (case-insensitive) to scope a generate to a subset of source groups in heterogeneous clusters. Mutually exclusive. Empty match is a validation error. Strict-subset filters split per-source rendering: NodePolicies emit one CR per source (each with its own machine-label nodeSelector but a shared bucket-level resourceName); IPPool/example DaemonSet emit one CR per bucket with an `In` list of source machine labels.
 
 > [!CAUTION]

--- a/skills/k8s-launch-kit-generate/references/profiles-summary.md
+++ b/skills/k8s-launch-kit-generate/references/profiles-summary.md
@@ -87,10 +87,10 @@ direct-drain controllers.
 - **Plugin**: network-operator
 - **Requirements**: `fabric=ethernet`, `deployment=sriov`, `multirail=true`,
   `spectrumX.spcxVersion=RA2.2`,
-  `spectrumX.multiplaneMode` in `[swplb, hwplb, uniplane, none]`,
+  `spectrumX.multiplaneMode` in `[swplb, hwplb, none]`,
   `minNetworkOperatorRelease=26.4`
 - **Node Capabilities**: `sriov: true`, `rdma: true`
-- **Description**: Unified Spectrum-X profile covering all four multiplane modes.
+- **Description**: Unified Spectrum-X profile covering all three multiplane modes.
   Emits a single `SpectrumXRailPoolConfig` (`v1alpha2`) that replaces the
   legacy SriovNetworkPoolConfig + SriovNetworkNodePolicy + OVSNetwork trio.
   In `swplb` the `railTopology[]` splits each rail into per-plane entries; in
@@ -107,7 +107,8 @@ direct-drain controllers.
   - `60-cidrpool.yaml` -- One CIDRPool per rail (non-swplb) or per rail-plane
     (swplb), with IP placeholders
   - `80-spectrumxrailpoolconfig.yaml` -- Single SpectrumXRailPoolConfig with
-    `railTopology[]`
+    `railTopology[]`; omits the removed `spec.withBCM` field because current
+    v1alpha2 strict decoding rejects it
   - `90-example-daemonset.yaml` -- Example workload
 
 ## 7. Spectrum-X Multi-Rail (RA2.1, Network Operator 26.1)
@@ -116,7 +117,7 @@ direct-drain controllers.
 - **Plugin**: network-operator
 - **Requirements**: `fabric=ethernet`, `deployment=sriov`, `multirail=true`,
   `spectrumX.spcxVersion=RA2.1`,
-  `spectrumX.multiplaneMode` in `[swplb, hwplb, uniplane, none]`,
+  `spectrumX.multiplaneMode` in `[swplb, hwplb, none]`,
   `minNetworkOperatorRelease=26.1`, `maxNetworkOperatorRelease=26.1`
   (pinned to exactly 26.1)
 - **Node Capabilities**: `sriov: true`, `rdma: true`
@@ -127,14 +128,14 @@ direct-drain controllers.
   otherConfig), per-rail `SriovNetworkNodePolicy`, `OVSNetwork` with
   `rdma`+`rail` meta-plugins, nv-ipam `CIDRPool`, and v1alpha1
   `SpectrumXRailPoolConfig` referencing the SR-IOV node policy and CIDR
-  pool. Same multiplane modes as the RA2.2 profile (swplb, hwplb, uniplane,
-  none). 26.1 NCP shape is leaner: no `nicFirmwareStorage`, no
+  pool. Same multiplane modes as the RA2.2 profile (swplb, hwplb, none).
+  26.1 NCP shape is leaner: no `nicFirmwareStorage`, no
   `spectrumXOperator.xPlane`.
 - **Mode-specific shape**:
   - `swplb` -- `bridge.groupingPolicy: perPF`, single PF per
     SriovNetworkNodePolicy, no `devlinkParams`. Per-plane resources named
     `rail-{i}-plane-{p}`.
-  - `hwplb`/`uniplane`/`none` -- `bridge.groupingPolicy: all`, all of a
+  - `hwplb`/`none` -- `bridge.groupingPolicy: all`, all of a
     rail's PFs grouped, plus `devlinkParams.params.esw_multiport: "true"`.
     Per-rail resources named `rail-{i}`.
 - **Templates**:

--- a/skills/k8s-launch-kit-generate/references/spectrum-x-modes.md
+++ b/skills/k8s-launch-kit-generate/references/spectrum-x-modes.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Spectrum-X supports four multiplane modes that determine how network planes are
+Spectrum-X supports three multiplane modes that determine how network planes are
 organized, how resources are named, and which NIC types are supported. The mode
 is selected via `--multiplane-mode` or `profile.spectrumX.multiplaneMode` in the
 config file.
@@ -73,39 +73,20 @@ ovs-network-rail-1
   is not needed and hardware efficiency matters.
 - **docaEswitchMax**: number of rails
 
-## Mode: uniplane
-
-- **NIC type**: ConnectX-8 (deviceID `1023`) or ConnectX-9 (deviceID `1025`)
-- **Number of planes**: 1 (fixed, no other value allowed)
-- **Profile**: `spectrum-x` (base Spectrum-X profile)
-- **Resource naming**: Per-rail only
-
-```
-sriov-network-node-policy-rail-0
-sriov-network-node-policy-rail-1
-ovs-network-rail-0
-ovs-network-rail-1
-```
-
-- **Description**: Single logical plane encompassing all physical connections.
-  Simplest CX8 topology with no plane management overhead. Use when the network
-  topology does not benefit from multiple planes.
-- **docaEswitchMax**: number of rails
-
 ## NIC Type Constraint Summary
 
-| NIC Type        | deviceID | Allowed Modes              | Default Mode |
-|-----------------|----------|----------------------------|--------------|
-| BlueField-3     | `a2dc`   | `none`                     | `none`       |
-| ConnectX-8      | `1023`   | `swplb`, `hwplb`, `uniplane` | `swplb`   |
-| ConnectX-9      | `1025`   | `swplb`, `hwplb`, `uniplane` | `swplb`   |
+| NIC Type        | deviceID | Allowed Modes       | Default Mode |
+|-----------------|----------|---------------------|--------------|
+| BlueField-3     | `a2dc`   | `none`              | `none`       |
+| ConnectX-7      | `1021`   | `none`              | `none`       |
+| ConnectX-8      | `1023`   | `swplb`, `hwplb`    | `swplb`      |
+| ConnectX-9      | `1025`   | `swplb`, `hwplb`    | `hwplb`      |
 
 ## Number of Planes Rules
 
 | Mode      | Valid Values | Default | Notes                                  |
 |-----------|-------------|---------|----------------------------------------|
-| `none`    | 1           | 1       | BF3 only, single plane                 |
-| `uniplane`| 1           | 1       | Single logical plane                   |
+| `none`    | 1           | 1       | CX7/BF3, single plane                  |
 | `swplb`   | 2, 4        | 4       | More planes = finer resource granularity|
 | `hwplb`   | 2, 4        | 4       | More planes = more hardware capacity   |
 
@@ -119,30 +100,33 @@ Two RA versions are supported, picked by the value of `--spectrum-x` together wi
 | `RA2.2` | 26.4+            | `spectrum-x`          | Single v1alpha2 `SpectrumXRailPoolConfig` with `railTopology[]`  |
 | `RA2.1` | 26.1 only        | `spectrum-x-ra2.1`    | Full SR-IOV operator chain + v1alpha1 `SpectrumXRailPoolConfig`  |
 
-Both profiles support all four multiplane modes (`none`, `swplb`, `hwplb`,
-`uniplane`). Selecting a mismatched `(spcxVersion, network-operator-release)`
+Both profiles support three multiplane modes (`none`, `swplb`, `hwplb`).
+Selecting a mismatched `(spcxVersion, network-operator-release)`
 pair (e.g. `RA2.1` with `26.4`) causes the matcher to skip both profiles and
 fall through to a non-Spectrum-X profile or error out.
+
+The v1alpha2 rail-pool template omits the removed `spec.withBCM` field.
+Current `SpectrumXRailPoolConfig` CRDs reject that field during strict
+decoding.
 
 ## Mode Selection Guide
 
 | Scenario                                  | Recommended Mode |
 |-------------------------------------------|------------------|
 | BF3 SuperNIC deployment                   | `none`           |
+| CX7 deployment                            | `none`           |
 | CX8, small cluster, fine-grained control  | `swplb`          |
 | CX8, large multi-tier topology            | `hwplb`          |
-| CX8, simple single-tier topology          | `uniplane`       |
 | Not sure (CX8)                            | `swplb` (default)|
 
 ## Validation Rules
 
 l8k validates the mode and planes combination at startup:
 
-1. If `nicType=a2dc` (BF3), mode must be `none` and planes must be 1
-2. If `nicType=1023` (CX8) or `1025` (CX9), mode must be `swplb`, `hwplb`, or `uniplane`
-3. If mode is `none` or `uniplane`, planes must be 1
-4. If mode is `swplb` or `hwplb`, planes must be 2 or 4
-5. Version must be `RA2.1` (with `--network-operator-release 26.1`) or
+1. Mode must be `none`, `swplb`, or `hwplb`
+2. If mode is `none`, planes must be 1
+3. Number of planes must be 1, 2, or 4
+4. Version must be `RA2.1` (with `--network-operator-release 26.1`) or
    `RA2.2` (with `--network-operator-release 26.4` or higher / no release pinned)
 
 Validation failures produce exit code 2 (validation error) with a descriptive

--- a/skills/k8s-network-engineer/SKILL.md
+++ b/skills/k8s-network-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-network-engineer
-version: 1.4.0
+version: 1.4.1
 description: "Embody a senior NVIDIA Networking Engineer who is an expert on deploying cloud-native networking on Kubernetes with k8s-launch-kit (l8k). Activate whenever the user mentions NVIDIA network profiles, SR-IOV, RDMA, Spectrum-X, BlueField, ConnectX, NIC configuration, Network Operator, DOCA drivers, multirail networking, l8k, k8s-launch-kit, or any Kubernetes networking topic involving NVIDIA hardware. Also activate when the user asks general questions about high-performance networking, GPU interconnect, or RDMA configuration."
 metadata:
   requires:
@@ -54,6 +54,9 @@ Use `l8k preset list` to see available presets. Multi-variant presets (same mach
 - Default to SR-IOV Ethernet for new GPU clusters unless told otherwise.
 - Recommend `--dry-run` before any production deployment.
 - For Spectrum-X, confirm NIC type (ConnectX-8 vs BlueField-3) before selecting multiplane mode.
+- Treat `spec.withBCM` as removed from v1alpha2
+  `SpectrumXRailPoolConfig`; current CRDs reject generated manifests that
+  include it.
 - Before recommending Spectrum-X, always ask the user if they have Spectrum-X switch fabric (Spectrum-4 switches) configured. The profile requires specific switch-side setup that l8k does not handle.
 - Always call l8k with `--output json 2>/dev/null` and parse the result with jq. Never use text mode. Do NOT add `--yes` — it doesn't work on subcommands; `--output json` auto-confirms.
 - Discovery resolves and persists the profile, including multirail. Reuse the

--- a/skills/k8s-network-engineer/references/config-schema.md
+++ b/skills/k8s-network-engineer/references/config-schema.md
@@ -217,7 +217,7 @@ the single CLI gateway: a non-empty value sets `enable: true` AND populates
 |------------------|--------|----------|------------------------------------------------------|----------------------------------------|
 | `enable`         | bool   | `false`  | derived from `--spectrum-x` (true when value is set) | Enable Spectrum-X profile              |
 | `spcxVersion`    | string | `RA2.2`  | value of `--spectrum-x`                              | Spectrum-X RA version. `RA2.2` (Network Operator 26.4+) or `RA2.1` (26.1 only). |
-| `multiplaneMode` | string | `swplb`  | `--multiplane-mode`                                  | `swplb`, `hwplb`, `uniplane`, or `none`|
+| `multiplaneMode` | string | `swplb`  | `--multiplane-mode`                                  | `swplb`, `hwplb`, or `none`|
 | `numberOfPlanes` | int    | `4`      | `--number-of-planes`                                 | 1, 2, or 4 (also used as pfsPerNic)   |
 
 CLI flags always override config file values for all profile fields.

--- a/skills/k8s-network-engineer/references/glossary.md
+++ b/skills/k8s-network-engineer/references/glossary.md
@@ -2,7 +2,7 @@
 
 ## Hardware
 
-- **ConnectX-8 (CX8)**: NVIDIA network adapter (deviceID `1023`). Supports SR-IOV, RDMA, and Spectrum-X with swplb/hwplb/uniplane multiplane modes.
+- **ConnectX-8 (CX8)**: NVIDIA network adapter (deviceID `1023`). Supports SR-IOV, RDMA, and Spectrum-X with swplb/hwplb multiplane modes.
 - **ConnectX-9 (CX9)**: NVIDIA network adapter (deviceID `1025`). Same Spectrum-X capabilities as ConnectX-8.
 - **BlueField-3 (BF3)**: NVIDIA DPU/SuperNIC (deviceID `a2dc`). When used with Spectrum-X, only supports multiplane mode `none` with 1 plane.
 - **PF (Physical Function)**: A physical NIC port exposed by the hardware. Each PF can be split into multiple VFs via SR-IOV.
@@ -26,10 +26,9 @@
 
 ## Spectrum-X
 
-- **Multiplane mode**: How Spectrum-X organizes switch fabric planes. Options: `none` (BF3 only), `swplb` (software plane load balancing), `hwplb` (hardware plane load balancing), `uniplane` (single logical plane).
+- **Multiplane mode**: How Spectrum-X organizes switch fabric planes. Options: `none` (CX7/BF3), `swplb` (software plane load balancing), and `hwplb` (hardware plane load balancing).
 - **SWPLB (Software Plane Load Balancing)**: Each rail-plane combination gets its own set of Kubernetes resources. Default for CX8.
 - **HWPLB (Hardware Plane Load Balancing)**: Planes managed by switch hardware. Resources generated per-rail only. For larger-scale 2/3-tier topologies.
-- **Uniplane**: Single logical plane, no plane separation. Simplest topology.
 
 ## Network Operator Components
 

--- a/skills/k8s-network-engineer/references/profile-decision-tree.md
+++ b/skills/k8s-network-engineer/references/profile-decision-tree.md
@@ -71,7 +71,7 @@ profile's `profileRequirements`.
 - **Directory**: `profiles/spectrum-x/`
 - **Requirements**: `fabric=ethernet`, `deployment=sriov`, `multirail=true`,
   `spectrumX.spcxVersion=RA2.2`, `spectrumX.multiplaneMode` in
-  `[swplb, hwplb, uniplane, none]`, `minNetworkOperatorRelease=26.4`
+  `[swplb, hwplb, none]`, `minNetworkOperatorRelease=26.4`
 - **Node capabilities**: `sriov: true`, `rdma: true`
 - **Use cases**: Multi-tenant AI cloud, Spectrum-X ethernet fabric with OVS
   hardware offload, BF3 SuperNIC deployments, CX8 with any multiplane mode
@@ -80,15 +80,15 @@ profile's `profileRequirements`.
   NicConfigurationTemplate, CIDRPool (one per rail or per rail-plane in
   swplb with IP placeholders), SpectrumXRailPoolConfig (`v1alpha2`, single
   resource with `railTopology[]` — per-plane entries in swplb, per-rail
-  entries otherwise), example DaemonSet
-- **Keywords**: Spectrum-X, SPCX, RA2.2, multi-rail, AI cloud, DOCA, swplb, hwplb, uniplane
+  entries otherwise, with removed `spec.withBCM` omitted), example DaemonSet
+- **Keywords**: Spectrum-X, SPCX, RA2.2, multi-rail, AI cloud, DOCA, swplb, hwplb
 
 ### 7. Spectrum-X Multi-Rail (RA2.1, Network Operator 26.1)
 
 - **Directory**: `profiles/spectrum-x-ra2.1/`
 - **Requirements**: `fabric=ethernet`, `deployment=sriov`, `multirail=true`,
   `spectrumX.spcxVersion=RA2.1`, `spectrumX.multiplaneMode` in
-  `[swplb, hwplb, uniplane, none]`, `minNetworkOperatorRelease=26.1`,
+  `[swplb, hwplb, none]`, `minNetworkOperatorRelease=26.1`,
   `maxNetworkOperatorRelease=26.1` (pinned to exactly 26.1)
 - **Node capabilities**: `sriov: true`, `rdma: true`
 - **Use cases**: Spectrum-X deployments on Network Operator 26.1 (where
@@ -99,11 +99,11 @@ profile's `profileRequirements`.
   NicInterfaceNameTemplate (applied first), NicConfigurationTemplate
   (RA2.1), cluster-scoped SriovNetworkPoolConfig (DOCA OVS otherConfig),
   per-rail SriovNetworkNodePolicy (groupingPolicy: `perPF` for swplb
-  with no devlinkParams; `all` for hwplb/uniplane/none with
+  with no devlinkParams; `all` for hwplb/none with
   `esw_multiport: "true"`), OVSNetwork with `rdma`+`rail` meta-plugins,
   CIDRPool, v1alpha1 glue SpectrumXRailPoolConfig referencing the
   SR-IOV node policy and CIDR pool, example DaemonSet
-- **Keywords**: Spectrum-X, SPCX, RA2.1, network-operator-26.1, multi-rail, AI cloud, DOCA, swplb, hwplb, uniplane
+- **Keywords**: Spectrum-X, SPCX, RA2.1, network-operator-26.1, multi-rail, AI cloud, DOCA, swplb, hwplb
 
 ## Spectrum-X NIC Type Rules
 
@@ -116,9 +116,8 @@ profile's `profileRequirements`.
 
 ### ConnectX-8 (deviceID: 1023) / ConnectX-9 (deviceID: 1025)
 
-- Multiplane modes: `swplb`, `hwplb`, or `uniplane`
+- Multiplane modes: `swplb` or `hwplb`
 - Number of planes:
-  - `uniplane`: always 1
   - `swplb`: 2 or 4 (default: 4)
   - `hwplb`: 2 or 4 (default: 4)
 - `swplb` is the default mode for CX8 when no explicit mode is given
@@ -131,14 +130,12 @@ profile's `profileRequirements`.
 | `none`   | BF3  | Any            | Per-rail                 | BF3 SuperNIC deployments          |
 | `swplb`  | CX8  | Small-medium   | Per-rail-per-plane       | Default for CX8, finer granularity|
 | `hwplb`  | CX8  | Large (2/3-tier)| Per-rail only           | Large-scale multi-tier topologies |
-| `uniplane`| CX8 | Simple         | Per-rail                 | Simplest CX8 topology             |
 
 ### Number of Planes Rules
 
 | Mode      | Valid Values | Default | Notes                          |
 |-----------|-------------|---------|--------------------------------|
-| `none`    | 1           | 1       | BF3 only, no planes            |
-| `uniplane`| 1           | 1       | Single logical plane            |
+| `none`    | 1           | 1       | CX7/BF3, no planes             |
 | `swplb`   | 2, 4        | 4       | More planes = more granularity  |
 | `hwplb`   | 2, 4        | 4       | More planes = more capacity     |
 

--- a/skills/k8s-network-engineer/references/spectrum-x-guide.md
+++ b/skills/k8s-network-engineer/references/spectrum-x-guide.md
@@ -8,7 +8,7 @@ It always requires `fabric=ethernet`, `deployment=sriov`, and `multirail=true`.
 
 ## Multiplane Modes
 
-Spectrum-X supports four multiplane modes that determine how network planes are
+Spectrum-X supports three multiplane modes that determine how network planes are
 organized and how resources are named:
 
 ### none (BF3 Only)
@@ -37,21 +37,13 @@ organized and how resources are named:
 - Resources are named per-rail only (hardware handles plane distribution)
 - Better for large-scale 2-tier and 3-tier network topologies
 
-### uniplane (Unified Plane)
-
-- ConnectX-8 (deviceID `1023`) or ConnectX-9 (deviceID `1025`)
-- Single logical plane encompassing all physical connections
-- Number of planes: 1 (fixed)
-- Resources are named per-rail only
-- Simplest CX8 topology
-
-All four modes are supported by both Spectrum-X profiles. Pick the profile
+All three modes are supported by the Spectrum-X profiles. Pick the profile
 by the value of `--spectrum-x` (the legacy `--spcx-version` has been folded
 into `--spectrum-x`):
 
 - `profiles/spectrum-x/` — RA2.2 on Network Operator 26.4+. Uses the
   consolidated v1alpha2 `SpectrumXRailPoolConfig` (`railTopology[]`) for
-  rail wiring.
+  rail wiring and omits the removed `spec.withBCM` field.
 - `profiles/spectrum-x-ra2.1/` — RA2.1 on Network Operator 26.1 only.
   Renders the full SR-IOV operator chain (`SriovNetworkPoolConfig` +
   `SriovNetworkNodePolicy` + `OVSNetwork` + `CIDRPool`) plus a v1alpha1
@@ -91,7 +83,7 @@ are already configured. This is a tech-preview feature for non-BCM workflows.
 
 Resources are named based on rail and (optionally) plane indices:
 
-### Per-Rail Resources (hwplb, uniplane, none)
+### Per-Rail Resources (hwplb, none)
 
 ```
 sriov-network-node-policy-rail-0
@@ -175,9 +167,4 @@ l8k --user-config config.yaml \
   --multirail --spectrum-x \
   --multiplane-mode hwplb --number-of-planes 4
 
-# CX8 uniplane (simplest)
-l8k --user-config config.yaml \
-  --fabric ethernet --deployment-type sriov \
-  --multirail --spectrum-x \
-  --multiplane-mode uniplane --number-of-planes 1
 ```


### PR DESCRIPTION
## Summary

- omit the removed `spec.withBCM` field from the RA2.2 and RA2.3 v1alpha2 `SpectrumXRailPoolConfig` templates
- remove `uniplane` from Spectrum-X CLI/config/profile support so the supported modes are `none`, `swplb`, and `hwplb`
- default ConnectX-7 and BF3 SuperNIC hardware to `none`, and align user docs plus bundled skills
- add regression coverage for both v1alpha2 rail-pool templates and explicit `uniplane` rejection

## Validation

- `make build`
- `go test ./...`
- smoke-rendered RA2.2 and RA2.3 with `none`, `hwplb`, and `swplb`; all generated rail-pool manifests omit `withBCM`
- verified `--multiplane-mode uniplane` returns `VALIDATION_ERROR` with exit code 2
- `git diff --check`

`golangci-lint` and `mkdocs` are not installed locally; their checks are covered by PR CI.