### PR TITLE
Fix prerelease catalog validation

### DIFF
--- a/hack/sync-network-operator-releases/sync_test.go
+++ b/hack/sync-network-operator-releases/sync_test.go
@@ -102,10 +102,10 @@ func TestSyncCatalogUpdatesAllReleasesAndFallsBackForLatest(t *testing.T) {
 				"doca3.3.0-26.01-1.0.0.0-6",
 			),
 			"master": upstreamReleaseYAML(
-				"v26.7.0-beta.5",
+				"v26.7.0-rc.1",
 				stagingOperatorRepository,
 				stagingComponentRepository,
-				"doca3.5.0-26.07-0.4.3.0-0",
+				"doca3.5.0-26.07-0.5.1.0-0",
 			),
 		},
 		requests: nil,
@@ -143,12 +143,12 @@ func TestSyncCatalogUpdatesAllReleasesAndFallsBackForLatest(t *testing.T) {
 	assert.Equal(t, "doca3.3.0-26.01-1.0.0.0-6", stable.DOCADriver.Version)
 
 	latest := catalog.Releases["26.7"]
-	assert.Equal(t, "v26.7.0-beta.5", latest.NetworkOperator.Version)
-	assert.Equal(t, "network-operator-v26.7.0-beta.5", latest.NetworkOperator.ComponentVersion)
+	assert.Equal(t, "v26.7.0-rc.1", latest.NetworkOperator.Version)
+	assert.Equal(t, "network-operator-v26.7.0-rc.1", latest.NetworkOperator.ComponentVersion)
 	assert.Equal(t, stagingComponentRepository, latest.NetworkOperator.Repository)
 	assert.Equal(t, stagingOperatorRepository, latest.NetworkOperator.OperatorRepository)
 	assert.Equal(t, stagingHelmRepoURL, latest.NetworkOperator.HelmRepoURL)
-	assert.Equal(t, "doca3.5.0-26.07-0.4.3.0-0", latest.DOCADriver.Version)
+	assert.Equal(t, "doca3.5.0-26.07-0.5.1.0-0", latest.DOCADriver.Version)
 
 	beforeSecondRun := append([]byte(nil), updated...)
 	secondResult, err := syncCatalog(context.Background(), syncOptions{
@@ -294,6 +294,7 @@ func TestLatestCatalogTag(t *testing.T) {
 
 func TestRequireNewerTag(t *testing.T) {
 	require.NoError(t, requireNewerTag("v26.7.0-beta.5", "v26.7.0-beta.4"))
+	require.NoError(t, requireNewerTag("v26.7.0-rc.1", "v26.7.0-beta.5"))
 	require.NoError(t, requireNewerTag("v26.7.0", "v26.7.0-rc.1"))
 
 	err := requireNewerTag("v26.7.0-beta.4", "v26.7.0-beta.5")

--- a/pkg/networkoperatorplugin/releases/releases_test.go
+++ b/pkg/networkoperatorplugin/releases/releases_test.go
@@ -17,9 +17,9 @@
 package releases
 
 import (
-	"strings"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,23 +35,29 @@ func TestLookupRelease_Known(t *testing.T) {
 	}
 }
 
-func TestLookupRelease_BetaReleasesUseStagingArtifacts(t *testing.T) {
-	checkedBeta := false
+func TestLookupRelease_ArtifactDestinationsMatchVersion(t *testing.T) {
 	for _, key := range SupportedReleases() {
-		r, ok := LookupRelease(key)
-		require.True(t, ok, "expected catalog entry for %q", key)
-		if !strings.Contains(r.NetworkOperator.Version, "-beta.") {
-			continue
-		}
-		checkedBeta = true
+		t.Run(key, func(t *testing.T) {
+			r, ok := LookupRelease(key)
+			require.True(t, ok, "expected catalog entry for %q", key)
 
-		assert.Equal(t, "network-operator-"+r.NetworkOperator.Version, r.NetworkOperator.ComponentVersion)
-		assert.Equal(t, "nvcr.io/nvstaging/mellanox", r.NetworkOperator.Repository)
-		assert.Equal(t, "nvcr.io/nvstaging/mellanox", r.NetworkOperator.OperatorRepository)
-		assert.Equal(t, "https://helm.ngc.nvidia.com/nvstaging/mellanox", r.NetworkOperator.HelmRepoURL)
-		assert.NotEmpty(t, r.DOCADriver.Version)
+			version, err := semver.NewVersion(r.NetworkOperator.Version)
+			require.NoError(t, err, "release %s has an invalid Network Operator version", key)
+			assert.Equal(t, "network-operator-"+r.NetworkOperator.Version, r.NetworkOperator.ComponentVersion)
+			assert.NotEmpty(t, r.DOCADriver.Version)
+
+			if version.Prerelease() != "" {
+				assert.Equal(t, "nvcr.io/nvstaging/mellanox", r.NetworkOperator.Repository)
+				assert.Equal(t, "nvcr.io/nvstaging/mellanox", r.NetworkOperator.OperatorRepository)
+				assert.Equal(t, "https://helm.ngc.nvidia.com/nvstaging/mellanox", r.NetworkOperator.HelmRepoURL)
+				return
+			}
+
+			assert.Equal(t, "nvcr.io/nvidia/mellanox", r.NetworkOperator.Repository)
+			assert.Equal(t, "nvcr.io/nvidia/cloud-native", r.NetworkOperator.OperatorRepository)
+			assert.Equal(t, "https://helm.ngc.nvidia.com/nvidia", r.NetworkOperator.HelmRepoURL)
+		})
 	}
-	require.True(t, checkedBeta, "expected at least one beta release catalog entry")
 }
 
 func TestLookupRelease_XPlaneArtifactsAreIndependent(t *testing.T) {


### PR DESCRIPTION
## Summary
- validate every Network Operator catalog entry using semantic prerelease status instead of requiring a beta entry
- enforce staging destinations for prereleases and production destinations for stable releases
- cover the beta-to-RC sync transition and semantic tag ordering

## Root cause
The synchronized catalog promoted the only beta entry to `v26.7.0-rc.1`. The verifier skipped RC versions and then failed because no beta remained, even though the RC artifact destinations were valid.

Fixes the failure in https://github.com/NVIDIA/k8s-launch-kit/actions/runs/30974004019.

## Testing
- `go test -race -count=1 ./pkg/networkoperatorplugin/releases ./hack/sync-network-operator-releases`
- temporarily applied the exact generated `v26.7.0-rc.1` and DOCA catalog values, then ran `make build`
- with those synchronized values: `go test -race -count=1 ./...`
- `git diff --check`

Local `golangci-lint` was unavailable; the repository pinned v2.11 lint job will run in PR CI.