### PR TITLE
feat: support NVIDIA AIR topology JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,9 +712,12 @@ feature gate, sets `SpectrumXRailPoolConfig.spec.draEnabled: true`, emits
 `ResourceClaimTemplate` manifests, and renders the example workload with DRA
 claims instead of `nvidia.com/rail_*` device-plugin resource requests.
 
-Spectrum-X CIDRPools are generated from a `topology.json` in the reference
-generator format plus the resolved l8k discovery data. Pass the topology scheme
-and file on the CLI, or set the same values under `profile.spectrumX`:
+Spectrum-X CIDRPools are generated from spcx-gen/reference-generator or contract-compliant
+NVIDIA AIR topology JSON plus the resolved l8k discovery data. l8k detects the
+format from the JSON structure. AIR support relies on the documented node and
+interface naming contract; see [Spectrum-X topology-driven CIDRPools](docs/user/spectrum-x.md#topology-driven-cidrpools).
+Pass the topology scheme and file on the CLI, or set the same values under
+`profile.spectrumX`:
 
 ```bash
 l8k generate --user-config cluster-config.yaml \

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,7 +72,7 @@ Discovery also accepts the profile and Spectrum-X flags below. Explicit flags ov
 | `--number-of-planes` | Plane count for Spectrum-X. |
 | `--topology-scheme` | `2-tier` or `3-tier` for topology-driven CIDRPool allocation. |
 | `--ip-version` | `ipv4` or `ipv6`. CIDRPool rendering currently supports IPv4. |
-| `--topology-file` | Path to an `spcx-gen` format `topology.json`. |
+| `--topology-file` | Path to spcx-gen/reference-generator or contract-compliant NVIDIA AIR topology JSON. The format is detected from its structure. |
 | `--spectrum-x-config` | Full ConfigMap YAML or raw `data.profile` YAML. Required for RA2.3. |
 | `--spectrum-x-configmap-name` | ConfigMap name when `--spectrum-x-config` is raw profile YAML. |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -259,7 +259,7 @@ profile:
 | `spectrumX.topologyType` | `2-tier` or `3-tier`. |
 | `spectrumX.ipVersion` | `ipv4` or `ipv6`; CIDRPool rendering currently supports IPv4. |
 | `spectrumX.hostFirstOctet` | Config-only first octet for generated IPv4 topology addressing. |
-| `spectrumX.topologyFile` | Path to `spcx-gen` format topology JSON. Relative paths resolve from the config file. |
+| `spectrumX.topologyFile` | Path to spcx-gen/reference-generator or contract-compliant NVIDIA AIR topology JSON. The format is detected from its structure; relative paths resolve from the config file. |
 | `spectrumX.configMapName` / `profile` | RA2.3 ConfigMap name and embedded profile data. |
 | `spectrumX.useDRA` | Render DRA `ResourceClaimTemplate` workload allocation. |
 

--- a/docs/user/spectrum-x.md
+++ b/docs/user/spectrum-x.md
@@ -98,7 +98,12 @@ The generated ConfigMap uses the label expected by the NIC Configuration Operato
 
 ## Topology-Driven CIDRPools
 
-Spectrum-X CIDRPools can be generated from an `spcx-gen` format `topology.json`. This replaces placeholder pool entries with per-host static allocations derived from the resolved topology.
+Spectrum-X CIDRPools can be generated from either spcx-gen/reference-generator topology JSON or a contract-compliant NVIDIA AIR topology export. This replaces placeholder pool entries with per-host static allocations derived from the resolved topology. l8k detects the format by JSON structure:
+
+- spcx-gen/reference-generator format has top-level `nodes` and `links` arrays.
+- NVIDIA AIR format has a `content` object containing a `nodes` map and a `links` array.
+
+The outer AIR `format` value is not used for detection.
 
 The file contains a `nodes` inventory and two-endpoint entries under `links`. This minimal 2-tier example connects one Kubernetes worker to one leaf:
 
@@ -145,6 +150,15 @@ The file contains a `nodes` inventory and two-endpoint entries under `links`. Th
 ```
 
 Add one host-to-leaf link for every selected worker rail. Host `node` values must match Kubernetes node names in the selected `clusterConfig` group. Every host endpoint requires `attributes.rail`, every leaf endpoint requires `attributes.plane`, and 3-tier allocation also requires host `attributes.pod`.
+
+NVIDIA AIR exports do not carry those numeric attributes directly, so AIR support relies on the following naming contract. All AIR ordinals are one-based and l8k converts them to its zero-based addressing fields:
+
+- A 2-tier host name contains hyphen-delimited `su<S>` and `h<H>` tokens, for example `worker-su01-rack01-h01`. A 3-tier host additionally contains `pod<D>`, for example `worker-pod01-su01-rack01-h01`.
+- A leaf name starts with `leaf-`. A 2-tier leaf also contains `p<P>`, `su<S>`, and `r<R>` tokens, for example `leaf-p1-su001-r1`. A 3-tier leaf additionally contains `pod<D>`, for example `leaf-p1-pod01-su001-r1`.
+- Each AIR host interface is named `rail<R>p<P>` and its endpoint `network_pci` value is `rail<R>`. That key must also exist in the host node's `network_pci` map.
+- The plane, rail, SU, and, for 3-tier, pod values encoded by both link endpoints must agree. `h<H>` is the host position within its pod/SU and must be unique there.
+
+Files with other AIR naming schemes are rejected with a contract error rather than assigned inferred addresses.
 
 ```bash
 l8k generate \

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -160,7 +160,7 @@ func init() {
 	discoverCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Spectrum-X plane count override: 1, 2, or 4 (requires --spectrum-x)")
 	discoverCmd.Flags().StringVar(&topologyScheme, "topology-scheme", "", "Spectrum-X topology scheme for guide-based IP allocation: 2-tier or 3-tier (requires --spectrum-x)")
 	discoverCmd.Flags().StringVar(&ipVersion, "ip-version", "", "Spectrum-X IP version for guide-based allocation: ipv4 or ipv6 (requires --spectrum-x)")
-	discoverCmd.Flags().StringVar(&topologyFile, "topology-file", "", "Path to spcx-gen-format topology.json for Spectrum-X CIDRPool generation (requires --spectrum-x)")
+	discoverCmd.Flags().StringVar(&topologyFile, "topology-file", "", "Path to spcx-gen/reference-generator or NVIDIA AIR topology JSON for Spectrum-X CIDRPool generation (requires --spectrum-x)")
 	discoverCmd.Flags().StringVar(&spectrumXConfig, "spectrum-x-config", "", "Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML (required for SPC-X RA versions newer than RA2.2)")
 	discoverCmd.Flags().StringVar(&spectrumXConfigMapName, "spectrum-x-configmap-name", "", "Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML")
 

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -202,7 +202,7 @@ func init() {
 	generateCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes (requires --spectrum-x)")
 	generateCmd.Flags().StringVar(&topologyScheme, "topology-scheme", "", "Spectrum-X topology scheme for guide-based IP allocation: 2-tier or 3-tier (requires --spectrum-x)")
 	generateCmd.Flags().StringVar(&ipVersion, "ip-version", "", "Spectrum-X IP version for guide-based allocation: ipv4 or ipv6 (requires --spectrum-x)")
-	generateCmd.Flags().StringVar(&topologyFile, "topology-file", "", "Path to spcx-gen-format topology.json for Spectrum-X CIDRPool generation (requires --spectrum-x)")
+	generateCmd.Flags().StringVar(&topologyFile, "topology-file", "", "Path to spcx-gen/reference-generator or NVIDIA AIR topology JSON for Spectrum-X CIDRPool generation (requires --spectrum-x)")
 	generateCmd.Flags().StringVar(&spectrumXConfig, "spectrum-x-config", "", "Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML (required for SPC-X RA versions newer than RA2.2)")
 	generateCmd.Flags().StringVar(&spectrumXConfigMapName, "spectrum-x-configmap-name", "", "Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML")
 	generateCmd.Flags().StringSliceVar(&groups, "groups", nil, "Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -269,7 +269,7 @@ func init() {
 	rootCmd.Flags().IntVar(&numberOfPlanes, "number-of-planes", 0, "Number of planes for Spectrum-X (requires --spectrum-x)")
 	rootCmd.Flags().StringVar(&topologyScheme, "topology-scheme", "", "Spectrum-X topology scheme for guide-based IP allocation: 2-tier or 3-tier (requires --spectrum-x)")
 	rootCmd.Flags().StringVar(&ipVersion, "ip-version", "", "Spectrum-X IP version for guide-based allocation: ipv4 or ipv6 (requires --spectrum-x)")
-	rootCmd.Flags().StringVar(&topologyFile, "topology-file", "", "Path to spcx-gen-format topology.json for Spectrum-X CIDRPool generation (requires --spectrum-x)")
+	rootCmd.Flags().StringVar(&topologyFile, "topology-file", "", "Path to spcx-gen/reference-generator or NVIDIA AIR topology JSON for Spectrum-X CIDRPool generation (requires --spectrum-x)")
 	rootCmd.Flags().StringVar(&spectrumXConfig, "spectrum-x-config", "", "Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML (required for SPC-X RA versions newer than RA2.2)")
 	rootCmd.Flags().StringVar(&spectrumXConfigMapName, "spectrum-x-configmap-name", "", "Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML")
 	rootCmd.Flags().StringSliceVar(&groups, "groups", nil, "Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.")

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -164,7 +164,7 @@ var schemaCmd = &cobra.Command{
 				},
 				"--topology-file": {
 					Type:        "string",
-					Description: "Path to a spcx-gen-format topology.json used to generate Spectrum-X CIDRPool host static allocations.",
+					Description: "Path to spcx-gen/reference-generator or contract-compliant NVIDIA AIR topology JSON used to generate Spectrum-X CIDRPool host static allocations. The format is detected from the JSON structure.",
 				},
 				"--spectrum-x-config": {
 					Type:        "string",

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -165,7 +165,7 @@ profile:
     # topologyType: 2-tier # CLI parameter (overrides this value): --topology-scheme (2-tier, 3-tier)
     # ipVersion: ipv4 # CLI parameter (overrides this value): --ip-version (ipv4, ipv6); CIDRPool rendering currently supports ipv4
     # hostFirstOctet: 172 # Config-only IPv4 first octet override; defaults to 172 for 2-tier, 10 for 3-tier
-    # topologyFile: ./topology.json # CLI parameter (overrides this value): --topology-file; spcx-gen-format topology.json
+    # topologyFile: ./topology.json # CLI parameter (overrides this value): --topology-file; spcx-gen/reference-generator or contract-compliant NVIDIA AIR JSON
     # configMapName: "site-ra23-profile" # Required for RA2.3 when profile is raw data.profile YAML; CLI: --spectrum-x-configmap-name
     # profile: | # Required for RA2.3; accepts raw data.profile YAML or a full ConfigMap YAML. CLI: --spectrum-x-config
     #   useSoftwareCCAlgorithm: true

--- a/pkg/networkoperatorplugin/spectrumx/addressing.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing.go
@@ -78,6 +78,7 @@ type topologyEndpoint struct {
 	Node      string             `json:"node"`
 	Interface string             `json:"interface"`
 	Attrs     topologyAttributes `json:"attributes"`
+	HostIndex *int               `json:"-"`
 }
 
 type topologyAttributes struct {
@@ -146,7 +147,7 @@ type poolKey struct {
 }
 
 // BuildCIDRPools builds nv-ipam CIDRPool data for the Spectrum-X profiles from
-// a topology.json that follows the reference generator schema.
+// a topology.json that follows the reference generator or NVIDIA AIR schema.
 func BuildCIDRPools(cfg *config.LaunchKitConfig, group config.ClusterConfig) ([]CIDRPool, error) {
 	if cfg == nil || cfg.Profile == nil || cfg.Profile.SpectrumX == nil || !cfg.Profile.SpectrumX.Enable {
 		return nil, nil
@@ -163,7 +164,7 @@ func BuildCIDRPools(cfg *config.LaunchKitConfig, group config.ClusterConfig) ([]
 	if topologyPath == "" {
 		topologyPath = spcx.TopologyFile
 	}
-	topology, err := loadTopology(topologyPath)
+	topology, err := loadTopology(topologyPath, spcx.TopologyType)
 	if err != nil {
 		return nil, err
 	}
@@ -207,19 +208,19 @@ func BuildCIDRPools(cfg *config.LaunchKitConfig, group config.ClusterConfig) ([]
 	return pools, nil
 }
 
-func loadTopology(path string) (*topologyFile, error) {
+func loadTopology(path, topologyType string) (*topologyFile, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read Spectrum-X topology file %s: %w", path, err)
 	}
-	var topology topologyFile
-	if err := json.Unmarshal(data, &topology); err != nil {
+	topology, err := parseTopology(data, topologyType)
+	if err != nil {
 		return nil, fmt.Errorf("failed to parse Spectrum-X topology file %s: %w", path, err)
 	}
 	if len(topology.Links) == 0 {
 		return nil, fmt.Errorf("Spectrum-X topology file %s has no links", path)
 	}
-	return &topology, nil
+	return topology, nil
 }
 
 func hostLinks(topology *topologyFile, spcx *config.ProfileSpectrumX) ([]hostLink, error) {
@@ -265,7 +266,11 @@ func hostLinks(topology *topologyFile, spcx *config.ProfileSpectrumX) ([]hostLin
 		key := hostIndexKey(host.Attrs)
 		index, ok := hostIndexes[key+"|"+host.Node]
 		if !ok {
-			index = countHostIndex(hostIndexes, key)
+			if host.HostIndex != nil {
+				index = *host.HostIndex
+			} else {
+				index = countHostIndex(hostIndexes, key)
+			}
 			hostIndexes[key+"|"+host.Node] = index
 		}
 		addressPlane := leaf.Attrs.Plane

--- a/pkg/networkoperatorplugin/spectrumx/addressing_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -150,6 +150,105 @@ func TestBuildCIDRPools3Tier(t *testing.T) {
 	}}, pools)
 }
 
+func TestBuildCIDRPoolsFromAIR2Tier(t *testing.T) {
+	topologyPath := filepath.Join("testdata", "air-simple-quadplane.json")
+	rail := 0
+	tests := []struct {
+		name          string
+		mode          string
+		wantPools     int
+		wantFirstName string
+		wantLastName  string
+		wantLastCIDR  string
+	}{
+		{
+			name:          "software plane load balancing",
+			mode:          "swplb",
+			wantPools:     4,
+			wantFirstName: "rail-0-plane-0",
+			wantLastName:  "rail-0-plane-3",
+			wantLastCIDR:  "172.28.0.0/18",
+		},
+		{
+			name:          "hardware plane load balancing",
+			mode:          "hwplb",
+			wantPools:     1,
+			wantFirstName: "rail-0",
+			wantLastName:  "rail-0",
+			wantLastCIDR:  "172.16.0.0/18",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.LaunchKitConfig{
+				Profile: &config.Profile{SpectrumX: &config.ProfileSpectrumX{
+					Enable:         true,
+					TopologyType:   config.SpectrumXTopology2Tier,
+					IPVersion:      config.SpectrumXIPVersionIPv4,
+					TopologyFile:   topologyPath,
+					MultiplaneMode: tt.mode,
+					NumberOfPlanes: 4,
+				}},
+			}
+			pools, err := BuildCIDRPools(cfg, config.ClusterConfig{
+				WorkerNodes: []string{"worker-su01-rack01-h01", "worker-su01-rack01-h02"},
+				PFs:         []config.PFConfig{{Traffic: "east-west", Rail: &rail}},
+			})
+			require.NoError(t, err)
+			require.Len(t, pools, tt.wantPools)
+			require.Equal(t, tt.wantFirstName, pools[0].Name)
+			require.Equal(t, []StaticAllocation{
+				{Gateway: "172.16.0.1", NodeName: "worker-su01-rack01-h01", Prefix: "172.16.0.0/31"},
+				{Gateway: "172.16.0.3", NodeName: "worker-su01-rack01-h02", Prefix: "172.16.0.2/31"},
+			}, pools[0].StaticAllocations)
+			require.Equal(t, tt.wantLastName, pools[len(pools)-1].Name)
+			require.Equal(t, tt.wantLastCIDR, pools[len(pools)-1].CIDR)
+		})
+	}
+}
+
+func TestBuildCIDRPoolsFromAIR3Tier(t *testing.T) {
+	topologyPath := writeTopology(t, `{
+  "content": {
+    "nodes": {
+      "worker-pod02-su03-h04": {"model": "host", "network_pci": {"rail2": {}}},
+      "leaf-p1-pod02-su03-r2": {"model": "SN5600", "network_pci": {}}
+    },
+    "links": [[
+      {"node": "worker-pod02-su03-h04", "interface": "rail2p1", "network_pci": "rail2"},
+      {"node": "leaf-p1-pod02-su03-r2", "interface": "swp1s0"}
+    ]]
+  }
+}`)
+	rail := 1
+	cfg := &config.LaunchKitConfig{
+		Profile: &config.Profile{SpectrumX: &config.ProfileSpectrumX{
+			Enable:         true,
+			TopologyType:   config.SpectrumXTopology3Tier,
+			IPVersion:      config.SpectrumXIPVersionIPv4,
+			TopologyFile:   topologyPath,
+			MultiplaneMode: "hwplb",
+			NumberOfPlanes: 4,
+		}},
+	}
+	pools, err := BuildCIDRPools(cfg, config.ClusterConfig{
+		WorkerNodes: []string{"worker-pod02-su03-h04"},
+		PFs:         []config.PFConfig{{Traffic: "east-west", Rail: &rail}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []CIDRPool{{
+		Name:   "rail-1",
+		CIDR:   "10.8.0.0/13",
+		Routes: []string{"10.8.0.0/13", "10.0.0.0/10"},
+		StaticAllocations: []StaticAllocation{{
+			Gateway:  "10.8.66.7",
+			NodeName: "worker-pod02-su03-h04",
+			Prefix:   "10.8.66.6/31",
+		}},
+	}}, pools)
+}
+
 func TestBuildCIDRPoolsRejectsIPv6UntilRenderable(t *testing.T) {
 	cfg := &config.LaunchKitConfig{
 		Profile: &config.Profile{SpectrumX: &config.ProfileSpectrumX{

--- a/pkg/networkoperatorplugin/spectrumx/air_topology.go
+++ b/pkg/networkoperatorplugin/spectrumx/air_topology.go
@@ -1,0 +1,438 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spectrumx
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+type topologyFormat int
+
+const (
+	topologyFormatReference topologyFormat = iota
+	topologyFormatAIR
+)
+
+type airTopologyFile struct {
+	Content airTopologyContent `json:"content"`
+}
+
+type airTopologyContent struct {
+	Nodes map[string]airTopologyNode `json:"nodes"`
+	Links []airTopologyLink          `json:"links"`
+}
+
+type airTopologyNode struct {
+	Model         string                     `json:"model"`
+	EmulationType string                     `json:"emulation_type"`
+	NetworkPCI    map[string]json.RawMessage `json:"network_pci"`
+}
+
+type airTopologyLink struct {
+	Endpoints    []airTopologyEndpoint
+	Disconnected bool
+}
+
+func (l *airTopologyLink) UnmarshalJSON(data []byte) error {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	for _, item := range raw {
+		var sentinel string
+		if err := json.Unmarshal(item, &sentinel); err == nil {
+			if sentinel != "unconnected" {
+				return fmt.Errorf("unsupported AIR link endpoint %q", sentinel)
+			}
+			l.Disconnected = true
+			continue
+		}
+		var endpoint airTopologyEndpoint
+		if err := json.Unmarshal(item, &endpoint); err != nil {
+			return err
+		}
+		l.Endpoints = append(l.Endpoints, endpoint)
+	}
+	return nil
+}
+
+type airTopologyEndpoint struct {
+	Node       string  `json:"node"`
+	Interface  string  `json:"interface"`
+	NetworkPCI *string `json:"network_pci"`
+}
+
+func parseTopology(data []byte, topologyType string) (*topologyFile, error) {
+	format, err := detectTopologyFormat(data)
+	if err != nil {
+		return nil, err
+	}
+
+	switch format {
+	case topologyFormatReference:
+		var topology topologyFile
+		if err := json.Unmarshal(data, &topology); err != nil {
+			return nil, err
+		}
+		return &topology, nil
+	case topologyFormatAIR:
+		var topology airTopologyFile
+		if err := json.Unmarshal(data, &topology); err != nil {
+			return nil, err
+		}
+		return normalizeAIRTopology(&topology, topologyType)
+	default:
+		return nil, fmt.Errorf("unsupported topology format")
+	}
+}
+
+func detectTopologyFormat(data []byte) (topologyFormat, error) {
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return 0, err
+	}
+	if root == nil {
+		return 0, fmt.Errorf("topology must be a JSON object")
+	}
+
+	reference := jsonValueKind(root["nodes"]) == '[' && jsonValueKind(root["links"]) == '['
+	air := false
+	if jsonValueKind(root["content"]) == '{' {
+		var content map[string]json.RawMessage
+		if err := json.Unmarshal(root["content"], &content); err != nil {
+			return 0, fmt.Errorf("content: %w", err)
+		}
+		air = jsonValueKind(content["nodes"]) == '{' && jsonValueKind(content["links"]) == '['
+	}
+
+	switch {
+	case reference && air:
+		return 0, fmt.Errorf("ambiguous topology format: both top-level nodes/links and content.nodes/content.links are present")
+	case reference:
+		return topologyFormatReference, nil
+	case air:
+		return topologyFormatAIR, nil
+	default:
+		return 0, fmt.Errorf("unsupported topology format: expected top-level nodes and links arrays, or an AIR content object with a nodes map and links array")
+	}
+}
+
+func jsonValueKind(raw json.RawMessage) byte {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return 0
+	}
+	return trimmed[0]
+}
+
+func normalizeAIRTopology(air *airTopologyFile, topologyType string) (*topologyFile, error) {
+	if air == nil {
+		return nil, fmt.Errorf("AIR topology is nil")
+	}
+
+	topology := &topologyFile{}
+	nodeNames := make([]string, 0, len(air.Content.Nodes))
+	for name := range air.Content.Nodes {
+		nodeNames = append(nodeNames, name)
+	}
+	sort.Strings(nodeNames)
+	for _, name := range nodeNames {
+		node := air.Content.Nodes[name]
+		role := ""
+		if isAIRHostNode(node) {
+			role = "host"
+		} else if isAIRLeafNode(name) {
+			role = "leaf"
+		}
+		topology.Nodes = append(topology.Nodes, topologyNode{Name: name, Role: role, Type: node.Model})
+	}
+
+	hostPositions := map[string]string{}
+	for linkIndex, link := range air.Content.Links {
+		if link.Disconnected {
+			continue
+		}
+		if len(link.Endpoints) != 2 {
+			return nil, fmt.Errorf("AIR topology link %d must contain exactly two endpoints", linkIndex)
+		}
+
+		hostEndpointIndex := -1
+		for endpointIndex, endpoint := range link.Endpoints {
+			node, ok := air.Content.Nodes[endpoint.Node]
+			if !ok {
+				return nil, fmt.Errorf("AIR topology link %d references unknown node %q", linkIndex, endpoint.Node)
+			}
+			if isAIRHostNode(node) {
+				if hostEndpointIndex != -1 {
+					return nil, fmt.Errorf("AIR topology link %d connects two host nodes", linkIndex)
+				}
+				hostEndpointIndex = endpointIndex
+			}
+		}
+		if hostEndpointIndex == -1 {
+			continue
+		}
+
+		host := link.Endpoints[hostEndpointIndex]
+		leaf := link.Endpoints[1-hostEndpointIndex]
+		if !isAIRLeafNode(leaf.Node) {
+			return nil, fmt.Errorf("AIR topology host link %d endpoint %q is not a leaf node; leaf node names must start with leaf-",
+				linkIndex, leaf.Node)
+		}
+		hostNode := air.Content.Nodes[host.Node]
+		normalized, err := normalizeAIRHostLink(linkIndex, host, leaf, hostNode, topologyType, hostPositions)
+		if err != nil {
+			return nil, err
+		}
+		topology.Links = append(topology.Links, normalized)
+	}
+	return topology, nil
+}
+
+func isAIRHostNode(node airTopologyNode) bool {
+	return strings.EqualFold(node.Model, "host") ||
+		strings.EqualFold(node.EmulationType, "HOST") || len(node.NetworkPCI) > 0
+}
+
+func isAIRLeafNode(name string) bool {
+	return strings.HasPrefix(strings.ToLower(name), "leaf-")
+}
+
+func normalizeAIRHostLink(
+	linkIndex int,
+	host, leaf airTopologyEndpoint,
+	hostNode airTopologyNode,
+	topologyType string,
+	hostPositions map[string]string,
+) (topologyLink, error) {
+	if host.NetworkPCI == nil || *host.NetworkPCI == "" {
+		return nil, fmt.Errorf("AIR topology host link %d endpoint %s/%s is missing network_pci",
+			linkIndex, host.Node, host.Interface)
+	}
+	if _, ok := hostNode.NetworkPCI[*host.NetworkPCI]; !ok {
+		return nil, fmt.Errorf("AIR topology host link %d endpoint %s/%s references network_pci %q not defined by node %q",
+			linkIndex, host.Node, host.Interface, *host.NetworkPCI, host.Node)
+	}
+
+	interfaceRail, interfacePlane, err := parseAIRHostInterface(host.Interface)
+	if err != nil {
+		return nil, fmt.Errorf("AIR topology host link %d endpoint %s/%s: %w", linkIndex, host.Node, host.Interface, err)
+	}
+	networkPCIRail, err := parseAIRNetworkPCI(*host.NetworkPCI)
+	if err != nil {
+		return nil, fmt.Errorf("AIR topology host link %d endpoint %s/%s: %w", linkIndex, host.Node, host.Interface, err)
+	}
+	if interfaceRail != networkPCIRail {
+		return nil, fmt.Errorf("AIR topology host link %d endpoint %s/%s has rail %d but network_pci %q identifies rail %d",
+			linkIndex, host.Node, host.Interface, interfaceRail+1, *host.NetworkPCI, networkPCIRail+1)
+	}
+
+	hostSU, err := requiredAIRNameOrdinal(host.Node, "su")
+	if err != nil {
+		return nil, fmt.Errorf("AIR topology host link %d: %w", linkIndex, err)
+	}
+	hostIndex, err := requiredAIRNameOrdinal(host.Node, "h")
+	if err != nil {
+		return nil, fmt.Errorf("AIR topology host link %d: %w", linkIndex, err)
+	}
+	leafPlane, err := requiredAIRNameOrdinal(leaf.Node, "p")
+	if err != nil {
+		return nil, fmt.Errorf("AIR topology host link %d: %w", linkIndex, err)
+	}
+	leafSU, err := requiredAIRNameOrdinal(leaf.Node, "su")
+	if err != nil {
+		return nil, fmt.Errorf("AIR topology host link %d: %w", linkIndex, err)
+	}
+	leafRail, err := requiredAIRNameOrdinal(leaf.Node, "r")
+	if err != nil {
+		return nil, fmt.Errorf("AIR topology host link %d: %w", linkIndex, err)
+	}
+	if hostSU != leafSU {
+		return nil, fmt.Errorf("AIR topology host link %d has host SU %d but leaf %q identifies SU %d",
+			linkIndex, hostSU+1, leaf.Node, leafSU+1)
+	}
+	if interfacePlane != leafPlane {
+		return nil, fmt.Errorf("AIR topology host link %d endpoint %s/%s has plane %d but leaf %q identifies plane %d",
+			linkIndex, host.Node, host.Interface, interfacePlane+1, leaf.Node, leafPlane+1)
+	}
+	if interfaceRail != leafRail {
+		return nil, fmt.Errorf("AIR topology host link %d endpoint %s/%s has rail %d but leaf %q identifies rail %d",
+			linkIndex, host.Node, host.Interface, interfaceRail+1, leaf.Node, leafRail+1)
+	}
+
+	hostPod, hostHasPod, err := optionalAIRNameOrdinal(host.Node, "pod")
+	if err != nil {
+		return nil, fmt.Errorf("AIR topology host link %d: %w", linkIndex, err)
+	}
+	leafPod, leafHasPod, err := optionalAIRNameOrdinal(leaf.Node, "pod")
+	if err != nil {
+		return nil, fmt.Errorf("AIR topology host link %d: %w", linkIndex, err)
+	}
+	if topologyType == config.SpectrumXTopology3Tier && (!hostHasPod || !leafHasPod) {
+		return nil, fmt.Errorf("AIR topology host link %d requires pod<N> name tokens on both host %q and leaf %q for 3-tier allocation",
+			linkIndex, host.Node, leaf.Node)
+	}
+	if hostHasPod != leafHasPod || (hostHasPod && hostPod != leafPod) {
+		return nil, fmt.Errorf("AIR topology host link %d has inconsistent pod<N> name tokens on host %q and leaf %q",
+			linkIndex, host.Node, leaf.Node)
+	}
+
+	position := fmt.Sprintf("%d/%d/%d", hostPod, hostSU, hostIndex)
+	if existing, ok := hostPositions[position]; ok && existing != host.Node {
+		return nil, fmt.Errorf("AIR topology host nodes %q and %q identify the same pod/SU/host position", existing, host.Node)
+	}
+	hostPositions[position] = host.Node
+
+	explicitHostIndex := hostIndex
+	hostAttrs := topologyAttributes{
+		Role:    "host",
+		Pod:     hostPod,
+		SU:      hostSU,
+		Rail:    interfaceRail,
+		HasPod:  hostHasPod,
+		HasSU:   true,
+		HasRail: true,
+	}
+	leafAttrs := topologyAttributes{
+		Role:     "leaf",
+		Plane:    leafPlane,
+		Pod:      leafPod,
+		SU:       leafSU,
+		Rail:     leafRail,
+		HasPlane: true,
+		HasPod:   leafHasPod,
+		HasSU:    true,
+		HasRail:  true,
+	}
+	return topologyLink{
+		{Node: host.Node, Interface: host.Interface, Attrs: hostAttrs, HostIndex: &explicitHostIndex},
+		{Node: leaf.Node, Interface: leaf.Interface, Attrs: leafAttrs},
+	}, nil
+}
+
+func parseAIRHostInterface(name string) (int, int, error) {
+	railText, planeText, ok := splitAIRCompoundOrdinal(name, "rail", "p")
+	if !ok {
+		return 0, 0, fmt.Errorf("interface must match rail<R>p<P> with one-based ordinals")
+	}
+	rail, err := parseOneBasedOrdinal(railText)
+	if err != nil {
+		return 0, 0, fmt.Errorf("interface rail: %w", err)
+	}
+	plane, err := parseOneBasedOrdinal(planeText)
+	if err != nil {
+		return 0, 0, fmt.Errorf("interface plane: %w", err)
+	}
+	return rail, plane, nil
+}
+
+func parseAIRNetworkPCI(name string) (int, error) {
+	if !strings.HasPrefix(name, "rail") || len(name) == len("rail") {
+		return 0, fmt.Errorf("network_pci must match rail<R> with a one-based ordinal")
+	}
+	rail, err := parseOneBasedOrdinal(strings.TrimPrefix(name, "rail"))
+	if err != nil {
+		return 0, fmt.Errorf("network_pci %q: %w", name, err)
+	}
+	return rail, nil
+}
+
+func splitAIRCompoundOrdinal(value, firstPrefix, secondPrefix string) (string, string, bool) {
+	if !strings.HasPrefix(value, firstPrefix) {
+		return "", "", false
+	}
+	remainder := strings.TrimPrefix(value, firstPrefix)
+	separator := strings.Index(remainder, secondPrefix)
+	if separator <= 0 || separator+len(secondPrefix) >= len(remainder) {
+		return "", "", false
+	}
+	first := remainder[:separator]
+	second := remainder[separator+len(secondPrefix):]
+	if !allDigits(first) || !allDigits(second) {
+		return "", "", false
+	}
+	return first, second, true
+}
+
+func requiredAIRNameOrdinal(name, prefix string) (int, error) {
+	value, found, err := optionalAIRNameOrdinal(name, prefix)
+	if err != nil {
+		return 0, err
+	}
+	if !found {
+		return 0, fmt.Errorf("AIR node name %q is missing required %s<N> token", name, prefix)
+	}
+	return value, nil
+}
+
+func optionalAIRNameOrdinal(name, prefix string) (int, bool, error) {
+	var value int
+	found := false
+	for _, token := range strings.Split(name, "-") {
+		if !strings.HasPrefix(token, prefix) {
+			continue
+		}
+		digits := strings.TrimPrefix(token, prefix)
+		if digits == "" || !allDigits(digits) {
+			continue
+		}
+		if found {
+			return 0, false, fmt.Errorf("AIR node name %q has more than one %s<N> token", name, prefix)
+		}
+		parsed, err := parseOneBasedOrdinal(digits)
+		if err != nil {
+			return 0, false, fmt.Errorf("AIR node name %q token %q: %w", name, token, err)
+		}
+		value = parsed
+		found = true
+	}
+	return value, found, nil
+}
+
+func parseOneBasedOrdinal(value string) (int, error) {
+	if !allDigits(value) {
+		return 0, fmt.Errorf("%q is not a decimal ordinal", value)
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, err
+	}
+	if parsed < 1 {
+		return 0, fmt.Errorf("ordinal must be at least 1")
+	}
+	return parsed - 1, nil
+}
+
+func allDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if !unicode.IsDigit(r) || r > unicode.MaxASCII {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/networkoperatorplugin/spectrumx/air_topology_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/air_topology_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spectrumx
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+func TestDetectTopologyFormat(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		wantFormat topologyFormat
+		wantError  string
+	}{
+		{
+			name:       "reference generator",
+			content:    `{"nodes": [], "links": []}`,
+			wantFormat: topologyFormatReference,
+		},
+		{
+			name:       "NVIDIA AIR ignores outer format value",
+			content:    `{"format": "not-used", "content": {"nodes": {}, "links": []}}`,
+			wantFormat: topologyFormatAIR,
+		},
+		{
+			name:      "ambiguous",
+			content:   `{"nodes": [], "links": [], "content": {"nodes": {}, "links": []}}`,
+			wantError: "ambiguous topology format",
+		},
+		{
+			name:      "unsupported shape",
+			content:   `{"format": "JSON", "nodes": {}, "links": []}`,
+			wantError: "unsupported topology format",
+		},
+		{
+			name:      "invalid JSON",
+			content:   `{"nodes":`,
+			wantError: "unexpected end of JSON input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			format, err := detectTopologyFormat([]byte(tt.content))
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantFormat, format)
+		})
+	}
+}
+
+func TestParseAIRTopologyNormalizesOneBasedNamingContract(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "air-simple-quadplane.json"))
+	require.NoError(t, err)
+
+	topology, err := parseTopology(data, config.SpectrumXTopology2Tier)
+	require.NoError(t, err)
+	require.Len(t, topology.Links, 8)
+
+	host := topology.Links[0][0]
+	leaf := topology.Links[0][1]
+	require.Equal(t, "host", host.Attrs.Role)
+	require.Equal(t, 0, host.Attrs.Rail)
+	require.Equal(t, 0, host.Attrs.SU)
+	require.NotNil(t, host.HostIndex)
+	require.Equal(t, 0, *host.HostIndex)
+	require.Equal(t, "leaf", leaf.Attrs.Role)
+	require.Equal(t, 0, leaf.Attrs.Plane)
+	require.Equal(t, 0, leaf.Attrs.Rail)
+	require.Equal(t, 0, leaf.Attrs.SU)
+	require.Equal(t, 3, topology.Links[3][1].Attrs.Plane)
+	require.Equal(t, 1, *topology.Links[4][0].HostIndex)
+}
+
+func TestParseAIRTopologyNormalizes3TierNamingContract(t *testing.T) {
+	topology, err := parseTopology([]byte(`{
+  "content": {
+    "nodes": {
+      "worker-pod02-su03-h04": {
+        "model": "host",
+        "network_pci": {"rail2": {}}
+      },
+      "leaf-p1-pod02-su03-r2": {"model": "SN5600", "network_pci": {}},
+      "spine-pod02-r2-s01": {"model": "SN5600", "network_pci": {}}
+    },
+    "links": [
+      [
+        {"node": "leaf-p1-pod02-su03-r2", "interface": "swp2"},
+        {"node": "spine-pod02-r2-s01", "interface": "swp1"}
+      ],
+      [
+        {"node": "worker-pod02-su03-h04", "interface": "rail2p1", "network_pci": "rail2"},
+        {"node": "leaf-p1-pod02-su03-r2", "interface": "swp1s0"}
+      ]
+    ]
+  }
+}`), config.SpectrumXTopology3Tier)
+	require.NoError(t, err)
+	require.Len(t, topology.Links, 1)
+
+	host := topology.Links[0][0]
+	leaf := topology.Links[0][1]
+	require.Equal(t, 1, host.Attrs.Pod)
+	require.True(t, host.Attrs.HasPod)
+	require.Equal(t, 2, host.Attrs.SU)
+	require.Equal(t, 1, host.Attrs.Rail)
+	require.Equal(t, 3, *host.HostIndex)
+	require.Equal(t, 1, leaf.Attrs.Pod)
+	require.Equal(t, 0, leaf.Attrs.Plane)
+}
+
+func TestParseAIRTopologyRejectsContractViolations(t *testing.T) {
+	tests := []struct {
+		name         string
+		hostName     string
+		leafName     string
+		hostIface    string
+		networkPCI   string
+		topologyType string
+		wantError    string
+	}{
+		{
+			name:         "host interface format",
+			hostName:     "worker-su01-h01",
+			leafName:     "leaf-p1-su01-r1",
+			hostIface:    "eth0",
+			networkPCI:   "rail1",
+			topologyType: config.SpectrumXTopology2Tier,
+			wantError:    "interface must match rail<R>p<P>",
+		},
+		{
+			name:         "interface and network PCI rail disagree",
+			hostName:     "worker-su01-h01",
+			leafName:     "leaf-p1-su01-r2",
+			hostIface:    "rail2p1",
+			networkPCI:   "rail1",
+			topologyType: config.SpectrumXTopology2Tier,
+			wantError:    "has rail 2 but network_pci \"rail1\" identifies rail 1",
+		},
+		{
+			name:         "host and leaf SU disagree",
+			hostName:     "worker-su01-h01",
+			leafName:     "leaf-p1-su02-r1",
+			hostIface:    "rail1p1",
+			networkPCI:   "rail1",
+			topologyType: config.SpectrumXTopology2Tier,
+			wantError:    "has host SU 1",
+		},
+		{
+			name:         "host connected to non-leaf",
+			hostName:     "worker-su01-h01",
+			leafName:     "spine-p1-su01-r1",
+			hostIface:    "rail1p1",
+			networkPCI:   "rail1",
+			topologyType: config.SpectrumXTopology2Tier,
+			wantError:    "is not a leaf node",
+		},
+		{
+			name:         "3-tier pod missing",
+			hostName:     "worker-su01-h01",
+			leafName:     "leaf-p1-su01-r1",
+			hostIface:    "rail1p1",
+			networkPCI:   "rail1",
+			topologyType: config.SpectrumXTopology3Tier,
+			wantError:    "requires pod<N> name tokens",
+		},
+		{
+			name:         "zero ordinal",
+			hostName:     "worker-su00-h01",
+			leafName:     "leaf-p1-su01-r1",
+			hostIface:    "rail1p1",
+			networkPCI:   "rail1",
+			topologyType: config.SpectrumXTopology2Tier,
+			wantError:    "ordinal must be at least 1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := `{
+  "content": {
+    "nodes": {
+      "` + tt.hostName + `": {"model": "host", "network_pci": {"` + tt.networkPCI + `": {}}},
+      "` + tt.leafName + `": {"model": "SN5600", "network_pci": {}}
+    },
+    "links": [[
+      {"node": "` + tt.hostName + `", "interface": "` + tt.hostIface + `", "network_pci": "` + tt.networkPCI + `"},
+      {"node": "` + tt.leafName + `", "interface": "swp1s0"}
+    ]]
+  }
+}`
+			_, err := parseTopology([]byte(content), tt.topologyType)
+			require.ErrorContains(t, err, tt.wantError)
+		})
+	}
+}

--- a/pkg/networkoperatorplugin/spectrumx/testdata/air-simple-quadplane.json
+++ b/pkg/networkoperatorplugin/spectrumx/testdata/air-simple-quadplane.json
@@ -1,0 +1,85 @@
+{
+  "format": "JSON",
+  "name": "simple-quadplane",
+  "ztp": null,
+  "content": {
+    "nodes": {
+      "worker-su01-rack01-h01": {
+        "model": "host",
+        "emulation_type": "HOST",
+        "network_pci": {
+          "rail1": {
+            "model": "connectx8",
+            "emulation_type": "NIC_ETHERNET",
+            "number_of_ports": 4
+          }
+        }
+      },
+      "worker-su01-rack01-h02": {
+        "model": "host",
+        "emulation_type": "HOST",
+        "network_pci": {
+          "rail1": {
+            "model": "connectx8",
+            "emulation_type": "NIC_ETHERNET",
+            "number_of_ports": 4
+          }
+        }
+      },
+      "leaf-p1-su001-r1": {
+        "model": "SN5600",
+        "emulation_type": "SWITCH_ETHERNET",
+        "network_pci": {}
+      },
+      "leaf-p2-su001-r1": {
+        "model": "SN5600",
+        "emulation_type": "SWITCH_ETHERNET",
+        "network_pci": {}
+      },
+      "leaf-p3-su001-r1": {
+        "model": "SN5600",
+        "emulation_type": "SWITCH_ETHERNET",
+        "network_pci": {}
+      },
+      "leaf-p4-su001-r1": {
+        "model": "SN5600",
+        "emulation_type": "SWITCH_ETHERNET",
+        "network_pci": {}
+      }
+    },
+    "links": [
+      [
+        {"node": "worker-su01-rack01-h01", "interface": "rail1p1", "network_pci": "rail1"},
+        {"node": "leaf-p1-su001-r1", "interface": "swp1s0"}
+      ],
+      [
+        {"node": "worker-su01-rack01-h01", "interface": "rail1p2", "network_pci": "rail1"},
+        {"node": "leaf-p2-su001-r1", "interface": "swp1s0"}
+      ],
+      [
+        {"node": "worker-su01-rack01-h01", "interface": "rail1p3", "network_pci": "rail1"},
+        {"node": "leaf-p3-su001-r1", "interface": "swp1s0"}
+      ],
+      [
+        {"node": "worker-su01-rack01-h01", "interface": "rail1p4", "network_pci": "rail1"},
+        {"node": "leaf-p4-su001-r1", "interface": "swp1s0"}
+      ],
+      [
+        {"node": "worker-su01-rack01-h02", "interface": "rail1p1", "network_pci": "rail1"},
+        {"node": "leaf-p1-su001-r1", "interface": "swp1s1"}
+      ],
+      [
+        {"node": "worker-su01-rack01-h02", "interface": "rail1p2", "network_pci": "rail1"},
+        {"node": "leaf-p2-su001-r1", "interface": "swp1s1"}
+      ],
+      [
+        {"node": "worker-su01-rack01-h02", "interface": "rail1p3", "network_pci": "rail1"},
+        {"node": "leaf-p3-su001-r1", "interface": "swp1s1"}
+      ],
+      [
+        {"node": "worker-su01-rack01-h02", "interface": "rail1p4", "network_pci": "rail1"},
+        {"node": "leaf-p4-su001-r1", "interface": "swp1s1"}
+      ]
+    ]
+  }
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -76,7 +76,7 @@ type Options struct {
 	NumberOfPlanes int    // Number of planes for Spectrum-X (default: 4)
 	TopologyScheme string // Spectrum-X topology scheme: 2-tier or 3-tier
 	IPVersion      string // Spectrum-X address family: ipv4 or ipv6
-	TopologyFile   string // Path to spcx-gen-format topology.json for Spectrum-X CIDRPool generation
+	TopologyFile   string // Path to spcx-gen/reference-generator or NVIDIA AIR topology JSON for Spectrum-X CIDRPool generation
 	// SpectrumXConfig is a path to either a full Spectrum-X profile ConfigMap
 	// YAML or the raw data.profile YAML body. SpectrumXConfigMapName is required
 	// only when SpectrumXConfig contains the raw profile body.

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-generate
-version: 1.2.3
+version: 1.2.4
 description: "Use this skill when the user wants to generate Kubernetes YAML manifests for NVIDIA networking deployment using k8s-launch-kit (l8k). Activate for: manifest generation, profile selection, choosing between SR-IOV/host-device/RDMA-shared/IPoIB/MacVLAN/Spectrum-X, creating deployment files, or when the user asks 'which profile should I use' or needs help choosing a network configuration."
 metadata:
   requires:
@@ -31,9 +31,12 @@ to that source file; embedded `--for` generation does not write a config.
 |------|----------|--------|-------------|
 | `--fabric` | Auto-defaulted | `ethernet`, `infiniband` | Network fabric. Auto-defaults from the cluster's unanimous `linkType` when omitted (Unit 5 fabric probe); skipped+warned when groups disagree or any has unverified linkType. |
 | `--deployment-type` | Auto-defaulted | `sriov`, `rdma_shared`, `host_device` | Deployment type. Auto-defaults to `sriov`. |
-| `--spectrum-x` | — | `RA2.1`, `RA2.2` | Enable Spectrum-X profile by passing the SPC-X RA version. Implies ethernet fabric, sriov deployment, and multirail. |
+| `--spectrum-x` | — | `RA2.1`, `RA2.2`, `RA2.3` | Enable Spectrum-X profile by passing the SPC-X RA version. Implies ethernet fabric, sriov deployment, and multirail. |
 | `--multiplane-mode` | Auto-defaulted with `--spectrum-x` | `none`, `swplb`, `hwplb` | Auto-defaults from east-west PF deviceID: CX7 / BF3 SuperNIC → `none`, CX8 → `swplb`, CX9 → `hwplb`. Skipped+warned when groups have mixed deviceIDs. |
 | `--number-of-planes` | Auto-defaulted with `--spectrum-x` | `1`, `2`, `4` | Auto-defaults from deviceID: CX7 / BF3 → 1, CX8 → 2, CX9 → 4. |
+| `--topology-scheme` | Required with `--spectrum-x` | `2-tier`, `3-tier` | Selects the Spectrum-X topology addressing scheme. |
+| `--ip-version` | Required with `--spectrum-x` | `ipv4`, `ipv6` | Selects the address family. CIDRPool rendering currently supports IPv4 only. |
+| `--topology-file` | Required with `--spectrum-x` | path | spcx-gen/reference-generator or contract-compliant NVIDIA AIR topology JSON. The format is detected from the JSON structure. |
 | `--multirail` | Auto-defaulted | — | Auto-defaults to `true`. Explicit `multirail: false` in YAML and `--multirail=false` on the CLI are both preserved. |
 | `--save-deployment-files` | Yes | — | Output directory for generated YAMLs |
 | `--groups` | — | `dgx-b200-nvidia-h100-nvl,poweredge-xe9680-nvidia-h200` | Restrict output to the named source groups (comma-separated). Mutually exclusive with `--gpu-type`. |
@@ -54,6 +57,8 @@ l8k generate --user-config cluster-config.yaml \
 # Spectrum-X with hardware plane load balancing
 l8k generate --user-config cluster-config.yaml \
   --spectrum-x RA2.2 --multiplane-mode hwplb --number-of-planes 4 \
+  --topology-scheme 2-tier --ip-version ipv4 \
+  --topology-file ./topology.json \
   --save-deployment-files ./output
 
 # Host device RDMA
@@ -150,6 +155,9 @@ win when a one-off override is needed.
 
 - Default to SR-IOV Ethernet for new GPU cluster deployments unless told otherwise.
 - For Spectrum-X, NIC type determines available multiplane modes — read `references/spectrum-x-guide.md`.
+- NVIDIA AIR topology support requires the documented one-based node/interface
+  naming contract (`su<S>`, `h<H>`, `leaf-p<P>`, `r<R>`, `rail<R>p<P>`, and
+  `pod<D>` for 3-tier). See `docs/user/spectrum-x.md` in the l8k repository.
 - RA2.2 and RA2.3 v1alpha2 `SpectrumXRailPoolConfig` output intentionally
   omits the removed `spec.withBCM` field; current CRDs reject it during strict
   decoding.


### PR DESCRIPTION
## Summary

- accept NVIDIA AIR topology exports for Spectrum-X CIDRPool generation in addition to the existing spcx-gen/reference-generator format
- detect the format from JSON structure and normalize AIR host-to-leaf links into the existing addressing model
- validate redundant AIR rail, plane, SU, pod, host-index, interface, and network_pci metadata before allocating addresses
- document the contract-compliant AIR naming scheme, including the corresponding 3-tier pod tokens

This is additive and preserves the existing spcx-gen/reference-generator path.

## AIR naming contract

- AIR ordinals are one-based and converted to l8k zero-based fields
- hosts use su<S> and h<H>, plus pod<D> for 3-tier
- leaves use p<P>, su<S>, and r<R>, plus pod<D> for 3-tier
- host interfaces use rail<R>p<P> and network_pci uses the matching rail<R> key

## Validation

- exercised the provided NVIDIA AIR file with swplb and hwplb generation
- go test -race -count=1 ./...
- make build
- make test
- golangci-lint v2.11.0: 0 issues
- mkdocs build --strict
- git diff --check