### PR TITLE
fix: select Spectrum-X interface prefixes by mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,8 +989,15 @@ nicConfigurationOperator:
 spectrumX:
   nicType: "1023"
   overlay: none
-  rdmaPrefix: roce_p%plane%_r%rail%    # Spectrum-X uses its own prefixes (with %plane%)
-  netdevPrefix: eth_p%plane%_r%rail%
+  singlePlane:
+    netdevPrefix: "eth_r%rail_id%"
+    rdmaPrefix: "roce_r%rail_id%"
+  hwplb:
+    netdevPrefix: "eth_r%rail_id%_p%plane_id%"
+    rdmaPrefix: "roce_r%rail_id%"
+  swplb:
+    netdevPrefix: "eth_r%rail_id%_p%plane_id%"
+    rdmaPrefix: "roce_r%rail_id%_p%plane_id%"
 profile:
   fabric: ethernet
   deployment: sriov
@@ -1293,6 +1300,16 @@ The `nicConfigurationOperator.deployNicInterfaceNameTemplate` setting controls w
 2. **rdma_shared deployment with empty network interface names** — When the deployment type is `rdma_shared` (macvlan-rdma-shared or ipoib-rdma-shared profiles) and PFs have empty `networkInterface` fields. The `rdmaSharedDevicePlugin` uses `ifNames` selectors that require interface names, so NicInterfaceNameTemplate must be enabled to provide them. This typically happens when discovery finds multiple nodes per group and omits device names for safety.
 
 When neither condition holds, name templates are disabled and the device plugin uses PCI addresses directly, avoiding the overhead of deploying the NIC configuration operator.
+
+Spectrum-X interface prefixes default according to the selected multiplane mode:
+
+| Mode | Network device prefix | RDMA device prefix |
+| --- | --- | --- |
+| `hwplb` | `eth_r%rail_id%_p%plane_id%` | `roce_r%rail_id%` |
+| `swplb` | `eth_r%rail_id%_p%plane_id%` | `roce_r%rail_id%_p%plane_id%` |
+| `none` | `eth_r%rail_id%` | `roce_r%rail_id%` |
+
+Set the prefixes in the corresponding `spectrumX.singlePlane`, `spectrumX.hwplb`, or `spectrumX.swplb` block to override that mode. The `none` mode uses `singlePlane`.
 
 ### Custom Workload Manifest
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -202,8 +202,15 @@ nicConfigurationOperator:
 spectrumX:
   nicType: "1023"
   overlay: "none"
-  rdmaPrefix: "roce_p%plane_id%_r%rail_id%"
-  netdevPrefix: "eth_p%plane_id%_r%rail_id%"
+  singlePlane:
+    netdevPrefix: "eth_r%rail_id%"
+    rdmaPrefix: "roce_r%rail_id%"
+  hwplb:
+    netdevPrefix: "eth_r%rail_id%_p%plane_id%"
+    rdmaPrefix: "roce_r%rail_id%"
+  swplb:
+    netdevPrefix: "eth_r%rail_id%_p%plane_id%"
+    rdmaPrefix: "roce_r%rail_id%_p%plane_id%"
 ```
 
 | Field | Meaning |
@@ -213,7 +220,9 @@ spectrumX:
 | `updateFW` | Enables firmware staging storage in generated Network Operator configuration. |
 | `spectrumX.nicType` | Device ID: `1021` ConnectX-7, `1023` ConnectX-8, `1025` ConnectX-9, or `a2dc` BlueField-3 SuperNIC. |
 | `spectrumX.overlay` | Spectrum-X overlay mode. |
-| `spectrumX.rdmaPrefix` / `netdevPrefix` | Spectrum-X names with plane and rail placeholders when the profile requires them. |
+| `spectrumX.singlePlane` | Prefix block selected by `none`; defaults both device types to rail-only names. |
+| `spectrumX.hwplb` | Prefix block selected by `hwplb`; defaults RDMA to rail-only and NET to rail-plane names. |
+| `spectrumX.swplb` | Prefix block selected by `swplb`; defaults both device types to rail-plane names. |
 
 ## Profile
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/go-logr/logr"
 	"gopkg.in/yaml.v2"
@@ -38,6 +39,12 @@ import (
 //
 //go:embed default-config.yaml
 var defaultConfigYAML []byte
+
+var (
+	spectrumXPrefixDefaultsOnce sync.Once
+	spectrumXPrefixDefaults     *SpectrumXConfig
+	spectrumXPrefixDefaultsErr  error
+)
 
 // DefaultConfigYAML returns a copy of the embedded default configuration
 // source. Discovery uses it to preserve field comments when no filesystem
@@ -277,10 +284,88 @@ type SriovConfig struct {
 }
 
 type SpectrumXConfig struct {
-	NicType      string `yaml:"nicType"`      // "1023" for ConnectX-8, "1025" for ConnectX-9, "a2dc" for BlueField-3 SuperNIC
-	Overlay      string `yaml:"overlay"`      // "none"
-	RdmaPrefix   string `yaml:"rdmaPrefix"`   // e.g., "roce_p%plane_id%_r%rail_id%"
-	NetdevPrefix string `yaml:"netdevPrefix"` // e.g., "eth_p%plane_id%_r%rail_id%"
+	NicType     string                              `yaml:"nicType"` // "1023" for ConnectX-8, "1025" for ConnectX-9, "a2dc" for BlueField-3 SuperNIC
+	Overlay     string                              `yaml:"overlay"` // "none"
+	SinglePlane *SpectrumXInterfaceNamePrefixConfig `yaml:"singlePlane,omitempty"`
+	HWPLB       *SpectrumXInterfaceNamePrefixConfig `yaml:"hwplb,omitempty"`
+	SWPLB       *SpectrumXInterfaceNamePrefixConfig `yaml:"swplb,omitempty"`
+}
+
+// SpectrumXInterfaceNamePrefixConfig contains the device-name templates for
+// one Spectrum-X multiplane mode family.
+type SpectrumXInterfaceNamePrefixConfig struct {
+	NetdevPrefix string `yaml:"netdevPrefix"`
+	RdmaPrefix   string `yaml:"rdmaPrefix"`
+}
+
+// SpectrumXInterfaceNamePrefixes returns the RDMA and network-device naming
+// templates from the Spectrum-X block selected by the multiplane mode.
+// Missing blocks or fields inherit from the matching block in the embedded
+// default-config.yaml, so file-backed and programmatic configs follow the same
+// defaults while explicit per-mode values remain authoritative.
+//
+// Hardware PLB exposes one RDMA bond per rail while retaining one network
+// device per rail-plane. Software PLB exposes both device types per rail-plane.
+// The none mode exposes one device of each type per rail.
+func SpectrumXInterfaceNamePrefixes(settings *SpectrumXConfig, multiplaneMode string) (string, string) {
+	defaults, err := defaultSpectrumXInterfaceNamePrefixes()
+	if err != nil {
+		return "", ""
+	}
+
+	var selected, selectedDefaults *SpectrumXInterfaceNamePrefixConfig
+
+	switch multiplaneMode {
+	case "hwplb":
+		selectedDefaults = defaults.HWPLB
+		if settings != nil {
+			selected = settings.HWPLB
+		}
+	case "swplb":
+		selectedDefaults = defaults.SWPLB
+		if settings != nil {
+			selected = settings.SWPLB
+		}
+	default:
+		selectedDefaults = defaults.SinglePlane
+		if settings != nil {
+			selected = settings.SinglePlane
+		}
+	}
+
+	if selectedDefaults == nil {
+		return "", ""
+	}
+
+	rdmaPrefix := selectedDefaults.RdmaPrefix
+	netdevPrefix := selectedDefaults.NetdevPrefix
+	if selected != nil {
+		if selected.RdmaPrefix != "" {
+			rdmaPrefix = selected.RdmaPrefix
+		}
+		if selected.NetdevPrefix != "" {
+			netdevPrefix = selected.NetdevPrefix
+		}
+	}
+	return rdmaPrefix, netdevPrefix
+}
+
+func defaultSpectrumXInterfaceNamePrefixes() (*SpectrumXConfig, error) {
+	spectrumXPrefixDefaultsOnce.Do(func() {
+		var defaults struct {
+			SpectrumX *SpectrumXConfig `yaml:"spectrumX"`
+		}
+		if err := yaml.Unmarshal(defaultConfigYAML, &defaults); err != nil {
+			spectrumXPrefixDefaultsErr = fmt.Errorf("failed to parse embedded Spectrum-X prefix defaults: %w", err)
+			return
+		}
+		if defaults.SpectrumX == nil {
+			spectrumXPrefixDefaultsErr = fmt.Errorf("embedded default config is missing spectrumX")
+			return
+		}
+		spectrumXPrefixDefaults = defaults.SpectrumX
+	})
+	return spectrumXPrefixDefaults, spectrumXPrefixDefaultsErr
 }
 
 type NicConfigurationOperatorConfig struct {
@@ -840,12 +925,26 @@ func DefaultSPCXReleaseFor(ra string) string {
 
 // validateSpectrumXTemplates validates that Spectrum-X templates have required placeholders
 func validateSpectrumXTemplates(config *LaunchKitConfig) error {
-	netdevPrefix := config.SpectrumX.NetdevPrefix
-	rdmaPrefix := config.SpectrumX.RdmaPrefix
+	mode := config.Profile.SpectrumX.MultiplaneMode
+	rdmaPrefix, netdevPrefix := SpectrumXInterfaceNamePrefixes(config.SpectrumX, mode)
+	prefixSection := "singlePlane"
+	switch mode {
+	case "hwplb":
+		prefixSection = "hwplb"
+	case "swplb":
+		prefixSection = "swplb"
+	}
+
+	if netdevPrefix == "" {
+		return fmt.Errorf("spectrumX.%s.netdevPrefix must not be empty", prefixSection)
+	}
+	if rdmaPrefix == "" {
+		return fmt.Errorf("spectrumX.%s.rdmaPrefix must not be empty", prefixSection)
+	}
 
 	// Non-`none` multiplane modes (swplb, hwplb) require a supported
 	// RA version.
-	if config.Profile.SpectrumX.MultiplaneMode != "none" && config.Profile.SpectrumX.MultiplaneMode != "" {
+	if mode != "none" && mode != "" {
 		got := config.Profile.SpectrumX.SPCXVersion
 		supported := false
 		for _, v := range SupportedSPCXVersions {
@@ -856,7 +955,7 @@ func validateSpectrumXTemplates(config *LaunchKitConfig) error {
 		}
 		if !supported {
 			return fmt.Errorf("multiplane mode %s requires spcxVersion in %v, got %q",
-				config.Profile.SpectrumX.MultiplaneMode, SupportedSPCXVersions, got)
+				mode, SupportedSPCXVersions, got)
 		}
 	}
 
@@ -868,23 +967,25 @@ func validateSpectrumXTemplates(config *LaunchKitConfig) error {
 	hasRailInNetdev := containsPlaceholder(netdevPrefix, "%rail%") || containsPlaceholder(netdevPrefix, "%rail_id%")
 
 	if isMultiplane && !hasPlaneInNetdev {
-		return fmt.Errorf("spectrumX.netdevPrefix must contain %%plane_id%% placeholder when numberOfPlanes > 1 (multiplane mode)")
+		return fmt.Errorf("spectrumX.%s.netdevPrefix must contain %%plane_id%% placeholder when numberOfPlanes > 1 (multiplane mode)", prefixSection)
 	}
 
 	if isMultirail && !hasRailInNetdev {
-		return fmt.Errorf("spectrumX.netdevPrefix must contain %%rail_id%% placeholder when multirail is enabled")
+		return fmt.Errorf("spectrumX.%s.netdevPrefix must contain %%rail_id%% placeholder when multirail is enabled", prefixSection)
 	}
 
-	// Check rdmaPrefix (same rules)
+	// SWPLB exposes one RDMA device per plane. HWPLB exposes a single RDMA
+	// bond per rail, so its correct prefix intentionally has no plane
+	// placeholder even when numberOfPlanes > 1.
 	hasPlaneInRdma := containsPlaceholder(rdmaPrefix, "%plane%") || containsPlaceholder(rdmaPrefix, "%plane_id%")
 	hasRailInRdma := containsPlaceholder(rdmaPrefix, "%rail%") || containsPlaceholder(rdmaPrefix, "%rail_id%")
 
-	if isMultiplane && !hasPlaneInRdma {
-		return fmt.Errorf("spectrumX.rdmaPrefix must contain %%plane_id%% placeholder when numberOfPlanes > 1 (multiplane mode)")
+	if isMultiplane && mode == "swplb" && !hasPlaneInRdma {
+		return fmt.Errorf("spectrumX.%s.rdmaPrefix must contain %%plane_id%% placeholder when multiplaneMode is swplb", prefixSection)
 	}
 
 	if isMultirail && !hasRailInRdma {
-		return fmt.Errorf("spectrumX.rdmaPrefix must contain %%rail_id%% placeholder when multirail is enabled")
+		return fmt.Errorf("spectrumX.%s.rdmaPrefix must contain %%rail_id%% placeholder when multirail is enabled", prefixSection)
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -158,6 +158,16 @@ func TestDefaultLaunchKitConfig(t *testing.T) {
 	assert.Equal(t, DefaultValidationIBWriteSize, cfg.Validation.RDMA.IBWriteSize)
 	require.NotNil(t, cfg.Validation.RDMA.IBWriteMinBandwidthGbps)
 	assert.Equal(t, float64(DefaultValidationIBWriteMinGbps), *cfg.Validation.RDMA.IBWriteMinBandwidthGbps)
+	require.NotNil(t, cfg.SpectrumX)
+	require.NotNil(t, cfg.SpectrumX.SinglePlane)
+	assert.Equal(t, "eth_r%rail_id%", cfg.SpectrumX.SinglePlane.NetdevPrefix)
+	assert.Equal(t, "roce_r%rail_id%", cfg.SpectrumX.SinglePlane.RdmaPrefix)
+	require.NotNil(t, cfg.SpectrumX.HWPLB)
+	assert.Equal(t, "eth_r%rail_id%_p%plane_id%", cfg.SpectrumX.HWPLB.NetdevPrefix)
+	assert.Equal(t, "roce_r%rail_id%", cfg.SpectrumX.HWPLB.RdmaPrefix)
+	require.NotNil(t, cfg.SpectrumX.SWPLB)
+	assert.Equal(t, "eth_r%rail_id%_p%plane_id%", cfg.SpectrumX.SWPLB.NetdevPrefix)
+	assert.Equal(t, "roce_r%rail_id%_p%plane_id%", cfg.SpectrumX.SWPLB.RdmaPrefix)
 }
 
 func TestValidationConfig(t *testing.T) {
@@ -462,8 +472,15 @@ sriov:
 spectrumX:
   nicType: "1023"
   overlay: "none"
-  rdmaPrefix: "roce_nic%nic_id%_p%plane%_r%rail%"
-  netdevPrefix: "nic%nic_id%_p%plane%_r%rail%"
+  singlePlane:
+    netdevPrefix: "nic%nic_id%_r%rail%"
+    rdmaPrefix: "roce_nic%nic_id%_r%rail%"
+  hwplb:
+    netdevPrefix: "nic%nic_id%_p%plane%_r%rail%"
+    rdmaPrefix: "roce_nic%nic_id%_r%rail%"
+  swplb:
+    netdevPrefix: "nic%nic_id%_p%plane%_r%rail%"
+    rdmaPrefix: "roce_nic%nic_id%_p%plane%_r%rail%"
 
 profile:
   fabric: ethernet
@@ -488,8 +505,15 @@ profile:
 		require.NotNil(t, config.SpectrumX)
 		assert.Equal(t, "1023", config.SpectrumX.NicType)
 		assert.Equal(t, "none", config.SpectrumX.Overlay)
-		assert.Equal(t, "roce_nic%nic_id%_p%plane%_r%rail%", config.SpectrumX.RdmaPrefix)
-		assert.Equal(t, "nic%nic_id%_p%plane%_r%rail%", config.SpectrumX.NetdevPrefix)
+		require.NotNil(t, config.SpectrumX.SinglePlane)
+		assert.Equal(t, "roce_nic%nic_id%_r%rail%", config.SpectrumX.SinglePlane.RdmaPrefix)
+		assert.Equal(t, "nic%nic_id%_r%rail%", config.SpectrumX.SinglePlane.NetdevPrefix)
+		require.NotNil(t, config.SpectrumX.HWPLB)
+		assert.Equal(t, "roce_nic%nic_id%_r%rail%", config.SpectrumX.HWPLB.RdmaPrefix)
+		assert.Equal(t, "nic%nic_id%_p%plane%_r%rail%", config.SpectrumX.HWPLB.NetdevPrefix)
+		require.NotNil(t, config.SpectrumX.SWPLB)
+		assert.Equal(t, "roce_nic%nic_id%_p%plane%_r%rail%", config.SpectrumX.SWPLB.RdmaPrefix)
+		assert.Equal(t, "nic%nic_id%_p%plane%_r%rail%", config.SpectrumX.SWPLB.NetdevPrefix)
 
 		// Verify profile flags
 		require.NotNil(t, config.Profile)
@@ -501,18 +525,56 @@ profile:
 		assert.True(t, config.Profile.Multirail)
 	})
 
+	t.Run("legacy file without mode blocks uses embedded mode defaults", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "legacy-spectrum-x-config.yaml")
+		configContent := `networkOperator:
+  version: v26.4.0
+  componentVersion: network-operator-v26.4.0
+  repository: nvcr.io/nvidia/mellanox
+  namespace: network-operator
+
+spectrumX:
+  nicType: "1023"
+  overlay: "none"
+  rdmaPrefix: "legacy-rdma"
+  netdevPrefix: "legacy-netdev"
+
+profile:
+  fabric: ethernet
+  deployment: sriov
+  multirail: true
+  spectrumX:
+    spcxVersion: "RA2.2"
+    multiplaneMode: hwplb
+    numberOfPlanes: 2
+`
+		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
+
+		loaded, err := LoadFullConfig(configPath, logr.Discard())
+		require.NoError(t, err)
+		require.NotNil(t, loaded.SpectrumX)
+		assert.Nil(t, loaded.SpectrumX.HWPLB)
+
+		rdmaPrefix, netdevPrefix := SpectrumXInterfaceNamePrefixes(loaded.SpectrumX, "hwplb")
+		assert.Equal(t, "roce_r%rail_id%", rdmaPrefix)
+		assert.Equal(t, "eth_r%rail_id%_p%plane_id%", netdevPrefix)
+	})
+
 	t.Run("verify Spectrum-X struct fields", func(t *testing.T) {
 		config := &SpectrumXConfig{
-			NicType:      "1023",
-			Overlay:      "none",
-			RdmaPrefix:   "roce_",
-			NetdevPrefix: "eth_p%plane%_r%rail%",
+			NicType: "1023",
+			Overlay: "none",
+			HWPLB: &SpectrumXInterfaceNamePrefixConfig{
+				RdmaPrefix:   "roce_",
+				NetdevPrefix: "eth_p%plane%_r%rail%",
+			},
 		}
 
 		assert.Equal(t, "1023", config.NicType)
 		assert.Equal(t, "none", config.Overlay)
-		assert.Equal(t, "roce_", config.RdmaPrefix)
-		assert.Equal(t, "eth_p%plane%_r%rail%", config.NetdevPrefix)
+		require.NotNil(t, config.HWPLB)
+		assert.Equal(t, "roce_", config.HWPLB.RdmaPrefix)
+		assert.Equal(t, "eth_p%plane%_r%rail%", config.HWPLB.NetdevPrefix)
 	})
 
 	t.Run("verify different multiplane modes", func(t *testing.T) {
@@ -540,7 +602,132 @@ profile:
 	})
 }
 
+func TestSpectrumXInterfaceNamePrefixes(t *testing.T) {
+	defaults, err := DefaultLaunchKitConfig()
+	require.NoError(t, err)
+	require.NotNil(t, defaults.SpectrumX)
+
+	testCases := []struct {
+		mode           string
+		wantRdmaPrefix string
+		wantNetPrefix  string
+	}{
+		{
+			mode:           "hwplb",
+			wantRdmaPrefix: "roce_r%rail_id%",
+			wantNetPrefix:  "eth_r%rail_id%_p%plane_id%",
+		},
+		{
+			mode:           "swplb",
+			wantRdmaPrefix: "roce_r%rail_id%_p%plane_id%",
+			wantNetPrefix:  "eth_r%rail_id%_p%plane_id%",
+		},
+		{
+			mode:           "none",
+			wantRdmaPrefix: "roce_r%rail_id%",
+			wantNetPrefix:  "eth_r%rail_id%",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.mode, func(t *testing.T) {
+			rdmaPrefix, netdevPrefix := SpectrumXInterfaceNamePrefixes(defaults.SpectrumX, tc.mode)
+			assert.Equal(t, tc.wantRdmaPrefix, rdmaPrefix)
+			assert.Equal(t, tc.wantNetPrefix, netdevPrefix)
+		})
+	}
+
+	t.Run("uses embedded defaults when the selected block is absent", func(t *testing.T) {
+		rdmaPrefix, netdevPrefix := SpectrumXInterfaceNamePrefixes(&SpectrumXConfig{}, "hwplb")
+		assert.Equal(t, defaults.SpectrumX.HWPLB.RdmaPrefix, rdmaPrefix)
+		assert.Equal(t, defaults.SpectrumX.HWPLB.NetdevPrefix, netdevPrefix)
+	})
+
+	t.Run("preserves a partial per-mode override", func(t *testing.T) {
+		settings := &SpectrumXConfig{
+			HWPLB: &SpectrumXInterfaceNamePrefixConfig{
+				RdmaPrefix: "custom-rdma-r%rail_id%",
+			},
+		}
+
+		rdmaPrefix, netdevPrefix := SpectrumXInterfaceNamePrefixes(settings, "hwplb")
+		assert.Equal(t, settings.HWPLB.RdmaPrefix, rdmaPrefix)
+		assert.Equal(t, defaults.SpectrumX.HWPLB.NetdevPrefix, netdevPrefix)
+	})
+
+	t.Run("selects explicit overrides from each mode block", func(t *testing.T) {
+		settings := &SpectrumXConfig{
+			SinglePlane: &SpectrumXInterfaceNamePrefixConfig{
+				RdmaPrefix:   "single-rdma-r%rail_id%",
+				NetdevPrefix: "single-net-r%rail_id%",
+			},
+			HWPLB: &SpectrumXInterfaceNamePrefixConfig{
+				RdmaPrefix:   "hw-rdma-r%rail_id%",
+				NetdevPrefix: "hw-net-r%rail_id%-p%plane_id%",
+			},
+			SWPLB: &SpectrumXInterfaceNamePrefixConfig{
+				RdmaPrefix:   "sw-rdma-r%rail_id%-p%plane_id%",
+				NetdevPrefix: "sw-net-r%rail_id%-p%plane_id%",
+			},
+		}
+
+		for _, tc := range []struct {
+			mode string
+			want *SpectrumXInterfaceNamePrefixConfig
+		}{
+			{mode: "none", want: settings.SinglePlane},
+			{mode: "hwplb", want: settings.HWPLB},
+			{mode: "swplb", want: settings.SWPLB},
+		} {
+			t.Run(tc.mode, func(t *testing.T) {
+				rdmaPrefix, netdevPrefix := SpectrumXInterfaceNamePrefixes(settings, tc.mode)
+				assert.Equal(t, tc.want.RdmaPrefix, rdmaPrefix)
+				assert.Equal(t, tc.want.NetdevPrefix, netdevPrefix)
+			})
+		}
+	})
+}
+
+func spectrumXConfigWithPrefixes(mode, netdevPrefix, rdmaPrefix string) *SpectrumXConfig {
+	prefixes := &SpectrumXInterfaceNamePrefixConfig{
+		NetdevPrefix: netdevPrefix,
+		RdmaPrefix:   rdmaPrefix,
+	}
+	settings := &SpectrumXConfig{}
+	switch mode {
+	case "hwplb":
+		settings.HWPLB = prefixes
+	case "swplb":
+		settings.SWPLB = prefixes
+	default:
+		settings.SinglePlane = prefixes
+	}
+	return settings
+}
+
 func TestValidateSpectrumXTemplates(t *testing.T) {
+	t.Run("selected prefix block inherits embedded defaults", func(t *testing.T) {
+		config := &LaunchKitConfig{
+			NetworkOperator: &NetworkOperatorConfig{
+				Repository:       "nvcr.io/nvidia/mellanox",
+				ComponentVersion: "v26.1.0",
+				Namespace:        "nvidia-network-operator",
+			},
+			Profile: &Profile{
+				Multirail: true,
+				SpectrumX: &ProfileSpectrumX{
+					SPCXVersion:    "RA2.2",
+					MultiplaneMode: "hwplb",
+					NumberOfPlanes: 2,
+				},
+			},
+			SpectrumX: &SpectrumXConfig{},
+		}
+
+		err := ValidateClusterConfig(config, "spectrum-x")
+		assert.NoError(t, err)
+	})
+
 	t.Run("valid multiplane and multirail templates", func(t *testing.T) {
 		config := &LaunchKitConfig{
 			NetworkOperator: &NetworkOperatorConfig{
@@ -556,10 +743,11 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 					NumberOfPlanes: 4,
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "nic%nic_id%_p%plane%_r%rail%",
-				RdmaPrefix:   "roce_nic%nic_id%_p%plane%_r%rail%",
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"swplb",
+				"nic%nic_id%_p%plane%_r%rail%",
+				"roce_nic%nic_id%_p%plane%_r%rail%",
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x")
@@ -581,10 +769,11 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 					NumberOfPlanes: 4, // Multiplane
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "nic%nic_id%_r%rail%", // Missing %plane%
-				RdmaPrefix:   "roce_p%plane%_r%rail%",
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"swplb",
+				"nic%nic_id%_r%rail%", // Missing %plane%
+				"roce_p%plane%_r%rail%",
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x")
@@ -592,7 +781,34 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 		assert.Contains(t, err.Error(), "netdevPrefix must contain %plane_id% placeholder")
 	})
 
-	t.Run("multiplane without plane placeholder in rdmaPrefix", func(t *testing.T) {
+	t.Run("swplb without plane placeholder in rdmaPrefix", func(t *testing.T) {
+		config := &LaunchKitConfig{
+			NetworkOperator: &NetworkOperatorConfig{
+				Repository:       "nvcr.io/nvidia/mellanox",
+				ComponentVersion: "v26.1.0",
+				Namespace:        "nvidia-network-operator",
+			},
+			Profile: &Profile{
+				Multirail: true,
+				SpectrumX: &ProfileSpectrumX{
+					SPCXVersion:    "RA2.2",
+					MultiplaneMode: "swplb",
+					NumberOfPlanes: 2, // Multiplane
+				},
+			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"swplb",
+				"nic_p%plane%_r%rail%",
+				"roce_nic%nic_id%_r%rail%", // Missing %plane%
+			),
+		}
+
+		err := ValidateClusterConfig(config, "spectrum-x")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "rdmaPrefix must contain %plane_id% placeholder when multiplaneMode is swplb")
+	})
+
+	t.Run("hwplb accepts rail-only rdmaPrefix", func(t *testing.T) {
 		config := &LaunchKitConfig{
 			NetworkOperator: &NetworkOperatorConfig{
 				Repository:       "nvcr.io/nvidia/mellanox",
@@ -604,18 +820,18 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 				SpectrumX: &ProfileSpectrumX{
 					SPCXVersion:    "RA2.2",
 					MultiplaneMode: "hwplb",
-					NumberOfPlanes: 2, // Multiplane
+					NumberOfPlanes: 2,
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "nic_p%plane%_r%rail%",
-				RdmaPrefix:   "roce_nic%nic_id%_r%rail%", // Missing %plane%
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"hwplb",
+				"eth_r%rail_id%_p%plane_id%",
+				"roce_r%rail_id%",
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x")
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "rdmaPrefix must contain %plane_id% placeholder")
+		assert.NoError(t, err)
 	})
 
 	t.Run("multirail without rail placeholder in netdevPrefix", func(t *testing.T) {
@@ -633,10 +849,11 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 					NumberOfPlanes: 1,
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "nic%nic_id%_p%plane%", // Missing %rail%
-				RdmaPrefix:   "roce_r%rail%",
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"swplb",
+				"nic%nic_id%_p%plane%", // Missing %rail%
+				"roce_r%rail%",
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x")
@@ -659,10 +876,11 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 					NumberOfPlanes: 1,
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "nic_p%plane%_r%rail%",
-				RdmaPrefix:   "roce_nic%nic_id%", // Missing %rail%
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"none",
+				"nic_p%plane%_r%rail%",
+				"roce_nic%nic_id%", // Missing %rail%
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x")
@@ -685,10 +903,11 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 					NumberOfPlanes: 4,
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "eth_p%plane%_r%rail%", // No %nic_id% but has plane and rail
-				RdmaPrefix:   "roce_p%plane%_r%rail%",
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"swplb",
+				"eth_p%plane%_r%rail%", // No %nic_id% but has plane and rail
+				"roce_p%plane%_r%rail%",
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x")
@@ -710,10 +929,11 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 					NumberOfPlanes: 1, // Single plane
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "nic%nic_id%", // No plane or rail required
-				RdmaPrefix:   "roce%nic_id%",
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"none",
+				"nic%nic_id%", // No plane or rail required
+				"roce%nic_id%",
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x")
@@ -756,10 +976,11 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 					NumberOfPlanes: 4,
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "nic_p%plane%_r%rail%",
-				RdmaPrefix:   "roce_p%plane%_r%rail%",
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"swplb",
+				"nic_p%plane%_r%rail%",
+				"roce_p%plane%_r%rail%",
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x")
@@ -784,10 +1005,11 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 					NumberOfPlanes: 4,
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "nic_p%plane%_r%rail%",
-				RdmaPrefix:   "roce_p%plane%_r%rail%",
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"hwplb",
+				"nic_p%plane%_r%rail%",
+				"roce_p%plane%_r%rail%",
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x")
@@ -810,10 +1032,11 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 					NumberOfPlanes: 2,
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "nic_p%plane%_r%rail%",
-				RdmaPrefix:   "roce_p%plane%_r%rail%",
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"swplb",
+				"nic_p%plane%_r%rail%",
+				"roce_p%plane%_r%rail%",
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x-ra2.1")
@@ -835,10 +1058,11 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 					NumberOfPlanes: 2,
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "nic_p%plane%_r%rail%",
-				RdmaPrefix:   "roce_p%plane%_r%rail%",
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"hwplb",
+				"nic_p%plane%_r%rail%",
+				"roce_p%plane%_r%rail%",
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x-ra2.1")
@@ -860,10 +1084,11 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 					NumberOfPlanes: 1,
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "nic%nic_id%",
-				RdmaPrefix:   "roce%nic_id%",
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"none",
+				"nic%nic_id%",
+				"roce%nic_id%",
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x")
@@ -885,10 +1110,11 @@ func TestValidateSpectrumXTemplates(t *testing.T) {
 					NumberOfPlanes: 4,
 				},
 			},
-			SpectrumX: &SpectrumXConfig{
-				NetdevPrefix: "static_interface", // Missing both %plane% and %rail%
-				RdmaPrefix:   "roce_p%plane%_r%rail%",
-			},
+			SpectrumX: spectrumXConfigWithPrefixes(
+				"swplb",
+				"static_interface", // Missing both %plane% and %rail%
+				"roce_p%plane%_r%rail%",
+			),
 		}
 
 		err := ValidateClusterConfig(config, "spectrum-x")

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -138,8 +138,15 @@ nicConfigurationOperator:
 spectrumX:
   nicType: "1023" # "1023" for ConnectX-8, "a2dc" for BlueField-3 SuperNIC
   overlay: "none"
-  rdmaPrefix: "roce_p%plane_id%_r%rail_id%"
-  netdevPrefix: "eth_p%plane_id%_r%rail_id%"
+  singlePlane: # Used by multiplaneMode none
+    netdevPrefix: "eth_r%rail_id%"
+    rdmaPrefix: "roce_r%rail_id%"
+  hwplb:
+    netdevPrefix: "eth_r%rail_id%_p%plane_id%"
+    rdmaPrefix: "roce_r%rail_id%"
+  swplb:
+    netdevPrefix: "eth_r%rail_id%_p%plane_id%"
+    rdmaPrefix: "roce_r%rail_id%_p%plane_id%"
 
 # This reference profile is used as-is when the file is passed explicitly via
 # --user-config. A fresh `l8k discover` ignores these example values, derives

--- a/pkg/networkoperatorplugin/grouping_test.go
+++ b/pkg/networkoperatorplugin/grouping_test.go
@@ -413,7 +413,7 @@ func TestSpectrumXGrouping_MergedRailPoolContent(t *testing.T) {
 		"merged rail pool must select by gpuType so it covers all y-model machines")
 	require.Contains(t, merged, "draEnabled: false",
 		"Spectrum-X DRA must stay disabled unless profile.spectrumX.useDRA is true")
-	require.Contains(t, merged, `pfNames: ["eth_p0_r0"]`,
+	require.Contains(t, merged, `pfNames: ["eth_r0"]`,
 		"merged rail pool must reference the renamed netdev names, not raw PCI")
 	require.NotContains(t, merged, "0000:19:00.0",
 		"merged rail pool must not leak any machine-specific PCI address")

--- a/pkg/networkoperatorplugin/spectrumx_railpool_test.go
+++ b/pkg/networkoperatorplugin/spectrumx_railpool_test.go
@@ -42,7 +42,10 @@ func TestSpectrumXRailPoolTemplatesOmitRemovedWithBCMField(t *testing.T) {
 				},
 				CurrentNetworkNamespace: "default",
 				SpectrumX: &config.SpectrumXConfig{
-					NetdevPrefix: "eth_p%plane_id%_r%rail_id%",
+					SinglePlane: &config.SpectrumXInterfaceNamePrefixConfig{
+						NetdevPrefix: "eth_r%rail_id%",
+						RdmaPrefix:   "roce_r%rail_id%",
+					},
 				},
 				Profile: &config.Profile{
 					SpectrumX: &config.ProfileSpectrumX{

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -123,6 +123,14 @@ var templateFuncs = template.FuncMap{
 	"spectrumXUseDRA": func(profile *config.Profile) bool {
 		return profile != nil && profile.SpectrumX != nil && profile.SpectrumX.UseDRA
 	},
+	"spectrumXRdmaPrefix": func(settings *config.SpectrumXConfig, multiplaneMode string) string {
+		rdmaPrefix, _ := config.SpectrumXInterfaceNamePrefixes(settings, multiplaneMode)
+		return rdmaPrefix
+	},
+	"spectrumXNetdevPrefix": func(settings *config.SpectrumXConfig, multiplaneMode string) string {
+		_, netdevPrefix := config.SpectrumXInterfaceNamePrefixes(settings, multiplaneMode)
+		return netdevPrefix
+	},
 	"spectrumXProfileConfigRequired": config.SpectrumXProfileConfigRequired,
 	"spectrumXCIDRPools": func(root any, clusterConfig *config.ClusterConfig) ([]spectrumxaddressing.CIDRPool, error) {
 		var cfg *config.LaunchKitConfig

--- a/pkg/networkoperatorplugin/templates_test.go
+++ b/pkg/networkoperatorplugin/templates_test.go
@@ -167,6 +167,112 @@ func TestMultiplaneInterfaceNaming(t *testing.T) {
 	})
 }
 
+func TestSpectrumXInterfaceNameTemplateModeDefaults(t *testing.T) {
+	templatePath := "../../profiles/spectrum-x-ra2.2/25-nicinterfacenametemplate.yaml"
+	rail0 := 0
+
+	testCases := []struct {
+		mode           string
+		planes         int
+		wantRdmaPrefix string
+		wantNetPrefix  string
+	}{
+		{
+			mode:           "hwplb",
+			planes:         2,
+			wantRdmaPrefix: "roce_r%rail_id%",
+			wantNetPrefix:  "eth_r%rail_id%_p%plane_id%",
+		},
+		{
+			mode:           "swplb",
+			planes:         2,
+			wantRdmaPrefix: "roce_r%rail_id%_p%plane_id%",
+			wantNetPrefix:  "eth_r%rail_id%_p%plane_id%",
+		},
+		{
+			mode:           "none",
+			planes:         1,
+			wantRdmaPrefix: "roce_r%rail_id%",
+			wantNetPrefix:  "eth_r%rail_id%",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.mode, func(t *testing.T) {
+			cfg := &config.LaunchKitConfig{
+				NetworkOperator: &config.NetworkOperatorConfig{
+					Namespace: "network-operator",
+				},
+				SpectrumX: &config.SpectrumXConfig{},
+				Profile: &config.Profile{
+					SpectrumX: &config.ProfileSpectrumX{
+						MultiplaneMode: tc.mode,
+						NumberOfPlanes: tc.planes,
+					},
+				},
+				ClusterConfig: []config.ClusterConfig{
+					{
+						Identifier: "machine-a",
+						PFs: []config.PFConfig{
+							{
+								DeviceID:   "1023",
+								PciAddress: "0000:03:00.0",
+								Traffic:    "east-west",
+								Rail:       &rail0,
+							},
+						},
+					},
+				},
+			}
+
+			results, err := ProcessTemplate(templatePath, cfg, "")
+			require.NoError(t, err)
+			content := results["25-nicinterfacenametemplate-machine-a.yaml"]
+			assert.Contains(t, content, `rdmaDevicePrefix: "`+tc.wantRdmaPrefix+`"`)
+			assert.Contains(t, content, `netDevicePrefix: "`+tc.wantNetPrefix+`"`)
+		})
+	}
+
+	t.Run("explicit overrides are preserved in rendered YAML", func(t *testing.T) {
+		cfg := &config.LaunchKitConfig{
+			NetworkOperator: &config.NetworkOperatorConfig{
+				Namespace: "network-operator",
+			},
+			SpectrumX: &config.SpectrumXConfig{
+				HWPLB: &config.SpectrumXInterfaceNamePrefixConfig{
+					RdmaPrefix:   "custom-rdma-r%rail_id%",
+					NetdevPrefix: "custom-net-r%rail_id%-p%plane_id%",
+				},
+			},
+			Profile: &config.Profile{
+				SpectrumX: &config.ProfileSpectrumX{
+					MultiplaneMode: "hwplb",
+					NumberOfPlanes: 2,
+				},
+			},
+			ClusterConfig: []config.ClusterConfig{
+				{
+					Identifier: "machine-a",
+					PFs: []config.PFConfig{
+						{
+							DeviceID:   "1023",
+							PciAddress: "0000:03:00.0",
+							Traffic:    "east-west",
+							Rail:       &rail0,
+						},
+					},
+				},
+			},
+		}
+
+		results, err := ProcessTemplate(templatePath, cfg, "")
+		require.NoError(t, err)
+		content := results["25-nicinterfacenametemplate-machine-a.yaml"]
+		assert.Contains(t, content, `rdmaDevicePrefix: "custom-rdma-r%rail_id%"`)
+		assert.Contains(t, content, `netDevicePrefix: "custom-net-r%rail_id%-p%plane_id%"`)
+	})
+}
+
 func TestEdgeCases(t *testing.T) {
 	replaceVarsFunc := templateFuncs["replaceVars"].(func(string, int, int, int) string)
 

--- a/pkg/networkoperatorplugin/testdata/grouping/mixed-same-type.yaml
+++ b/pkg/networkoperatorplugin/testdata/grouping/mixed-same-type.yaml
@@ -34,8 +34,15 @@ macvlan:
 spectrumX:
   nicType: "1023"
   overlay: none
-  rdmaPrefix: roce_p%plane_id%_r%rail_id%
-  netdevPrefix: eth_p%plane_id%_r%rail_id%
+  singlePlane:
+    netdevPrefix: eth_r%rail_id%
+    rdmaPrefix: roce_r%rail_id%
+  hwplb:
+    netdevPrefix: eth_r%rail_id%_p%plane_id%
+    rdmaPrefix: roce_r%rail_id%
+  swplb:
+    netdevPrefix: eth_r%rail_id%_p%plane_id%
+    rdmaPrefix: roce_r%rail_id%_p%plane_id%
 nicConfigurationOperator:
   deployNicInterfaceNameTemplate: true
   rdmaPrefix: rdma_r%rail_id%

--- a/pkg/networkoperatorplugin/testdata/grouping/same-ew-different-ns.yaml
+++ b/pkg/networkoperatorplugin/testdata/grouping/same-ew-different-ns.yaml
@@ -36,8 +36,15 @@ macvlan:
 spectrumX:
   nicType: "1023"
   overlay: none
-  rdmaPrefix: roce_p%plane_id%_r%rail_id%
-  netdevPrefix: eth_p%plane_id%_r%rail_id%
+  singlePlane:
+    netdevPrefix: eth_r%rail_id%
+    rdmaPrefix: roce_r%rail_id%
+  hwplb:
+    netdevPrefix: eth_r%rail_id%_p%plane_id%
+    rdmaPrefix: roce_r%rail_id%
+  swplb:
+    netdevPrefix: eth_r%rail_id%_p%plane_id%
+    rdmaPrefix: roce_r%rail_id%_p%plane_id%
 nicConfigurationOperator:
   deployNicInterfaceNameTemplate: true
   rdmaPrefix: rdma_r%rail_id%

--- a/pkg/networkoperatorplugin/testdata/grouping/true-heterogeneous.yaml
+++ b/pkg/networkoperatorplugin/testdata/grouping/true-heterogeneous.yaml
@@ -34,8 +34,15 @@ macvlan:
 spectrumX:
   nicType: "1023"
   overlay: none
-  rdmaPrefix: roce_p%plane_id%_r%rail_id%
-  netdevPrefix: eth_p%plane_id%_r%rail_id%
+  singlePlane:
+    netdevPrefix: eth_r%rail_id%
+    rdmaPrefix: roce_r%rail_id%
+  hwplb:
+    netdevPrefix: eth_r%rail_id%_p%plane_id%
+    rdmaPrefix: roce_r%rail_id%
+  swplb:
+    netdevPrefix: eth_r%rail_id%_p%plane_id%
+    rdmaPrefix: roce_r%rail_id%_p%plane_id%
 nicConfigurationOperator:
   deployNicInterfaceNameTemplate: true
   rdmaPrefix: rdma_r%rail_id%

--- a/profiles/spectrum-x-ra2.1/25-nicinterfacenametemplate.yaml
+++ b/profiles/spectrum-x-ra2.1/25-nicinterfacenametemplate.yaml
@@ -10,7 +10,7 @@ spec:
     {{ $key }}: "{{ $value }}"
     {{- end }}
   {{- end }}
-  rdmaDevicePrefix: "{{.SpectrumX.RdmaPrefix}}"
-  netDevicePrefix: "{{.SpectrumX.NetdevPrefix}}"
+  rdmaDevicePrefix: "{{spectrumXRdmaPrefix .SpectrumX .Profile.SpectrumX.MultiplaneMode}}"
+  netDevicePrefix: "{{spectrumXNetdevPrefix .SpectrumX .Profile.SpectrumX.MultiplaneMode}}"
   pfsPerNic: {{spectrumXPfsPerNic .ClusterConfig.PFs .Profile.SpectrumX.NumberOfPlanes}}
   railPciAddresses: [{{- $first := true }}{{- range $group := railPciGroups .ClusterConfig.PFs .Profile.SpectrumX.NumberOfPlanes }}{{- if not $first }}, {{ end }}{{- $first = false }}[{{- $firstInner := true }}{{- range $addr := $group }}{{- if not $firstInner }}, {{ end }}{{- $firstInner = false }}"{{$addr}}"{{- end }}]{{- end }}]

--- a/profiles/spectrum-x-ra2.1/50-sriovnetworknodepolicy.yaml
+++ b/profiles/spectrum-x-ra2.1/50-sriovnetworknodepolicy.yaml
@@ -5,6 +5,7 @@
 {{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
 {{- $railCount := railCount .ClusterConfig.PFs $planes }}
 {{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
+{{- $netdevPrefix := spectrumXNetdevPrefix .SpectrumX .Profile.SpectrumX.MultiplaneMode }}
 {{- $first := true }}
 {{- range $railIdx := untilStep 0 $railCount 1 }}
 {{- if $swplb }}
@@ -35,7 +36,7 @@ spec:
   numVfs: 1
   nicSelector:
     pfNames:
-      - "{{ replaceVars $.SpectrumX.NetdevPrefix $railIdx $planeIdx $railIdx }}"
+      - "{{ replaceVars $netdevPrefix $railIdx $planeIdx $railIdx }}"
   resourceName: rail_{{$railIdx}}_plane_{{$planeIdx}}  {{- if $.ClusterConfig.NodeSelector }}
   nodeSelector:
     {{- range $key, $value := $.ClusterConfig.NodeSelector }}
@@ -75,7 +76,7 @@ spec:
   mtu: 9216
   numVfs: 1
   nicSelector:
-    pfNames: [{{- $firstPF := true }}{{- range $planeIdx := untilStep 0 $planes 1 }}{{- if not $firstPF }}, {{ end }}{{- $firstPF = false }}"{{ replaceVars $.SpectrumX.NetdevPrefix $railIdx $planeIdx $railIdx }}"{{- end }}]
+    pfNames: [{{- $firstPF := true }}{{- range $planeIdx := untilStep 0 $planes 1 }}{{- if not $firstPF }}, {{ end }}{{- $firstPF = false }}"{{ replaceVars $netdevPrefix $railIdx $planeIdx $railIdx }}"{{- end }}]
   resourceName: rail_{{$railIdx}}  {{- if $.ClusterConfig.NodeSelector }}
   nodeSelector:
     {{- range $key, $value := $.ClusterConfig.NodeSelector }}

--- a/profiles/spectrum-x-ra2.2/25-nicinterfacenametemplate.yaml
+++ b/profiles/spectrum-x-ra2.2/25-nicinterfacenametemplate.yaml
@@ -10,7 +10,7 @@ spec:
     {{ $key }}: "{{ $value }}"
     {{- end }}
   {{- end }}
-  rdmaDevicePrefix: "{{.SpectrumX.RdmaPrefix}}"
-  netDevicePrefix: "{{.SpectrumX.NetdevPrefix}}"
+  rdmaDevicePrefix: "{{spectrumXRdmaPrefix .SpectrumX .Profile.SpectrumX.MultiplaneMode}}"
+  netDevicePrefix: "{{spectrumXNetdevPrefix .SpectrumX .Profile.SpectrumX.MultiplaneMode}}"
   pfsPerNic: {{spectrumXPfsPerNic .ClusterConfig.PFs .Profile.SpectrumX.NumberOfPlanes}}
   railPciAddresses: [{{- $first := true }}{{- range $group := railPciGroups .ClusterConfig.PFs .Profile.SpectrumX.NumberOfPlanes }}{{- if not $first }}, {{ end }}{{- $first = false }}[{{- $firstInner := true }}{{- range $addr := $group }}{{- if not $firstInner }}, {{ end }}{{- $firstInner = false }}"{{$addr}}"{{- end }}]{{- end }}]

--- a/profiles/spectrum-x-ra2.2/80-spectrumxrailpoolconfig.yaml
+++ b/profiles/spectrum-x-ra2.2/80-spectrumxrailpoolconfig.yaml
@@ -1,6 +1,7 @@
 {{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
 {{- $railCount := railCount .ClusterConfig.PFs $planes }}
 {{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
+{{- $netdevPrefix := spectrumXNetdevPrefix .SpectrumX .Profile.SpectrumX.MultiplaneMode }}
 apiVersion: spectrumx.nvidia.com/v1alpha2
 kind: SpectrumXRailPoolConfig
 metadata:
@@ -22,14 +23,14 @@ spec:
     {{- range $planeIdx := untilStep 0 $planes 1 }}
   - name: rail{{$railIdx}}p{{$planeIdx}}
     nicSelector:
-      pfNames: ["{{ replaceVars $.SpectrumX.NetdevPrefix $railIdx $planeIdx $railIdx }}"]
+      pfNames: ["{{ replaceVars $netdevPrefix $railIdx $planeIdx $railIdx }}"]
     cidrPoolRef: rail-{{$railIdx}}-plane-{{$planeIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
     mtu: 9216
     {{- end }}
   {{- else }}
   - name: rail{{$railIdx}}
     nicSelector:
-      pfNames: [{{- $firstPF := true }}{{- range $planeIdx := untilStep 0 $planes 1 }}{{- if not $firstPF }}, {{ end }}{{- $firstPF = false }}"{{ replaceVars $.SpectrumX.NetdevPrefix $railIdx $planeIdx $railIdx }}"{{- end }}]
+      pfNames: [{{- $firstPF := true }}{{- range $planeIdx := untilStep 0 $planes 1 }}{{- if not $firstPF }}, {{ end }}{{- $firstPF = false }}"{{ replaceVars $netdevPrefix $railIdx $planeIdx $railIdx }}"{{- end }}]
     cidrPoolRef: rail-{{$railIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
     mtu: 9216
   {{- end }}

--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -64,8 +64,9 @@ nodeCapabilities:
 ### RDMA Configuration
 
 - **rdmaMode**: `exclusive` or `shared`
-- **rdmaPrefix**: Prefix for RDMA device names (e.g., `"roce_"`)
-- **netdevPrefix**: Template for network interface names (e.g., `"nic%nic_id%_p%plane%_r%rail%"`)
+- **singlePlane**: User-overridable NET and RDMA prefixes for `none`
+- **hwplb**: User-overridable rail-plane NET and rail-only RDMA prefixes
+- **swplb**: User-overridable rail-plane NET and RDMA prefixes
 
 ### Bridge Configuration
 
@@ -137,8 +138,15 @@ spectrumX:
   ovsBridgeDatapathType: netdev
   ovsBridgeFailMode: secure
   ovsUplinkInterfaceType: dpdk
-  rdmaPrefix: "roce_"
-  netdevPrefix: "nic%nic_id%_p%plane%_r%rail%"
+  singlePlane:
+    netdevPrefix: "eth_r%rail_id%"
+    rdmaPrefix: "roce_r%rail_id%"
+  hwplb:
+    netdevPrefix: "eth_r%rail_id%_p%plane_id%"
+    rdmaPrefix: "roce_r%rail_id%"
+  swplb:
+    netdevPrefix: "eth_r%rail_id%_p%plane_id%"
+    rdmaPrefix: "roce_r%rail_id%_p%plane_id%"
   eSwitchMultiport: "true"
   bridgeGroupingPolicy: perPF
   cidrPoolPerNodePrefix: 31

--- a/profiles/spectrum-x/25-nicinterfacenametemplate.yaml
+++ b/profiles/spectrum-x/25-nicinterfacenametemplate.yaml
@@ -10,7 +10,7 @@ spec:
     {{ $key }}: "{{ $value }}"
     {{- end }}
   {{- end }}
-  rdmaDevicePrefix: "{{.SpectrumX.RdmaPrefix}}"
-  netDevicePrefix: "{{.SpectrumX.NetdevPrefix}}"
+  rdmaDevicePrefix: "{{spectrumXRdmaPrefix .SpectrumX .Profile.SpectrumX.MultiplaneMode}}"
+  netDevicePrefix: "{{spectrumXNetdevPrefix .SpectrumX .Profile.SpectrumX.MultiplaneMode}}"
   pfsPerNic: {{spectrumXPfsPerNic .ClusterConfig.PFs .Profile.SpectrumX.NumberOfPlanes}}
   railPciAddresses: [{{- $first := true }}{{- range $group := railPciGroups .ClusterConfig.PFs .Profile.SpectrumX.NumberOfPlanes }}{{- if not $first }}, {{ end }}{{- $first = false }}[{{- $firstInner := true }}{{- range $addr := $group }}{{- if not $firstInner }}, {{ end }}{{- $firstInner = false }}"{{$addr}}"{{- end }}]{{- end }}]

--- a/profiles/spectrum-x/80-spectrumxrailpoolconfig.yaml
+++ b/profiles/spectrum-x/80-spectrumxrailpoolconfig.yaml
@@ -1,6 +1,7 @@
 {{- $planes := .Profile.SpectrumX.NumberOfPlanes }}
 {{- $railCount := railCount .ClusterConfig.PFs $planes }}
 {{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
+{{- $netdevPrefix := spectrumXNetdevPrefix .SpectrumX .Profile.SpectrumX.MultiplaneMode }}
 apiVersion: spectrumx.nvidia.com/v1alpha2
 kind: SpectrumXRailPoolConfig
 metadata:
@@ -22,14 +23,14 @@ spec:
     {{- range $planeIdx := untilStep 0 $planes 1 }}
   - name: rail{{$railIdx}}p{{$planeIdx}}
     nicSelector:
-      pfNames: ["{{ replaceVars $.SpectrumX.NetdevPrefix $railIdx $planeIdx $railIdx }}"]
+      pfNames: ["{{ replaceVars $netdevPrefix $railIdx $planeIdx $railIdx }}"]
     cidrPoolRef: rail-{{$railIdx}}-plane-{{$planeIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
     mtu: 9216
     {{- end }}
   {{- else }}
   - name: rail{{$railIdx}}
     nicSelector:
-      pfNames: [{{- $firstPF := true }}{{- range $planeIdx := untilStep 0 $planes 1 }}{{- if not $firstPF }}, {{ end }}{{- $firstPF = false }}"{{ replaceVars $.SpectrumX.NetdevPrefix $railIdx $planeIdx $railIdx }}"{{- end }}]
+      pfNames: [{{- $firstPF := true }}{{- range $planeIdx := untilStep 0 $planes 1 }}{{- if not $firstPF }}, {{ end }}{{- $firstPF = false }}"{{ replaceVars $netdevPrefix $railIdx $planeIdx $railIdx }}"{{- end }}]
     cidrPoolRef: rail-{{$railIdx}}{{suffix $.ClusterConfig.MergedIdentifier}}
     mtu: 9216
   {{- end }}

--- a/profiles/spectrum-x/README.md
+++ b/profiles/spectrum-x/README.md
@@ -72,8 +72,9 @@ nodeCapabilities:
 ### RDMA Configuration
 
 - **rdmaMode**: `exclusive` or `shared`
-- **rdmaPrefix**: Prefix for RDMA device names (e.g., `"roce_"`)
-- **netdevPrefix**: Template for network interface names (e.g., `"nic%nic_id%_p%plane%_r%rail%"`)
+- **singlePlane**: User-overridable NET and RDMA prefixes for `none`
+- **hwplb**: User-overridable rail-plane NET and rail-only RDMA prefixes
+- **swplb**: User-overridable rail-plane NET and RDMA prefixes
 
 ### Bridge Configuration
 
@@ -150,8 +151,15 @@ spectrumX:
   ovsBridgeDatapathType: netdev
   ovsBridgeFailMode: secure
   ovsUplinkInterfaceType: dpdk
-  rdmaPrefix: "roce_"
-  netdevPrefix: "nic%nic_id%_p%plane%_r%rail%"
+  singlePlane:
+    netdevPrefix: "eth_r%rail_id%"
+    rdmaPrefix: "roce_r%rail_id%"
+  hwplb:
+    netdevPrefix: "eth_r%rail_id%_p%plane_id%"
+    rdmaPrefix: "roce_r%rail_id%"
+  swplb:
+    netdevPrefix: "eth_r%rail_id%_p%plane_id%"
+    rdmaPrefix: "roce_r%rail_id%_p%plane_id%"
   eSwitchMultiport: "true"
   bridgeGroupingPolicy: perPF
   cidrPoolPerNodePrefix: 31

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -267,13 +267,20 @@ spectrumX:
   # Overlay mode for Spectrum-X fabric.
   overlay: "none"
 
-  # string | default: "roce_p%plane_id%_r%rail_id%"
-  # RDMA device naming pattern. %plane_id% and %rail_id% are replaced.
-  rdmaPrefix: "roce_p%plane_id%_r%rail_id%"
+  # Prefix block selected for multiplaneMode none.
+  singlePlane:
+    netdevPrefix: "eth_r%rail_id%"
+    rdmaPrefix: "roce_r%rail_id%"
 
-  # string | default: "eth_p%plane_id%_r%rail_id%"
-  # Network device naming pattern. %plane_id% and %rail_id% are replaced.
-  netdevPrefix: "eth_p%plane_id%_r%rail_id%"
+  # Prefix block selected for multiplaneMode hwplb.
+  hwplb:
+    netdevPrefix: "eth_r%rail_id%_p%plane_id%"
+    rdmaPrefix: "roce_r%rail_id%"
+
+  # Prefix block selected for multiplaneMode swplb.
+  swplb:
+    netdevPrefix: "eth_r%rail_id%_p%plane_id%"
+    rdmaPrefix: "roce_r%rail_id%_p%plane_id%"
 
 # ============================================================================
 # Profile Selection

--- a/skills/k8s-network-engineer/references/config-schema.md
+++ b/skills/k8s-network-engineer/references/config-schema.md
@@ -194,8 +194,11 @@ Spectrum-X specific NIC and overlay configuration.
 |---------------|--------|----------------------------------|------------------------------------------------|
 | `nicType`     | string | `1023`                           | NIC device ID: `1023` (CX8) or `a2dc` (BF3)   |
 | `overlay`     | string | `none`                           | Overlay network type                           |
-| `rdmaPrefix`  | string | `roce_p%plane_id%_r%rail_id%`    | RDMA device name template with plane and rail  |
-| `netdevPrefix`| string | `eth_p%plane_id%_r%rail_id%`     | Network interface name template                |
+| `singlePlane` | object | rail-only prefixes                | Prefix block selected by `none` |
+| `hwplb`       | object | rail-only RDMA, rail-plane NET    | Prefix block selected by `hwplb` |
+| `swplb`       | object | rail-plane RDMA and NET           | Prefix block selected by `swplb` |
+
+Each mode object contains user-overridable `rdmaPrefix` and `netdevPrefix` strings.
 
 ## profile
 

--- a/skills/k8s-network-engineer/references/spectrum-x-guide.md
+++ b/skills/k8s-network-engineer/references/spectrum-x-guide.md
@@ -69,11 +69,12 @@ exclusive mode for each rail.
 ## RDMA Configuration
 
 - **Mode**: `exclusive` -- each workload gets dedicated RDMA resources (not shared)
-- **rdmaPrefix**: Template for RDMA device names
-  - Non-swplb: `"roce_p%plane_id%_r%rail_id%"` (from spectrumX config)
-  - swplb: `"roce_p%plane_id%_r%rail_id%"` with per-plane expansion
-- **netdevPrefix**: Template for network interface names
-  - Pattern: `"eth_p%plane_id%_r%rail_id%"`
+- **rdmaPrefix**: Selected from the mode's `spectrumX` block
+  - hwplb/none: `"roce_r%rail_id%"`
+  - swplb: `"roce_r%rail_id%_p%plane_id%"`
+- **netdevPrefix**: Selected from the mode's `spectrumX` block
+  - hwplb/swplb: `"eth_r%rail_id%_p%plane_id%"`
+  - none: `"eth_r%rail_id%"`
 - **eSwitchMultiport**: `"true"` for Spectrum-X configurations
 
 Note: RDMA exclusive mode requires a node reboot and cannot be set when namespaces


### PR DESCRIPTION
## Summary

- replace the shared `spectrumX.rdmaPrefix` and `spectrumX.netdevPrefix` keys with user-overridable `singlePlane`, `hwplb`, and `swplb` prefix blocks
- select the matching block for `NicInterfaceNameTemplate` and Spectrum-X PF selectors
- allow the recommended rail-only HWPLB RDMA prefix while retaining placeholder validation for each selected block
- keep prefix defaults in `default-config.yaml` and update the configuration/profile documentation

## Default naming

| Mode | NET | RDMA |
| --- | --- | --- |
| `none` | `eth_r%rail_id%` | `roce_r%rail_id%` |
| `hwplb` | `eth_r%rail_id%_p%plane_id%` | `roce_r%rail_id%` |
| `swplb` | `eth_r%rail_id%_p%plane_id%` | `roce_r%rail_id%_p%plane_id%` |

Users can override either prefix in the corresponding mode block.

## Validation

- `go test -race -count=1 ./...`
- `go vet ./...`
- `golangci-lint` v2.11: 0 issues
- `mkdocs build --strict`
- `make build`
- generated the GB300 RA2.2 manifests for `none`, `hwplb`, and `swplb` and verified both interface prefixes and rail-pool `pfNames`

Naming defaults follow the [Spectrum-X SuperNIC interface renaming guide](https://nvidia.atlassian.net/wiki/spaces/NVIDIASpectrumXDeploymentGuide/pages/3450210018/SuperNIC+Interfaces+Renaming).