### PR TITLE
fix: declare ICMP helper in validation profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,10 @@ connectivity matrix —
 apply the example DaemonSet, wait for it to roll out completely (`numberReady ==
 desiredNumberScheduled > 0` — a single ContainerCreating-stuck pod fails),
 and run the configured checks (`icmp`, `rping`, and/or `ib_write_bw`) with
-source-bound rail identity. ICMP uses `ping -I <src-iface>`, `rping` uses
+source-bound rail identity. Every profile renders the DaemonSet with a DOCA
+container for RDMA checks and a declared `netshoot` container for ICMP; validate
+applies that manifest without injecting containers at runtime. ICMP uses
+`ping -I <src-iface>`, `rping` uses
 `-I <src-ip>`, and `ib_write_bw` uses `--bind_source_ip <src-ip>`; every test
 also records a source-qualified `ip route get <dst> from <src>` lookup. The
 matrix is on by default (`--connectivity=false` to skip) and cleans up the

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -28,6 +28,12 @@ When `--user-config` is omitted, Launch Kit checks `./cluster-config.yaml`, the 
 
 Connectivity is skipped when manifests are missing, errored, or still in progress.
 
+Each generated example DaemonSet declares two validation containers: the DOCA
+container runs `rping` and `ib_write_bw`, while the `netshoot` container runs
+ICMP and route checks from the same pod network namespace. Validation applies
+the generated DaemonSet as written; it does not inject a helper container at
+runtime.
+
 Manifest-state checks for `NicConfigurationTemplate` and `NicFirmwareTemplate` use the operator-populated `status.nicDevices` list as the matched device set. An empty list, a list that does not yet reflect the current node, NIC type, PCI-address, serial-number, and part-number selectors, a missing named `NicDevice`, a device spec that does not yet reflect the current template payload, or a relevant device condition with a stale `observedGeneration` remains `IN-PROGRESS`. `NicConfigurationTemplate` considers `FirmwareUpdateInProgress` relevant only when the matched device has `spec.firmware`; a stale firmware condition cannot block a configuration-only deployment. Unrelated discovered devices are used only to verify selector freshness; their configuration and firmware state is ignored.
 
 Preflight uses the same checks as deployment: Helm chart version, generated Helm values, component versions, and stray l8k-managed CRs. SR-IOV pool configs, node policies, and OVS networks labeled with `spectrumx.nvidia.com/owner-name` are controller-owned outputs of `SpectrumXRailPoolConfig`, so they are not reported as strays. Validation never remediates drift.

--- a/pkg/networkoperatorplugin/connectivity/connectivity.go
+++ b/pkg/networkoperatorplugin/connectivity/connectivity.go
@@ -150,9 +150,7 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 
 	hasICMP := checksContain(opts.Checks, CheckICMP)
 	hasRDMA := checksContain(opts.Checks, CheckRPing) || checksContain(opts.Checks, CheckIBWriteBW)
-	deferICMPSidecar := hasICMP && hasRDMA
-	includeICMP := hasICMP && !deferICMPSidecar
-	objs, refs, err := LoadExampleDaemonSets(opts.ManifestDir, includeICMP)
+	objs, refs, err := LoadExampleDaemonSets(opts.ManifestDir)
 	if err != nil {
 		return nil, err
 	}
@@ -160,6 +158,14 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 		return &MatrixResult{
 			Skipped: &MatrixSkip{Reason: "no example DaemonSet manifests found under " + opts.ManifestDir},
 		}, nil
+	}
+	if hasICMP {
+		for _, ref := range refs {
+			if ref.ICMPContainer == "" {
+				return nil, fmt.Errorf("example DaemonSet %s/%s from %s does not declare the %q ICMP helper container",
+					ref.Namespace, ref.Name, ref.SourceFile, icmpTestContainerName)
+			}
+		}
 	}
 
 	result := &MatrixResult{}
@@ -324,10 +330,6 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 	// tooling stays in the DOCA container that owns the RDMA resources.
 	rdmaContainerByPod, icmpContainerByPod, namespaceByPod := containerMaps(allPods)
 
-	// Stages run RDMA first when ICMP and RDMA are both enabled. In that case
-	// the initial DaemonSet rollout stays DOCA-only; the netshoot sidecar is
-	// patched in only before the ICMP stage so a restricted cluster can still
-	// produce RDMA results if the helper image cannot be pulled.
 	stages := []struct {
 		check Check
 		label string
@@ -359,26 +361,6 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			continue
 		}
 		tests := stage.tests
-		if stage.check == CheckICMP && deferICMPSidecar {
-			uiOutput.Info("Adding ICMP helper sidecar before ICMP stage")
-			icmpObjs, icmpRefs, err := LoadExampleDaemonSets(opts.ManifestDir, true)
-			if err != nil {
-				return result, err
-			}
-			icmpPods, err := applyAndCollectPods(icmpObjs, icmpRefs)
-			if err != nil {
-				uiOutput.Warning("ICMP helper rollout failed: %v — skipping ICMP stage", err)
-				log.Log.V(1).Info("skipping ICMP stage after helper rollout failure", "error", err.Error())
-				continue
-			}
-			_, icmpContainerByPod, namespaceByPod = containerMaps(icmpPods)
-			icmpPlan := PlanWithOptions(buildMatrixPods(icmpPods, false), opts.Mode, opts.Routing)
-			if icmpPlan.Skip != nil {
-				uiOutput.Warning("ICMP matrix skipped: %s", icmpPlan.Skip.Reason)
-				continue
-			}
-			tests = append(append([]PingTest{}, icmpPlan.ICMPSameRail...), icmpPlan.ICMPCrossRail...)
-		}
 		if len(tests) == 0 {
 			continue
 		}

--- a/pkg/networkoperatorplugin/connectivity/daemonset.go
+++ b/pkg/networkoperatorplugin/connectivity/daemonset.go
@@ -37,8 +37,6 @@ import (
 const (
 	rdmaTestContainerName = "test-container"
 	icmpTestContainerName = "netshoot"
-	icmpTestImage         = "nicolaka/netshoot:latest"
-	icmpTestCommand       = `trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done`
 )
 
 // DaemonSetRef identifies an applied test DaemonSet so the orchestrator
@@ -57,7 +55,7 @@ type DaemonSetRef struct {
 // per file. Multi-doc YAMLs are walked; non-DaemonSet docs are skipped
 // (the file pattern is descriptive, not enforced, so we tolerate a
 // ConfigMap or two beside the DS).
-func LoadExampleDaemonSets(manifestDir string, includeICMP bool) ([]*unstructured.Unstructured, []DaemonSetRef, error) {
+func LoadExampleDaemonSets(manifestDir string) ([]*unstructured.Unstructured, []DaemonSetRef, error) {
 	entries, err := os.ReadDir(manifestDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("read manifest dir %s: %w", manifestDir, err)
@@ -95,9 +93,6 @@ func LoadExampleDaemonSets(manifestDir string, includeICMP bool) ([]*unstructure
 				if gv, err := schema.ParseGroupVersion(apiv); err == nil {
 					obj.SetGroupVersionKind(gv.WithKind(obj.GetKind()))
 				}
-			}
-			if includeICMP {
-				ensureICMPContainer(obj)
 			}
 			rdmaContainer, icmpContainer := testContainerNames(obj)
 			objs = append(objs, obj)
@@ -274,43 +269,11 @@ func testContainerNames(ds *unstructured.Unstructured) (rdmaContainer, icmpConta
 		if rdmaContainer == "" || name == rdmaTestContainerName || strings.Contains(image, "/doca/") {
 			rdmaContainer = name
 		}
-		if icmpContainer == "" || name == icmpTestContainerName || strings.Contains(image, "netshoot") {
+		if name == icmpTestContainerName || (icmpContainer == "" && strings.Contains(image, "netshoot")) {
 			icmpContainer = name
 		}
 	}
-	if icmpContainer == "" {
-		icmpContainer = rdmaContainer
-	}
 	return rdmaContainer, icmpContainer
-}
-
-func ensureICMPContainer(ds *unstructured.Unstructured) {
-	containers, found, _ := unstructured.NestedSlice(ds.Object, "spec", "template", "spec", "containers")
-	if !found {
-		return
-	}
-	for _, raw := range containers {
-		c, ok := raw.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		name, _, _ := unstructured.NestedString(c, "name")
-		image, _, _ := unstructured.NestedString(c, "image")
-		if name == icmpTestContainerName || strings.Contains(image, "netshoot") {
-			return
-		}
-	}
-	containers = append(containers, map[string]interface{}{
-		"name":    icmpTestContainerName,
-		"image":   icmpTestImage,
-		"command": []interface{}{"/bin/bash", "-c", icmpTestCommand},
-		"securityContext": map[string]interface{}{
-			"capabilities": map[string]interface{}{
-				"add": []interface{}{"NET_RAW"},
-			},
-		},
-	})
-	_ = unstructured.SetNestedSlice(ds.Object, containers, "spec", "template", "spec", "containers")
 }
 
 // splitYAMLDocs is a minimal local copy of the YAML doc splitter in

--- a/pkg/networkoperatorplugin/connectivity/daemonset_test.go
+++ b/pkg/networkoperatorplugin/connectivity/daemonset_test.go
@@ -19,6 +19,7 @@ package connectivity
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,12 @@ spec:
       containers:
       - name: test-container
         image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
 `
 
 // writeExampleDS drops a single example DaemonSet manifest into a temp dir and
@@ -62,7 +69,7 @@ func writeExampleDS(t *testing.T) string {
 // its namespace baked in), so validate fans out across them automatically
 // without any namespace flag of its own.
 func TestLoadExampleDaemonSetsUsesManifestNamespace(t *testing.T) {
-	objs, refs, err := LoadExampleDaemonSets(writeExampleDS(t), true)
+	objs, refs, err := LoadExampleDaemonSets(writeExampleDS(t))
 	require.NoError(t, err)
 	require.Len(t, objs, 1)
 	require.Len(t, refs, 1)
@@ -76,16 +83,27 @@ func TestLoadExampleDaemonSetsUsesManifestNamespace(t *testing.T) {
 	require.Len(t, containers, 2)
 	sidecar, ok := containers[1].(map[string]interface{})
 	require.True(t, ok)
-	require.Equal(t, []interface{}{"/bin/bash", "-c", icmpTestCommand}, sidecar["command"])
+	require.Equal(t, "netshoot", sidecar["name"])
+	require.Equal(t, "nicolaka/netshoot:latest", sidecar["image"])
 }
 
-func TestLoadExampleDaemonSetsSkipsICMPSidecarWhenDisabled(t *testing.T) {
-	objs, refs, err := LoadExampleDaemonSets(writeExampleDS(t), false)
+func TestLoadExampleDaemonSetsDoesNotInventICMPContainer(t *testing.T) {
+	dir := t.TempDir()
+	manifest := strings.Replace(exampleDaemonSetManifest, `      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
+`, "", 1)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "60-example-daemonset.yaml"), []byte(manifest), 0o600))
+
+	objs, refs, err := LoadExampleDaemonSets(dir)
 	require.NoError(t, err)
 	require.Len(t, objs, 1)
 	require.Len(t, refs, 1)
 	require.Equal(t, "test-container", refs[0].RDMAContainer)
-	require.Equal(t, "test-container", refs[0].ICMPContainer)
+	require.Empty(t, refs[0].ICMPContainer)
 	containers, ok, err := unstructured.NestedSlice(objs[0].Object, "spec", "template", "spec", "containers")
 	require.NoError(t, err)
 	require.True(t, ok)

--- a/pkg/networkoperatorplugin/example_daemonset_test.go
+++ b/pkg/networkoperatorplugin/example_daemonset_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkoperatorplugin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/stretchr/testify/require"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestExampleDaemonSetTemplatesDeclareICMPHelper(t *testing.T) {
+	templates, err := filepath.Glob(filepath.Join("..", "..", "profiles", "*", "*-example-daemonset.yaml"))
+	require.NoError(t, err)
+	require.NotEmpty(t, templates)
+
+	const (
+		helperName    = "- name: netshoot"
+		helperImage   = "image: nicolaka/netshoot:latest"
+		helperCommand = "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"
+	)
+
+	for _, templatePath := range templates {
+		t.Run(filepath.Base(filepath.Dir(templatePath)), func(t *testing.T) {
+			content, err := os.ReadFile(templatePath)
+			require.NoError(t, err)
+			body := string(content)
+			daemonSetBranches := strings.Count(body, "kind: DaemonSet")
+			require.Greater(t, daemonSetBranches, 0)
+			require.Equal(t, daemonSetBranches, strings.Count(body, helperName),
+				"every rendered DaemonSet branch must declare the ICMP helper")
+			require.Equal(t, daemonSetBranches, strings.Count(body, helperImage))
+			require.Equal(t, daemonSetBranches, strings.Count(body, helperCommand))
+		})
+	}
+}
+
+func TestRenderedExampleDaemonSetsDeclareICMPHelper(t *testing.T) {
+	profilesUnderTest := []struct {
+		dir        string
+		fabric     string
+		deployment string
+	}{
+		{dir: "sriov-ethernet-rdma", fabric: "ethernet", deployment: "sriov"},
+		{dir: "sriov-ib-rdma", fabric: "infiniband", deployment: "sriov"},
+		{dir: "host-device-rdma", fabric: "ethernet", deployment: "host_device"},
+		{dir: "macvlan-rdma-shared", fabric: "ethernet", deployment: "rdma_shared"},
+		{dir: "ipoib-rdma-shared", fabric: "infiniband", deployment: "rdma_shared"},
+	}
+
+	for _, profile := range profilesUnderTest {
+		for _, multirail := range []bool{false, true} {
+			name := profile.dir + "/single-rail"
+			if multirail {
+				name = profile.dir + "/multirail"
+			}
+			t.Run(name, func(t *testing.T) {
+				rendered := renderProfileWithProfile(t, profile.dir, &config.Profile{
+					Fabric:     profile.fabric,
+					Deployment: profile.deployment,
+					Multirail:  multirail,
+				})
+				manifestName, manifest := fileMatching(t, rendered, "example-daemonset")
+				docs := parseDocs(t, manifestName, manifest)
+				require.Len(t, docs, 1)
+
+				spec := requireMap(t, docs[0], "spec")
+				template := requireMap(t, spec, "template")
+				podSpec := requireMap(t, template, "spec")
+				containers, ok := podSpec["containers"].([]any)
+				require.True(t, ok)
+				require.Len(t, containers, 2)
+				helper, ok := containers[1].(map[string]any)
+				require.True(t, ok)
+				require.Equal(t, "netshoot", helper["name"])
+				require.Equal(t, "nicolaka/netshoot:latest", helper["image"])
+			})
+		}
+	}
+}
+
+func TestRenderedSpectrumXExampleDaemonSetsDeclareICMPHelper(t *testing.T) {
+	testCases := []struct {
+		name           string
+		dir            string
+		spcxVersion    string
+		multiplaneMode string
+		numberOfPlanes int
+	}{
+		{name: "ra2.3-none", dir: "spectrum-x", spcxVersion: "RA2.3", multiplaneMode: "none", numberOfPlanes: 1},
+		{name: "ra2.3-uniplane", dir: "spectrum-x", spcxVersion: "RA2.3", multiplaneMode: "uniplane", numberOfPlanes: 1},
+		{name: "ra2.3-hwplb", dir: "spectrum-x", spcxVersion: "RA2.3", multiplaneMode: "hwplb", numberOfPlanes: 4},
+		{name: "ra2.3-swplb", dir: "spectrum-x", spcxVersion: "RA2.3", multiplaneMode: "swplb", numberOfPlanes: 2},
+		{name: "ra2.2-swplb", dir: "spectrum-x-ra2.2", spcxVersion: "RA2.2", multiplaneMode: "swplb", numberOfPlanes: 2},
+		{name: "ra2.1-none", dir: "spectrum-x-ra2.1", spcxVersion: "RA2.1", multiplaneMode: "none", numberOfPlanes: 1},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg, err := config.LoadFullConfig(
+				filepath.Join("testdata", "grouping", "mixed-same-type.yaml"), ctrllog.Log)
+			require.NoError(t, err)
+			topologyFile := writeSpectrumXTopology(t, cfg, testCase.numberOfPlanes)
+			rendered := renderProfileWithProfile(t, testCase.dir, &config.Profile{
+				Fabric:     "ethernet",
+				Deployment: "sriov",
+				Multirail:  true,
+				SpectrumX: &config.ProfileSpectrumX{
+					Enable:         true,
+					SPCXVersion:    testCase.spcxVersion,
+					MultiplaneMode: testCase.multiplaneMode,
+					NumberOfPlanes: testCase.numberOfPlanes,
+					TopologyType:   config.SpectrumXTopology2Tier,
+					TopologyFile:   topologyFile,
+				},
+			})
+
+			manifestName, manifest := fileMatching(t, rendered, "example-daemonset")
+			docs := parseDocs(t, manifestName, manifest)
+			require.Len(t, docs, 1)
+			spec := requireMap(t, docs[0], "spec")
+			template := requireMap(t, spec, "template")
+			podSpec := requireMap(t, template, "spec")
+			containers, ok := podSpec["containers"].([]any)
+			require.True(t, ok)
+			require.Len(t, containers, 2)
+			helper, ok := containers[1].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "netshoot", helper["name"])
+			require.Equal(t, "nicolaka/netshoot:latest", helper["image"])
+		})
+	}
+}
+
+func requireMap(t *testing.T, parent map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := parent[key].(map[string]any)
+	require.Truef(t, ok, "%s is missing or is not a map in %v", key, parent)
+	return value
+}

--- a/profiles/host-device-rdma/40-example-daemonset.yaml
+++ b/profiles/host-device-rdma/40-example-daemonset.yaml
@@ -62,6 +62,12 @@ spec:
             nvidia.com/{{$.Hostdev.ResourceName}}_rail_{{$pf.Rail}}: '1'
             {{- end}}
             {{- end}}
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
 {{- else}}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -117,4 +123,10 @@ spec:
             nvidia.com/{{.Hostdev.ResourceName}}: '1'
           limits:
             nvidia.com/{{.Hostdev.ResourceName}}: '1'
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
 {{- end}}

--- a/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
@@ -62,6 +62,12 @@ spec:
             rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
             {{- end}}
             {{- end}}
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
 {{- else}}
 {{/* Create DaemonSet for shared or first device network */}}
 apiVersion: apps/v1
@@ -118,4 +124,10 @@ spec:
             rdma/{{.RdmaShared.ResourceName}}: 1
           limits:
             rdma/{{.RdmaShared.ResourceName}}: 1
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
 {{end}}

--- a/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
@@ -62,6 +62,12 @@ spec:
             rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
             {{- end}}
             {{- end}}
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
 {{- else}}
 {{/* Create DaemonSet for shared network */}}
 apiVersion: apps/v1
@@ -118,4 +124,10 @@ spec:
             rdma/{{.RdmaShared.ResourceName}}: 1
           limits:
             rdma/{{.RdmaShared.ResourceName}}: 1
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
 {{end}}

--- a/profiles/spectrum-x-ra2.1/90-example-daemonset.yaml
+++ b/profiles/spectrum-x-ra2.1/90-example-daemonset.yaml
@@ -47,7 +47,6 @@ spec:
       containers:
       - name: spectrum-x-test
         image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
-        command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK", "NET_RAW"]
@@ -85,3 +84,9 @@ spec:
           echo ""
           echo "Sleeping indefinitely for manual testing..."
           sleep infinity
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]

--- a/profiles/spectrum-x-ra2.2/90-example-daemonset.yaml
+++ b/profiles/spectrum-x-ra2.2/90-example-daemonset.yaml
@@ -47,7 +47,6 @@ spec:
       containers:
       - name: spectrum-x-test
         image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
-        command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK", "NET_RAW"]
@@ -99,6 +98,12 @@ spec:
           echo ""
           echo "Sleeping indefinitely for manual testing..."
           sleep infinity
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
       {{- if spectrumXUseDRA .Profile }}
       resourceClaims:
         {{- range $railIdx := untilStep 0 $railCount 1 }}

--- a/profiles/spectrum-x/90-example-daemonset.yaml
+++ b/profiles/spectrum-x/90-example-daemonset.yaml
@@ -47,7 +47,6 @@ spec:
       containers:
       - name: spectrum-x-test
         image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
-        command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK", "NET_RAW"]
@@ -99,6 +98,12 @@ spec:
           echo ""
           echo "Sleeping indefinitely for manual testing..."
           sleep infinity
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
       {{- if spectrumXUseDRA .Profile }}
       resourceClaims:
         {{- range $railIdx := untilStep 0 $railCount 1 }}

--- a/profiles/sriov-ethernet-rdma/60-example-daemonset.yaml
+++ b/profiles/sriov-ethernet-rdma/60-example-daemonset.yaml
@@ -62,6 +62,12 @@ spec:
             nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
             {{- end}}
             {{- end}}
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
 {{- else}}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -117,4 +123,10 @@ spec:
             nvidia.com/{{.Sriov.ResourceName}}: '1'
           limits:
             nvidia.com/{{.Sriov.ResourceName}}: '1'
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
 {{- end}}

--- a/profiles/sriov-ib-rdma/60-example-daemonset.yaml
+++ b/profiles/sriov-ib-rdma/60-example-daemonset.yaml
@@ -62,6 +62,12 @@ spec:
             nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
             {{- end}}
             {{- end}}
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
 {{- else}}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -117,4 +123,10 @@ spec:
             nvidia.com/{{.Sriov.ResourceName}}: '1'
           limits:
             nvidia.com/{{.Sriov.ResourceName}}: '1'
+      - name: netshoot
+        image: nicolaka/netshoot:latest
+        command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]
+        securityContext:
+          capabilities:
+            add: ["NET_RAW"]
 {{- end}}

--- a/skills/k8s-launch-kit-validate/SKILL.md
+++ b/skills/k8s-launch-kit-validate/SKILL.md
@@ -38,7 +38,10 @@ Operator release.
    `READY`, `IN-PROGRESS`, `ERROR`, or `MISSING`.
 3. **Connectivity matrix.** By default, `l8k validate` applies the generated
    example DaemonSet, waits for ready pods, and runs source-bound `icmp`,
-   `rping`, and `ib_write_bw` tests. The default mode is `strict`.
+   `rping`, and `ib_write_bw` tests. Profile templates declare both validation
+   containers: DOCA for the RDMA checks and `netshoot` for ICMP and route
+   checks. Validate applies the generated DaemonSet without runtime container
+   injection. The default mode is `strict`.
 
 Validation also reports deploy-preflight drift without remediating it.
 `SriovNetworkPoolConfig`, `SriovNetworkNodePolicy`, and `OVSNetwork` objects


### PR DESCRIPTION
## Summary

- declare the netshoot ICMP helper in every generated example DaemonSet profile
- stop mutating validation manifests to inject the helper at runtime
- fail clearly when ICMP is requested against a manifest without the declared helper
- add raw-template and rendered-profile regression coverage, including Spectrum-X modes
- document that generated validation DaemonSets contain separate DOCA and netshoot containers

The strict-render coverage also exposed duplicate command keys in the Spectrum-X example templates. This removes the redundant first key while preserving the existing multiline DOCA command.

## Validation

- CGO_ENABLED=0 go test ./... -count=1
- CGO_ENABLED=0 go build ./...
- golangci-lint v2.11.1: 0 issues
- generated representative single-rail, multirail, heterogeneous, and Spectrum-X profiles
- built and installed the committed revision locally; installed-binary generation produced the netshoot helper with NET_RAW