### PR TITLE
fix: derive Spectrum-X NIC type from rail inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,7 +1036,7 @@ nicConfigurationOperator:
   rdmaPrefix: "rdma_r%rail%"           # RDMA device name template (%rail% substituted per rail)
   netdevPrefix: "eth_r%rail%"          # Network interface name template (%rail% substituted per rail)
 spectrumX:
-  nicType: "1023"
+  # nicSelector.nicType is derived from the shared east-west PF deviceID.
   overlay: none
   singlePlane:
     netdevPrefix: "eth_r%rail_id%"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -210,7 +210,6 @@ nicConfigurationOperator:
   updateFW: false
 
 spectrumX:
-  nicType: "1023"
   overlay: "none"
   singlePlane:
     netdevPrefix: "eth_r%rail_id%"
@@ -228,11 +227,16 @@ spectrumX:
 | `deployNicInterfaceNameTemplate` | Allows per-source interface-name templates when profile or PCI-layout rules require stable names. |
 | `rdmaPrefix` / `netdevPrefix` | Standard-profile names. Multirail values require a rail placeholder. |
 | `updateFW` | Enables firmware staging storage in generated Network Operator configuration. |
-| `spectrumX.nicType` | Device ID: `1021` ConnectX-7, `1023` ConnectX-8, `1025` ConnectX-9, or `a2dc` BlueField-3 SuperNIC. |
 | `spectrumX.overlay` | Spectrum-X overlay mode. |
 | `spectrumX.singlePlane` | Prefix block selected by `none`; defaults both device types to rail-only names. |
 | `spectrumX.hwplb` | Prefix block selected by `hwplb`; defaults RDMA to rail-only and NET to rail-plane names. |
 | `spectrumX.swplb` | Prefix block selected by `swplb`; defaults both device types to rail-plane names. |
+
+Spectrum-X `NicConfigurationTemplate.spec.nicSelector.nicType` is not a
+separate configuration input. Launch Kit derives it for each generated group
+from `clusterConfig[].pfs[].deviceID` entries whose `traffic` is `east-west`.
+North-south PFs are ignored; every selected east-west PF must have the same
+non-empty device ID or generation fails.
 
 ## Profile
 

--- a/docs/user/spectrum-x.md
+++ b/docs/user/spectrum-x.md
@@ -50,6 +50,12 @@ The platform is read from `clusterConfig[].gpuType`, with `machineType` as a
 fallback. `--for` presets participate in the same resolution before manifests
 are rendered.
 
+The generated `NicConfigurationTemplate` also derives
+`spec.nicSelector.nicType` from the target group's east-west PF device IDs.
+There is no separate `spectrumX.nicType` setting. North-south PFs are ignored,
+and generation requires every selected east-west PF to have the same non-empty
+`deviceID`.
+
 B300 and GB300 support both `swplb` and `hwplb`, so platform type does not
 identify which load-balancing mechanism the fabric uses. l8k defaults to the
 documented GA `swplb` path. Select `hwplb` explicitly when the site topology

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -288,7 +288,6 @@ type SriovConfig struct {
 }
 
 type SpectrumXConfig struct {
-	NicType     string                              `yaml:"nicType"` // "1023" for ConnectX-8, "1025" for ConnectX-9, "a2dc" for BlueField-3 SuperNIC
 	Overlay     string                              `yaml:"overlay"` // "none"
 	SinglePlane *SpectrumXInterfaceNamePrefixConfig `yaml:"singlePlane,omitempty"`
 	HWPLB       *SpectrumXInterfaceNamePrefixConfig `yaml:"hwplb,omitempty"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -497,7 +497,6 @@ sriov:
   networkName: rail-1
 
 spectrumX:
-  nicType: "1023"
   overlay: "none"
   singlePlane:
     netdevPrefix: "nic%nic_id%_r%rail%"
@@ -530,7 +529,6 @@ profile:
 
 		// Verify Spectrum-X config
 		require.NotNil(t, config.SpectrumX)
-		assert.Equal(t, "1023", config.SpectrumX.NicType)
 		assert.Equal(t, "none", config.SpectrumX.Overlay)
 		require.NotNil(t, config.SpectrumX.SinglePlane)
 		assert.Equal(t, "roce_nic%nic_id%_r%rail%", config.SpectrumX.SinglePlane.RdmaPrefix)
@@ -561,7 +559,6 @@ profile:
   namespace: network-operator
 
 spectrumX:
-  nicType: "1023"
   overlay: "none"
   rdmaPrefix: "legacy-rdma"
   netdevPrefix: "legacy-netdev"
@@ -589,7 +586,6 @@ profile:
 
 	t.Run("verify Spectrum-X struct fields", func(t *testing.T) {
 		config := &SpectrumXConfig{
-			NicType: "1023",
 			Overlay: "none",
 			HWPLB: &SpectrumXInterfaceNamePrefixConfig{
 				RdmaPrefix:   "roce_",
@@ -597,7 +593,6 @@ profile:
 			},
 		}
 
-		assert.Equal(t, "1023", config.NicType)
 		assert.Equal(t, "none", config.Overlay)
 		require.NotNil(t, config.HWPLB)
 		assert.Equal(t, "roce_", config.HWPLB.RdmaPrefix)
@@ -616,17 +611,6 @@ profile:
 		}
 	})
 
-	t.Run("verify NIC types", func(t *testing.T) {
-		connectX8 := &SpectrumXConfig{
-			NicType: "1023",
-		}
-		blueField3 := &SpectrumXConfig{
-			NicType: "a2dc",
-		}
-
-		assert.Equal(t, "1023", connectX8.NicType, "ConnectX-8 NIC type")
-		assert.Equal(t, "a2dc", blueField3.NicType, "BlueField-3 SuperNIC type")
-	})
 }
 
 func TestSpectrumXInterfaceNamePrefixes(t *testing.T) {

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -141,7 +141,8 @@ nicConfigurationOperator:
   netdevPrefix: "eth_r%rail_id%"
 
 spectrumX:
-  nicType: "1023" # "1023" for ConnectX-8, "a2dc" for BlueField-3 SuperNIC
+  # NicConfigurationTemplate nicSelector.nicType is derived from the
+  # deviceID shared by all selected east-west PFs.
   overlay: "none"
   singlePlane: # Used by multiplaneMode none
     netdevPrefix: "eth_r%rail_id%"

--- a/pkg/config/spectrumx_device.go
+++ b/pkg/config/spectrumx_device.go
@@ -1,0 +1,69 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// EastWestDeviceID returns the normalized PCI device ID shared by every
+// east-west PF in a source or render group. North-south PFs do not participate
+// because Spectrum-X configuration targets the rail fabric only.
+//
+// The bool reports whether the group contains any east-west PFs. A group with
+// missing or mixed east-west device IDs returns an error so hardware defaulting
+// and manifest generation enforce the same inventory constraints.
+func EastWestDeviceID(group ClusterConfig) (deviceID string, hasEastWest bool, err error) {
+	for _, pf := range group.PFs {
+		if pf.Traffic != "east-west" {
+			continue
+		}
+		hasEastWest = true
+		normalizedID := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(pf.DeviceID)), "0x")
+		if normalizedID == "" {
+			return "", true, fmt.Errorf("group %q has an east-west PF without a deviceID", group.Identifier)
+		}
+		if deviceID == "" {
+			deviceID = normalizedID
+			continue
+		}
+		if deviceID != normalizedID {
+			return "", true, fmt.Errorf(
+				"group %q east-west PFs have mixed deviceIDs: %q vs %q",
+				group.Identifier, deviceID, normalizedID,
+			)
+		}
+	}
+	return deviceID, hasEastWest, nil
+}
+
+// EastWestDeviceIDForGroups returns the single device ID shared by all
+// east-west PFs in the supplied groups. Groups without east-west PFs are
+// skipped. This preserves the Spectrum-X constraint that one generation run
+// cannot target multiple east-west NIC types with one profile configuration.
+func EastWestDeviceIDForGroups(groups []ClusterConfig) (deviceID string, hasEastWest bool, err error) {
+	for _, group := range groups {
+		groupDeviceID, groupHasEastWest, groupErr := EastWestDeviceID(group)
+		if groupErr != nil {
+			return "", true, groupErr
+		}
+		if !groupHasEastWest {
+			continue
+		}
+		hasEastWest = true
+		if deviceID == "" {
+			deviceID = groupDeviceID
+			continue
+		}
+		if deviceID != groupDeviceID {
+			return "", true, fmt.Errorf(
+				"east-west PFs have mixed deviceIDs: %q vs %q",
+				deviceID, groupDeviceID,
+			)
+		}
+	}
+	return deviceID, hasEastWest, nil
+}

--- a/pkg/config/spectrumx_device_test.go
+++ b/pkg/config/spectrumx_device_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEastWestDeviceID(t *testing.T) {
+	t.Run("normalizes a unanimous east-west device ID", func(t *testing.T) {
+		group := ClusterConfig{
+			Identifier: "group-a",
+			PFs: []PFConfig{
+				{DeviceID: " 0xA2DC ", Traffic: "east-west"},
+				{DeviceID: "a2dc", Traffic: "east-west"},
+				{DeviceID: "101f", Traffic: "north-south"},
+			},
+		}
+
+		deviceID, hasEastWest, err := EastWestDeviceID(group)
+
+		require.NoError(t, err)
+		assert.True(t, hasEastWest)
+		assert.Equal(t, "a2dc", deviceID)
+	})
+
+	t.Run("reports no east-west PFs", func(t *testing.T) {
+		deviceID, hasEastWest, err := EastWestDeviceID(ClusterConfig{
+			Identifier: "north-south-only",
+			PFs:        []PFConfig{{DeviceID: "101f", Traffic: "north-south"}},
+		})
+
+		require.NoError(t, err)
+		assert.False(t, hasEastWest)
+		assert.Empty(t, deviceID)
+	})
+
+	t.Run("rejects a missing east-west device ID", func(t *testing.T) {
+		_, hasEastWest, err := EastWestDeviceID(ClusterConfig{
+			Identifier: "group-a",
+			PFs:        []PFConfig{{DeviceID: "", Traffic: "east-west"}},
+		})
+
+		assert.True(t, hasEastWest)
+		require.ErrorContains(t, err, `group "group-a" has an east-west PF without a deviceID`)
+	})
+
+	t.Run("rejects mixed east-west device IDs", func(t *testing.T) {
+		_, hasEastWest, err := EastWestDeviceID(ClusterConfig{
+			Identifier: "group-a",
+			PFs: []PFConfig{
+				{DeviceID: "1023", Traffic: "east-west"},
+				{DeviceID: "a2dc", Traffic: "east-west"},
+			},
+		})
+
+		assert.True(t, hasEastWest)
+		require.ErrorContains(t, err, `group "group-a" east-west PFs have mixed deviceIDs: "1023" vs "a2dc"`)
+	})
+}
+
+func TestEastWestDeviceIDForGroups(t *testing.T) {
+	t.Run("accepts one device ID across groups", func(t *testing.T) {
+		deviceID, hasEastWest, err := EastWestDeviceIDForGroups([]ClusterConfig{
+			{Identifier: "group-a", PFs: []PFConfig{{DeviceID: "1023", Traffic: "east-west"}}},
+			{Identifier: "north-south-only", PFs: []PFConfig{{DeviceID: "101f", Traffic: "north-south"}}},
+			{Identifier: "group-b", PFs: []PFConfig{{DeviceID: "0x1023", Traffic: "east-west"}}},
+		})
+
+		require.NoError(t, err)
+		assert.True(t, hasEastWest)
+		assert.Equal(t, "1023", deviceID)
+	})
+
+	t.Run("rejects different device IDs across groups", func(t *testing.T) {
+		_, hasEastWest, err := EastWestDeviceIDForGroups([]ClusterConfig{
+			{Identifier: "group-a", PFs: []PFConfig{{DeviceID: "1023", Traffic: "east-west"}}},
+			{Identifier: "group-b", PFs: []PFConfig{{DeviceID: "a2dc", Traffic: "east-west"}}},
+		})
+
+		assert.True(t, hasEastWest)
+		require.ErrorContains(t, err, `east-west PFs have mixed deviceIDs: "1023" vs "a2dc"`)
+	})
+}

--- a/pkg/networkoperatorplugin/grouping_test.go
+++ b/pkg/networkoperatorplugin/grouping_test.go
@@ -231,6 +231,7 @@ func TestSpectrumXGrouping(t *testing.T) {
 		wantNameTmpls   []string // expected nic-interface-name-template filenames (sorted)
 		wantCidrPools   []string // expected cidrpool filenames (sorted)
 		wantNicCfgTmpls []string // expected nic-configuration-template filenames (sorted)
+		wantNicType     string   // expected nicSelector.nicType derived from east-west PFs
 	}{
 		{
 			// Two groups that share every east-west PCI address but have different
@@ -253,6 +254,7 @@ func TestSpectrumXGrouping(t *testing.T) {
 			wantNicCfgTmpls: []string{
 				"30-nicconfigurationtemplate-gpu-model-x.yaml",
 			},
+			wantNicType: "1023",
 		},
 		{
 			// Three groups with the same gpuType and east-west rail count but
@@ -276,6 +278,7 @@ func TestSpectrumXGrouping(t *testing.T) {
 			wantNicCfgTmpls: []string{
 				"30-nicconfigurationtemplate-gpu-model-y.yaml",
 			},
+			wantNicType: "a2dc",
 		},
 		{
 			// Two groups of gpu-model-y (8 east-west rails each) + one group of
@@ -306,6 +309,7 @@ func TestSpectrumXGrouping(t *testing.T) {
 				"30-nicconfigurationtemplate-gpu-model-y.yaml",
 				"30-nicconfigurationtemplate-group-2.yaml",
 			},
+			wantNicType: "a2dc",
 		},
 	}
 
@@ -325,11 +329,83 @@ func TestSpectrumXGrouping(t *testing.T) {
 			require.Equal(t, tc.wantNicCfgTmpls,
 				fileNamesMatching(rendered, "30-nicconfigurationtemplate"),
 				"nic-configuration-template manifests mismatch")
+			for _, fileName := range tc.wantNicCfgTmpls {
+				require.Contains(t, rendered[fileName], fmt.Sprintf(`nicType: %q`, tc.wantNicType),
+					"NicConfigurationTemplate must derive nicType from the group's east-west PFs")
+			}
 
 			// NCP is cluster-wide and always produced exactly once.
 			require.Equal(t, []string{"10-nicclusterpolicy.yaml"},
 				fileNamesMatching(rendered, "10-nicclusterpolicy"),
 				"expected exactly one NicClusterPolicy")
+		})
+	}
+}
+
+func TestSpectrumXGenerationValidatesEastWestDeviceIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*config.LaunchKitConfig)
+		wantErr string
+	}{
+		{
+			name: "missing device ID",
+			mutate: func(cfg *config.LaunchKitConfig) {
+				cfg.ClusterConfig[0].PFs[0].DeviceID = ""
+			},
+			wantErr: `group "group-0" has an east-west PF without a deviceID`,
+		},
+		{
+			name: "mixed device IDs across groups",
+			mutate: func(cfg *config.LaunchKitConfig) {
+				for i := range cfg.ClusterConfig[1].PFs {
+					if cfg.ClusterConfig[1].PFs[i].Traffic == "east-west" {
+						cfg.ClusterConfig[1].PFs[i].DeviceID = "1023"
+					}
+				}
+			},
+			wantErr: `east-west PFs have mixed deviceIDs: "a2dc" vs "1023"`,
+		},
+		{
+			name: "no east-west PFs",
+			mutate: func(cfg *config.LaunchKitConfig) {
+				for groupIndex := range cfg.ClusterConfig {
+					for pfIndex := range cfg.ClusterConfig[groupIndex].PFs {
+						cfg.ClusterConfig[groupIndex].PFs[pfIndex].Traffic = "north-south"
+					}
+				}
+			},
+			wantErr: "no east-west PFs",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrllog.SetLogger(zap.New(zap.UseDevMode(true)))
+			cfg, err := config.LoadFullConfig(
+				filepath.Join("testdata", "grouping", "mixed-same-type.yaml"),
+				ctrllog.Log,
+			)
+			require.NoError(t, err)
+			test.mutate(cfg)
+			topologyFile := writeSpectrumXTopology(t, cfg, 1)
+			cfg.Profile = &config.Profile{
+				Fabric:     "ethernet",
+				Deployment: "sriov",
+				Multirail:  true,
+				SpectrumX: &config.ProfileSpectrumX{
+					Enable:         true,
+					SPCXVersion:    "RA2.2",
+					MultiplaneMode: "none",
+					NumberOfPlanes: 1,
+					TopologyType:   config.SpectrumXTopology2Tier,
+					TopologyFile:   topologyFile,
+				},
+			}
+
+			_, err = (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(loadSpectrumXProfile(t), cfg)
+
+			require.ErrorContains(t, err, test.wantErr)
 		})
 	}
 }

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -131,6 +131,7 @@ var templateFuncs = template.FuncMap{
 		_, netdevPrefix := config.SpectrumXInterfaceNamePrefixes(settings, multiplaneMode)
 		return netdevPrefix
 	},
+	"spectrumXNicType":               spectrumXNicType,
 	"spectrumXProfileConfigRequired": config.SpectrumXProfileConfigRequired,
 	"spectrumXCIDRPools": func(root any, clusterConfig *config.ClusterConfig) ([]spectrumxaddressing.CIDRPool, error) {
 		var cfg *config.LaunchKitConfig
@@ -205,6 +206,24 @@ var templateFuncs = template.FuncMap{
 	// legacySriovDevicePluginConfigList does the same shape for the
 	// sriovDevicePlugin used by the 26.1 host-device profile.
 	"legacySriovDevicePluginConfigList": legacySriovDevicePluginConfigList,
+}
+
+// spectrumXNicType resolves the NicConfigurationTemplate selector from the
+// east-west rail inventory. The same resolver drives Spectrum-X hardware
+// defaults, keeping missing and mixed device-ID handling consistent between
+// profile resolution and manifest generation.
+func spectrumXNicType(group *config.ClusterConfig) (string, error) {
+	if group == nil {
+		return "", fmt.Errorf("Spectrum-X NIC type requires a clusterConfig group")
+	}
+	deviceID, hasEastWest, err := config.EastWestDeviceID(*group)
+	if err != nil {
+		return "", err
+	}
+	if !hasEastWest {
+		return "", fmt.Errorf("group %q has no east-west PFs", group.Identifier)
+	}
+	return deviceID, nil
 }
 
 func secondaryNetworkMetaPlugins(profile *config.Profile) string {
@@ -862,6 +881,19 @@ func (p *NetworkOperatorPlugin) GenerateProfileDeploymentFiles(profile *profiles
 	filtered, err := applyGroupFilter(cfg.ClusterConfig, p.Groups, p.GpuType)
 	if err != nil {
 		return nil, err
+	}
+	// Spectrum-X uses one resolved profile configuration for the whole
+	// generation target. Validate the filtered source inventory before merging
+	// so a representative merged PF list cannot hide a missing or different
+	// east-west device ID in another source group.
+	if isSpectrumX(cfg) {
+		_, hasEastWest, deviceIDErr := config.EastWestDeviceIDForGroups(filtered)
+		if deviceIDErr != nil {
+			return nil, fmt.Errorf("resolve Spectrum-X NIC type from east-west PFs: %w", deviceIDErr)
+		}
+		if !hasEastWest {
+			return nil, fmt.Errorf("resolve Spectrum-X NIC type from east-west PFs: no east-west PFs")
+		}
 	}
 
 	// Temporary workaround for the NicInterfaceNameTemplate collision

--- a/pkg/networkoperatorplugin/testdata/grouping/mixed-same-type.yaml
+++ b/pkg/networkoperatorplugin/testdata/grouping/mixed-same-type.yaml
@@ -32,7 +32,6 @@ ipoib:
 macvlan:
   networkName: macvlan-network
 spectrumX:
-  nicType: "1023"
   overlay: none
   singlePlane:
     netdevPrefix: eth_r%rail_id%

--- a/pkg/networkoperatorplugin/testdata/grouping/same-ew-different-ns.yaml
+++ b/pkg/networkoperatorplugin/testdata/grouping/same-ew-different-ns.yaml
@@ -34,7 +34,6 @@ ipoib:
 macvlan:
   networkName: macvlan-network
 spectrumX:
-  nicType: "1023"
   overlay: none
   singlePlane:
     netdevPrefix: eth_r%rail_id%

--- a/pkg/networkoperatorplugin/testdata/grouping/true-heterogeneous.yaml
+++ b/pkg/networkoperatorplugin/testdata/grouping/true-heterogeneous.yaml
@@ -32,7 +32,6 @@ ipoib:
 macvlan:
   networkName: macvlan-network
 spectrumX:
-  nicType: "1023"
   overlay: none
   singlePlane:
     netdevPrefix: eth_r%rail_id%

--- a/pkg/resolve/defaults.go
+++ b/pkg/resolve/defaults.go
@@ -318,25 +318,25 @@ func spectrumXDefaultsForHardware(groups []config.ClusterConfig) (mode string, p
 	if len(groups) == 0 {
 		return "", 0, false, "no clusterConfig groups"
 	}
-	var seenID string
+	_, hasEastWest, deviceIDErr := config.EastWestDeviceIDForGroups(groups)
+	if deviceIDErr != nil {
+		return "", 0, false, deviceIDErr.Error()
+	}
+	if !hasEastWest {
+		return "", 0, false, "no east-west PFs"
+	}
 	var seenPlatform string
 	var seenMode string
 	var seenPlanes int
 	groupsConsidered := 0
 	for _, g := range groups {
-		deviceID, hasEastWest, idReason := eastWestDeviceID(g)
+		deviceID, hasEastWest, idErr := config.EastWestDeviceID(g)
 		if !hasEastWest {
 			continue
 		}
-		if idReason != "" {
-			return "", 0, false, idReason
+		if idErr != nil {
+			return "", 0, false, idErr.Error()
 		}
-		if seenID == "" {
-			seenID = deviceID
-		} else if seenID != deviceID {
-			return "", 0, false, fmt.Sprintf("east-west PFs have mixed deviceIDs: %q vs %q", seenID, deviceID)
-		}
-
 		platform := spectrumXGPUPlatform(g)
 		groupMode, groupPlanes, groupReason := spectrumXDefaultForDeviceAndPlatform(deviceID, platform)
 		if groupMode == "" {
@@ -356,31 +356,7 @@ func spectrumXDefaultsForHardware(groups []config.ClusterConfig) (mode string, p
 		}
 		groupsConsidered++
 	}
-	if groupsConsidered == 0 {
-		return "", 0, false, "no east-west PFs"
-	}
 	return seenMode, seenPlanes, true, reason
-}
-
-func eastWestDeviceID(group config.ClusterConfig) (deviceID string, hasEastWest bool, reason string) {
-	for _, pf := range group.PFs {
-		if pf.Traffic != "east-west" {
-			continue
-		}
-		hasEastWest = true
-		normID := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(pf.DeviceID)), "0x")
-		if normID == "" {
-			return "", true, fmt.Sprintf("group %q has an east-west PF without a deviceID", group.Identifier)
-		}
-		if deviceID == "" {
-			deviceID = normID
-			continue
-		}
-		if deviceID != normID {
-			return "", true, fmt.Sprintf("group %q east-west PFs have mixed deviceIDs: %q vs %q", group.Identifier, deviceID, normID)
-		}
-	}
-	return deviceID, hasEastWest, ""
 }
 
 func spectrumXDefaultForDeviceAndPlatform(deviceID, platform string) (mode string, planes int, reason string) {

--- a/profiles/spectrum-x-ra2.1/30-nicconfigurationtemplate.yaml
+++ b/profiles/spectrum-x-ra2.1/30-nicconfigurationtemplate.yaml
@@ -11,7 +11,7 @@ spec:
     {{- end }}
   {{- end }}
   nicSelector:
-    nicType: "{{.SpectrumX.NicType}}"  # "1023" for ConnectX-8, "1025" for ConnectX-9, "a2dc" for BlueField-3 SuperNIC
+    nicType: "{{spectrumXNicType .ClusterConfig}}"
   template:
     numVfs: 1
     linkType: Ethernet

--- a/profiles/spectrum-x-ra2.2/30-nicconfigurationtemplate.yaml
+++ b/profiles/spectrum-x-ra2.2/30-nicconfigurationtemplate.yaml
@@ -11,7 +11,7 @@ spec:
     {{- end }}
   {{- end }}
   nicSelector:
-    nicType: "{{.SpectrumX.NicType}}"  # "1023" for ConnectX-8, "1025" for ConnectX-9, "a2dc" for BlueField-3 SuperNIC
+    nicType: "{{spectrumXNicType .ClusterConfig}}"
   template:
     numVfs: 1
     linkType: Ethernet

--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -31,10 +31,10 @@ nodeCapabilities:
 
 ### NIC Configuration
 
-- **nicType**: NIC device type
-  - `"1023"` for ConnectX-8
-  - `"1025"` for ConnectX-9
-  - `"a2dc"` for BlueField-3 SuperNIC
+- **nicSelector.nicType**: Derived in each generated
+  `NicConfigurationTemplate` from the device ID shared by the selected
+  east-west PFs. North-south PFs are ignored; missing or mixed east-west
+  device IDs fail generation.
 - **firmwareVersion**: Spectrum-X firmware version (e.g., `"RA2.2"`)
 - **multiplaneMode**: Multiplane configuration
   - `none`: Single plane
@@ -126,7 +126,6 @@ operator; l8k does not generate them.
 
 ```yaml
 spectrumX:
-  nicType: "1023"
   firmwareVersion: "RA2.2"
   multiplaneMode: hwplb
   numberOfPlanes: 4

--- a/profiles/spectrum-x/30-nicconfigurationtemplate.yaml
+++ b/profiles/spectrum-x/30-nicconfigurationtemplate.yaml
@@ -11,7 +11,7 @@ spec:
     {{- end }}
   {{- end }}
   nicSelector:
-    nicType: "{{.SpectrumX.NicType}}"  # "1023" for ConnectX-8, "1025" for ConnectX-9, "a2dc" for BlueField-3 SuperNIC
+    nicType: "{{spectrumXNicType .ClusterConfig}}"
   template:
     numVfs: 1
     linkType: Ethernet

--- a/profiles/spectrum-x/README.md
+++ b/profiles/spectrum-x/README.md
@@ -31,10 +31,10 @@ nodeCapabilities:
 
 ### NIC Configuration
 
-- **nicType**: NIC device type
-  - `"1023"` for ConnectX-8
-  - `"1025"` for ConnectX-9
-  - `"a2dc"` for BlueField-3 SuperNIC
+- **nicSelector.nicType**: Derived in each generated
+  `NicConfigurationTemplate` from the device ID shared by the selected
+  east-west PFs. North-south PFs are ignored; missing or mixed east-west
+  device IDs fail generation.
 - **firmwareVersion**: Spectrum-X firmware version (e.g., `"RA2.3"`)
 - **multiplaneMode**: Multiplane configuration
   - `none`: Single plane
@@ -139,7 +139,6 @@ operator; l8k does not generate them.
 
 ```yaml
 spectrumX:
-  nicType: "1023"
   firmwareVersion: "RA2.3"
   multiplaneMode: hwplb
   numberOfPlanes: 4

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -259,10 +259,6 @@ nicConfigurationOperator:
 # Used only when profile.spectrumX.enable is true.
 # ============================================================================
 spectrumX:
-  # string | default: "1023"
-  # PCI device ID of the NIC. "1023" = ConnectX-8, "1025" = ConnectX-9, "a2dc" = BlueField-3 SuperNIC.
-  nicType: "1023"
-
   # string | default: "none"
   # Overlay mode for Spectrum-X fabric.
   overlay: "none"
@@ -281,6 +277,10 @@ spectrumX:
   swplb:
     netdevPrefix: "eth_r%rail_id%_p%plane_id%"
     rdmaPrefix: "roce_r%rail_id%_p%plane_id%"
+
+# Generated Spectrum-X NicConfigurationTemplate resources derive
+# spec.nicSelector.nicType from the non-empty deviceID shared by every
+# selected east-west PF. North-south PFs are ignored.
 
 # ============================================================================
 # Profile Selection

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -158,6 +158,10 @@ win when a one-off override is needed.
   B300/GB300 platform type does not distinguish SWPLB from HWPLB. l8k defaults
   to SWPLB; use an explicit HWPLB override when the site topology requires it.
   Read `references/spectrum-x-modes.md`.
+- Spectrum-X `NicConfigurationTemplate.spec.nicSelector.nicType` is derived
+  from the device ID shared by the selected east-west PFs; do not ask users to
+  configure `spectrumX.nicType`. Missing or mixed east-west device IDs are a
+  generation error.
 - NVIDIA AIR topology support requires the documented one-based node/interface
   naming contract (`su<S>`, `h<H>`, `leaf-p<P>`, `r<R>`, `rail<R>p<P>`, and
   `pod<D>` for 3-tier). See `docs/user/spectrum-x.md` in the l8k repository.

--- a/skills/k8s-launch-kit-generate/references/spectrum-x-modes.md
+++ b/skills/k8s-launch-kit-generate/references/spectrum-x-modes.md
@@ -13,6 +13,12 @@ All Spectrum-X deployments require:
 - `multirail=true`
 - `spectrumX.enable=true`
 
+Launch Kit derives each generated
+`NicConfigurationTemplate.spec.nicSelector.nicType` from the selected
+east-west PF `deviceID` values. The selector is not configured under
+`spectrumX`; north-south PFs are ignored, and the selected east-west IDs must
+be non-empty and unanimous.
+
 ## Mode: none
 
 - **NIC type**: BlueField-3 SuperNIC (`a2dc`), ConnectX-7 (`1021`), or

--- a/skills/k8s-network-engineer/references/config-schema.md
+++ b/skills/k8s-network-engineer/references/config-schema.md
@@ -192,13 +192,15 @@ Spectrum-X specific NIC and overlay configuration.
 
 | Field         | Type   | Default                          | Description                                    |
 |---------------|--------|----------------------------------|------------------------------------------------|
-| `nicType`     | string | `1023`                           | NIC device ID: `1023` (CX8) or `a2dc` (BF3)   |
 | `overlay`     | string | `none`                           | Overlay network type                           |
 | `singlePlane` | object | rail-only prefixes                | Prefix block selected by `none` |
 | `hwplb`       | object | rail-only RDMA, rail-plane NET    | Prefix block selected by `hwplb` |
 | `swplb`       | object | rail-plane RDMA and NET           | Prefix block selected by `swplb` |
 
 Each mode object contains user-overridable `rdmaPrefix` and `netdevPrefix` strings.
+The generated `NicConfigurationTemplate.spec.nicSelector.nicType` comes from
+the unanimous, non-empty `deviceID` of the selected east-west PFs;
+north-south PFs do not participate.
 
 ## profile
 

--- a/skills/k8s-network-engineer/references/profile-decision-tree.md
+++ b/skills/k8s-network-engineer/references/profile-decision-tree.md
@@ -173,9 +173,9 @@ guide profile selection:
 | Spectrum-X, SPCX, AI cloud           | `spectrumX=true`              |
 | host device, DPDK, passthrough        | `deployment=host_device`      |
 | shared, multi-tenant, many pods       | `deployment=rdma_shared`      |
-| BlueField, BF3, SuperNIC, DPU        | `spectrumX.nicType=a2dc`      |
-| ConnectX-8, CX8                       | `spectrumX.nicType=1023`      |
-| ConnectX-9, CX9                       | `spectrumX.nicType=1025`      |
+| BlueField, BF3, SuperNIC, DPU        | east-west PF `deviceID=a2dc`  |
+| ConnectX-8, CX8                       | east-west PF `deviceID=1023`  |
+| ConnectX-9, CX9                       | east-west PF `deviceID=1025`  |
 
 ## Decision Flow
 


### PR DESCRIPTION
## Summary

- remove the duplicate `spectrumX.nicType` configuration input
- derive generated `NicConfigurationTemplate.spec.nicSelector.nicType` from the selected east-west PF inventory
- reuse the same missing and mixed device-ID constraints for hardware defaulting and generation
- update all Spectrum-X profile variants, docs, fixtures, and bundled skills

## Validation

- `go test -count=1 ./...`
- `CGO_ENABLED=0 go build ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `mkdocs build --strict --clean`
- `git diff --check`