### PR TITLE
feat: add l8k clean command

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,30 +164,9 @@ Deploy a minimal Network Operator profile to automatically discover your cluster
 network capabilities and hardware configuration by using --discover-cluster-config.
 This phase can be skipped if you provide your own configuration file by using --user-config.
 This phase requires --kubeconfig to be specified.
-
 Discovery fills missing profile settings from the detected hardware and built-in
 defaults, applies explicit CLI overrides, and saves the final profile with the
 hardware inventory in cluster-config.yaml.
-
-By default discovery advertises **one rail per NIC**. When a NIC exposes several
-east-west PFs that are planes of a single physical port (e.g. Spectrum-X
-multi-plane ConnectX-8/9), only the master PF is written to `cluster-config.yaml`
-so the rail count reflects physical NICs, not PFs. A NIC whose VPD model name is
-genuinely dual-port (e.g. "... QSFP112 **2-port** ...", "... **Dual-port** ...")
-keeps a rail per port. Pass `--collapse-nic-rails=false` to restore the legacy
-behaviour of one rail per PF (useful on dev setups). The model string is read
-from `NicDevice.Status.modelName`; when it is empty the NIC is collapsed by
-default.
-
-Node groups whose NICs are **all north-south** (e.g. BlueField-DPU-only or
-out-of-band-NIC-only nodes) are **not written** to `cluster-config.yaml` — they
-produce no networking manifests and would otherwise consume an NV-IPAM subnet
-slice. North-south NICs that sit alongside east-west NICs in the same group are
-still recorded.
-
-The saved `cluster-config.yaml` also **keeps the documentation comments** from
-the config you started from (the default `l8k-config.yaml` or your
-`--user-config`), so the field reference travels with the generated file.
 
 ### Generate Deployment Files
 Based on the discovered or provided configuration,
@@ -198,15 +177,6 @@ or via a profile section in the user-config file.
 
 ### Deploy to Cluster
 Apply the generated deployment files to your Kubernetes cluster by using --deploy. This phase requires --kubeconfig and can be skipped if --deploy is not specified.
-
-The deploy step installs (or upgrades) the `nvidia/network-operator` Helm chart in-process before applying the post-install CRs. The chart version and Helm repository URL are taken from the embedded release catalog and can be selected via `--network-operator-release <MAJOR.MINOR>`. Each profile renders a per-profile `values.yaml` next to the CR manifests; `l8k deploy` reads that file and runs the install. When `networkOperator.imagePullSecrets` is configured, l8k reads matching Docker credentials from Secrets already present in the operator namespace and uses them for the chart download (including the `nvcr.io` to `helm.ngc.nvidia.com` NGC credential mapping). Secret data remains in memory and is never logged. When a release already exists with different values, deploy fails fast — pass `--overwrite-existing` to promote to `helm upgrade --install`.
-
-Deploy preflight does not treat `SriovNetworkPoolConfig`,
-`SriovNetworkNodePolicy`, or `OVSNetwork` objects labeled with
-`spectrumx.nvidia.com/owner-name` as conflicting resources. The Spectrum-X
-operator derives and owns those objects from `SpectrumXRailPoolConfig`, so a
-deploy restarted after the rail-pool controller has run remains idempotent and
-does not require `--overwrite-existing`.
 
 ### AI Agent / Automation Support
 Use --output json for structured machine-readable output (single JSON object to stdout).
@@ -240,6 +210,7 @@ Examples:
   l8k schema
 
 Available Commands:
+  clean       Remove a Network Operator deployment from a Kubernetes cluster
   completion  Generate the autocompletion script for the specified shell
   deploy      Apply previously generated manifests to a Kubernetes cluster
   discover    Discover cluster network hardware capabilities
@@ -262,7 +233,6 @@ Common Flags:
       --user-config string                  Use provided cluster configuration file (as base config for discovery or as full config without discovery)
 
 Discovery Flags:
-      --collapse-nic-rails           Advertise one rail per NIC: collapse a NIC's multi-plane PFs to its master PF, keeping a rail per port only for NICs whose VPD model is genuinely dual-port ("2-port"/"Dual-port"). Set to false to keep the legacy one-rail-per-PF behaviour (dev setups). (default true)
       --discover-cluster-config      Deploy a thin Network Operator profile to discover cluster capabilities
       --save-cluster-config string   Save discovered cluster configuration to the specified path (defaults to --user-config path if set, otherwise ./cluster-config.yaml)
 
@@ -272,18 +242,23 @@ Profile Selection Flags:
       --for string               Generate for a known server preset (replaces clusterConfig from the preset). Requires --node-selector. Run 'l8k preset list' with the same --config-dir to list available names.
       --gpu-type string          Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.
       --groups strings           Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.
+      --ignore-arp               Chain the tuning CNI meta-plugin to prevent ARP flux across pod rails
       --multirail                Override multirail deployment (defaults to true when absent; use --multirail=false to opt out)
+      --routing string           Secondary-network routing mode: destination-based or source-based. source-based chains the automatic sbr CNI meta-plugin.
       --spectrum-x string        Enable Spectrum-X by passing the SPC-X RA version (folds in the legacy --spcx-version). Supported: [RA2.1 RA2.2 RA2.3]
 
 Spectrum-X Flags:
+      --ip-version string                  Spectrum-X IP version for guide-based allocation: ipv4 or ipv6 (requires --spectrum-x)
       --multiplane-mode string             Spectrum-X multiplane mode: none, swplb, hwplb (requires --spectrum-x)
       --number-of-planes int               Number of planes for Spectrum-X (requires --spectrum-x)
       --spectrum-x-config string           Path to full Spectrum-X profile ConfigMap YAML or raw data.profile YAML (required for SPC-X RA versions newer than RA2.2)
       --spectrum-x-configmap-name string   Spectrum-X profile ConfigMap name when --spectrum-x-config contains raw data.profile YAML
+      --topology-file string               Path to spcx-gen/reference-generator or NVIDIA AIR topology JSON for Spectrum-X CIDRPool generation (requires --spectrum-x)
+      --topology-scheme string             Spectrum-X topology scheme for guide-based IP allocation: 2-tier or 3-tier (requires --spectrum-x)
 
 Generation Output Flags:
       --enable-doca-driver             Enable DOCA driver deployment (overrides config file docaDriver.enable)
-      --network-namespaces strings     Comma-separated namespaces for the secondary-network CRs and example test DaemonSets; one copy is rendered per namespace (shared resources like IPPools/NodePolicies are NOT duplicated). Overrides config networkNamespaces; default: 'default'.
+      --network-namespaces strings     Comma-separated namespaces for the secondary-network CRs and example test DaemonSets. One independent copy is rendered per namespace (shared resources like IPPools and NodePolicies are NOT duplicated). Overrides config networkNamespaces; default: 'default'.
       --save-deployment-files string   Save generated deployment files to the specified directory (default "./deployment")
       --workload-manifest string       Path to a custom workload manifest YAML (replaces the profile's default example workload)
 
@@ -299,6 +274,9 @@ Output & Logging Flags:
       --output string      Output format: text (default, human-readable) or json (structured, for automation and AI agents) (default "text")
   -q, --quiet              Suppress informational output (errors still shown)
   -y, --yes                Auto-confirm all prompts without interactive input
+
+Other Flags:
+      --collapse-nic-rails   Advertise one rail per NIC: collapse a NIC's multi-plane PFs to its master PF, keeping a rail per port only for NICs whose VPD model is genuinely dual-port ("2-port"/"Dual-port"). Set to false to keep the legacy one-rail-per-PF behaviour (dev setups). (default true)
 
 Use "l8k [command] --help" for more information about a command.
 ```
@@ -574,6 +552,30 @@ l8k generate \
 
 The preset YAML must declare a `capabilities.nodes.{sriov,rdma,ib}` block to be usable with `--for`; presets shipped with l8k already have one. See [docs/presets.rst](docs/presets.rst) for the full preset format and how to add new ones.
 
+### Remove a Network Operator Deployment
+
+`l8k clean` removes a Network Operator installation from the selected cluster:
+
+```bash
+l8k clean --kubeconfig ~/.kube/config
+```
+
+The command resolves the operator namespace from an explicit
+`--network-operator-namespace`, `networkOperator.namespace` in
+`--user-config`, `./cluster-config.yaml`, or an explicit `--config-dir`, a
+unique live Helm release, or the `nvidia-network-operator` default. It deletes
+every namespaced custom resource in that namespace, removes the known
+cluster-scoped Network Operator CRs, waits for their finalizers, and uninstalls
+the `network-operator` Helm release last. The namespace, CRDs, unrelated
+Secrets, files on disk, and custom resources outside the namespace are
+preserved; Helm metadata and chart-managed resources are removed with the
+release.
+
+Pass `--keep-helm-chart` to delete the custom resources while leaving the Helm
+release installed. Cleanup is destructive and confirms the resolved target in
+text mode. See [the cleanup guide](docs/user/cleanup.md) for the full deletion
+boundary and automation output.
+
 ### Troubleshooting Network Operator Issues
 
 Collect a diagnostic dump from the cluster:
@@ -586,7 +588,7 @@ The sosreport contains NicClusterPolicy, pod logs, node info, CRDs, and other di
 
 ### AI Agent / Automation Usage
 
-l8k supports structured output for AI agents and CI/CD pipelines. Use `--output json` to get machine-readable output, `--yes` to skip interactive prompts, and `--dry-run` to preview changes safely.
+l8k supports structured output for AI agents and CI/CD pipelines. Use `--output json` to get machine-readable output and auto-confirm subcommand prompts; `--yes` is available on the root pipeline. Use `--dry-run` to preview deployment changes safely. Because `l8k clean` has no dry-run mode, verify its kubeconfig and resolved namespace before using JSON mode.
 
 #### Structured JSON Output
 

--- a/README.md
+++ b/README.md
@@ -562,14 +562,15 @@ l8k clean --kubeconfig ~/.kube/config
 
 The command resolves the operator namespace from an explicit
 `--network-operator-namespace`, `networkOperator.namespace` in
-`--user-config`, `./cluster-config.yaml`, or an explicit `--config-dir`, a
-unique live Helm release, or the `nvidia-network-operator` default. It deletes
-every namespaced custom resource in that namespace, removes the known
-cluster-scoped Network Operator CRs, waits for their finalizers, and uninstalls
-the `network-operator` Helm release last. The namespace, CRDs, unrelated
-Secrets, files on disk, and custom resources outside the namespace are
-preserved; Helm metadata and chart-managed resources are removed with the
-release.
+`--user-config`, `./cluster-config.yaml`, or an explicit `--config-dir`, then
+the `nvidia-network-operator` default. Custom installation namespaces must be
+supplied by flag or config; in-cluster objects never select this destructive
+target. The command deletes every namespaced custom resource in that namespace,
+removes the known cluster-scoped Network Operator CRs, waits for their
+finalizers, and uninstalls the `network-operator` Helm release last. The
+namespace, CRDs, unrelated Secrets, files on disk, and custom resources outside
+the namespace are preserved; Helm metadata and chart-managed resources are
+removed with the release.
 
 Pass `--keep-helm-chart` to delete the custom resources while leaving the Helm
 release installed. Cleanup is destructive and confirms the resolved target in

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ Use this site when you are deploying SR-IOV, RDMA shared-device, host-device, In
 | CI/CD or GitOps integrator | [Automation](integrator/automation.md) |
 | AI agent integrator | [AI Skills](integrator/ai-skills.md) |
 | Operator confirming a deployment is ready for use | [Validation](user/validation.md) |
+| Operator removing a deployment | [Cleanup](user/cleanup.md) |
 | Operator investigating a failed stage | [Troubleshooting](user/troubleshooting.md) |
 
 ## Workflow
@@ -55,6 +56,7 @@ Each stage is independently invocable:
 - `l8k generate` renders a profile-specific manifest bundle under `deployment/network-operator/`.
 - `l8k deploy` installs or upgrades the Network Operator Helm chart, applies CRs in dependency order, and waits for reconciliation.
 - `l8k validate` runs the deployment acceptance checks and produces the report used to green-light the deployment.
+- `l8k clean` removes Network Operator custom resources and then uninstalls its Helm release.
 
 ## Links
 

--- a/docs/integrator/ai-skills.md
+++ b/docs/integrator/ai-skills.md
@@ -20,6 +20,7 @@ AI skills are documentation for an agent. They are not Launch Kit runtime plugin
 | `k8s-launch-kit-generate` | Select a profile and render manifests. |
 | `k8s-launch-kit-dryrun` | Preview generated or server-side deployment changes. |
 | `k8s-launch-kit-deploy` | Apply generated resources in dependency order. |
+| `k8s-launch-kit-clean` | Remove Network Operator custom resources and its Helm release. |
 | `k8s-launch-kit-validate` | Run deployment acceptance and interpret the validation report. |
 | `k8s-launch-kit-pipeline` | Coordinate discovery, generation, and deployment as an end-to-end flow. |
 | `k8s-launch-kit-troubleshoot` | Diagnose discovery, operator, SR-IOV, RDMA, and IPAM failures. |
@@ -115,6 +116,7 @@ An AI agent should:
 - Generate and inspect manifests before applying them.
 - Use `l8k deploy --dry-run` for a server-side preview.
 - Require clear authority before changing a live cluster.
+- Treat cleanup as destructive: verify the kubeconfig and resolved operator namespace before running `l8k clean`.
 - Treat `--overwrite-existing` as an explicit decision after reviewing Helm value drift.
 - Run `l8k validate` as the normal acceptance stage after deployment.
 - Use `l8k sosreport` and focused Kubernetes inspection when acceptance fails.

--- a/docs/integrator/automation.md
+++ b/docs/integrator/automation.md
@@ -67,6 +67,28 @@ A structured failure includes a stable category and retry guidance:
 
 Use `error.transient` to decide whether retry is appropriate. Treat `suggestion` as operator guidance, not a command to execute without review. The process exit code remains authoritative even when a JSON object is emitted.
 
+Cleanup returns a command-specific summary:
+
+```json
+{
+  "success": true,
+  "phase": "clean",
+  "deployed": false,
+  "cleanup": {
+    "namespace": "nvidia-network-operator",
+    "customResourcesDeleted": 12,
+    "helmReleaseRemoved": true,
+    "keepHelmChart": false
+  },
+  "messages": []
+}
+```
+
+`l8k clean --output json` auto-confirms an irreversible cluster mutation and
+has no dry-run mode. Automation must pin the intended kubeconfig and should
+pass `--network-operator-namespace` explicitly after independently checking
+the target.
+
 ## Capability Discovery
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,6 +14,7 @@ Run `l8k <command> --help` for the authoritative flag list. Run `l8k schema` for
 | `l8k discover` | Discover cluster network hardware and write `cluster-config.yaml`. |
 | `l8k generate` | Generate deployment manifests for a selected profile. |
 | `l8k deploy` | Apply previously generated manifests to a cluster. |
+| `l8k clean` | Delete Network Operator custom resources and optionally uninstall its Helm release. |
 | `l8k validate` | Verify Helm release, component versions, manifest state, and connectivity. |
 | `l8k preset list` | List local topology presets. |
 | `l8k preset update` | Download topology presets from GitHub. |
@@ -25,11 +26,11 @@ Run `l8k <command> --help` for the authoritative flag list. Run `l8k schema` for
 
 | Flag | Applies to | Description |
 | --- | --- | --- |
-| `--kubeconfig` | discover, deploy, validate | Path to kubeconfig. Falls back to `$KUBECONFIG` and then `~/.kube/config`. |
-| `--user-config` | discover, generate, deploy, validate | Config file to merge, render, or validate against. |
+| `--kubeconfig` | discover, deploy, clean, validate | Path to kubeconfig. Falls back to `$KUBECONFIG` and then `~/.kube/config`. |
+| `--user-config` | discover, generate, deploy, clean, validate | Config file to merge, render, validate against, or use for cleanup namespace resolution. |
 | `--config-dir` | all | Directory containing optional `l8k-config.yaml` and `presets/` overrides. |
 | `--network-operator-release` | discover, generate | Release line such as `26.1`, `26.4`, or `26.7`. |
-| `--network-operator-namespace` | generate, deploy, validate | Override the Network Operator namespace. It is a no-op for discovery. |
+| `--network-operator-namespace` | generate, deploy, clean, validate | Override the Network Operator namespace. It is a no-op for discovery. |
 | `--output json` | all | Emit a single JSON result to stdout for automation. |
 | `--quiet` | all | Suppress informational output. |
 | `--log-level` | all | Enable `debug`, `info`, `warn`, or `error` logging. |
@@ -98,6 +99,34 @@ Discovery also accepts the profile and Spectrum-X flags below. Explicit flags ov
 | `--dry-run` | Use server-side dry run. |
 | `--deploy-timeout` | End-to-end deploy timeout. `0` means unbounded. |
 | `--overwrite-existing` | Allow Helm upgrade when an existing Network Operator release has different values. |
+
+## Clean Flags
+
+`l8k clean` deletes every namespaced custom-resource instance in the resolved
+Network Operator namespace, then deletes the known cluster-scoped Network
+Operator CRs. It waits for their finalizers before uninstalling the
+`network-operator` Helm release. It preserves the namespace, CRDs, unrelated
+Secrets, generated files, and resources outside the namespace. Helm release
+metadata and chart-managed resources are removed with the release.
+
+Namespace resolution uses the first available source: an explicit
+`--network-operator-namespace`, `networkOperator.namespace` from
+`--user-config`, `./cluster-config.yaml`, or an explicit
+`--config-dir/l8k-config.yaml`, one unique live Helm release namespace, or
+`nvidia-network-operator`. Multiple live release namespaces are an error
+unless the namespace is explicit.
+
+| Flag | Description |
+| --- | --- |
+| `--keep-helm-chart` | Delete custom resources but leave the Network Operator Helm release and chart-managed resources installed. |
+| `--kubeconfig` | Cluster to clean. Falls back to `$KUBECONFIG` and then `~/.kube/config`. |
+| `--user-config` | Optional config used only to read `networkOperator.namespace`. |
+| `--network-operator-namespace` | Explicit cleanup namespace; takes precedence over config and live Helm discovery. |
+
+Cleanup is destructive and asks for confirmation in text mode. JSON mode is
+non-interactive and auto-confirms, so use `--output json` only after verifying
+the kubeconfig and resolved namespace. See [Cleanup](../user/cleanup.md) for the
+full deletion boundary.
 
 ## Validate Flags
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -112,16 +112,16 @@ metadata and chart-managed resources are removed with the release.
 Namespace resolution uses the first available source: an explicit
 `--network-operator-namespace`, `networkOperator.namespace` from
 `--user-config`, `./cluster-config.yaml`, or an explicit
-`--config-dir/l8k-config.yaml`, one unique live Helm release namespace, or
-`nvidia-network-operator`. Multiple live release namespaces are an error
-unless the namespace is explicit.
+`--config-dir/l8k-config.yaml`, then `nvidia-network-operator`. Custom
+installation namespaces must be explicit in a flag or config; untrusted
+in-cluster objects do not select a destructive cleanup target.
 
 | Flag | Description |
 | --- | --- |
 | `--keep-helm-chart` | Delete custom resources but leave the Network Operator Helm release and chart-managed resources installed. |
 | `--kubeconfig` | Cluster to clean. Falls back to `$KUBECONFIG` and then `~/.kube/config`. |
 | `--user-config` | Optional config used only to read `networkOperator.namespace`. |
-| `--network-operator-namespace` | Explicit cleanup namespace; takes precedence over config and live Helm discovery. |
+| `--network-operator-namespace` | Explicit cleanup namespace; takes precedence over config and the standard default. |
 
 Cleanup is destructive and asks for confirmation in text mode. JSON mode is
 non-interactive and auto-confirms, so use `--output json` only after verifying

--- a/docs/user/cleanup.md
+++ b/docs/user/cleanup.md
@@ -1,0 +1,120 @@
+<!--
+SPDX-FileCopyrightText: Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Remove a Network Operator Deployment
+
+Use `l8k clean` to tear down the Network Operator deployment on one Kubernetes
+cluster. The command removes custom resources first so the installed
+controllers can process their finalizers, then uninstalls the Helm release.
+
+```bash
+l8k clean --kubeconfig ~/.kube/config
+```
+
+The command is destructive and asks for confirmation before changing the
+cluster. Verify the kubeconfig and the displayed target namespace before
+confirming.
+
+The kubeconfig identity must be able to list CRDs and Helm release Secrets
+cluster-wide, and to list, get, and delete the selected custom resources and
+Helm-managed objects. Cluster-administrator access normally satisfies this
+requirement.
+
+## Namespace Resolution
+
+The first available namespace source wins:
+
+1. `--network-operator-namespace <namespace>`
+2. `networkOperator.namespace` in `--user-config` or
+   `./cluster-config.yaml`
+3. `networkOperator.namespace` in an explicit
+   `--config-dir/l8k-config.yaml`
+4. The namespace of one unique live `network-operator` Helm release
+5. `nvidia-network-operator`
+
+If Helm release records exist in multiple namespaces, cleanup stops and
+requires `--network-operator-namespace`. The config is read only for the
+namespace; stale release settings elsewhere in the file do not block cleanup.
+
+```bash
+l8k clean --kubeconfig ~/.kube/config \
+  --network-operator-namespace operator-system
+```
+
+## Deletion Boundary
+
+Cleanup performs these operations in order:
+
+1. Discover every namespaced CRD served by the cluster and delete all of its
+   custom-resource instances in the resolved operator namespace.
+2. Delete all instances of the Network Operator's known cluster-scoped CR
+   kinds: `HostDeviceNetwork`, `IPoIBNetwork`, `MacvlanNetwork`,
+   `NicNodePolicy`, and `NicClusterPolicy`. `NicClusterPolicy` is deleted last.
+3. Re-scan the operator namespace and the known cluster-scoped kinds, removing
+   any custom resources created or exposed during policy teardown.
+4. Wait until all selected custom resources are gone, including finalizer
+   processing.
+5. Uninstall the `network-operator` Helm release and wait for Helm-managed
+   resources to be removed.
+
+Because step 1 intentionally covers every custom-resource kind, do not keep
+unrelated custom resources in the Network Operator namespace. Cluster-scoped
+resources cannot be associated with a namespace, so every live instance of
+the five listed kinds is removed.
+
+The command preserves:
+
+- The resolved namespace
+- CustomResourceDefinitions
+- Secrets not owned by the Helm release, including unrelated registry
+  credentials
+- Custom resources outside the resolved namespace, except the five explicitly
+  listed cluster-scoped kinds
+- Generated configuration and deployment files on disk
+
+When Helm is uninstalled, Helm release metadata and any Secret rendered as a
+chart-managed resource are removed with the release.
+
+Missing CRDs, custom resources, or the Helm release are treated as successful
+no-ops, making the command safe to re-run after a partial cleanup.
+
+## Keep the Helm Release
+
+Use `--keep-helm-chart` to remove the custom resources while leaving the
+Network Operator release and its chart-managed resources installed:
+
+```bash
+l8k clean --kubeconfig ~/.kube/config --keep-helm-chart
+```
+
+This option does not narrow the custom-resource deletion boundary.
+
+## Automation
+
+JSON output is non-interactive and auto-confirms the cleanup. Use it only when
+the target has already been reviewed:
+
+```bash
+l8k clean --kubeconfig ~/.kube/config --output json 2>/dev/null | jq .
+```
+
+A successful result includes the resolved namespace, the number of deleted
+custom resources, whether Helm removed a release, and whether
+`--keep-helm-chart` was requested:
+
+```json
+{
+  "success": true,
+  "phase": "clean",
+  "deployed": false,
+  "cleanup": {
+    "namespace": "nvidia-network-operator",
+    "customResourcesDeleted": 12,
+    "helmReleaseRemoved": true,
+    "keepHelmChart": false
+  },
+  "messages": []
+}
+```

--- a/docs/user/cleanup.md
+++ b/docs/user/cleanup.md
@@ -17,10 +17,9 @@ The command is destructive and asks for confirmation before changing the
 cluster. Verify the kubeconfig and the displayed target namespace before
 confirming.
 
-The kubeconfig identity must be able to list CRDs and Helm release Secrets
-cluster-wide, and to list, get, and delete the selected custom resources and
-Helm-managed objects. Cluster-administrator access normally satisfies this
-requirement.
+The kubeconfig identity must be able to list CRDs cluster-wide, list, get, and
+delete the selected custom resources, and manage the Helm release in the target
+namespace. Cluster-administrator access normally satisfies this requirement.
 
 ## Namespace Resolution
 
@@ -31,12 +30,13 @@ The first available namespace source wins:
    `./cluster-config.yaml`
 3. `networkOperator.namespace` in an explicit
    `--config-dir/l8k-config.yaml`
-4. The namespace of one unique live `network-operator` Helm release
-5. `nvidia-network-operator`
+4. `nvidia-network-operator`
 
-If Helm release records exist in multiple namespaces, cleanup stops and
-requires `--network-operator-namespace`. The config is read only for the
-namespace; stale release settings elsewhere in the file do not block cleanup.
+Custom installation namespaces must be supplied by flag or trusted local
+config. Cleanup deliberately does not infer a destructive target from
+user-creatable in-cluster objects such as Helm release Secrets. The config is
+read only for the namespace; stale release settings elsewhere in the file do
+not block cleanup.
 
 ```bash
 l8k clean --kubeconfig ~/.kube/config \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Deployment Profiles: user/profiles.md
       - Spectrum-X: user/spectrum-x.md
       - Validation: user/validation.md
+      - Cleanup: user/cleanup.md
       - Troubleshooting: user/troubleshooting.md
   - Advanced:
       - Concepts: advanced/concepts.md

--- a/pkg/cmd/clean.go
+++ b/pkg/cmd/clean.go
@@ -1,0 +1,222 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/yaml"
+
+	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
+	"github.com/nvidia/k8s-launch-kit/pkg/kubeclient"
+	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
+	"github.com/nvidia/k8s-launch-kit/pkg/ui"
+)
+
+var keepHelmChart bool
+
+var cleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Remove a Network Operator deployment from a Kubernetes cluster",
+	Long: `Delete custom resources associated with the Network Operator deployment and,
+by default, uninstall the network-operator Helm release.
+
+The operator namespace is resolved from --network-operator-namespace, then a
+user or explicit default config, then a uniquely installed network-operator
+Helm release, and finally defaults to nvidia-network-operator. All namespaced
+custom resources in that namespace are deleted. The known cluster-scoped
+Network Operator policy and network custom resources are also removed.
+
+The namespace and CustomResourceDefinitions are preserved. Pass
+--keep-helm-chart to remove the custom resources while leaving the Helm release
+and its chart-managed resources installed.`,
+	Example: `  # Remove Network Operator CRs and uninstall the Helm release
+  l8k clean --kubeconfig ~/.kube/config
+
+  # Resolve a custom operator namespace explicitly
+  l8k clean --kubeconfig ~/.kube/config \
+    --network-operator-namespace custom-network-operator
+
+  # Remove all CRs but keep the operator chart installed
+  l8k clean --kubeconfig ~/.kube/config --keep-helm-chart
+
+  # Non-interactive agent mode (JSON output auto-confirms)
+  l8k clean --kubeconfig ~/.kube/config --output json`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		resolved, err := resolveKubeconfig(kubeconfig)
+		if err != nil {
+			exitWithError(apperrors.NewValidationError(
+				"kubeconfig required for clean",
+				err,
+				"Set $KUBECONFIG or pass --kubeconfig <path>",
+			), outputFormat)
+		}
+
+		k8sClient, restConfig, err := kubeclient.New(resolved)
+		if err != nil {
+			exitWithError(apperrors.NewClusterError(
+				"failed to create Kubernetes client",
+				err,
+				"Check that kubeconfig is valid and the cluster is reachable",
+			), outputFormat)
+		}
+
+		uiOutput, jsonOutput := ui.NewOutputForFormat(outputFormat, yesFlag)
+		ctx := ui.WithOutput(cmd.Context(), uiOutput)
+
+		configuredNamespace, source, err := configuredCleanNamespace()
+		if err != nil {
+			exitWithError(apperrors.NewValidationError(
+				"failed to resolve namespace from user config",
+				err,
+				"Fix the config or pass --network-operator-namespace <namespace>",
+			), outputFormat)
+		}
+		namespace, err := networkoperatorplugin.ResolveNetworkOperatorNamespace(
+			ctx, k8sClient, configuredNamespace)
+		if err != nil {
+			exitWithError(apperrors.NewClusterError(
+				"failed to resolve the Network Operator namespace",
+				err,
+				"Pass --network-operator-namespace <namespace> explicitly",
+			), outputFormat)
+		}
+		if problems := validation.IsDNS1123Label(namespace); len(problems) > 0 {
+			exitWithError(apperrors.NewValidationError(
+				fmt.Sprintf("invalid Network Operator namespace %q", namespace),
+				fmt.Errorf("%s", problems[0]),
+				"Pass a valid DNS-1123 namespace with --network-operator-namespace",
+			), outputFormat)
+		}
+
+		uiOutput.Section("Network Operator cleanup")
+		if source == "" {
+			source = "live Helm release or default"
+		}
+		uiOutput.Info("Target namespace: %s (%s)", namespace, source)
+		if keepHelmChart {
+			uiOutput.Info("Helm release: keep %s installed", "network-operator")
+		} else {
+			uiOutput.Info("Helm release: uninstall %s", "network-operator")
+		}
+
+		confirmed, err := uiOutput.Confirm(fmt.Sprintf(
+			"Delete all custom resources in namespace %s and the known cluster-scoped Network Operator resources?",
+			namespace,
+		))
+		if err != nil {
+			exitWithError(apperrors.NewGeneralError("failed to read cleanup confirmation", err), outputFormat)
+		}
+		if !confirmed {
+			uiOutput.Info("Cleanup cancelled; no changes were made")
+			finalizeCleanJSON(jsonOutput, namespace, 0, false, keepHelmChart)
+			return
+		}
+
+		result, err := networkoperatorplugin.Clean(ctx, k8sClient, networkoperatorplugin.CleanOptions{
+			Namespace:     namespace,
+			KeepHelmChart: keepHelmChart,
+			RestConfig:    restConfig,
+		})
+		if err != nil {
+			var structured *apperrors.StructuredError
+			if errors.As(err, &structured) {
+				exitWithError(structured, outputFormat)
+			}
+			exitWithError(apperrors.NewDeploymentError(
+				"Network Operator cleanup failed",
+				err,
+				"Resolve any stuck finalizers or RBAC errors, then re-run `l8k clean`",
+			), outputFormat)
+		}
+
+		uiOutput.Success("Cleanup completed: deleted %d custom resource(s)", result.CustomResourcesDeleted)
+		finalizeCleanJSON(
+			jsonOutput,
+			result.Namespace,
+			result.CustomResourcesDeleted,
+			result.HelmReleaseRemoved,
+			keepHelmChart,
+		)
+	},
+}
+
+func configuredCleanNamespace() (string, string, error) {
+	if networkOperatorNamespace != "" {
+		return networkOperatorNamespace, "--network-operator-namespace", nil
+	}
+	// Cleanup only needs one field from the user config. Do not apply release
+	// catalog defaults or validate unrelated deployment settings here: an old
+	// generated config must not prevent the operator from being removed.
+	path := userConfigPathBeforeDefaults()
+	if path == "" && configDir != "" {
+		var err error
+		path, err = defaultConfigPathFor(configDir)
+		if err != nil {
+			return "", "--config-dir", err
+		}
+	}
+	if path == "" {
+		return "", "", nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", path, fmt.Errorf("read %s: %w", path, err)
+	}
+	var cfg struct {
+		NetworkOperator *struct {
+			Namespace string `yaml:"namespace"`
+		} `yaml:"networkOperator"`
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return "", path, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if cfg.NetworkOperator == nil || cfg.NetworkOperator.Namespace == "" {
+		return "", "", nil
+	}
+	return cfg.NetworkOperator.Namespace, path, nil
+}
+
+func finalizeCleanJSON(
+	jsonOutput *ui.JSONOutput,
+	namespace string,
+	resources int,
+	helmRemoved bool,
+	keepHelm bool,
+) {
+	if jsonOutput == nil {
+		return
+	}
+	_ = jsonOutput.Finalize(&ui.JSONResult{
+		Success:  true,
+		Phase:    "clean",
+		Deployed: false,
+		Cleanup: &ui.CleanupResult{
+			Namespace:              namespace,
+			CustomResourcesDeleted: resources,
+			HelmReleaseRemoved:     helmRemoved,
+			KeepHelmChart:          keepHelm,
+		},
+	})
+}
+
+func init() {
+	rootCmd.AddCommand(cleanCmd)
+
+	cleanCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (falls back to $KUBECONFIG, then ~/.kube/config)")
+	cleanCmd.Flags().StringVar(&userConfig, "user-config", "", "Cluster config file used to resolve networkOperator.namespace")
+	cleanCmd.Flags().StringVar(&networkOperatorNamespace, "network-operator-namespace", "", "Override the Network Operator namespace from cluster-config.yaml")
+	cleanCmd.Flags().BoolVar(&keepHelmChart, "keep-helm-chart", false, "Delete Network Operator custom resources but keep the network-operator Helm release installed")
+
+	setFlagGroup(cleanCmd, "kubeconfig", GroupCommon)
+	setFlagGroup(cleanCmd, "user-config", GroupCommon)
+	setFlagGroup(cleanCmd, "network-operator-namespace", GroupCommon)
+	setFlagGroup(cleanCmd, "keep-helm-chart", GroupClean)
+}

--- a/pkg/cmd/clean.go
+++ b/pkg/cmd/clean.go
@@ -28,10 +28,11 @@ var cleanCmd = &cobra.Command{
 by default, uninstall the network-operator Helm release.
 
 The operator namespace is resolved from --network-operator-namespace, then a
-user or explicit default config, then a uniquely installed network-operator
-Helm release, and finally defaults to nvidia-network-operator. All namespaced
-custom resources in that namespace are deleted. The known cluster-scoped
-Network Operator policy and network custom resources are also removed.
+user or explicit default config, and finally defaults to
+nvidia-network-operator. All namespaced custom resources in that namespace are
+deleted. The known cluster-scoped Network Operator policy and network custom
+resources are also removed. Custom installation namespaces must be supplied by
+flag or config; untrusted in-cluster objects never select the cleanup target.
 
 The namespace and CustomResourceDefinitions are preserved. Pass
 --keep-helm-chart to remove the custom resources while leaving the Helm release
@@ -71,21 +72,12 @@ and its chart-managed resources installed.`,
 		uiOutput, jsonOutput := ui.NewOutputForFormat(outputFormat, yesFlag)
 		ctx := ui.WithOutput(cmd.Context(), uiOutput)
 
-		configuredNamespace, source, err := configuredCleanNamespace()
+		namespace, source, err := resolveCleanNamespace()
 		if err != nil {
 			exitWithError(apperrors.NewValidationError(
 				"failed to resolve namespace from user config",
 				err,
 				"Fix the config or pass --network-operator-namespace <namespace>",
-			), outputFormat)
-		}
-		namespace, err := networkoperatorplugin.ResolveNetworkOperatorNamespace(
-			ctx, k8sClient, configuredNamespace)
-		if err != nil {
-			exitWithError(apperrors.NewClusterError(
-				"failed to resolve the Network Operator namespace",
-				err,
-				"Pass --network-operator-namespace <namespace> explicitly",
 			), outputFormat)
 		}
 		if problems := validation.IsDNS1123Label(namespace); len(problems) > 0 {
@@ -97,9 +89,6 @@ and its chart-managed resources installed.`,
 		}
 
 		uiOutput.Section("Network Operator cleanup")
-		if source == "" {
-			source = "live Helm release or default"
-		}
 		uiOutput.Info("Target namespace: %s (%s)", namespace, source)
 		if keepHelmChart {
 			uiOutput.Info("Helm release: keep %s installed", "network-operator")
@@ -148,7 +137,7 @@ and its chart-managed resources installed.`,
 	},
 }
 
-func configuredCleanNamespace() (string, string, error) {
+func resolveCleanNamespace() (string, string, error) {
 	if networkOperatorNamespace != "" {
 		return networkOperatorNamespace, "--network-operator-namespace", nil
 	}
@@ -164,7 +153,7 @@ func configuredCleanNamespace() (string, string, error) {
 		}
 	}
 	if path == "" {
-		return "", "", nil
+		return defaultOperatorNamespace, "default", nil
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -179,7 +168,7 @@ func configuredCleanNamespace() (string, string, error) {
 		return "", path, fmt.Errorf("parse %s: %w", path, err)
 	}
 	if cfg.NetworkOperator == nil || cfg.NetworkOperator.Namespace == "" {
-		return "", "", nil
+		return defaultOperatorNamespace, "default", nil
 	}
 	return cfg.NetworkOperator.Namespace, path, nil
 }

--- a/pkg/cmd/clean_test.go
+++ b/pkg/cmd/clean_test.go
@@ -43,13 +43,13 @@ func TestCleanCommandFlags(t *testing.T) {
 	assert.Equal(t, "false", cleanCmd.Flags().Lookup("keep-helm-chart").DefValue)
 }
 
-func TestConfiguredCleanNamespace(t *testing.T) {
+func TestResolveCleanNamespace(t *testing.T) {
 	t.Run("explicit flag wins", func(t *testing.T) {
 		preserveCleanFlagState(t)
 		networkOperatorNamespace = "explicit-namespace"
 		userConfig = filepath.Join(t.TempDir(), "does-not-exist.yaml")
 
-		namespace, source, err := configuredCleanNamespace()
+		namespace, source, err := resolveCleanNamespace()
 		require.NoError(t, err)
 		assert.Equal(t, "explicit-namespace", namespace)
 		assert.Equal(t, "--network-operator-namespace", source)
@@ -66,7 +66,7 @@ unrelatedSetting:
 		networkOperatorNamespace = ""
 		userConfig = path
 
-		namespace, source, err := configuredCleanNamespace()
+		namespace, source, err := resolveCleanNamespace()
 		require.NoError(t, err)
 		assert.Equal(t, "operator-system", namespace)
 		assert.Equal(t, path, source)
@@ -79,7 +79,7 @@ unrelatedSetting:
 		networkOperatorNamespace = ""
 		userConfig = path
 
-		_, source, err := configuredCleanNamespace()
+		_, source, err := resolveCleanNamespace()
 		require.Error(t, err)
 		assert.Equal(t, path, source)
 		assert.Contains(t, err.Error(), "parse")
@@ -97,10 +97,24 @@ unrelatedSetting:
 		deploymentFiles = ""
 		configDir = dir
 
-		namespace, source, err := configuredCleanNamespace()
+		namespace, source, err := resolveCleanNamespace()
 		require.NoError(t, err)
 		assert.Equal(t, "config-dir-operator", namespace)
 		assert.Equal(t, path, source)
+	})
+
+	t.Run("uses the standard default without trusted config", func(t *testing.T) {
+		preserveCleanFlagState(t)
+		t.Chdir(t.TempDir())
+		networkOperatorNamespace = ""
+		userConfig = ""
+		deploymentFiles = ""
+		configDir = ""
+
+		namespace, source, err := resolveCleanNamespace()
+		require.NoError(t, err)
+		assert.Equal(t, defaultOperatorNamespace, namespace)
+		assert.Equal(t, "default", source)
 	})
 }
 

--- a/pkg/cmd/clean_test.go
+++ b/pkg/cmd/clean_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/ui"
+)
+
+func preserveCleanFlagState(t *testing.T) {
+	t.Helper()
+	oldNamespace := networkOperatorNamespace
+	oldUserConfig := userConfig
+	oldDeploymentFiles := deploymentFiles
+	oldConfigDir := configDir
+	t.Cleanup(func() {
+		networkOperatorNamespace = oldNamespace
+		userConfig = oldUserConfig
+		deploymentFiles = oldDeploymentFiles
+		configDir = oldConfigDir
+	})
+}
+
+func TestCleanCommandFlags(t *testing.T) {
+	for _, name := range []string{
+		"kubeconfig",
+		"user-config",
+		"network-operator-namespace",
+		"keep-helm-chart",
+	} {
+		assert.NotNil(t, cleanCmd.Flags().Lookup(name), "missing --%s", name)
+	}
+	assert.Equal(t, "false", cleanCmd.Flags().Lookup("keep-helm-chart").DefValue)
+}
+
+func TestConfiguredCleanNamespace(t *testing.T) {
+	t.Run("explicit flag wins", func(t *testing.T) {
+		preserveCleanFlagState(t)
+		networkOperatorNamespace = "explicit-namespace"
+		userConfig = filepath.Join(t.TempDir(), "does-not-exist.yaml")
+
+		namespace, source, err := configuredCleanNamespace()
+		require.NoError(t, err)
+		assert.Equal(t, "explicit-namespace", namespace)
+		assert.Equal(t, "--network-operator-namespace", source)
+	})
+
+	t.Run("reads only namespace from user config", func(t *testing.T) {
+		preserveCleanFlagState(t)
+		path := filepath.Join(t.TempDir(), "cluster-config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`networkOperator:
+  namespace: operator-system
+unrelatedSetting:
+  oldField: still-ignored
+`), 0o600))
+		networkOperatorNamespace = ""
+		userConfig = path
+
+		namespace, source, err := configuredCleanNamespace()
+		require.NoError(t, err)
+		assert.Equal(t, "operator-system", namespace)
+		assert.Equal(t, path, source)
+	})
+
+	t.Run("reports malformed user config", func(t *testing.T) {
+		preserveCleanFlagState(t)
+		path := filepath.Join(t.TempDir(), "cluster-config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("networkOperator: [\n"), 0o600))
+		networkOperatorNamespace = ""
+		userConfig = path
+
+		_, source, err := configuredCleanNamespace()
+		require.Error(t, err)
+		assert.Equal(t, path, source)
+		assert.Contains(t, err.Error(), "parse")
+	})
+
+	t.Run("reads an explicit config directory override", func(t *testing.T) {
+		preserveCleanFlagState(t)
+		dir := t.TempDir()
+		path := filepath.Join(dir, "l8k-config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`networkOperator:
+  namespace: config-dir-operator
+`), 0o600))
+		networkOperatorNamespace = ""
+		userConfig = ""
+		deploymentFiles = ""
+		configDir = dir
+
+		namespace, source, err := configuredCleanNamespace()
+		require.NoError(t, err)
+		assert.Equal(t, "config-dir-operator", namespace)
+		assert.Equal(t, path, source)
+	})
+}
+
+func TestFinalizeCleanJSON(t *testing.T) {
+	var stdout bytes.Buffer
+	jsonOutput := ui.NewJSON(&stdout, &bytes.Buffer{})
+
+	finalizeCleanJSON(jsonOutput, "operator-system", 7, false, true)
+
+	var result ui.JSONResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	assert.True(t, result.Success)
+	assert.Equal(t, "clean", result.Phase)
+	require.NotNil(t, result.Cleanup)
+	assert.Equal(t, "operator-system", result.Cleanup.Namespace)
+	assert.Equal(t, 7, result.Cleanup.CustomResourcesDeleted)
+	assert.False(t, result.Cleanup.HelmReleaseRemoved)
+	assert.True(t, result.Cleanup.KeepHelmChart)
+}

--- a/pkg/cmd/flaggroups.go
+++ b/pkg/cmd/flaggroups.go
@@ -37,8 +37,9 @@ const (
 	GroupSpectrumX     = "4-spectrumx"
 	GroupGeneration    = "5-generation"
 	GroupDeploy        = "6-deploy"
-	GroupValidation    = "7-validation"
-	GroupOutputLogging = "8-output-logging"
+	GroupClean         = "7-clean"
+	GroupValidation    = "8-validation"
+	GroupOutputLogging = "9-output-logging"
 )
 
 var groupOrder = []string{
@@ -48,6 +49,7 @@ var groupOrder = []string{
 	GroupSpectrumX,
 	GroupGeneration,
 	GroupDeploy,
+	GroupClean,
 	GroupValidation,
 	GroupOutputLogging,
 }
@@ -59,6 +61,7 @@ var groupTitles = map[string]string{
 	GroupSpectrumX:     "Spectrum-X Flags",
 	GroupGeneration:    "Generation Output Flags",
 	GroupDeploy:        "Deploy Flags",
+	GroupClean:         "Clean Flags",
 	GroupValidation:    "Validation Flags",
 	GroupOutputLogging: "Output & Logging Flags",
 }

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -74,6 +74,10 @@ var schemaCmd = &cobra.Command{
 					Description: "Apply previously generated manifests to a Kubernetes cluster (NicClusterPolicy → per-group NicNodePolicy → remaining)",
 					Example:     "l8k deploy --deployment-files ./deployment --kubeconfig ~/.kube/config",
 				},
+				"clean": {
+					Description: "Delete Network Operator custom resources and uninstall its Helm release",
+					Example:     "l8k clean --kubeconfig ~/.kube/config [--keep-helm-chart]",
+				},
 				"validate": {
 					Description: "Verify a deployment matches the selected Network Operator release (Helm chart version + manifest state + configurable ICMP/RDMA connectivity checks)",
 					Example:     "l8k validate --user-config ./cluster-config.yaml --deployment-files ./deployment",
@@ -183,6 +187,11 @@ var schemaCmd = &cobra.Command{
 					Type:        "bool",
 					Default:     "false",
 					Description: "Deploy the generated files to the Kubernetes cluster",
+				},
+				"--keep-helm-chart": {
+					Type:        "bool",
+					Default:     "false",
+					Description: "With l8k clean, delete custom resources but keep the network-operator Helm release installed",
 				},
 				"--dry-run": {
 					Type:        "bool",

--- a/pkg/networkoperatorplugin/clean.go
+++ b/pkg/networkoperatorplugin/clean.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -66,60 +65,6 @@ type cleanObjectRef struct {
 }
 
 type helmUninstallFunc func(context.Context, *rest.Config, string, time.Duration) (bool, error)
-
-// ResolveNetworkOperatorNamespace applies the live-cluster portion of clean's
-// namespace resolution. A caller-supplied namespace wins. Otherwise Helm
-// release Secrets are inspected cluster-wide; one unique release namespace is
-// selected, multiple namespaces are rejected as ambiguous, and no release
-// falls back to l8k's normal Network Operator namespace.
-func ResolveNetworkOperatorNamespace(
-	ctx context.Context,
-	kubeClient client.Client,
-	configured string,
-) (string, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if configured != "" {
-		return configured, nil
-	}
-	if kubeClient == nil {
-		return "", fmt.Errorf("resolve network operator namespace: nil Kubernetes client")
-	}
-
-	releases := &corev1.SecretList{}
-	if err := kubeClient.List(ctx, releases, client.MatchingLabels{
-		"owner": "helm",
-		"name":  helmclient.DefaultReleaseName,
-	}); err != nil {
-		return "", fmt.Errorf("list Helm release Secrets: %w", err)
-	}
-
-	set := make(map[string]struct{})
-	for i := range releases.Items {
-		namespace := releases.Items[i].Namespace
-		if namespace != "" {
-			set[namespace] = struct{}{}
-		}
-	}
-	namespaces := make([]string, 0, len(set))
-	for namespace := range set {
-		namespaces = append(namespaces, namespace)
-	}
-	sort.Strings(namespaces)
-
-	switch len(namespaces) {
-	case 0:
-		return helmclient.DefaultNamespace, nil
-	case 1:
-		return namespaces[0], nil
-	default:
-		return "", fmt.Errorf(
-			"network-operator Helm releases exist in multiple namespaces (%v); pass --network-operator-namespace",
-			namespaces,
-		)
-	}
-}
 
 // Clean deletes Network Operator custom resources and then uninstalls the
 // Helm release unless KeepHelmChart is set. Helm is always last so controllers

--- a/pkg/networkoperatorplugin/clean.go
+++ b/pkg/networkoperatorplugin/clean.go
@@ -1,0 +1,403 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkoperatorplugin
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/helmclient"
+	"github.com/nvidia/k8s-launch-kit/pkg/ui"
+)
+
+const defaultCleanPollInterval = 2 * time.Second
+
+// Cluster-scoped custom resources cannot be selected by namespace. Keep this
+// list deliberately narrow: these are the cluster-scoped kinds rendered and
+// owned by the Network Operator flow. All other cluster-scoped CRs are outside
+// l8k clean's deletion boundary.
+var clusterScopedCleanKinds = []schema.GroupVersionKind{
+	{Group: "mellanox.com", Version: "v1alpha1", Kind: "HostDeviceNetwork"},
+	{Group: "mellanox.com", Version: "v1alpha1", Kind: "IPoIBNetwork"},
+	{Group: "mellanox.com", Version: "v1alpha1", Kind: "MacvlanNetwork"},
+	{Group: "mellanox.com", Version: "v1alpha1", Kind: "NicNodePolicy"},
+	// NicClusterPolicy is last so its controller remains available while the
+	// dependent custom resources above process deletion and finalizers.
+	{Group: "mellanox.com", Version: "v1alpha1", Kind: "NicClusterPolicy"},
+}
+
+// CleanOptions controls Network Operator teardown.
+type CleanOptions struct {
+	Namespace     string
+	KeepHelmChart bool
+	RestConfig    *rest.Config
+	PollInterval  time.Duration
+	HelmTimeout   time.Duration
+}
+
+// CleanResult summarizes mutations performed by Clean.
+type CleanResult struct {
+	Namespace              string
+	CustomResourcesDeleted int
+	HelmReleaseRemoved     bool
+}
+
+type cleanObjectRef struct {
+	GVK       schema.GroupVersionKind
+	Namespace string
+	Name      string
+}
+
+type helmUninstallFunc func(context.Context, *rest.Config, string, time.Duration) (bool, error)
+
+// ResolveNetworkOperatorNamespace applies the live-cluster portion of clean's
+// namespace resolution. A caller-supplied namespace wins. Otherwise Helm
+// release Secrets are inspected cluster-wide; one unique release namespace is
+// selected, multiple namespaces are rejected as ambiguous, and no release
+// falls back to l8k's normal Network Operator namespace.
+func ResolveNetworkOperatorNamespace(
+	ctx context.Context,
+	kubeClient client.Client,
+	configured string,
+) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if configured != "" {
+		return configured, nil
+	}
+	if kubeClient == nil {
+		return "", fmt.Errorf("resolve network operator namespace: nil Kubernetes client")
+	}
+
+	releases := &corev1.SecretList{}
+	if err := kubeClient.List(ctx, releases, client.MatchingLabels{
+		"owner": "helm",
+		"name":  helmclient.DefaultReleaseName,
+	}); err != nil {
+		return "", fmt.Errorf("list Helm release Secrets: %w", err)
+	}
+
+	set := make(map[string]struct{})
+	for i := range releases.Items {
+		namespace := releases.Items[i].Namespace
+		if namespace != "" {
+			set[namespace] = struct{}{}
+		}
+	}
+	namespaces := make([]string, 0, len(set))
+	for namespace := range set {
+		namespaces = append(namespaces, namespace)
+	}
+	sort.Strings(namespaces)
+
+	switch len(namespaces) {
+	case 0:
+		return helmclient.DefaultNamespace, nil
+	case 1:
+		return namespaces[0], nil
+	default:
+		return "", fmt.Errorf(
+			"network-operator Helm releases exist in multiple namespaces (%v); pass --network-operator-namespace",
+			namespaces,
+		)
+	}
+}
+
+// Clean deletes Network Operator custom resources and then uninstalls the
+// Helm release unless KeepHelmChart is set. Helm is always last so controllers
+// remain available to process custom-resource finalizers.
+func Clean(
+	ctx context.Context,
+	kubeClient client.Client,
+	opts CleanOptions,
+) (CleanResult, error) {
+	return cleanWithUninstaller(ctx, kubeClient, opts, Uninstall)
+}
+
+func cleanWithUninstaller(
+	ctx context.Context,
+	kubeClient client.Client,
+	opts CleanOptions,
+	uninstall helmUninstallFunc,
+) (CleanResult, error) {
+	result := CleanResult{Namespace: opts.Namespace}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if kubeClient == nil {
+		return result, fmt.Errorf("clean network operator: nil Kubernetes client")
+	}
+	if opts.Namespace == "" {
+		return result, fmt.Errorf("clean network operator: namespace is required")
+	}
+	if opts.PollInterval <= 0 {
+		opts.PollInterval = defaultCleanPollInterval
+	}
+
+	uiOutput := ui.FromContext(ctx)
+	uiOutput.Section("Delete Network Operator custom resources")
+
+	deleted, err := deleteNetworkOperatorCustomResources(
+		ctx, kubeClient, opts.Namespace, opts.PollInterval, uiOutput)
+	if err != nil {
+		return result, err
+	}
+	result.CustomResourcesDeleted = deleted
+
+	if opts.KeepHelmChart {
+		uiOutput.Success("Kept Helm release %s in namespace %s",
+			helmclient.DefaultReleaseName, opts.Namespace)
+		return result, nil
+	}
+	if opts.RestConfig == nil {
+		return result, fmt.Errorf("uninstall network-operator Helm release: nil REST config")
+	}
+
+	uiOutput.Section("Uninstall Network Operator Helm chart")
+	removed, err := uninstall(ctx, opts.RestConfig, opts.Namespace, opts.HelmTimeout)
+	if err != nil {
+		return result, err
+	}
+	result.HelmReleaseRemoved = removed
+	if removed {
+		uiOutput.Success("Uninstalled Helm release %s from namespace %s",
+			helmclient.DefaultReleaseName, opts.Namespace)
+	} else {
+		uiOutput.Info("Helm release %s was not installed in namespace %s",
+			helmclient.DefaultReleaseName, opts.Namespace)
+	}
+	return result, nil
+}
+
+func deleteNetworkOperatorCustomResources(
+	ctx context.Context,
+	kubeClient client.Client,
+	namespace string,
+	pollInterval time.Duration,
+	uiOutput ui.Output,
+) (int, error) {
+	// Resolve the full initial deletion set before mutating anything. A list
+	// permission failure therefore cannot silently produce a partial cleanup.
+	namespaced, err := listNamespacedCustomResources(ctx, kubeClient, namespace)
+	if err != nil {
+		return 0, err
+	}
+	clusterScoped, err := listClusterScopedCleanResources(ctx, kubeClient)
+	if err != nil {
+		return 0, err
+	}
+
+	deleted := 0
+	for _, refs := range [][]cleanObjectRef{namespaced, clusterScoped} {
+		count, err := deleteAndWait(ctx, kubeClient, refs, pollInterval, uiOutput)
+		deleted += count
+		if err != nil {
+			return deleted, err
+		}
+	}
+
+	// Controllers can remove or briefly recreate service CRs while the root
+	// policies disappear. Sweep both scopes until they are empty after deleting
+	// NicClusterPolicy so no operator-generated CR is left behind.
+	for {
+		remainingNamespaced, err := listNamespacedCustomResources(ctx, kubeClient, namespace)
+		if err != nil {
+			return deleted, err
+		}
+		remainingClusterScoped, err := listClusterScopedCleanResources(ctx, kubeClient)
+		if err != nil {
+			return deleted, err
+		}
+		if len(remainingNamespaced) == 0 && len(remainingClusterScoped) == 0 {
+			return deleted, nil
+		}
+		for _, refs := range [][]cleanObjectRef{remainingNamespaced, remainingClusterScoped} {
+			count, err := deleteAndWait(ctx, kubeClient, refs, pollInterval, uiOutput)
+			deleted += count
+			if err != nil {
+				return deleted, err
+			}
+		}
+	}
+}
+
+func listNamespacedCustomResources(
+	ctx context.Context,
+	kubeClient client.Client,
+	namespace string,
+) ([]cleanObjectRef, error) {
+	crds := &apiextv1.CustomResourceDefinitionList{}
+	if err := kubeClient.List(ctx, crds); err != nil {
+		return nil, fmt.Errorf("list CustomResourceDefinitions: %w", err)
+	}
+	sort.Slice(crds.Items, func(i, j int) bool {
+		return crds.Items[i].Name < crds.Items[j].Name
+	})
+
+	var refs []cleanObjectRef
+	for i := range crds.Items {
+		crd := &crds.Items[i]
+		if crd.Spec.Scope != apiextv1.NamespaceScoped {
+			continue
+		}
+		version := servedStorageVersion(crd)
+		if version == "" {
+			continue
+		}
+		gvk := schema.GroupVersionKind{
+			Group:   crd.Spec.Group,
+			Version: version,
+			Kind:    crd.Spec.Names.Kind,
+		}
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(gvk.GroupVersion().WithKind(gvk.Kind + "List"))
+		if err := kubeClient.List(ctx, list, client.InNamespace(namespace)); err != nil {
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				log.Log.V(1).Info("clean: custom resource kind is no longer served",
+					"gvk", gvk.String(), "error", err.Error())
+				continue
+			}
+			return nil, fmt.Errorf("list %s custom resources in namespace %s: %w",
+				gvk.String(), namespace, err)
+		}
+		for j := range list.Items {
+			refs = append(refs, cleanObjectRef{
+				GVK:       gvk,
+				Namespace: namespace,
+				Name:      list.Items[j].GetName(),
+			})
+		}
+	}
+	sortCleanRefs(refs)
+	return refs, nil
+}
+
+func listClusterScopedCleanResources(
+	ctx context.Context,
+	kubeClient client.Client,
+) ([]cleanObjectRef, error) {
+	var refs []cleanObjectRef
+	for _, gvk := range clusterScopedCleanKinds {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(gvk.GroupVersion().WithKind(gvk.Kind + "List"))
+		if err := kubeClient.List(ctx, list); err != nil {
+			if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				continue
+			}
+			return nil, fmt.Errorf("list cluster-scoped %s custom resources: %w", gvk.String(), err)
+		}
+		sort.Slice(list.Items, func(i, j int) bool {
+			return list.Items[i].GetName() < list.Items[j].GetName()
+		})
+		for i := range list.Items {
+			refs = append(refs, cleanObjectRef{GVK: gvk, Name: list.Items[i].GetName()})
+		}
+	}
+	return refs, nil
+}
+
+func servedStorageVersion(crd *apiextv1.CustomResourceDefinition) string {
+	if crd == nil {
+		return ""
+	}
+	for _, version := range crd.Spec.Versions {
+		if version.Served && version.Storage {
+			return version.Name
+		}
+	}
+	for _, version := range crd.Spec.Versions {
+		if version.Served {
+			return version.Name
+		}
+	}
+	return ""
+}
+
+func deleteAndWait(
+	ctx context.Context,
+	kubeClient client.Client,
+	refs []cleanObjectRef,
+	pollInterval time.Duration,
+	uiOutput ui.Output,
+) (int, error) {
+	if len(refs) == 0 {
+		return 0, nil
+	}
+	propagation := metav1.DeletePropagationBackground
+	deleted := 0
+	for _, ref := range refs {
+		obj := objectForCleanRef(ref)
+		if err := kubeClient.Delete(ctx, obj, client.PropagationPolicy(propagation)); err != nil {
+			if client.IgnoreNotFound(err) == nil || meta.IsNoMatchError(err) {
+				continue
+			}
+			return deleted, fmt.Errorf("delete %s: %w", cleanRefString(ref), err)
+		}
+		deleted++
+		uiOutput.Info("Deleting %s", cleanRefString(ref))
+	}
+
+	err := wait.PollUntilContextCancel(ctx, pollInterval, true, func(ctx context.Context) (bool, error) {
+		for _, ref := range refs {
+			obj := objectForCleanRef(ref)
+			err := kubeClient.Get(ctx, types.NamespacedName{
+				Namespace: ref.Namespace,
+				Name:      ref.Name,
+			}, obj)
+			switch {
+			case err == nil:
+				return false, nil
+			case apierrors.IsNotFound(err), meta.IsNoMatchError(err):
+				continue
+			default:
+				return false, fmt.Errorf("wait for deletion of %s: %w", cleanRefString(ref), err)
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return deleted, fmt.Errorf("wait for custom resource deletion: %w", err)
+	}
+	return deleted, nil
+}
+
+func objectForCleanRef(ref cleanObjectRef) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(ref.GVK)
+	obj.SetNamespace(ref.Namespace)
+	obj.SetName(ref.Name)
+	return obj
+}
+
+func sortCleanRefs(refs []cleanObjectRef) {
+	sort.Slice(refs, func(i, j int) bool {
+		left := refs[i].GVK.String() + "/" + refs[i].Namespace + "/" + refs[i].Name
+		right := refs[j].GVK.String() + "/" + refs[j].Namespace + "/" + refs[j].Name
+		return left < right
+	})
+}
+
+func cleanRefString(ref cleanObjectRef) string {
+	if ref.Namespace == "" {
+		return fmt.Sprintf("%s %s", ref.GVK.Kind, ref.Name)
+	}
+	return fmt.Sprintf("%s %s/%s", ref.GVK.Kind, ref.Namespace, ref.Name)
+}

--- a/pkg/networkoperatorplugin/clean_test.go
+++ b/pkg/networkoperatorplugin/clean_test.go
@@ -1,0 +1,287 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkoperatorplugin
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/helmclient"
+	"github.com/nvidia/k8s-launch-kit/pkg/ui"
+)
+
+var (
+	testNamespacedGVK = schema.GroupVersionKind{
+		Group: "example.com", Version: "v1", Kind: "Widget",
+	}
+	testUnrelatedClusterGVK = schema.GroupVersionKind{
+		Group: "example.com", Version: "v1", Kind: "ClusterWidget",
+	}
+)
+
+func newCleanTestClient(t *testing.T, objects ...runtime.Object) client.WithWatch {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, apiextv1.AddToScheme(scheme))
+
+	gvks := append([]schema.GroupVersionKind{}, clusterScopedCleanKinds...)
+	gvks = append(gvks, testNamespacedGVK, testUnrelatedClusterGVK)
+	for _, gvk := range gvks {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		scheme.AddKnownTypeWithName(gvk, obj)
+
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(gvk.GroupVersion().WithKind(gvk.Kind + "List"))
+		scheme.AddKnownTypeWithName(list.GroupVersionKind(), list)
+	}
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(objects...).
+		Build()
+}
+
+func testNamespacedCRD() *apiextv1.CustomResourceDefinition {
+	return &apiextv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "widgets.example.com"},
+		Spec: apiextv1.CustomResourceDefinitionSpec{
+			Group: "example.com",
+			Names: apiextv1.CustomResourceDefinitionNames{
+				Plural: "widgets",
+				Kind:   testNamespacedGVK.Kind,
+			},
+			Scope: apiextv1.NamespaceScoped,
+			Versions: []apiextv1.CustomResourceDefinitionVersion{{
+				Name: "v1", Served: true, Storage: true,
+			}},
+		},
+	}
+}
+
+func testCleanObject(gvk schema.GroupVersionKind, namespace, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	obj.SetNamespace(namespace)
+	obj.SetName(name)
+	return obj
+}
+
+func testHelmSecret(namespace, name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				"owner": "helm",
+				"name":  helmclient.DefaultReleaseName,
+			},
+		},
+	}
+}
+
+func TestResolveNetworkOperatorNamespace(t *testing.T) {
+	t.Run("explicit namespace wins without cluster access", func(t *testing.T) {
+		namespace, err := ResolveNetworkOperatorNamespace(context.Background(), nil, "custom-ns")
+		require.NoError(t, err)
+		assert.Equal(t, "custom-ns", namespace)
+	})
+
+	t.Run("defaults when Helm release is absent", func(t *testing.T) {
+		namespace, err := ResolveNetworkOperatorNamespace(
+			context.Background(), newCleanTestClient(t), "")
+		require.NoError(t, err)
+		assert.Equal(t, helmclient.DefaultNamespace, namespace)
+	})
+
+	t.Run("resolves one unique Helm release namespace", func(t *testing.T) {
+		kubeClient := newCleanTestClient(t,
+			testHelmSecret("operator-system", "sh.helm.release.v1.network-operator.v1"),
+			testHelmSecret("operator-system", "sh.helm.release.v1.network-operator.v2"),
+		)
+		namespace, err := ResolveNetworkOperatorNamespace(context.Background(), kubeClient, "")
+		require.NoError(t, err)
+		assert.Equal(t, "operator-system", namespace)
+	})
+
+	t.Run("rejects releases in multiple namespaces", func(t *testing.T) {
+		kubeClient := newCleanTestClient(t,
+			testHelmSecret("operator-b", "release-b"),
+			testHelmSecret("operator-a", "release-a"),
+		)
+		_, err := ResolveNetworkOperatorNamespace(context.Background(), kubeClient, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "[operator-a operator-b]")
+		assert.Contains(t, err.Error(), "--network-operator-namespace")
+	})
+}
+
+func TestListNamespacedCustomResources(t *testing.T) {
+	target := testCleanObject(testNamespacedGVK, "operator-system", "target")
+	other := testCleanObject(testNamespacedGVK, "application", "preserved")
+	kubeClient := newCleanTestClient(t, testNamespacedCRD(), target, other)
+
+	refs, err := listNamespacedCustomResources(context.Background(), kubeClient, "operator-system")
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	assert.Equal(t, cleanObjectRef{
+		GVK: testNamespacedGVK, Namespace: "operator-system", Name: "target",
+	}, refs[0])
+}
+
+func TestDeleteNetworkOperatorCustomResources(t *testing.T) {
+	target := testCleanObject(testNamespacedGVK, "operator-system", "target")
+	otherNamespace := testCleanObject(testNamespacedGVK, "application", "preserved")
+	clusterScoped := make([]*unstructured.Unstructured, 0, len(clusterScopedCleanKinds))
+	for i, gvk := range clusterScopedCleanKinds {
+		clusterScoped = append(clusterScoped, testCleanObject(gvk, "", fmt.Sprintf("policy-%d", i)))
+	}
+	unrelatedCluster := testCleanObject(testUnrelatedClusterGVK, "", "preserved")
+	crd := testNamespacedCRD()
+	objects := []runtime.Object{crd, target, otherNamespace, unrelatedCluster}
+	for _, obj := range clusterScoped {
+		objects = append(objects, obj)
+	}
+	kubeClient := newCleanTestClient(t, objects...)
+
+	deleted, err := deleteNetworkOperatorCustomResources(
+		context.Background(), kubeClient, "operator-system", time.Millisecond, ui.NewSilent())
+	require.NoError(t, err)
+	assert.Equal(t, 1+len(clusterScopedCleanKinds), deleted)
+
+	deletedObjects := append([]*unstructured.Unstructured{target}, clusterScoped...)
+	for _, deletedObject := range deletedObjects {
+		actual := &unstructured.Unstructured{}
+		actual.SetGroupVersionKind(deletedObject.GroupVersionKind())
+		err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(deletedObject), actual)
+		assert.True(t, apierrors.IsNotFound(err), "%s should be deleted", deletedObject.GetName())
+	}
+
+	for _, preserved := range []*unstructured.Unstructured{otherNamespace, unrelatedCluster} {
+		actual := &unstructured.Unstructured{}
+		actual.SetGroupVersionKind(preserved.GroupVersionKind())
+		require.NoError(t, kubeClient.Get(
+			context.Background(), client.ObjectKeyFromObject(preserved), actual))
+	}
+	actualCRD := &apiextv1.CustomResourceDefinition{}
+	require.NoError(t, kubeClient.Get(
+		context.Background(), client.ObjectKey{Name: crd.Name}, actualCRD))
+}
+
+func TestDeleteNetworkOperatorCustomResourcesSweepsRecreatedClusterResource(t *testing.T) {
+	original := testCleanObject(clusterScopedCleanKinds[3], "", "original-node-policy")
+	nicClusterPolicy := testCleanObject(clusterScopedCleanKinds[4], "", "nic-cluster-policy")
+	recreated := testCleanObject(clusterScopedCleanKinds[3], "", "recreated-node-policy")
+	baseClient := newCleanTestClient(t, original, nicClusterPolicy)
+	recreatedOnce := false
+	kubeClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Delete: func(
+			ctx context.Context,
+			underlying client.WithWatch,
+			obj client.Object,
+			opts ...client.DeleteOption,
+		) error {
+			if err := underlying.Delete(ctx, obj, opts...); err != nil {
+				return err
+			}
+			if !recreatedOnce && obj.GetName() == original.GetName() {
+				recreatedOnce = true
+				return underlying.Create(ctx, recreated.DeepCopy())
+			}
+			return nil
+		},
+	})
+
+	deleted, err := deleteNetworkOperatorCustomResources(
+		context.Background(), kubeClient, "operator-system", time.Millisecond, ui.NewSilent())
+	require.NoError(t, err)
+	assert.True(t, recreatedOnce)
+	assert.Equal(t, 3, deleted)
+
+	actual := &unstructured.Unstructured{}
+	actual.SetGroupVersionKind(recreated.GroupVersionKind())
+	err = kubeClient.Get(context.Background(), client.ObjectKeyFromObject(recreated), actual)
+	assert.True(t, apierrors.IsNotFound(err), "recreated cluster-scoped CR should be swept")
+}
+
+func TestCleanKeepsHelmChart(t *testing.T) {
+	uninstallCalled := false
+	result, err := cleanWithUninstaller(
+		context.Background(),
+		newCleanTestClient(t),
+		CleanOptions{Namespace: "operator-system", KeepHelmChart: true},
+		func(context.Context, *rest.Config, string, time.Duration) (bool, error) {
+			uninstallCalled = true
+			return true, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.False(t, uninstallCalled)
+	assert.False(t, result.HelmReleaseRemoved)
+}
+
+func TestCleanUninstallsHelmAfterCustomResources(t *testing.T) {
+	target := testCleanObject(testNamespacedGVK, "operator-system", "target")
+	kubeClient := newCleanTestClient(t, testNamespacedCRD(), target)
+	restConfig := &rest.Config{Host: "https://example.invalid"}
+	uninstallCalled := false
+
+	result, err := cleanWithUninstaller(
+		context.Background(),
+		kubeClient,
+		CleanOptions{
+			Namespace:    "operator-system",
+			RestConfig:   restConfig,
+			PollInterval: time.Millisecond,
+		},
+		func(_ context.Context, actualConfig *rest.Config, namespace string, _ time.Duration) (bool, error) {
+			uninstallCalled = true
+			assert.Same(t, restConfig, actualConfig)
+			assert.Equal(t, "operator-system", namespace)
+
+			actual := &unstructured.Unstructured{}
+			actual.SetGroupVersionKind(testNamespacedGVK)
+			err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(target), actual)
+			assert.True(t, apierrors.IsNotFound(err), "custom resources must be gone before Helm uninstall")
+			return true, nil
+		},
+	)
+	require.NoError(t, err)
+	assert.True(t, uninstallCalled)
+	assert.Equal(t, 1, result.CustomResourcesDeleted)
+	assert.True(t, result.HelmReleaseRemoved)
+}
+
+func TestServedStorageVersion(t *testing.T) {
+	crd := testNamespacedCRD()
+	crd.Spec.Versions = []apiextv1.CustomResourceDefinitionVersion{
+		{Name: "v1alpha1", Served: true, Storage: false},
+		{Name: "v1", Served: true, Storage: true},
+	}
+	assert.Equal(t, "v1", servedStorageVersion(crd))
+
+	crd.Spec.Versions[1].Served = false
+	assert.Equal(t, "v1alpha1", servedStorageVersion(crd))
+
+	assert.Empty(t, servedStorageVersion(nil))
+}

--- a/pkg/networkoperatorplugin/clean_test.go
+++ b/pkg/networkoperatorplugin/clean_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/helmclient"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 )
 
@@ -41,7 +39,6 @@ var (
 func newCleanTestClient(t *testing.T, objects ...runtime.Object) client.WithWatch {
 	t.Helper()
 	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, apiextv1.AddToScheme(scheme))
 
 	gvks := append([]schema.GroupVersionKind{}, clusterScopedCleanKinds...)
@@ -85,55 +82,6 @@ func testCleanObject(gvk schema.GroupVersionKind, namespace, name string) *unstr
 	obj.SetNamespace(namespace)
 	obj.SetName(name)
 	return obj
-}
-
-func testHelmSecret(namespace, name string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-			Labels: map[string]string{
-				"owner": "helm",
-				"name":  helmclient.DefaultReleaseName,
-			},
-		},
-	}
-}
-
-func TestResolveNetworkOperatorNamespace(t *testing.T) {
-	t.Run("explicit namespace wins without cluster access", func(t *testing.T) {
-		namespace, err := ResolveNetworkOperatorNamespace(context.Background(), nil, "custom-ns")
-		require.NoError(t, err)
-		assert.Equal(t, "custom-ns", namespace)
-	})
-
-	t.Run("defaults when Helm release is absent", func(t *testing.T) {
-		namespace, err := ResolveNetworkOperatorNamespace(
-			context.Background(), newCleanTestClient(t), "")
-		require.NoError(t, err)
-		assert.Equal(t, helmclient.DefaultNamespace, namespace)
-	})
-
-	t.Run("resolves one unique Helm release namespace", func(t *testing.T) {
-		kubeClient := newCleanTestClient(t,
-			testHelmSecret("operator-system", "sh.helm.release.v1.network-operator.v1"),
-			testHelmSecret("operator-system", "sh.helm.release.v1.network-operator.v2"),
-		)
-		namespace, err := ResolveNetworkOperatorNamespace(context.Background(), kubeClient, "")
-		require.NoError(t, err)
-		assert.Equal(t, "operator-system", namespace)
-	})
-
-	t.Run("rejects releases in multiple namespaces", func(t *testing.T) {
-		kubeClient := newCleanTestClient(t,
-			testHelmSecret("operator-b", "release-b"),
-			testHelmSecret("operator-a", "release-a"),
-		)
-		_, err := ResolveNetworkOperatorNamespace(context.Background(), kubeClient, "")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "[operator-a operator-b]")
-		assert.Contains(t, err.Error(), "--network-operator-namespace")
-	})
 }
 
 func TestListNamespacedCustomResources(t *testing.T) {

--- a/pkg/networkoperatorplugin/helm.go
+++ b/pkg/networkoperatorplugin/helm.go
@@ -4,7 +4,8 @@
 
 // Package networkoperatorplugin's helm.go wraps the Helm Go SDK so that
 // `l8k deploy` can install or upgrade the network-operator chart in-process
-// before applying the post-install CRs.
+// before applying the post-install CRs, and `l8k clean` can uninstall it after
+// its custom resources have been removed.
 //
 //   - InstallOrUpgrade is the only entry point. It fetches the chart tgz
 //     from cfg.HelmRepoURL, decides install-vs-upgrade-vs-no-op by checking
@@ -68,6 +69,67 @@ var ErrReleaseExistsWithDifferentChartVersion = errors.New("network-operator rel
 // follow-up operation with "another operation in progress" until the
 // release is unstuck via `helm rollback` or `helm uninstall`.
 var ErrReleaseStuckInPendingState = errors.New("network-operator release is stuck in pending state")
+
+const defaultHelmUninstallTimeout = 10 * time.Minute
+
+// Uninstall removes l8k's network-operator Helm release from namespace. A
+// missing release is an idempotent no-op and returns removed=false.
+func Uninstall(
+	ctx context.Context,
+	restConfig *rest.Config,
+	namespace string,
+	timeout time.Duration,
+) (bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if restConfig == nil {
+		return false, pkgerrors.NewValidationError(
+			"helm uninstall requires a Kubernetes REST config",
+			nil,
+			"pass a valid kubeconfig to `l8k clean`",
+		)
+	}
+	if namespace == "" {
+		namespace = helmclient.DefaultNamespace
+	}
+	if timeout <= 0 {
+		timeout = defaultHelmUninstallTimeout
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	actionCfg, err := helmclient.NewActionConfig(restConfig, namespace, helmclient.StorageDriver)
+	if err != nil {
+		return false, pkgerrors.NewClusterError(
+			"failed to initialize helm action configuration",
+			err,
+			"verify the kubeconfig is valid and the cluster is reachable",
+		)
+	}
+	return uninstallWithActionConfig(actionCfg, namespace, timeout)
+}
+
+func uninstallWithActionConfig(
+	actionCfg *action.Configuration,
+	namespace string,
+	timeout time.Duration,
+) (bool, error) {
+	uninstall := action.NewUninstall(actionCfg)
+	uninstall.IgnoreNotFound = true
+	uninstall.Wait = true
+	uninstall.Timeout = timeout
+	response, err := uninstall.Run(helmclient.DefaultReleaseName)
+	if err != nil {
+		return false, pkgerrors.NewDeploymentError(
+			fmt.Sprintf("helm uninstall of network-operator failed in namespace %s", namespace),
+			err,
+			"inspect Helm release hooks and cluster events, then re-run `l8k clean`",
+		)
+	}
+	return response != nil, nil
+}
 
 // InstallOrUpgrade installs the nvidia/network-operator helm chart into
 // cfg.Namespace, or upgrades it when overwriteExisting=true. When the

--- a/pkg/networkoperatorplugin/helm_test.go
+++ b/pkg/networkoperatorplugin/helm_test.go
@@ -87,6 +87,30 @@ func seedRelease(t *testing.T, cfg *action.Configuration, values map[string]inte
 	require.NoError(t, cfg.Releases.Create(rel))
 }
 
+func TestUninstallWithActionConfig(t *testing.T) {
+	t.Run("removes an installed release", func(t *testing.T) {
+		actionCfg := newTestActionConfig(t)
+		seedRelease(t, actionCfg, map[string]interface{}{"nfd": map[string]interface{}{"enabled": true}})
+
+		removed, err := uninstallWithActionConfig(
+			actionCfg, helmclient.DefaultNamespace, 30*time.Second)
+		require.NoError(t, err)
+		assert.True(t, removed)
+
+		_, err = actionCfg.Releases.Last(helmclient.DefaultReleaseName)
+		assert.ErrorIs(t, err, driver.ErrReleaseNotFound)
+	})
+
+	t.Run("missing release is an idempotent no-op", func(t *testing.T) {
+		actionCfg := newTestActionConfig(t)
+
+		removed, err := uninstallWithActionConfig(
+			actionCfg, helmclient.DefaultNamespace, 30*time.Second)
+		require.NoError(t, err)
+		assert.False(t, removed)
+	})
+}
+
 func TestInstallOrUpgrade_FreshInstall(t *testing.T) {
 	actionCfg := newTestActionConfig(t)
 	generated := map[string]interface{}{"nfd": map[string]interface{}{"enabled": true}}

--- a/pkg/ui/json_output.go
+++ b/pkg/ui/json_output.go
@@ -32,6 +32,14 @@ type LogEntry struct {
 	Timestamp string `json:"timestamp"`
 }
 
+// CleanupResult is the machine-readable summary produced by l8k clean.
+type CleanupResult struct {
+	Namespace              string `json:"namespace"`
+	CustomResourcesDeleted int    `json:"customResourcesDeleted"`
+	HelmReleaseRemoved     bool   `json:"helmReleaseRemoved"`
+	KeepHelmChart          bool   `json:"keepHelmChart"`
+}
+
 // JSONResult is the structured output emitted to stdout in JSON mode.
 type JSONResult struct {
 	Success        bool              `json:"success"`
@@ -40,6 +48,7 @@ type JSONResult struct {
 	GeneratedFiles []string          `json:"generatedFiles,omitempty"`
 	Deployed       bool              `json:"deployed"`
 	DryRun         bool              `json:"dryRun,omitempty"`
+	Cleanup        *CleanupResult    `json:"cleanup,omitempty"`
 	Error          json.RawMessage   `json:"error,omitempty"`
 	Messages       []LogEntry        `json:"messages"`
 }

--- a/skills/k8s-launch-kit-clean/SKILL.md
+++ b/skills/k8s-launch-kit-clean/SKILL.md
@@ -45,7 +45,8 @@ l8k clean \
 
 Omit `--network-operator-namespace` only when the user expects l8k to resolve
 it from `--user-config`, `./cluster-config.yaml`, an explicit `--config-dir`,
-one unique live Helm release, or the `nvidia-network-operator` default.
+or the `nvidia-network-operator` default. l8k does not trust in-cluster objects
+to select a destructive cleanup target.
 
 To retain the installed release and its chart-managed resources:
 

--- a/skills/k8s-launch-kit-clean/SKILL.md
+++ b/skills/k8s-launch-kit-clean/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: k8s-launch-kit-clean
+description: "Remove an NVIDIA Network Operator deployment from a Kubernetes cluster with l8k clean. Use when the user explicitly asks to uninstall, tear down, remove, reset, or clean a Network Operator installation, delete its custom resources, or keep the Helm chart while clearing Network Operator CRs."
+---
+
+# Clean a Network Operator Deployment
+
+Read `k8s-launch-kit-shared` first for binary discovery, JSON output, and error
+handling.
+
+## Safety Boundary
+
+Treat cleanup as an irreversible live-cluster mutation. Require explicit user
+authority to remove the deployment. Do not infer cleanup authority from a
+request to inspect, validate, troubleshoot, or explain the command.
+
+Before running it:
+
+1. Resolve the intended kubeconfig and show its current context.
+2. Determine the intended Network Operator namespace.
+3. Explain that all namespaced custom resources in that namespace and every
+   known cluster-scoped Network Operator CR will be deleted.
+4. Confirm whether the Helm release should be uninstalled or retained.
+
+Use read-only checks when the target is not already explicit:
+
+```bash
+kubectl --kubeconfig <PATH> config current-context
+helm --kubeconfig <PATH> list --all-namespaces --filter '^network-operator$'
+```
+
+Stop and ask for direction if the kubeconfig, cluster, namespace, or Helm
+retention choice remains ambiguous.
+
+## Run Cleanup
+
+An AI agent uses JSON mode after the user authorizes the exact target:
+
+```bash
+l8k clean \
+  --kubeconfig <PATH> \
+  --network-operator-namespace <NAMESPACE> \
+  --output json 2>/dev/null | jq .
+```
+
+Omit `--network-operator-namespace` only when the user expects l8k to resolve
+it from `--user-config`, `./cluster-config.yaml`, an explicit `--config-dir`,
+one unique live Helm release, or the `nvidia-network-operator` default.
+
+To retain the installed release and its chart-managed resources:
+
+```bash
+l8k clean \
+  --kubeconfig <PATH> \
+  --network-operator-namespace <NAMESPACE> \
+  --keep-helm-chart \
+  --output json 2>/dev/null | jq .
+```
+
+JSON mode auto-confirms. Do not invoke it until the read-only target checks and
+authorization are complete. `l8k clean` has no dry-run mode.
+
+## Deletion Semantics
+
+The command:
+
+- Deletes every namespaced custom-resource instance in the resolved operator
+  namespace.
+- Deletes all `HostDeviceNetwork`, `IPoIBNetwork`, `MacvlanNetwork`,
+  `NicNodePolicy`, and `NicClusterPolicy` instances cluster-wide.
+- Keeps controllers installed until CR deletion and finalizers complete.
+- Uninstalls the `network-operator` Helm release last unless
+  `--keep-helm-chart` is set.
+- Preserves the namespace, CRDs, Secrets not owned by Helm, local files, and
+  namespaced custom resources elsewhere. Helm metadata and chart-managed
+  resources are removed with the release.
+- Treats already-missing resources and Helm releases as successful no-ops.
+
+Do not manually strip finalizers as part of the normal workflow. If cleanup
+waits indefinitely, inspect the affected CR, operator pods, and events; request
+separate authority before forcing finalizer removal.
+
+## Verify the Result
+
+Require `.success == true`, then report:
+
+- `.cleanup.namespace`
+- `.cleanup.customResourcesDeleted`
+- `.cleanup.helmReleaseRemoved`
+- `.cleanup.keepHelmChart`
+
+If the Helm release was meant to be removed, verify it is absent with the same
+read-only `helm list` command. If it was kept, verify it remains deployed.

--- a/skills/k8s-launch-kit-clean/agents/openai.yaml
+++ b/skills/k8s-launch-kit-clean/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "K8s Launch Kit Clean"
+  short_description: "Remove a Network Operator deployment safely"
+  default_prompt: "Use $k8s-launch-kit-clean to remove the Network Operator deployment from the selected Kubernetes cluster."

--- a/skills/k8s-launch-kit-deploy/SKILL.md
+++ b/skills/k8s-launch-kit-deploy/SKILL.md
@@ -135,4 +135,5 @@ these by applying `MaintenanceOperatorConfig` alone.
 
 - [k8s-launch-kit-shared](../k8s-launch-kit-shared/SKILL.md) — Global flags and exit codes
 - [k8s-launch-kit-dryrun](../k8s-launch-kit-dryrun/SKILL.md) — Preview before deploying
+- [k8s-launch-kit-clean](../k8s-launch-kit-clean/SKILL.md) — Remove an installed deployment
 - [k8s-launch-kit-troubleshoot](../k8s-launch-kit-troubleshoot/SKILL.md) — Debug deployment failures

--- a/skills/k8s-launch-kit-shared/SKILL.md
+++ b/skills/k8s-launch-kit-shared/SKILL.md
@@ -44,6 +44,9 @@ After installation, `l8k` is available system-wide.
 |---------|-------------|
 | `l8k discover` | Discover cluster hardware and produce cluster-config.yaml |
 | `l8k generate` | Generate Kubernetes YAML manifests from config + profile (use `--for <preset>` to skip cluster discovery for known SKUs) |
+| `l8k deploy` | Apply generated manifests and install or upgrade the Network Operator Helm release |
+| `l8k clean` | Delete Network Operator custom resources and optionally uninstall its Helm release |
+| `l8k validate` | Verify the Helm release, manifests, component versions, and connectivity |
 | `l8k preset list` | List bundled topology presets (directory + machineType + gpuType) |
 | `l8k preset update` | Download latest topology presets from GitHub |
 | `l8k sosreport` | Collect diagnostic dump from cluster |
@@ -61,7 +64,7 @@ The root command `l8k --discover-cluster-config ...` still works for backward-co
 | `--output <FORMAT>` | Output format: `text` (default), `json` |
 | `--yes` / `-y` | Auto-confirm all prompts (root command only — **not available on subcommands**; `--output json` auto-confirms) |
 | `--quiet` / `-q` | Suppress informational output (errors still shown) |
-| `--network-operator-namespace <NS>` | Override network operator namespace (default: `nvidia-network-operator`). **No-op for `l8k discover`** — discover always bootstraps into `nvidia-k8s-launch-kit`; the flag still applies to `l8k generate` / `l8k deploy` / `l8k validate`. |
+| `--network-operator-namespace <NS>` | Override network operator namespace (default: `nvidia-network-operator`). **No-op for `l8k discover`** — discover always bootstraps into `nvidia-k8s-launch-kit`; the flag still applies to `l8k generate` / `l8k deploy` / `l8k clean` / `l8k validate`. |
 | `--network-namespaces <NS,...>` | Comma-separated namespaces for the secondary-network CRs + example test DaemonSets; one copy rendered per namespace (shared resources like IPPools/NodePolicies are NOT duplicated). Default: `default` |
 | `--node-selector <LABELS>` | Restrict to nodes matching labels (comma-separated, ANDed) |
 | `--image-pull-secrets <NAMES>` | Image pull secret names for Network Operator components and authenticated Helm chart downloads (comma-separated) |

--- a/skills/k8s-network-engineer/SKILL.md
+++ b/skills/k8s-network-engineer/SKILL.md
@@ -9,6 +9,7 @@ metadata:
       - k8s-launch-kit-discover
       - k8s-launch-kit-generate
       - k8s-launch-kit-deploy
+      - k8s-launch-kit-clean
       - k8s-launch-kit-validate
       - k8s-launch-kit-pipeline
       - k8s-launch-kit-troubleshoot
@@ -18,7 +19,7 @@ metadata:
 
 # NVIDIA Network Engineer
 
-> **PREREQUISITE:** Load the following utility skills to operate as this persona: `k8s-launch-kit-shared`, `k8s-launch-kit-discover`, `k8s-launch-kit-generate`, `k8s-launch-kit-deploy`, `k8s-launch-kit-validate`, `k8s-launch-kit-pipeline`, `k8s-launch-kit-troubleshoot`, `k8s-launch-kit-config`, `k8s-launch-kit-dryrun`
+> **PREREQUISITE:** Load the following utility skills to operate as this persona: `k8s-launch-kit-shared`, `k8s-launch-kit-discover`, `k8s-launch-kit-generate`, `k8s-launch-kit-deploy`, `k8s-launch-kit-clean`, `k8s-launch-kit-validate`, `k8s-launch-kit-pipeline`, `k8s-launch-kit-troubleshoot`, `k8s-launch-kit-config`, `k8s-launch-kit-dryrun`
 
 Senior NVIDIA Networking Engineer specializing in Kubernetes cloud-native networking with k8s-launch-kit (l8k).
 
@@ -31,6 +32,7 @@ Senior NVIDIA Networking Engineer specializing in Kubernetes cloud-native networ
 - Skip discovery for known SKUs: use `l8k generate --for <preset>` (skill: `k8s-launch-kit-generate`)
 - Preview before applying: use `l8k generate --dry-run` (skill: `k8s-launch-kit-dryrun`)
 - Deploy to cluster: use `l8k deploy` (skill: `k8s-launch-kit-deploy`); legacy one-shot `l8k generate --deploy` still works.
+- Remove a deployment: use `l8k clean` only with explicit cleanup authority (skill: `k8s-launch-kit-clean`).
 - Verify a deployment matches the selected release: use `l8k validate` (skill: `k8s-launch-kit-validate`)
 - End-to-end automation: use `l8k --discover-cluster-config ... --deploy` (skill: `k8s-launch-kit-pipeline`)
 - Collect diagnostics: use `l8k sosreport` (skill: `k8s-launch-kit-troubleshoot`)
@@ -53,6 +55,7 @@ Use `l8k preset list` to see available presets. Multi-variant presets (same mach
 - Use kubectl only for supplementary tasks: pod logs, events, non-networking resources.
 - Default to SR-IOV Ethernet for new GPU clusters unless told otherwise.
 - Recommend `--dry-run` before any production deployment.
+- Before cleanup, verify the kubeconfig context and resolved Network Operator namespace, and confirm whether to retain the Helm release. Cleanup has no dry-run mode.
 - For Spectrum-X, confirm NIC type (ConnectX-8 vs BlueField-3) before selecting multiplane mode.
 - Treat `spec.withBCM` as removed from v1alpha2
   `SpectrumXRailPoolConfig`; current CRDs reject generated manifests that


### PR DESCRIPTION
## Summary

- add l8k clean with kubeconfig, user-config, operator namespace, and --keep-helm-chart support
- resolve the destructive target only from an explicit flag, trusted local config, or the standard namespace default; in-cluster objects never select it
- dynamically delete every namespaced custom resource in the target namespace, remove the five known cluster-scoped Network Operator resource kinds, sweep resources recreated during teardown, and uninstall Helm last
- preserve the namespace, CRDs, unrelated Secrets, local deployment files, and namespaced custom resources elsewhere
- expose structured cleanup results and document the command for operators, automation, and the bundled AI skills

## Safety and idempotency

The command resolves the full initial CR deletion set before mutating the cluster, waits for finalizers while controllers are still installed, and treats missing CRDs, resources, and Helm releases as successful no-ops. Text mode requires confirmation; JSON mode follows the existing subcommand convention and auto-confirms. --keep-helm-chart skips Helm uninstall without narrowing CR cleanup.

Custom installation namespaces must be passed explicitly or recorded in trusted local config. Cleanup does not trust user-creatable Helm release Secrets to choose its target.

## Validation

- go test ./... -count=1 -skip TestGetPresetsDir_(NotFound|SkipsFiles)
- go test -race ./pkg/networkoperatorplugin ./pkg/cmd ./pkg/ui
- go vet ./...
- golangci-lint v2 run ./... (0 issues)
- mkdocs build --strict --clean
- cleanup skill quick validation
- l8k clean --help and l8k schema smoke checks

No live cluster cleanup was run as part of development.