### PR TITLE
fix: validate matched NIC template devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,9 +343,13 @@ chart's appVersion matches the version expected by
 manifest under `--deployment-files` is classified against the live cluster
 as `READY` / `IN-PROGRESS` / `ERROR` / `MISSING` via the per-Kind validator
 registry (with SR-IOV silent-failure detection, NicConfigurationTemplate
-condition-Reason classification, NicClusterPolicy appliedStates breakdown,
-etc.); and (3) a data-plane connectivity matrix — apply the example
-DaemonSet, wait for it to roll out completely (`numberReady ==
+and NicFirmwareTemplate validation scoped to the operator-populated
+`status.nicDevices`, current template-payload and device-generation checks,
+matched-set checks for node, NIC type, PCI, serial-number, and part-number
+selectors, condition-Reason classification,
+NicClusterPolicy appliedStates breakdown, etc.); and (3) a data-plane
+connectivity matrix —
+apply the example DaemonSet, wait for it to roll out completely (`numberReady ==
 desiredNumberScheduled > 0` — a single ContainerCreating-stuck pod fails),
 and run the configured checks (`icmp`, `rping`, and/or `ib_write_bw`) with
 source-bound rail identity. ICMP uses `ping -I <src-iface>`, `rping` uses

--- a/docs/advanced/deployment.md
+++ b/docs/advanced/deployment.md
@@ -71,6 +71,8 @@ The shared resource-state registry classifies generated objects as:
 
 Kind-specific checks include per-component Network Operator state, SR-IOV per-node sync, matched PF counts, NIC configuration templates, IP pools, and Spectrum-X rail configuration.
 
+For `NicConfigurationTemplate` and `NicFirmwareTemplate`, Launch Kit first waits for the operator to publish matched device names in `status.nicDevices` and for that name set to reflect the current `nodeSelector`, NIC type, PCI-address, serial-number, and part-number selectors. It then evaluates only those `NicDevice` objects and waits for the corresponding `spec.configuration` or `spec.firmware` field to reflect the current template payload. A successful device condition is accepted only after its `observedGeneration` catches up with the `NicDevice` generation. Other discovered NICs do not block on configuration or firmware state. Changed templates are also observation-gated before this status is accepted, so status left by an earlier generation cannot produce a false success.
+
 ## Timeout
 
 The default deploy budget is unbounded because SR-IOV and driver reconciliation can exceed a small fixed timeout on large clusters.

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -28,6 +28,8 @@ When `--user-config` is omitted, Launch Kit checks `./cluster-config.yaml`, the 
 
 Connectivity is skipped when manifests are missing, errored, or still in progress.
 
+Manifest-state checks for `NicConfigurationTemplate` and `NicFirmwareTemplate` use the operator-populated `status.nicDevices` list as the matched device set. An empty list, a list that does not yet reflect the current node, NIC type, PCI-address, serial-number, and part-number selectors, a missing named `NicDevice`, a device spec that does not yet reflect the current template payload, or a device condition with a stale `observedGeneration` remains `IN-PROGRESS`. Unrelated discovered devices are used only to verify selector freshness; their configuration and firmware state is ignored.
+
 Preflight uses the same checks as deployment: Helm chart version, generated Helm values, component versions, and stray managed CRs. Validation never remediates drift.
 
 ## Validation Modes

--- a/pkg/networkoperatorplugin/crstate/nicconfig.go
+++ b/pkg/networkoperatorplugin/crstate/nicconfig.go
@@ -19,8 +19,10 @@ package crstate
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/Mellanox/nic-configuration-operator/pkg/consts"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,11 +31,12 @@ import (
 )
 
 const (
-	nicopGroup                      = "configuration.net.nvidia.com"
-	nicopVersion                    = "v1alpha1"
-	nicopKindInterfaceNameTemplate  = "NicInterfaceNameTemplate"
-	nicopKindConfigurationTemplate  = "NicConfigurationTemplate"
-	nicopKindDevice                 = "NicDevice"
+	nicopGroup                     = "configuration.net.nvidia.com"
+	nicopVersion                   = "v1alpha1"
+	nicopKindInterfaceNameTemplate = "NicInterfaceNameTemplate"
+	nicopKindConfigurationTemplate = "NicConfigurationTemplate"
+	nicopKindFirmwareTemplate      = "NicFirmwareTemplate"
+	nicopKindDevice                = "NicDevice"
 )
 
 // templateKind identifies which NicDevice spec field a template populates.
@@ -42,17 +45,21 @@ type templateKind int
 const (
 	templateKindInterfaceName templateKind = iota
 	templateKindConfiguration
+	templateKindFirmware
 )
 
 // nicTemplateValidator returns a Validator closure for the given template
 // kind. The validator:
-//   1. Verifies the template CR exists.
-//   2. Lists NicDevice CRs on the template's target nodes.
-//   3. Filters to devices whose spec was populated by the operator
-//      (the template-relevant spec field is non-nil).
-//   4. Classifies each contributing device via its conditions[] and
-//      aggregates the per-device verdicts (any error→error, any
-//      in-progress→in-progress, all success→success).
+//  1. Verifies the template CR exists.
+//  2. For configuration and firmware templates, waits for the operator's
+//     authoritative status.nicDevices matched-device list. Interface-name
+//     templates have no such status and retain node/spec-based discovery.
+//  3. Lists and filters NicDevice CRs to the matched devices whose
+//     template-relevant spec field reflects the current template payload.
+//  4. Classifies each contributing device via its current-generation
+//     conditions[] and
+//     aggregates the per-device verdicts (any error→error, any
+//     in-progress→in-progress, all success→success).
 func nicTemplateValidator(kind templateKind) Validator {
 	return func(ctx context.Context, c client.Client, obj *unstructured.Unstructured) (Result, error) {
 		src := fmt.Sprintf("%s/%s", obj.GetKind(), obj.GetName())
@@ -68,23 +75,25 @@ func nicTemplateValidator(kind templateKind) Validator {
 			return Result{State: StateError, Reason: fmt.Sprintf("get error: %v", err), Source: src}, err
 		}
 
-		nodeSelector, _, _ := unstructured.NestedStringMap(live.Object, "spec", "nodeSelector")
-		targetNodes, err := listNodesMatchingSelector(ctx, c, nodeSelector)
-		if err != nil {
-			return Result{State: StateError, Reason: fmt.Sprintf("list nodes: %v", err), Source: src}, err
-		}
-		if len(targetNodes) == 0 {
-			return Result{State: StateError, Reason: "spec.nodeSelector matched no nodes — check labels", Source: src}, nil
-		}
-		targetSet := make(map[string]struct{}, len(targetNodes))
-		for _, n := range targetNodes {
-			targetSet[n] = struct{}{}
+		var matchedDeviceNames []string
+		if templateUsesMatchedDeviceStatus(kind) {
+			var err error
+			matchedDeviceNames, _, err = unstructured.NestedStringSlice(live.Object, "status", "nicDevices")
+			if err != nil {
+				return Result{State: StateError, Reason: fmt.Sprintf("read status.nicDevices: %v", err), Source: src}, nil
+			}
+			if len(matchedDeviceNames) == 0 {
+				return Result{
+					State:  StateInProgress,
+					Reason: "waiting for nic-configuration-operator to populate status.nicDevices with matched devices",
+					Source: src,
+				}, nil
+			}
 		}
 
-		// 2. List all NicDevice CRs cluster-wide. NicDevice is namespaced;
+		// 2. List all NicDevice CRs in the template namespace. NicDevice is namespaced;
 		//    the operator creates them in the operator namespace
-		//    alongside the template. List with no namespace constraint —
-		//    we filter by node next.
+		//    alongside the template.
 		devices := &unstructured.UnstructuredList{}
 		devices.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   nicopGroup,
@@ -94,63 +103,93 @@ func nicTemplateValidator(kind templateKind) Validator {
 		if err := c.List(ctx, devices, client.InNamespace(obj.GetNamespace())); err != nil {
 			return Result{State: StateError, Reason: fmt.Sprintf("list NicDevice: %v", err), Source: src}, err
 		}
-
-		// 3. Filter to devices on target nodes whose template-relevant
-		//    spec is populated. Also count devices-on-target-nodes
-		//    (regardless of spec) so we can distinguish "no NicDevice
-		//    CRs yet" from "CRs exist but template hasn't been
-		//    applied".
-		var (
-			contributing    []unstructured.Unstructured
-			devicesOnTarget int
-		)
-		for _, d := range devices.Items {
-			node, _, _ := unstructured.NestedString(d.Object, "status", "node")
-			if node == "" {
-				continue
+		if templateUsesMatchedDeviceStatus(kind) {
+			expectedDeviceNames, err := devicesMatchingCurrentSelectors(ctx, c, live, devices.Items)
+			if err != nil {
+				return Result{State: StateError, Reason: fmt.Sprintf("evaluate current template selectors: %v", err), Source: src}, err
 			}
-			if _, ok := targetSet[node]; !ok {
-				continue
+			if allDeviceNamesPresent(matchedDeviceNames, devices.Items) && !sameStringSet(matchedDeviceNames, expectedDeviceNames) {
+				return Result{
+					State: StateInProgress,
+					Reason: fmt.Sprintf(
+						"waiting for status.nicDevices to reflect current template selectors (reported: %v; expected: %v)",
+						sortedStrings(matchedDeviceNames), sortedStrings(expectedDeviceNames)),
+					Source: src,
+				}, nil
 			}
-			devicesOnTarget++
-			if !deviceTargetedByTemplate(&d, kind) {
-				continue
-			}
-			contributing = append(contributing, d)
 		}
-		if len(contributing) == 0 {
-			// nic-configuration-operator populates each NicDevice's
-			// spec.{interfaceNameTemplate|configuration} when it
-			// reconciles a matching template. Until that happens (or
-			// when no NicDevice CRs exist on the target nodes at all)
-			// we report in-progress rather than error — at deploy
-			// time the operator may still be catching up. Persistent
-			// misconfiguration surfaces as the deploy ultimately
-			// timing out, at which point the Reason explains where
-			// to look.
-			specField := "spec.interfaceNameTemplate"
-			if kind == templateKindConfiguration {
-				specField = "spec.configuration"
+
+		var (
+			contributing  []unstructured.Unstructured
+			details       = make(map[string]string)
+			anyInProgress bool
+		)
+		if templateUsesMatchedDeviceStatus(kind) {
+			devicesByName := make(map[string]*unstructured.Unstructured, len(devices.Items))
+			for i := range devices.Items {
+				device := &devices.Items[i]
+				devicesByName[device.GetName()] = device
 			}
-			var reason string
-			if devicesOnTarget == 0 {
-				reason = fmt.Sprintf("no NicDevice CRs on target nodes yet — waiting for nic-configuration-operator daemon to discover devices (selector: %v)", nodeSelector)
-			} else {
-				reason = fmt.Sprintf("found %d NicDevice(s) on target nodes; waiting for nic-configuration-operator to populate %s (check spec.nicSelector: nicType, pciAddresses, serialNumbers)", devicesOnTarget, specField)
+			for _, name := range matchedDeviceNames {
+				device, ok := devicesByName[name]
+				if !ok {
+					details[name] = "listed in template status but NicDevice not found yet"
+					anyInProgress = true
+					continue
+				}
+				if !deviceTargetedByTemplate(device, kind) {
+					details[deviceLabel(device)] = fmt.Sprintf("matched by template; waiting for %s", templateSpecField(kind))
+					anyInProgress = true
+					continue
+				}
+				if current, reason := deviceSpecReflectsTemplate(device, live, kind); !current {
+					details[deviceLabel(device)] = reason
+					anyInProgress = true
+					continue
+				}
+				contributing = append(contributing, *device)
 			}
-			return Result{
-				State:  StateInProgress,
-				Reason: reason,
-				Source: src,
-			}, nil
+		} else {
+			// NicInterfaceNameTemplate has no matched-device status. Retain
+			// the existing node-selector and populated-spec discovery path.
+			nodeSelector, _, _ := unstructured.NestedStringMap(live.Object, "spec", "nodeSelector")
+			targetNodes, err := listNodesMatchingSelector(ctx, c, nodeSelector)
+			if err != nil {
+				return Result{State: StateError, Reason: fmt.Sprintf("list nodes: %v", err), Source: src}, err
+			}
+			if len(targetNodes) == 0 {
+				return Result{State: StateError, Reason: "spec.nodeSelector matched no nodes — check labels", Source: src}, nil
+			}
+			targetSet := make(map[string]struct{}, len(targetNodes))
+			for _, node := range targetNodes {
+				targetSet[node] = struct{}{}
+			}
+
+			devicesOnTarget := 0
+			for i := range devices.Items {
+				device := &devices.Items[i]
+				node, _, _ := unstructured.NestedString(device.Object, "status", "node")
+				if _, ok := targetSet[node]; !ok {
+					continue
+				}
+				devicesOnTarget++
+				if deviceTargetedByTemplate(device, kind) {
+					contributing = append(contributing, *device)
+				}
+			}
+			if len(contributing) == 0 {
+				var reason string
+				if devicesOnTarget == 0 {
+					reason = fmt.Sprintf("no NicDevice CRs on target nodes yet — waiting for nic-configuration-operator daemon to discover devices (selector: %v)", nodeSelector)
+				} else {
+					reason = fmt.Sprintf("found %d NicDevice(s) on target nodes; waiting for nic-configuration-operator to populate %s", devicesOnTarget, templateSpecField(kind))
+				}
+				return Result{State: StateInProgress, Reason: reason, Source: src}, nil
+			}
 		}
 
 		// 4. Classify each contributing device.
-		var (
-			anyError      bool
-			anyInProgress bool
-			details       = make(map[string]string)
-		)
+		var anyError bool
 		for i := range contributing {
 			d := &contributing[i]
 			label := deviceLabel(d)
@@ -175,8 +214,29 @@ func nicTemplateValidator(kind templateKind) Validator {
 		case anyInProgress:
 			return Result{State: StateInProgress, Reason: summarizeNodeStates(details), Details: details, Source: src}, nil
 		default:
-			return Result{State: StateSuccess, Reason: fmt.Sprintf("%d device(s) reconciled", len(details)), Details: details, Source: src}, nil
+			reason := fmt.Sprintf("%d device(s) reconciled", len(contributing))
+			if templateUsesMatchedDeviceStatus(kind) {
+				reason = fmt.Sprintf("%d matched device(s) reconciled", len(contributing))
+			}
+			return Result{State: StateSuccess, Reason: reason, Details: details, Source: src}, nil
 		}
+	}
+}
+
+func templateUsesMatchedDeviceStatus(kind templateKind) bool {
+	return kind == templateKindConfiguration || kind == templateKindFirmware
+}
+
+func templateSpecField(kind templateKind) string {
+	switch kind {
+	case templateKindInterfaceName:
+		return "spec.interfaceNameTemplate"
+	case templateKindConfiguration:
+		return "spec.configuration"
+	case templateKindFirmware:
+		return "spec.firmware"
+	default:
+		return "device spec"
 	}
 }
 
@@ -191,9 +251,199 @@ func deviceTargetedByTemplate(d *unstructured.Unstructured, kind templateKind) b
 	case templateKindConfiguration:
 		_, found, _ := unstructured.NestedMap(d.Object, "spec", "configuration")
 		return found
+	case templateKindFirmware:
+		_, found, _ := unstructured.NestedMap(d.Object, "spec", "firmware")
+		return found
 	default:
 		return false
 	}
+}
+
+// deviceSpecReflectsTemplate verifies that the template controller has
+// propagated the current template payload to a status-listed device. This
+// prevents standalone validation from accepting successful conditions left
+// by a previous template generation before the device spec has been updated.
+func deviceSpecReflectsTemplate(device, template *unstructured.Unstructured, kind templateKind) (bool, string) {
+	waiting := fmt.Sprintf("matched by template; waiting for %s to reflect the current template", templateSpecField(kind))
+
+	switch kind {
+	case templateKindConfiguration:
+		deviceConfig, found, err := unstructured.NestedMap(device.Object, "spec", "configuration")
+		if err != nil || !found {
+			return false, waiting
+		}
+
+		expectedReset, _, err := unstructured.NestedBool(template.Object, "spec", "resetToDefault")
+		if err != nil {
+			return false, waiting
+		}
+		actualReset, _, err := unstructured.NestedBool(deviceConfig, "resetToDefault")
+		if err != nil || actualReset != expectedReset {
+			return false, waiting
+		}
+
+		expectedTemplate, expectedFound, err := unstructured.NestedMap(template.Object, "spec", "template")
+		if err != nil {
+			return false, waiting
+		}
+		actualTemplate, actualFound, err := unstructured.NestedMap(deviceConfig, "template")
+		if err != nil || actualFound != expectedFound || !apiequality.Semantic.DeepEqual(actualTemplate, expectedTemplate) {
+			return false, waiting
+		}
+	case templateKindFirmware:
+		deviceFirmware, found, err := unstructured.NestedMap(device.Object, "spec", "firmware")
+		if err != nil || !found {
+			return false, waiting
+		}
+		expectedFirmware, expectedFound, err := unstructured.NestedMap(template.Object, "spec", "template")
+		if err != nil || !expectedFound || !apiequality.Semantic.DeepEqual(deviceFirmware, expectedFirmware) {
+			return false, waiting
+		}
+	}
+
+	return true, ""
+}
+
+// devicesMatchingCurrentSelectors mirrors the NIC operator's template
+// selector contract to prove that status.nicDevices belongs to the current
+// template generation. It computes names only; specs and conditions are still
+// validated exclusively for the operator-reported status devices.
+func devicesMatchingCurrentSelectors(
+	ctx context.Context,
+	c client.Client,
+	template *unstructured.Unstructured,
+	devices []unstructured.Unstructured,
+) ([]string, error) {
+	nodeSelector, _, err := unstructured.NestedStringMap(template.Object, "spec", "nodeSelector")
+	if err != nil {
+		return nil, fmt.Errorf("read spec.nodeSelector: %w", err)
+	}
+
+	var targetNodes map[string]struct{}
+	if len(nodeSelector) > 0 {
+		nodes, err := listNodesMatchingSelector(ctx, c, nodeSelector)
+		if err != nil {
+			return nil, fmt.Errorf("list nodes: %w", err)
+		}
+		targetNodes = make(map[string]struct{}, len(nodes))
+		for _, name := range nodes {
+			targetNodes[name] = struct{}{}
+		}
+	}
+
+	nicType, _, err := unstructured.NestedString(template.Object, "spec", "nicSelector", "nicType")
+	if err != nil {
+		return nil, fmt.Errorf("read spec.nicSelector.nicType: %w", err)
+	}
+	pciAddresses, _, err := unstructured.NestedStringSlice(template.Object, "spec", "nicSelector", "pciAddresses")
+	if err != nil {
+		return nil, fmt.Errorf("read spec.nicSelector.pciAddresses: %w", err)
+	}
+	serialNumbers, _, err := unstructured.NestedStringSlice(template.Object, "spec", "nicSelector", "serialNumbers")
+	if err != nil {
+		return nil, fmt.Errorf("read spec.nicSelector.serialNumbers: %w", err)
+	}
+	partNumbers, _, err := unstructured.NestedStringSlice(template.Object, "spec", "nicSelector", "partNumbers")
+	if err != nil {
+		return nil, fmt.Errorf("read spec.nicSelector.partNumbers: %w", err)
+	}
+
+	matches := make([]string, 0, len(devices))
+	for i := range devices {
+		device := &devices[i]
+		node, _, _ := unstructured.NestedString(device.Object, "status", "node")
+		if node == "" {
+			continue
+		}
+		if targetNodes != nil {
+			if _, ok := targetNodes[node]; !ok {
+				continue
+			}
+		}
+		deviceType, _, _ := unstructured.NestedString(device.Object, "status", "type")
+		if nicType != "" && nicType != deviceType {
+			continue
+		}
+		if !deviceMatchesPCIAddresses(device, pciAddresses) {
+			continue
+		}
+		serialNumber, _, _ := unstructured.NestedString(device.Object, "status", "serialNumber")
+		if len(serialNumbers) > 0 && !containsString(serialNumbers, serialNumber) {
+			continue
+		}
+		partNumber, _, _ := unstructured.NestedString(device.Object, "status", "partNumber")
+		if len(partNumbers) > 0 && !containsString(partNumbers, partNumber) {
+			continue
+		}
+		matches = append(matches, device.GetName())
+	}
+	return matches, nil
+}
+
+func deviceMatchesPCIAddresses(device *unstructured.Unstructured, pciAddresses []string) bool {
+	if len(pciAddresses) == 0 {
+		return true
+	}
+	ports, _, _ := unstructured.NestedSlice(device.Object, "status", "ports")
+	for _, raw := range ports {
+		port, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		pci, _, _ := unstructured.NestedString(port, "pci")
+		if containsString(pciAddresses, pci) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}
+
+func sameStringSet(left, right []string) bool {
+	leftSet := make(map[string]struct{}, len(left))
+	for _, value := range left {
+		leftSet[value] = struct{}{}
+	}
+	rightSet := make(map[string]struct{}, len(right))
+	for _, value := range right {
+		rightSet[value] = struct{}{}
+	}
+	if len(leftSet) != len(rightSet) {
+		return false
+	}
+	for value := range rightSet {
+		if _, ok := leftSet[value]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func allDeviceNamesPresent(names []string, devices []unstructured.Unstructured) bool {
+	present := make(map[string]struct{}, len(devices))
+	for i := range devices {
+		present[devices[i].GetName()] = struct{}{}
+	}
+	for _, name := range names {
+		if _, ok := present[name]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func sortedStrings(values []string) []string {
+	result := append([]string(nil), values...)
+	sort.Strings(result)
+	return result
 }
 
 // deviceLabel returns "<node>/<first-pci-address>" for a NicDevice, used
@@ -238,9 +488,43 @@ func classifyDevice(d *unstructured.Unstructured, kind templateKind) (CRState, s
 	case templateKindInterfaceName:
 		return classifyInterfaceName(byType)
 	case templateKindConfiguration:
-		return classifyConfiguration(byType)
+		return classifyConfiguration(d, byType)
+	case templateKindFirmware:
+		return classifyFirmware(d, byType)
 	default:
 		return StateInProgress, "unknown template kind"
+	}
+}
+
+// classifyFirmware inspects FirmwareUpdateInProgress for a device explicitly
+// listed in a NicFirmwareTemplate's status.nicDevices.
+func classifyFirmware(device *unstructured.Unstructured, byType map[string]map[string]interface{}) (CRState, string) {
+	cond, ok := byType[consts.FirmwareUpdateInProgressCondition]
+	if !ok {
+		return StateInProgress, "FirmwareUpdateInProgress condition not yet set"
+	}
+	if pending, reason := conditionGenerationPending(device, cond, consts.FirmwareUpdateInProgressCondition); pending {
+		return StateInProgress, reason
+	}
+	reason, _, _ := unstructured.NestedString(cond, "reason")
+	message, _, _ := unstructured.NestedString(cond, "message")
+
+	switch reason {
+	case consts.DeviceFwMatchReason:
+		return StateSuccess, "device firmware matches"
+	case consts.FirmwareUpdateStartedReason, consts.PendingNodeMaintenanceReason:
+		return StateInProgress, fallbackMessage(message, "firmware update in progress: "+reason)
+	case consts.FirmwareUpdateFailedReason,
+		consts.FirmwareSourceNotReadyReason,
+		consts.FirmwareSourceFailedReason,
+		consts.DeviceFwMismatchReason:
+		return StateError, fallbackMessage(message, "firmware update failed: "+reason)
+	case consts.DeviceFirmwareSpecEmptyReason:
+		return StateInProgress, "firmware spec not yet observed"
+	case "":
+		return StateInProgress, "FirmwareUpdateInProgress reason not yet set"
+	default:
+		return StateInProgress, fallbackMessage(message, "FirmwareUpdateInProgress reason="+reason)
 	}
 }
 
@@ -271,8 +555,11 @@ func classifyInterfaceName(byType map[string]map[string]interface{}) (CRState, s
 // FirmwareUpdateInProgress (when present). Reason is the authoritative
 // classifier — Status=False with Reason=UpdateSuccessful is the *success*
 // terminal state, not failure.
-func classifyConfiguration(byType map[string]map[string]interface{}) (CRState, string) {
+func classifyConfiguration(device *unstructured.Unstructured, byType map[string]map[string]interface{}) (CRState, string) {
 	if cond, ok := byType[consts.ConfigUpdateInProgressCondition]; ok {
+		if pending, reason := conditionGenerationPending(device, cond, consts.ConfigUpdateInProgressCondition); pending {
+			return StateInProgress, reason
+		}
 		reason, _, _ := unstructured.NestedString(cond, "reason")
 		message, _, _ := unstructured.NestedString(cond, "message")
 		switch reason {
@@ -289,10 +576,9 @@ func classifyConfiguration(byType map[string]map[string]interface{}) (CRState, s
 			consts.FirmwareError:
 			return StateError, fallbackMessage(message, "config update failed: "+reason)
 		case consts.DeviceConfigSpecEmptyReason:
-			// Device not targeted by any NicConfigurationTemplate —
-			// callers should filter these out before classify(); if we
-			// reach here, treat as success-but-empty.
-			return StateSuccess, "no config requested"
+			// status.nicDevices says this template targets the device, so
+			// this is the previous empty-spec condition waiting to be replaced.
+			return StateInProgress, "configuration spec not yet observed"
 		case "":
 			return StateInProgress, "ConfigUpdateInProgress reason not yet set"
 		default:
@@ -305,6 +591,9 @@ func classifyConfiguration(byType map[string]map[string]interface{}) (CRState, s
 	// At this point ConfigUpdateInProgress.Reason=UpdateSuccessful.
 	// If firmware section is also present, gate on its terminal state.
 	if cond, ok := byType[consts.FirmwareUpdateInProgressCondition]; ok {
+		if pending, reason := conditionGenerationPending(device, cond, consts.FirmwareUpdateInProgressCondition); pending {
+			return StateInProgress, reason
+		}
 		reason, _, _ := unstructured.NestedString(cond, "reason")
 		message, _, _ := unstructured.NestedString(cond, "message")
 		switch reason {
@@ -329,6 +618,19 @@ func classifyConfiguration(byType map[string]map[string]interface{}) (CRState, s
 	return StateSuccess, "config reconciled"
 }
 
+func conditionGenerationPending(device *unstructured.Unstructured, condition map[string]interface{}, conditionType string) (bool, string) {
+	generation := device.GetGeneration()
+	if generation <= 0 {
+		return false, ""
+	}
+
+	observed, found, err := unstructured.NestedInt64(condition, "observedGeneration")
+	if err != nil || !found || observed < generation {
+		return true, fmt.Sprintf("%s has not observed NicDevice generation %d", conditionType, generation)
+	}
+	return false, ""
+}
+
 func fallbackMessage(msg, def string) string {
 	if msg == "" {
 		return def
@@ -340,4 +642,5 @@ func registerNicConfigValidators(r *Registry) {
 	gv := schema.GroupVersion{Group: nicopGroup, Version: nicopVersion}
 	r.Register(gv.WithKind(nicopKindInterfaceNameTemplate), nicTemplateValidator(templateKindInterfaceName))
 	r.Register(gv.WithKind(nicopKindConfigurationTemplate), nicTemplateValidator(templateKindConfiguration))
+	r.Register(gv.WithKind(nicopKindFirmwareTemplate), nicTemplateValidator(templateKindFirmware))
 }

--- a/pkg/networkoperatorplugin/crstate/nicconfig_test.go
+++ b/pkg/networkoperatorplugin/crstate/nicconfig_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const nicopAPIVersion = nicopGroup + "/" + nicopVersion
@@ -37,6 +39,33 @@ func nicTemplateManifest(kind, name, ns string, nodeSelector map[string]string) 
 		}
 		_ = unstructured.SetNestedMap(obj.Object, nsRaw, "spec", "nodeSelector")
 	}
+	switch kind {
+	case nicopKindConfigurationTemplate:
+		_ = unstructured.SetNestedMap(obj.Object, map[string]interface{}{"nicType": "101d"}, "spec", "nicSelector")
+		_ = unstructured.SetNestedMap(obj.Object, configurationTemplatePayload(), "spec", "template")
+	case nicopKindFirmwareTemplate:
+		_ = unstructured.SetNestedMap(obj.Object, map[string]interface{}{"nicType": "101d"}, "spec", "nicSelector")
+		_ = unstructured.SetNestedMap(obj.Object, firmwareTemplatePayload(), "spec", "template")
+	}
+	return obj
+}
+
+func configurationTemplatePayload() map[string]interface{} {
+	return map[string]interface{}{
+		"numVfs":   int64(1),
+		"linkType": "Ethernet",
+	}
+}
+
+func firmwareTemplatePayload() map[string]interface{} {
+	return map[string]interface{}{
+		"nicFirmwareSourceRef": "fw-source",
+		"updatePolicy":         "Update",
+	}
+}
+
+func withMatchedDevices(obj *unstructured.Unstructured, names ...string) *unstructured.Unstructured {
+	_ = unstructured.SetNestedStringSlice(obj.Object, names, "status", "nicDevices")
 	return obj
 }
 
@@ -49,6 +78,7 @@ func nicDevice(name, ns, node string, ports []map[string]interface{}, interfaceT
 	if node != "" {
 		_ = unstructured.SetNestedField(obj.Object, node, "status", "node")
 	}
+	_ = unstructured.SetNestedField(obj.Object, "101d", "status", "type")
 	if len(ports) > 0 {
 		raw := make([]interface{}, len(ports))
 		for i, p := range ports {
@@ -65,7 +95,9 @@ func nicDevice(name, ns, node string, ports []map[string]interface{}, interfaceT
 		}, "spec", "interfaceNameTemplate")
 	}
 	if configTargeted {
-		_ = unstructured.SetNestedMap(obj.Object, map[string]interface{}{}, "spec", "configuration")
+		_ = unstructured.SetNestedMap(obj.Object, map[string]interface{}{
+			"template": configurationTemplatePayload(),
+		}, "spec", "configuration")
 	}
 	if len(conds) > 0 {
 		raw := make([]interface{}, len(conds))
@@ -77,6 +109,26 @@ func nicDevice(name, ns, node string, ports []map[string]interface{}, interfaceT
 	return obj
 }
 
+func withFirmwareSpec(obj *unstructured.Unstructured) *unstructured.Unstructured {
+	_ = unstructured.SetNestedMap(obj.Object, firmwareTemplatePayload(), "spec", "firmware")
+	return obj
+}
+
+func withDeviceType(obj *unstructured.Unstructured, deviceType string) *unstructured.Unstructured {
+	_ = unstructured.SetNestedField(obj.Object, deviceType, "status", "type")
+	return obj
+}
+
+func withSerialNumber(obj *unstructured.Unstructured, serialNumber string) *unstructured.Unstructured {
+	_ = unstructured.SetNestedField(obj.Object, serialNumber, "status", "serialNumber")
+	return obj
+}
+
+func withPartNumber(obj *unstructured.Unstructured, partNumber string) *unstructured.Unstructured {
+	_ = unstructured.SetNestedField(obj.Object, partNumber, "status", "partNumber")
+	return obj
+}
+
 func condition(t, status, reason, message string) map[string]interface{} {
 	return map[string]interface{}{
 		"type":    t,
@@ -84,6 +136,12 @@ func condition(t, status, reason, message string) map[string]interface{} {
 		"reason":  reason,
 		"message": message,
 	}
+}
+
+func conditionWithGeneration(t, status, reason, message string, observedGeneration int64) map[string]interface{} {
+	cond := condition(t, status, reason, message)
+	cond["observedGeneration"] = observedGeneration
+	return cond
 }
 
 func port(pci string) map[string]interface{} {
@@ -196,6 +254,253 @@ func TestNicInterfaceNameTemplate_ConditionAbsentIsInProgress(t *testing.T) {
 	assert.Equal(t, StateInProgress, res.State)
 }
 
+func TestNicConfigurationTemplate_WaitsForMatchedDeviceStatus(t *testing.T) {
+	manifest := nicTemplateManifest(nicopKindConfigurationTemplate, "tpl", "ns", nil)
+	live := manifest.DeepCopy()
+	c := newClient(t,
+		live,
+		nicDevice("dev-1", "ns", "worker-1",
+			[]map[string]interface{}{port("0000:1a:00.0")},
+			false, true,
+			[]map[string]interface{}{
+				condition(consts.ConfigUpdateInProgressCondition, "False", consts.UpdateSuccessfulReason, ""),
+			}),
+	)
+
+	res, err := nicTemplateValidator(templateKindConfiguration)(context.Background(), c, manifest)
+	require.NoError(t, err)
+	assert.Equal(t, StateInProgress, res.State)
+	assert.Contains(t, res.Reason, "status.nicDevices")
+}
+
+func TestNicConfigurationTemplate_UsesOnlyStatusMatchedDevices(t *testing.T) {
+	manifest := nicTemplateManifest(nicopKindConfigurationTemplate, "tpl", "ns", nil)
+	live := withMatchedDevices(manifest.DeepCopy(), "dev-matched")
+	c := newClient(t,
+		live,
+		nicDevice("dev-matched", "ns", "worker-1",
+			[]map[string]interface{}{port("0000:1a:00.0")},
+			false, true,
+			[]map[string]interface{}{
+				condition(consts.ConfigUpdateInProgressCondition, "False", consts.UpdateSuccessfulReason, ""),
+			}),
+		withDeviceType(nicDevice("dev-unmatched", "ns", "worker-1",
+			[]map[string]interface{}{port("0000:2a:00.0")},
+			false, true,
+			[]map[string]interface{}{
+				condition(consts.ConfigUpdateInProgressCondition, "False", consts.NonVolatileConfigUpdateFailedReason, "must be ignored"),
+			}), "other"),
+	)
+
+	res, err := nicTemplateValidator(templateKindConfiguration)(context.Background(), c, manifest)
+	require.NoError(t, err)
+	assert.Equal(t, StateSuccess, res.State)
+	assert.Equal(t, "1 matched device(s) reconciled", res.Reason)
+	assert.Len(t, res.Details, 1)
+	assert.NotContains(t, res.Details, "worker-1/0000:2a:00.0")
+}
+
+func TestNicConfigurationTemplate_MatchedDeviceSpecPending(t *testing.T) {
+	manifest := nicTemplateManifest(nicopKindConfigurationTemplate, "tpl", "ns", nil)
+	live := withMatchedDevices(manifest.DeepCopy(), "dev-1")
+	c := newClient(t,
+		live,
+		nicDevice("dev-1", "ns", "worker-1",
+			[]map[string]interface{}{port("0000:1a:00.0")},
+			false, false, nil),
+	)
+
+	res, err := nicTemplateValidator(templateKindConfiguration)(context.Background(), c, manifest)
+	require.NoError(t, err)
+	assert.Equal(t, StateInProgress, res.State)
+	assert.Contains(t, res.Reason, "waiting for spec.configuration")
+}
+
+func TestNicConfigurationTemplate_MatchedDeviceMissing(t *testing.T) {
+	manifest := nicTemplateManifest(nicopKindConfigurationTemplate, "tpl", "ns", nil)
+	live := withMatchedDevices(manifest.DeepCopy(), "dev-1")
+
+	res, err := nicTemplateValidator(templateKindConfiguration)(context.Background(), newClient(t, live), manifest)
+	require.NoError(t, err)
+	assert.Equal(t, StateInProgress, res.State)
+	assert.Equal(t, "listed in template status but NicDevice not found yet", res.Details["dev-1"])
+}
+
+func TestNicConfigurationTemplate_WaitsForCurrentTemplatePayload(t *testing.T) {
+	manifest := nicTemplateManifest(nicopKindConfigurationTemplate, "tpl", "ns", nil)
+	_ = unstructured.SetNestedField(manifest.Object, int64(8), "spec", "template", "numVfs")
+	live := withMatchedDevices(manifest.DeepCopy(), "dev-1")
+	device := nicDevice("dev-1", "ns", "worker-1",
+		[]map[string]interface{}{port("0000:1a:00.0")},
+		false, true,
+		[]map[string]interface{}{
+			condition(consts.ConfigUpdateInProgressCondition, "False", consts.UpdateSuccessfulReason, ""),
+		})
+
+	res, err := nicTemplateValidator(templateKindConfiguration)(context.Background(), newClient(t, live, device), manifest)
+	require.NoError(t, err)
+	assert.Equal(t, StateInProgress, res.State)
+	assert.Contains(t, res.Reason, "reflect the current template")
+}
+
+func TestNicConfigurationTemplate_WaitsForCurrentDeviceGeneration(t *testing.T) {
+	manifest := nicTemplateManifest(nicopKindConfigurationTemplate, "tpl", "ns", nil)
+	live := withMatchedDevices(manifest.DeepCopy(), "dev-1")
+	device := nicDevice("dev-1", "ns", "worker-1",
+		[]map[string]interface{}{port("0000:1a:00.0")},
+		false, true,
+		[]map[string]interface{}{
+			conditionWithGeneration(consts.ConfigUpdateInProgressCondition, "False", consts.UpdateSuccessfulReason, "", 1),
+		})
+	device.SetGeneration(2)
+
+	res, err := nicTemplateValidator(templateKindConfiguration)(context.Background(), newClient(t, live, device), manifest)
+	require.NoError(t, err)
+	assert.Equal(t, StateInProgress, res.State)
+	assert.Contains(t, res.Reason, "has not observed NicDevice generation 2")
+}
+
+func TestNicConfigurationTemplate_AcceptsCurrentDeviceGeneration(t *testing.T) {
+	manifest := nicTemplateManifest(nicopKindConfigurationTemplate, "tpl", "ns", nil)
+	live := withMatchedDevices(manifest.DeepCopy(), "dev-1")
+	device := nicDevice("dev-1", "ns", "worker-1",
+		[]map[string]interface{}{port("0000:1a:00.0")},
+		false, true,
+		[]map[string]interface{}{
+			conditionWithGeneration(consts.ConfigUpdateInProgressCondition, "False", consts.UpdateSuccessfulReason, "", 2),
+		})
+	device.SetGeneration(2)
+
+	res, err := nicTemplateValidator(templateKindConfiguration)(context.Background(), newClient(t, live, device), manifest)
+	require.NoError(t, err)
+	assert.Equal(t, StateSuccess, res.State)
+}
+
+func TestNicTemplates_WaitForStatusMatchingCurrentSelectors(t *testing.T) {
+	tests := []struct {
+		name           string
+		kind           string
+		typeOfTemplate templateKind
+		device         func(*unstructured.Unstructured) *unstructured.Unstructured
+	}{
+		{
+			name:           "configuration selector broadened",
+			kind:           nicopKindConfigurationTemplate,
+			typeOfTemplate: templateKindConfiguration,
+			device: func(device *unstructured.Unstructured) *unstructured.Unstructured {
+				return device
+			},
+		},
+		{
+			name:           "firmware selector broadened",
+			kind:           nicopKindFirmwareTemplate,
+			typeOfTemplate: templateKindFirmware,
+			device:         withFirmwareSpec,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := nicTemplateManifest(tc.kind, "tpl", "ns", nil)
+			_ = unstructured.SetNestedField(manifest.Object, "101d", "spec", "nicSelector", "nicType")
+			live := withMatchedDevices(manifest.DeepCopy(), "dev-1")
+			conditionType := consts.ConfigUpdateInProgressCondition
+			reason := consts.UpdateSuccessfulReason
+			if tc.typeOfTemplate == templateKindFirmware {
+				conditionType = consts.FirmwareUpdateInProgressCondition
+				reason = consts.DeviceFwMatchReason
+			}
+			devices := []client.Object{live}
+			for _, name := range []string{"dev-1", "dev-2"} {
+				device := nicDevice(name, "ns", "worker-1",
+					[]map[string]interface{}{port("0000:1a:00.0")},
+					false, tc.typeOfTemplate == templateKindConfiguration,
+					[]map[string]interface{}{condition(conditionType, "False", reason, "")})
+				devices = append(devices, tc.device(withDeviceType(device, "101d")))
+			}
+
+			res, err := nicTemplateValidator(tc.typeOfTemplate)(context.Background(), newClient(t, devices...), manifest)
+			require.NoError(t, err)
+			assert.Equal(t, StateInProgress, res.State)
+			assert.Contains(t, res.Reason, "status.nicDevices to reflect current template selectors")
+			assert.Contains(t, res.Reason, "dev-2")
+		})
+	}
+}
+
+func TestDevicesMatchingCurrentSelectors(t *testing.T) {
+	template := nicTemplateManifest(nicopKindConfigurationTemplate, "tpl", "ns", map[string]string{"role": "worker"})
+	_ = unstructured.SetNestedStringSlice(template.Object, []string{"0000:1a:00.0"}, "spec", "nicSelector", "pciAddresses")
+	_ = unstructured.SetNestedStringSlice(template.Object, []string{"serial-1"}, "spec", "nicSelector", "serialNumbers")
+	_ = unstructured.SetNestedStringSlice(template.Object, []string{"part-1"}, "spec", "nicSelector", "partNumbers")
+
+	devices := []unstructured.Unstructured{
+		*withPartNumber(withSerialNumber(nicDevice("matched", "ns", "worker-1", []map[string]interface{}{port("0000:1a:00.0")}, false, true, nil), "serial-1"), "part-1"),
+		*withPartNumber(withSerialNumber(nicDevice("wrong-node", "ns", "worker-2", []map[string]interface{}{port("0000:1a:00.0")}, false, true, nil), "serial-1"), "part-1"),
+		*withPartNumber(withSerialNumber(withDeviceType(nicDevice("wrong-type", "ns", "worker-1", []map[string]interface{}{port("0000:1a:00.0")}, false, true, nil), "other"), "serial-1"), "part-1"),
+		*withPartNumber(withSerialNumber(nicDevice("wrong-pci", "ns", "worker-1", []map[string]interface{}{port("0000:2a:00.0")}, false, true, nil), "serial-1"), "part-1"),
+		*withPartNumber(withSerialNumber(nicDevice("wrong-serial", "ns", "worker-1", []map[string]interface{}{port("0000:1a:00.0")}, false, true, nil), "serial-2"), "part-1"),
+		*withPartNumber(withSerialNumber(nicDevice("wrong-part", "ns", "worker-1", []map[string]interface{}{port("0000:1a:00.0")}, false, true, nil), "serial-1"), "part-2"),
+	}
+	c := newClient(t,
+		node("worker-1", map[string]string{"role": "worker"}),
+		node("worker-2", map[string]string{"role": "infra"}),
+	)
+
+	matches, err := devicesMatchingCurrentSelectors(context.Background(), c, template, devices)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"matched"}, matches)
+}
+
+func TestNicTemplates_PartNumberSelectorsExcludeUnmatchedDevices(t *testing.T) {
+	tests := []struct {
+		name            string
+		kind            string
+		templateKind    templateKind
+		prepareDevice   func(*unstructured.Unstructured) *unstructured.Unstructured
+		conditionType   string
+		conditionReason string
+	}{
+		{
+			name:            "configuration",
+			kind:            nicopKindConfigurationTemplate,
+			templateKind:    templateKindConfiguration,
+			prepareDevice:   func(device *unstructured.Unstructured) *unstructured.Unstructured { return device },
+			conditionType:   consts.ConfigUpdateInProgressCondition,
+			conditionReason: consts.UpdateSuccessfulReason,
+		},
+		{
+			name:            "firmware",
+			kind:            nicopKindFirmwareTemplate,
+			templateKind:    templateKindFirmware,
+			prepareDevice:   withFirmwareSpec,
+			conditionType:   consts.FirmwareUpdateInProgressCondition,
+			conditionReason: consts.DeviceFwMatchReason,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := nicTemplateManifest(tc.kind, "tpl", "ns", nil)
+			_ = unstructured.SetNestedStringSlice(manifest.Object, []string{"part-1"}, "spec", "nicSelector", "partNumbers")
+			live := withMatchedDevices(manifest.DeepCopy(), "matched")
+
+			matched := nicDevice("matched", "ns", "worker-1",
+				[]map[string]interface{}{port("0000:1a:00.0")}, false,
+				tc.templateKind == templateKindConfiguration,
+				[]map[string]interface{}{condition(tc.conditionType, "False", tc.conditionReason, "")})
+			matched = tc.prepareDevice(withPartNumber(matched, "part-1"))
+			unmatched := withPartNumber(nicDevice("unmatched", "ns", "worker-1",
+				[]map[string]interface{}{port("0000:2a:00.0")}, false, false, nil), "part-2")
+
+			res, err := nicTemplateValidator(tc.templateKind)(context.Background(), newClient(t, live, matched, unmatched), manifest)
+			require.NoError(t, err)
+			assert.Equal(t, StateSuccess, res.State)
+			assert.Equal(t, "1 matched device(s) reconciled", res.Reason)
+		})
+	}
+}
+
 func TestNicConfigurationTemplate_AllReasonsClassified(t *testing.T) {
 	// Walk every Reason listed in §1.2b for ConfigUpdateInProgress and
 	// confirm the validator's classification matches the plan's
@@ -215,12 +520,13 @@ func TestNicConfigurationTemplate_AllReasonsClassified(t *testing.T) {
 		{"SpecValidationFailed→error", consts.SpecValidationFailed, "False", StateError},
 		{"IncorrectSpec→error", consts.IncorrectSpecReason, "False", StateError},
 		{"FirmwareError→error", consts.FirmwareError, "False", StateError},
+		{"DeviceConfigSpecEmpty→in-progress", consts.DeviceConfigSpecEmptyReason, "False", StateInProgress},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			manifest := nicTemplateManifest(nicopKindConfigurationTemplate, "tpl", "ns", map[string]string{"role": "worker"})
-			live := manifest.DeepCopy()
+			live := withMatchedDevices(manifest.DeepCopy(), "dev-1")
 			c := newClient(t,
 				live,
 				nicDevice("dev-1", "ns", "worker-1",
@@ -258,7 +564,7 @@ func TestNicConfigurationTemplate_FirmwareGate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			manifest := nicTemplateManifest(nicopKindConfigurationTemplate, "tpl", "ns", map[string]string{"role": "worker"})
-			live := manifest.DeepCopy()
+			live := withMatchedDevices(manifest.DeepCopy(), "dev-1")
 			c := newClient(t,
 				live,
 				nicDevice("dev-1", "ns", "worker-1",
@@ -281,7 +587,7 @@ func TestNicConfigurationTemplate_FirmwareGate(t *testing.T) {
 func TestNicConfigurationTemplate_AggregatesAcrossDevices(t *testing.T) {
 	// Two devices: one success, one error. Aggregate must be error.
 	manifest := nicTemplateManifest(nicopKindConfigurationTemplate, "tpl", "ns", map[string]string{"role": "worker"})
-	live := manifest.DeepCopy()
+	live := withMatchedDevices(manifest.DeepCopy(), "dev-1", "dev-2")
 	c := newClient(t,
 		live,
 		nicDevice("dev-1", "ns", "worker-1",
@@ -304,4 +610,96 @@ func TestNicConfigurationTemplate_AggregatesAcrossDevices(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, StateError, res.State)
 	assert.Len(t, res.Details, 2)
+}
+
+func TestNicFirmwareTemplate_WaitsForMatchedDeviceStatus(t *testing.T) {
+	manifest := nicTemplateManifest(nicopKindFirmwareTemplate, "tpl", "ns", nil)
+	live := manifest.DeepCopy()
+
+	res, err := nicTemplateValidator(templateKindFirmware)(context.Background(), newClient(t, live), manifest)
+	require.NoError(t, err)
+	assert.Equal(t, StateInProgress, res.State)
+	assert.Contains(t, res.Reason, "status.nicDevices")
+}
+
+func TestNicFirmwareTemplate_WaitsForCurrentTemplatePayload(t *testing.T) {
+	manifest := nicTemplateManifest(nicopKindFirmwareTemplate, "tpl", "ns", nil)
+	_ = unstructured.SetNestedField(manifest.Object, "new-fw-source", "spec", "template", "nicFirmwareSourceRef")
+	live := withMatchedDevices(manifest.DeepCopy(), "dev-1")
+	device := withFirmwareSpec(nicDevice("dev-1", "ns", "worker-1",
+		[]map[string]interface{}{port("0000:1a:00.0")},
+		false, false,
+		[]map[string]interface{}{
+			condition(consts.FirmwareUpdateInProgressCondition, "False", consts.DeviceFwMatchReason, ""),
+		}))
+
+	res, err := nicTemplateValidator(templateKindFirmware)(context.Background(), newClient(t, live, device), manifest)
+	require.NoError(t, err)
+	assert.Equal(t, StateInProgress, res.State)
+	assert.Contains(t, res.Reason, "reflect the current template")
+}
+
+func TestNicFirmwareTemplate_WaitsForCurrentDeviceGeneration(t *testing.T) {
+	manifest := nicTemplateManifest(nicopKindFirmwareTemplate, "tpl", "ns", nil)
+	live := withMatchedDevices(manifest.DeepCopy(), "dev-1")
+	device := withFirmwareSpec(nicDevice("dev-1", "ns", "worker-1",
+		[]map[string]interface{}{port("0000:1a:00.0")},
+		false, false,
+		[]map[string]interface{}{
+			conditionWithGeneration(consts.FirmwareUpdateInProgressCondition, "False", consts.DeviceFwMatchReason, "", 3),
+		}))
+	device.SetGeneration(4)
+
+	res, err := nicTemplateValidator(templateKindFirmware)(context.Background(), newClient(t, live, device), manifest)
+	require.NoError(t, err)
+	assert.Equal(t, StateInProgress, res.State)
+	assert.Contains(t, res.Reason, "has not observed NicDevice generation 4")
+}
+
+func TestNicFirmwareTemplate_AllReasonsClassified(t *testing.T) {
+	cases := []struct {
+		name   string
+		reason string
+		status string
+		want   CRState
+	}{
+		{"firmware matched→success", consts.DeviceFwMatchReason, "False", StateSuccess},
+		{"update started→in-progress", consts.FirmwareUpdateStartedReason, "True", StateInProgress},
+		{"pending maintenance→in-progress", consts.PendingNodeMaintenanceReason, "True", StateInProgress},
+		{"update failed→error", consts.FirmwareUpdateFailedReason, "False", StateError},
+		{"source not ready→error", consts.FirmwareSourceNotReadyReason, "False", StateError},
+		{"source failed→error", consts.FirmwareSourceFailedReason, "False", StateError},
+		{"firmware mismatch→error", consts.DeviceFwMismatchReason, "False", StateError},
+		{"empty firmware spec→in-progress", consts.DeviceFirmwareSpecEmptyReason, "False", StateInProgress},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manifest := nicTemplateManifest(nicopKindFirmwareTemplate, "tpl", "ns", nil)
+			live := withMatchedDevices(manifest.DeepCopy(), "dev-1")
+			device := withFirmwareSpec(nicDevice("dev-1", "ns", "worker-1",
+				[]map[string]interface{}{port("0000:1a:00.0")},
+				false, false,
+				[]map[string]interface{}{
+					condition(consts.FirmwareUpdateInProgressCondition, tc.status, tc.reason, "msg"),
+				}))
+
+			res, err := nicTemplateValidator(templateKindFirmware)(context.Background(), newClient(t, live, device), manifest)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, res.State, "reason=%s", tc.reason)
+		})
+	}
+}
+
+func TestNicTemplateValidators_RegisteredKinds(t *testing.T) {
+	r := NewDefault()
+	for _, kind := range []string{
+		nicopKindInterfaceNameTemplate,
+		nicopKindConfigurationTemplate,
+		nicopKindFirmwareTemplate,
+	} {
+		gvk := schema.GroupVersionKind{Group: nicopGroup, Version: nicopVersion, Kind: kind}
+		_, ok := r.validators[gvk]
+		assert.Truef(t, ok, "%s not registered", kind)
+	}
 }

--- a/pkg/networkoperatorplugin/crstate/registry.go
+++ b/pkg/networkoperatorplugin/crstate/registry.go
@@ -74,17 +74,17 @@ func (r *Registry) Validate(ctx context.Context, c client.Client, obj *unstructu
 // signal:
 //
 //   - true  — validator reads `obj.status.*` directly (NCP/NNP/the
-//     three Mellanox Network Kinds, SpectrumXRailPoolConfig
-//     v1alpha2). Until the controller writes status back the RV
-//     stays at the apply-time value, and the validator would return
-//     stale data from the previous reconcile. Gate the verdict
-//     until live RV moves past apply-time RV.
+//     three Mellanox Network Kinds, NicConfigurationTemplate /
+//     NicFirmwareTemplate status.nicDevices, SpectrumXRailPoolConfig
+//     v1alpha2). Until the controller writes status back the RV stays
+//     at the apply-time value, and the validator would return stale
+//     data from the previous reconcile. Gate the verdict until live RV
+//     moves past apply-time RV.
 //
 //   - false — validator reads companion CRs whose lifecycle is
 //     independent of the apply (SriovNetworkNodePolicy →
-//     SriovNetworkNodeState per node; NicInterfaceNameTemplate /
-//     NicConfigurationTemplate → NicDevice per device). The
-//     companion's RV evolves on its own schedule and the
+//     SriovNetworkNodeState per node; NicInterfaceNameTemplate →
+//     NicDevice per device). The companion's RV evolves on its own schedule and the
 //     SriovNetworkNodePolicy itself never gets a status write, so
 //     gating on its RV would block forever. Validators in this
 //     bucket get to give an immediate verdict — staleness is their
@@ -105,6 +105,12 @@ func NeedsObservationGate(gvk schema.GroupVersionKind) bool {
 	}
 	if gvk.Group == spcxGroup && gvk.Version == spcxVersionAlpha2 && gvk.Kind == spcxKindRailPoolConfig {
 		return true
+	}
+	if gvk.Group == nicopGroup && gvk.Version == nicopVersion {
+		switch gvk.Kind {
+		case nicopKindConfigurationTemplate, nicopKindFirmwareTemplate:
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/networkoperatorplugin/crstate/registry_test.go
+++ b/pkg/networkoperatorplugin/crstate/registry_test.go
@@ -204,12 +204,13 @@ func TestNeedsObservationGate(t *testing.T) {
 		{schema.GroupVersionKind{Group: "mellanox.com", Version: "v1alpha1", Kind: "IPoIBNetwork"}, true, "IPoIBNetwork"},
 		{schema.GroupVersionKind{Group: "mellanox.com", Version: "v1alpha1", Kind: "MacvlanNetwork"}, true, "MacvlanNetwork"},
 		{schema.GroupVersionKind{Group: "spectrumx.nvidia.com", Version: "v1alpha2", Kind: "SpectrumXRailPoolConfig"}, true, "SpectrumXRailPoolConfig"},
+		{schema.GroupVersionKind{Group: "configuration.net.nvidia.com", Version: "v1alpha1", Kind: "NicConfigurationTemplate"}, true, "NicConfigurationTemplate"},
+		{schema.GroupVersionKind{Group: "configuration.net.nvidia.com", Version: "v1alpha1", Kind: "NicFirmwareTemplate"}, true, "NicFirmwareTemplate"},
 
 		// Kinds whose validators read companion CRs — gate would
 		// block forever waiting for an RV bump that never lands.
 		{schema.GroupVersionKind{Group: "sriovnetwork.openshift.io", Version: "v1", Kind: "SriovNetworkNodePolicy"}, false, "SriovNetworkNodePolicy (companion = SriovNetworkNodeState)"},
 		{schema.GroupVersionKind{Group: "configuration.net.nvidia.com", Version: "v1alpha1", Kind: "NicInterfaceNameTemplate"}, false, "NicInterfaceNameTemplate (companion = NicDevice)"},
-		{schema.GroupVersionKind{Group: "configuration.net.nvidia.com", Version: "v1alpha1", Kind: "NicConfigurationTemplate"}, false, "NicConfigurationTemplate (companion = NicDevice)"},
 
 		// Existence-only Kinds — no status at all, gate irrelevant.
 		{schema.GroupVersionKind{Group: "nv-ipam.nvidia.com", Version: "v1alpha1", Kind: "IPPool"}, false, "IPPool"},

--- a/skills/k8s-launch-kit-deploy/SKILL.md
+++ b/skills/k8s-launch-kit-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-deploy
-version: 1.3.0
+version: 1.3.1
 description: "Use this skill when the user wants to deploy generated NVIDIA networking manifests to a Kubernetes cluster using k8s-launch-kit (l8k). Activate for: applying manifests, deploying to cluster, the `l8k deploy` subcommand or the legacy --deploy flag on `l8k generate`, applying generated files, or any mention of pushing l8k output to a live cluster. Even if the user just says 'apply these' or 'push to cluster' after generating manifests, use this skill."
 metadata:
   requires:
@@ -85,6 +85,15 @@ l8k applies resources in dependency order:
 6. Example workload DaemonSets (optional)
 
 ## Post-Deploy Verification
+
+During reconciliation, `NicConfigurationTemplate` and
+`NicFirmwareTemplate` wait for the operator-populated `status.nicDevices`
+list to reflect the current node, NIC type, PCI-address, serial-number, and
+part-number selectors. l8k validates only those
+named `NicDevice` objects and waits for their corresponding
+`spec.configuration` or `spec.firmware` to reflect the current template
+payload and for device conditions to observe the current device generation;
+unrelated device configuration state does not block deployment.
 
 ```bash
 kubectl get nicclusterpolicy -o yaml          # Check policy state

--- a/skills/k8s-launch-kit-validate/SKILL.md
+++ b/skills/k8s-launch-kit-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-validate
-version: 1.0.0
+version: 1.0.1
 description: "Use this skill when the user wants to verify that an NVIDIA networking deployment matches the configuration that produced it. Activate for: 'is my deployment correct', 'are all the manifests applied', 'does the network operator version match', 'verify deployment', 'check cluster state against config', or any question about whether the cluster reflects what l8k generated. Wraps the `l8k validate` subcommand."
 metadata:
   requires:
@@ -23,10 +23,16 @@ Operator release.
    "network-operator", in the operator namespace. Compares with the
    version expected by `networkOperator.selectedRelease` in
    `cluster-config.yaml` (looked up in l8k's embedded release catalog).
-2. **Manifest presence.** Every YAML manifest under
+2. **Manifest state.** Every YAML manifest under
    `--deployment-files` (skipping any file with "example" in its name)
-   is fetched from the cluster via `client.Get`. Each manifest is
-   reported `FOUND`, `MISSING`, or `ERROR`.
+   is fetched from the cluster and classified by the per-Kind resource-state
+   registry. `NicConfigurationTemplate` and `NicFirmwareTemplate` wait for
+   the operator-populated `status.nicDevices` list to reflect current node,
+   NIC type, PCI-address, serial-number, and part-number selectors and validate
+   only the named devices. Their propagated template
+   payload and condition `observedGeneration` must also be current; unrelated
+   discovered NIC configuration state is ignored. Each manifest is reported
+   `READY`, `IN-PROGRESS`, `ERROR`, or `MISSING`.
 3. **Connectivity matrix.** By default, `l8k validate` applies the generated
    example DaemonSet, waits for ready pods, and runs source-bound `icmp`,
    `rping`, and `ib_write_bw` tests. The default mode is `strict`.
@@ -93,12 +99,12 @@ Network Operator release
   result: MATCH
 
 Manifests
-  [FOUND] NicClusterPolicy/nic-cluster-policy in (cluster-scoped)
-  [FOUND] NicNodePolicy/nicnodepolicy-h100 in (cluster-scoped)
-  [MISSING] SriovNetwork/sriov-network-rail-0 in default — not found in cluster
+  [READY      ] NicClusterPolicy/nic-cluster-policy in (cluster-scoped)
+  [IN-PROGRESS] NicConfigurationTemplate/spectrum-x-config in network-operator — waiting for nic-configuration-operator to populate status.nicDevices with matched devices
+  [MISSING    ] SriovNetwork/sriov-network-rail-0 in default — not found in cluster
   ...
 
-Summary: 12 manifests, 1 missing/error; version: match
+Summary: 1/3 ready, 1 in-progress, 0 error, 1 missing; version: match; topology mismatches: 0 group(s)
 ```
 
 JSON mode (`--output json`) emits one object with `versionCheck`,


### PR DESCRIPTION
## Summary

- use `NicConfigurationTemplate.status.nicDevices` and `NicFirmwareTemplate.status.nicDevices` as the authoritative matched-device set during deploy and validate reconciliation
- wait for that name set to reflect the current `nodeSelector`, `nicType`, `pciAddresses`, `serialNumbers`, and `partNumbers`, including selector broadening and narrowing
- require status-listed devices to carry the current `spec.configuration` or `spec.firmware` payload while ignoring unrelated device configuration state
- require relevant device conditions to observe the current `NicDevice` generation before reporting success
- add firmware-template condition classification and deploy observation gating
- keep `NicInterfaceNameTemplate` on its existing node/spec-based validation path because it has no matched-device status

## Testing

- `make test`
- `make build`
- `golangci-lint v2.11.3 run ./...`
- `mkdocs build --strict`
- `git diff --check`