### PR TITLE
Add target-aware CLI foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 K8s Launch Kit (l8k) is a CLI tool for deploying and managing NVIDIA cloud-native solutions on Kubernetes. The tool helps provide flexible deployment workflows for optimal network performance with SR-IOV, RDMA, and other networking technologies.
 
+The four lifecycle commands are target-aware. The existing Network Operator
+workflow is the `host` target and remains the default, so current commands do
+not need to change. `--target host` is an explicit synonym. The `dpf` target
+name is reserved for future DPU-plane provisioning and currently reports its
+phases as unavailable instead of executing host logic. See the
+[target-aware CLI architecture](docs/advanced/targets.md) and run `l8k schema`
+for machine-readable target, phase, and flag ownership information.
+
 ## Documentation
 
 Standalone documentation is published from this repository to GitHub Pages:
@@ -231,7 +239,10 @@ Available Commands:
   validate    Verify a deployment matches the selected Network Operator release
   version     Print the version number
 
-Common Flags:
+Target Selection Flags:
+      --target string   Deployment target: host (default) or dpf (reserved; phases are unavailable until the DPF driver is added) (default "host")
+
+Host Target Common Flags:
       --config-dir string                   Directory containing optional l8k-config.yaml and presets/ overrides
       --enabled-plugins string              Comma-separated list of plugins to enable (default "network-operator")
       --image-pull-secrets strings          Image pull secret names for Network Operator components and authenticated Helm downloads (comma-separated)
@@ -241,11 +252,12 @@ Common Flags:
       --node-selector string                Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe (default "feature.node.kubernetes.io/pci-15b3.present=true")
       --user-config string                  Use provided cluster configuration file (as base config for discovery or as full config without discovery)
 
-Discovery Flags:
+Host Target Discovery Flags:
+      --collapse-nic-rails           Advertise one rail per NIC: collapse a NIC's multi-plane PFs to its master PF, keeping a rail per port only for NICs whose VPD model is genuinely dual-port ("2-port"/"Dual-port"). Set to false to keep the legacy one-rail-per-PF behaviour (dev setups). (default true)
       --discover-cluster-config      Deploy a thin Network Operator profile to discover cluster capabilities
       --save-cluster-config string   Save discovered cluster configuration to the specified path (defaults to --user-config path if set, otherwise ./cluster-config.yaml)
 
-Profile Selection Flags:
+Host Target Profile Selection Flags:
       --deployment-type string   Select the deployment type (sriov, rdma_shared, host_device)
       --fabric string            Select the fabric type to deploy (infiniband, ethernet)
       --for string               Generate for a known server preset (replaces clusterConfig from the preset). Requires --node-selector. Run 'l8k preset list' with the same --config-dir to list available names.
@@ -256,7 +268,7 @@ Profile Selection Flags:
       --routing string           Secondary-network routing mode: destination-based or source-based. source-based chains the automatic sbr CNI meta-plugin.
       --spectrum-x string        Enable Spectrum-X by passing the SPC-X RA version (folds in the legacy --spcx-version). Supported: [RA2.1 RA2.2 RA2.3]
 
-Spectrum-X Flags:
+Host Target Spectrum-X Flags:
       --ip-version string                  Spectrum-X IP version for guide-based allocation: ipv4 or ipv6 (requires --spectrum-x)
       --multiplane-mode string             Spectrum-X multiplane mode: none, swplb, hwplb (requires --spectrum-x)
       --number-of-planes int               Number of planes for Spectrum-X (requires --spectrum-x)
@@ -265,27 +277,24 @@ Spectrum-X Flags:
       --topology-file string               Path to spcx-gen/reference-generator or NVIDIA AIR topology JSON for Spectrum-X CIDRPool generation (requires --spectrum-x)
       --topology-scheme string             Spectrum-X topology scheme for guide-based IP allocation: 2-tier or 3-tier (requires --spectrum-x)
 
-Generation Output Flags:
+Host Target Generation Output Flags:
       --enable-doca-driver             Enable DOCA driver deployment (overrides config file docaDriver.enable)
       --network-namespaces strings     Comma-separated namespaces for the secondary-network CRs and example test DaemonSets. One independent copy is rendered per namespace (shared resources like IPPools and NodePolicies are NOT duplicated). Overrides config networkNamespaces; default: 'default'.
       --save-deployment-files string   Save generated deployment files to the specified directory (default "./deployment")
       --workload-manifest string       Path to a custom workload manifest YAML (replaces the profile's default example workload)
 
-Deploy Flags:
+Target-Agnostic Execution Flags:
       --deploy                    Deploy the generated files to the Kubernetes cluster
       --deploy-timeout duration   Maximum end-to-end wall-clock budget for the deploy phase (e.g. 45m, 2h). 0 (the default) means no deadline; the deploy polls until every manifest reaches a terminal state.
       --dry-run                   Preview what would be deployed without applying changes to the cluster
 
-Output & Logging Flags:
+Target-Agnostic Output & Logging Flags:
   -h, --help               help for l8k
       --log-file string    Write logs to file instead of stderr
       --log-level string   Enable logging at specified level (debug, info, warn, error)
       --output string      Output format: text (default, human-readable) or json (structured, for automation and AI agents) (default "text")
   -q, --quiet              Suppress informational output (errors still shown)
   -y, --yes                Auto-confirm all prompts without interactive input
-
-Other Flags:
-      --collapse-nic-rails   Advertise one rail per NIC: collapse a NIC's multi-plane PFs to its master PF, keeping a rail per port only for NICs whose VPD model is genuinely dual-port ("2-port"/"Dual-port"). Set to false to keep the legacy one-rail-per-PF behaviour (dev setups). (default true)
 
 Use "l8k [command] --help" for more information about a command.
 ```

--- a/docs/advanced/targets.md
+++ b/docs/advanced/targets.md
@@ -1,0 +1,150 @@
+<!--
+SPDX-FileCopyrightText: Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Target-aware CLI architecture
+
+Launch Kit uses the same four lifecycle commands for independently managed
+infrastructure domains:
+
+```text
+discover -> generate -> deploy -> validate
+```
+
+The existing Network Operator workflow is the `host` target. It remains the
+default, so existing commands, configuration files, artifacts, JSON output,
+and exit codes do not require migration:
+
+```bash
+l8k discover ...
+l8k generate ...
+l8k deploy ...
+l8k validate ...
+```
+
+Passing `--target host` is an explicit synonym:
+
+```bash
+l8k generate --target host ...
+```
+
+The `dpf` target name is reserved for the future DPU-plane workflow. Its
+phases are intentionally reported as unavailable until a typed DPF driver is
+installed. Launch Kit returns validation exit code `2` instead of falling
+through to host behavior:
+
+```console
+$ l8k discover --target dpf
+Error: invalid target invocation: target "dpf" does not implement phase "discover" ...
+```
+
+Use `l8k schema` to inspect target and phase availability programmatically.
+
+## Flag ownership
+
+Flags are classified by their exact semantics, not by whether their names
+sound generic:
+
+- target-agnostic flags have identical meaning for every target, such as
+  `--target`, `--output`, and logging controls;
+- host flags describe Network Operator behavior, such as `--fabric`,
+  `--deployment-type`, Spectrum-X settings, and connectivity checks;
+- existing path and kubeconfig flags remain host compatibility inputs until a
+  multi-context environment contract gives them target-independent semantics.
+
+Help output separates target selection, host configuration, and
+target-agnostic output controls. Every target-aware Cobra flag also carries a
+`launchkit.nvidia.com/targets` annotation. The same ownership is exposed in
+`l8k schema` through each flag's `targets` field.
+
+Only explicitly supplied flags are checked for target compatibility. Defaults
+do not become accidental overrides. This distinction preserves commands such
+as `--multirail=false` and `--connectivity=false`:
+
+```console
+$ l8k validate --target dpf --connectivity=false
+Error: invalid target invocation: flags not valid for target "dpf":
+  --connectivity (targets: host)
+```
+
+## Binding boundary
+
+The target package contains no Cobra or target-native configuration types.
+The command layer performs the following sequence:
+
+1. Parse the target, defaulting omission to `host`.
+2. Check explicitly changed flags against their target ownership.
+3. Resolve the selected target and phase through the registry.
+4. Ask the target CLI adapter to bind its typed arguments.
+5. Execute the resulting target-neutral operation.
+
+The central contracts are:
+
+```go
+type Driver interface {
+    Descriptor() Descriptor
+    Bind(Invocation) (Operation, error)
+}
+
+type Operation interface {
+    Run(context.Context) error
+}
+```
+
+`Invocation` contains only target-neutral output and execution policy. A CLI
+adapter owns target-specific flags, loads its target-native configuration,
+applies only explicit overrides, validates phase requirements, and captures a
+typed domain request in the returned `Operation`. Drivers never receive a
+Cobra command, `pflag.FlagSet`, untyped option map, or host/DPF union config.
+
+The first migration stage validates target selection in Cobra `PreRun` and
+then enters the existing host command body unchanged. This prevents host
+behavioral drift while the standalone deploy and validate bodies are prepared
+for extraction. The DPF target remains unavailable during this stage, so it
+cannot accidentally execute host logic.
+
+## Registry guarantees
+
+Registry construction rejects:
+
+- nil drivers;
+- invalid or duplicate target names;
+- unknown phases;
+- unavailable phases without a reason;
+- target descriptors that omit any of the four public lifecycle phases.
+
+Binding rejects unknown targets, unavailable target phases, invalid common
+execution policy, and nil operations. Target names are lower-case identifiers;
+the CLI does not silently normalize misspellings.
+
+## Adding a target
+
+A target integration should:
+
+1. Define a typed target configuration outside the host `config` and `options`
+   packages.
+2. Register target-specific flags separately and annotate their ownership.
+3. Prefer configuration fields over a broad set of target-specific CLI flags.
+4. Bind explicit CLI values into a typed request; do not pass Cobra to the
+   domain driver.
+5. Declare all four phase capabilities and their required logical cluster
+   roles.
+6. Implement all four phases before marking them available in the schema.
+7. Keep target artifacts separate; host output remains
+   `deployment/network-operator/`.
+8. Add omitted-target and explicit-host compatibility tests before routing the
+   host command through a new adapter.
+
+The existing `plugin.Plugin` interface remains a host profile/rendering
+extension. It is not the target abstraction.
+
+## Future context model
+
+`--kubeconfig` currently means the host workload cluster and therefore remains
+host-owned. DPF will require logical context roles such as `management`,
+`workload`, and generated `dpu` clusters. A later environment layer will map
+those roles to credentials without changing the four lifecycle command names.
+
+That environment layer composes target plans and cross-target ownership
+contracts; it does not merge host and DPF configuration structures.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,12 @@ NVIDIA Kubernetes Launch Kit (`l8k`) generates, deploys, and validates NVIDIA cl
 
 Use this site when you are deploying SR-IOV, RDMA shared-device, host-device, InfiniBand, or Spectrum-X networking on NVIDIA accelerated clusters.
 
+These four lifecycle commands operate on the `host` target by default. Existing
+commands remain valid; `--target host` is an explicit synonym. Launch Kit also
+reserves the `dpf` target name, but its phases remain unavailable until the DPF
+driver is implemented. See [Target-aware CLI](advanced/targets.md) for the
+compatibility and extension contract.
+
 ## Find Your Path
 
 | If you are a... | Start here |
@@ -21,6 +27,7 @@ Use this site when you are deploying SR-IOV, RDMA shared-device, host-device, In
 | Platform engineer managing mixed hardware | [Heterogeneous Clusters](user/heterogeneous-clusters.md) |
 | Spectrum-X operator | [Spectrum-X](user/spectrum-x.md) |
 | CI/CD or GitOps integrator | [Automation](integrator/automation.md) |
+| Integrator adding an infrastructure target | [Target-aware CLI](advanced/targets.md) |
 | AI agent integrator | [AI Skills](integrator/ai-skills.md) |
 | Operator confirming a deployment is ready for use | [Validation](user/validation.md) |
 | Operator removing a deployment | [Cleanup](user/cleanup.md) |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -22,19 +22,34 @@ Run `l8k <command> --help` for the authoritative flag list. Run `l8k schema` for
 | `l8k schema` | Print JSON capabilities for automation. |
 | `l8k version` | Print version information. |
 
-## Common Flags
+## Target selection and flag ownership
 
-| Flag | Applies to | Description |
-| --- | --- | --- |
-| `--kubeconfig` | discover, deploy, clean, validate | Path to kubeconfig. Falls back to `$KUBECONFIG` and then `~/.kube/config`. |
-| `--user-config` | discover, generate, deploy, clean, validate | Config file to merge, render, validate against, or use for cleanup namespace resolution. |
-| `--config-dir` | all | Directory containing optional `l8k-config.yaml` and `presets/` overrides. |
-| `--network-operator-release` | discover, generate | Release line such as `26.1`, `26.4`, or `26.7`. |
-| `--network-operator-namespace` | generate, deploy, clean, validate | Override the Network Operator namespace. It is a no-op for discovery. |
-| `--output json` | all | Emit a single JSON result to stdout for automation. |
-| `--quiet` | all | Suppress informational output. |
-| `--log-level` | all | Enable `debug`, `info`, `warn`, or `error` logging. |
-| `--log-file` | all | Write logs to a file instead of `stderr`. |
+Omitting `--target` selects `host`; adding `--target host` follows the same
+code path. `dpf` is a recognized target name whose phases are unavailable in
+this build. Selecting it returns validation exit code `2`. This explicit
+capability error prevents DPF invocations from falling through to host logic.
+
+Host-only flags are rejected when they are explicitly supplied for another
+target. Defaults are ignored by this check, including explicit-value flags
+where `false` differs from omission. Run `l8k <command> --help` for target-aware
+flag groups and `l8k schema` for each flag's `targets` list.
+
+| Flag | Applies to | Target scope | Description |
+| --- | --- | --- | --- |
+| `--target` | discover, generate, deploy, validate, root pipeline | target-agnostic | Target name. Defaults to `host`. |
+| `--kubeconfig` | discover, deploy, clean, validate | host | Path to kubeconfig. Falls back to `$KUBECONFIG` and then `~/.kube/config`. It represents the host workload cluster, not a universal multi-context input. |
+| `--user-config` | discover, generate, deploy, clean, validate | host | Config file to merge, render, validate against, or use for cleanup namespace resolution. |
+| `--config-dir` | all | host | Directory containing optional `l8k-config.yaml` and `presets/` overrides. |
+| `--network-operator-release` | discover, generate | host | Release line such as `26.1`, `26.4`, or `26.7`. |
+| `--network-operator-namespace` | generate, deploy, clean, validate | host | Override the Network Operator namespace. It is a no-op for discovery. |
+| `--output json` | all | target-agnostic | Emit a single JSON result to stdout for automation. |
+| `--quiet` | root pipeline | target-agnostic | Suppress informational output. |
+| `--log-level` | all | target-agnostic | Enable `debug`, `info`, `warn`, or `error` logging. |
+| `--log-file` | all | target-agnostic | Write logs to a file instead of `stderr`. |
+
+The current host config and artifact contract is unchanged:
+`cluster-config.yaml` remains flat and generated manifests remain under
+`deployment/network-operator/`.
 
 ## Discover Flags
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - Troubleshooting: user/troubleshooting.md
   - Advanced:
       - Concepts: advanced/concepts.md
+      - Target-aware CLI: advanced/targets.md
       - Cluster Discovery: user/discovery.md
       - Manifest Generation: advanced/generation.md
       - Deployment Mechanics: advanced/deployment.md

--- a/pkg/cmd/deploy.go
+++ b/pkg/cmd/deploy.go
@@ -32,6 +32,7 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/kubeclient"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
+	"github.com/nvidia/k8s-launch-kit/pkg/target"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 )
 
@@ -91,6 +92,7 @@ is used as the manifest directory.`,
 
   # Server-side dry run: validate against the cluster without persisting
   l8k deploy --dry-run`,
+	PreRun: targetPreRun(target.Deploy),
 	Run: func(cmd *cobra.Command, args []string) {
 		resolved, err := resolveKubeconfig(kubeconfig)
 		if err != nil {
@@ -212,6 +214,7 @@ func resolveDeploymentDir(dir string) (string, error) {
 
 func init() {
 	rootCmd.AddCommand(deployCmd)
+	addTargetFlag(deployCmd)
 
 	deployCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (falls back to $KUBECONFIG, then ~/.kube/config)")
 	deployCmd.Flags().StringVar(&deploymentFiles, "deployment-files", DefaultDeploymentDir, "Directory containing the manifests to apply")
@@ -226,11 +229,13 @@ func init() {
 	deployCmd.Flags().BoolVar(&overwriteExistingFlag, "overwrite-existing", false, "Converge the cluster to the rendered manifests when preflight detects drift: helm upgrade the chart on chart-version/values mismatch, delete stray Network Operator CRs in the operator namespace, and rewrite NicClusterPolicy component versions via SSA. Off by default — preflight fails fast and lists what would change.")
 
 	setFlagGroup(deployCmd, "kubeconfig", GroupCommon)
+	setFlagGroup(deployCmd, "user-config", GroupCommon)
 	setFlagGroup(deployCmd, "deployment-files", GroupGeneration)
 	setFlagGroup(deployCmd, "network-operator-namespace", GroupCommon)
-	setFlagGroup(deployCmd, "deploy-timeout", GroupDeploy)
-	setFlagGroup(deployCmd, "dry-run", GroupDeploy)
+	setFlagGroup(deployCmd, "deploy-timeout", GroupExecution)
+	setFlagGroup(deployCmd, "dry-run", GroupExecution)
 	setFlagGroup(deployCmd, "overwrite-existing", GroupDeploy)
+	markDeployTargetScopes()
 }
 
 // selectedReleaseFromCfg returns the catalog key the user-config pinned, or

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -28,6 +28,7 @@ import (
 	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/releases"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
+	"github.com/nvidia/k8s-launch-kit/pkg/target"
 )
 
 var discoverCmd = &cobra.Command{
@@ -69,6 +70,7 @@ and writes the final profile back to cluster-config.yaml.`,
   # Agent mode (JSON output)
   l8k discover --save-cluster-config ./cluster-config.yaml \
     --output json 2>/dev/null`,
+	PreRun: targetPreRun(target.Discover),
 	Run: func(cmd *cobra.Command, args []string) {
 		resolved, err := resolveKubeconfig(kubeconfig)
 		if err != nil {
@@ -132,6 +134,7 @@ and writes the final profile back to cluster-config.yaml.`,
 
 func init() {
 	rootCmd.AddCommand(discoverCmd)
+	addTargetFlag(discoverCmd)
 
 	discoverCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (falls back to $KUBECONFIG, then ~/.kube/config)")
 	discoverCmd.Flags().StringVar(&userConfig, "user-config", "", "Base config to merge with discovered hardware")
@@ -187,4 +190,5 @@ func init() {
 	setFlagGroup(discoverCmd, "topology-file", GroupSpectrumX)
 	setFlagGroup(discoverCmd, "spectrum-x-config", GroupSpectrumX)
 	setFlagGroup(discoverCmd, "spectrum-x-configmap-name", GroupSpectrumX)
+	markDiscoverTargetScopes()
 }

--- a/pkg/cmd/flaggroups.go
+++ b/pkg/cmd/flaggroups.go
@@ -31,23 +31,27 @@ const flagGroupAnnotation = "flagGroup"
 // also encodes ordering, leaving groupOrder as the single source of truth
 // for what gets rendered.
 const (
+	GroupTarget        = "0-target"
 	GroupCommon        = "1-common"
 	GroupDiscovery     = "2-discovery"
 	GroupProfile       = "3-profile"
 	GroupSpectrumX     = "4-spectrumx"
 	GroupGeneration    = "5-generation"
-	GroupDeploy        = "6-deploy"
-	GroupClean         = "7-clean"
-	GroupValidation    = "8-validation"
-	GroupOutputLogging = "9-output-logging"
+	GroupExecution     = "6-execution"
+	GroupDeploy        = "7-deploy"
+	GroupClean         = "8-clean"
+	GroupValidation    = "9-validation"
+	GroupOutputLogging = "10-output-logging"
 )
 
 var groupOrder = []string{
+	GroupTarget,
 	GroupCommon,
 	GroupDiscovery,
 	GroupProfile,
 	GroupSpectrumX,
 	GroupGeneration,
+	GroupExecution,
 	GroupDeploy,
 	GroupClean,
 	GroupValidation,
@@ -55,15 +59,17 @@ var groupOrder = []string{
 }
 
 var groupTitles = map[string]string{
-	GroupCommon:        "Common Flags",
-	GroupDiscovery:     "Discovery Flags",
-	GroupProfile:       "Profile Selection Flags",
-	GroupSpectrumX:     "Spectrum-X Flags",
-	GroupGeneration:    "Generation Output Flags",
-	GroupDeploy:        "Deploy Flags",
-	GroupClean:         "Clean Flags",
-	GroupValidation:    "Validation Flags",
-	GroupOutputLogging: "Output & Logging Flags",
+	GroupTarget:        "Target Selection Flags",
+	GroupCommon:        "Host Target Common Flags",
+	GroupDiscovery:     "Host Target Discovery Flags",
+	GroupProfile:       "Host Target Profile Selection Flags",
+	GroupSpectrumX:     "Host Target Spectrum-X Flags",
+	GroupGeneration:    "Host Target Generation Output Flags",
+	GroupExecution:     "Target-Agnostic Execution Flags",
+	GroupDeploy:        "Host Target Deploy Flags",
+	GroupClean:         "Host Target Clean Flags",
+	GroupValidation:    "Host Target Validation Flags",
+	GroupOutputLogging: "Target-Agnostic Output & Logging Flags",
 }
 
 // setFlagGroup tags the named flag on cmd with the given group key.

--- a/pkg/cmd/flaggroups_test.go
+++ b/pkg/cmd/flaggroups_test.go
@@ -57,9 +57,9 @@ func TestGroupedFlagUsages_RendersGroupsInOrderWithBlankLines(t *testing.T) {
 
 	out := groupedFlagUsages(cmd)
 
-	commonIdx := strings.Index(out, "Common Flags:")
-	profileIdx := strings.Index(out, "Profile Selection Flags:")
-	deployIdx := strings.Index(out, "Deploy Flags:")
+	commonIdx := strings.Index(out, groupTitles[GroupCommon]+":")
+	profileIdx := strings.Index(out, groupTitles[GroupProfile]+":")
+	deployIdx := strings.Index(out, groupTitles[GroupDeploy]+":")
 	require.NotEqual(t, -1, commonIdx, "Common Flags section missing:\n%s", out)
 	require.NotEqual(t, -1, profileIdx, "Profile Selection Flags section missing:\n%s", out)
 	require.NotEqual(t, -1, deployIdx, "Deploy Flags section missing:\n%s", out)
@@ -73,8 +73,8 @@ func TestGroupedFlagUsages_RendersGroupsInOrderWithBlankLines(t *testing.T) {
 	assert.NotContains(t, commonSection, "--deploy-flag")
 
 	// Sections are visually separated by a blank line.
-	assert.Contains(t, out, "\n\nProfile Selection Flags:")
-	assert.Contains(t, out, "\n\nDeploy Flags:")
+	assert.Contains(t, out, "\n\n"+groupTitles[GroupProfile]+":")
+	assert.Contains(t, out, "\n\n"+groupTitles[GroupDeploy]+":")
 }
 
 func TestGroupedFlagUsages_UntaggedFlagFallsIntoOtherFlags(t *testing.T) {
@@ -86,7 +86,7 @@ func TestGroupedFlagUsages_UntaggedFlagFallsIntoOtherFlags(t *testing.T) {
 	setFlagGroup(cmd, "tagged", GroupCommon)
 
 	out := groupedFlagUsages(cmd)
-	assert.Contains(t, out, "Common Flags:")
+	assert.Contains(t, out, groupTitles[GroupCommon]+":")
 	assert.Contains(t, out, "Other Flags:")
 
 	otherIdx := strings.Index(out, "Other Flags:")
@@ -123,8 +123,8 @@ func TestGroupedFlagUsages_IncludesInheritedFlagsFromParent(t *testing.T) {
 	setFlagGroup(child, "local-flag", GroupCommon)
 
 	out := groupedFlagUsages(child)
-	assert.Contains(t, out, "Common Flags:")
+	assert.Contains(t, out, groupTitles[GroupCommon]+":")
 	assert.Contains(t, out, "--local-flag")
-	assert.Contains(t, out, "Output & Logging Flags:")
+	assert.Contains(t, out, groupTitles[GroupOutputLogging]+":")
 	assert.Contains(t, out, "--global-output")
 }

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -28,6 +28,7 @@ import (
 	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/releases"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
+	"github.com/nvidia/k8s-launch-kit/pkg/target"
 )
 
 // generateNodeSelector is the per-subcommand node selector value. It must be
@@ -83,6 +84,7 @@ Optionally deploy the generated manifests with --deploy.`,
     --node-selector "feature.node.kubernetes.io/pci-15b3.present=true" \
     --fabric ethernet --deployment-type sriov \
     --save-deployment-files ./output`,
+	PreRun: targetPreRun(target.Generate),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Probe explicit/discovered cluster configs here, but leave an
 		// explicit --config-dir for Launcher.Run to resolve exactly once.
@@ -185,6 +187,7 @@ Optionally deploy the generated manifests with --deploy.`,
 
 func init() {
 	rootCmd.AddCommand(generateCmd)
+	addTargetFlag(generateCmd)
 
 	// Config
 	generateCmd.Flags().StringVar(&userConfig, "user-config", "", "Cluster config file (otherwise auto-detected from ./cluster-config.yaml; --for can use embedded defaults)")
@@ -260,7 +263,8 @@ func init() {
 	setFlagGroup(generateCmd, "enable-doca-driver", GroupGeneration)
 	setFlagGroup(generateCmd, "workload-manifest", GroupGeneration)
 
-	setFlagGroup(generateCmd, "deploy", GroupDeploy)
-	setFlagGroup(generateCmd, "dry-run", GroupDeploy)
+	setFlagGroup(generateCmd, "deploy", GroupExecution)
+	setFlagGroup(generateCmd, "dry-run", GroupExecution)
 	setFlagGroup(generateCmd, "overwrite-existing", GroupDeploy)
+	markGenerateTargetScopes()
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -36,6 +36,7 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/releases"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
+	"github.com/nvidia/k8s-launch-kit/pkg/target"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 )
 
@@ -149,6 +150,7 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
 
   # Get tool capabilities as JSON (for AI agents)
   l8k schema`,
+	PreRun: targetPreRun(target.Pipeline),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Bare `l8k` invocation: print help instead of erroring on the
 		// missing-config validation. Any flag or positional argument
@@ -243,6 +245,7 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+	addTargetFlag(rootCmd)
 
 	// Phase 0: Plugin flags
 	rootCmd.Flags().StringVar(&enabledPlugins, "enabled-plugins", "network-operator", "Comma-separated list of plugins to enable")
@@ -315,6 +318,7 @@ func init() {
 
 	setFlagGroup(rootCmd, "discover-cluster-config", GroupDiscovery)
 	setFlagGroup(rootCmd, "save-cluster-config", GroupDiscovery)
+	setFlagGroup(rootCmd, "collapse-nic-rails", GroupDiscovery)
 
 	setFlagGroup(rootCmd, "fabric", GroupProfile)
 	setFlagGroup(rootCmd, "deployment-type", GroupProfile)
@@ -339,15 +343,16 @@ func init() {
 	setFlagGroup(rootCmd, "enable-doca-driver", GroupGeneration)
 	setFlagGroup(rootCmd, "workload-manifest", GroupGeneration)
 
-	setFlagGroup(rootCmd, "deploy", GroupDeploy)
-	setFlagGroup(rootCmd, "deploy-timeout", GroupDeploy)
-	setFlagGroup(rootCmd, "dry-run", GroupDeploy)
+	setFlagGroup(rootCmd, "deploy", GroupExecution)
+	setFlagGroup(rootCmd, "deploy-timeout", GroupExecution)
+	setFlagGroup(rootCmd, "dry-run", GroupExecution)
 
 	setFlagGroup(rootCmd, "output", GroupOutputLogging)
 	setFlagGroup(rootCmd, "yes", GroupOutputLogging)
 	setFlagGroup(rootCmd, "quiet", GroupOutputLogging)
 	setFlagGroup(rootCmd, "log-level", GroupOutputLogging)
 	setFlagGroup(rootCmd, "log-file", GroupOutputLogging)
+	markRootTargetScopes()
 
 	installGroupedUsage(rootCmd)
 }

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -19,11 +19,13 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/releases"
+	"github.com/nvidia/k8s-launch-kit/pkg/target"
 )
 
 // commandSchema describes a subcommand for AI agent discovery.
@@ -37,6 +39,8 @@ type schema struct {
 	Version                          string                   `json:"version"`
 	Description                      string                   `json:"description"`
 	Commands                         map[string]commandSchema `json:"commands"`
+	DefaultTarget                    string                   `json:"defaultTarget"`
+	Targets                          []targetSchema           `json:"targets"`
 	Phases                           []string                 `json:"phases"`
 	Fabrics                          []string                 `json:"fabrics"`
 	DeploymentTypes                  []string                 `json:"deploymentTypes"`
@@ -47,10 +51,18 @@ type schema struct {
 }
 
 type flagSchema struct {
-	Type        string `json:"type"`
-	Default     string `json:"default,omitempty"`
-	Description string `json:"description"`
-	Required    bool   `json:"required,omitempty"`
+	Type        string   `json:"type"`
+	Default     string   `json:"default,omitempty"`
+	Description string   `json:"description"`
+	Required    bool     `json:"required,omitempty"`
+	Targets     []string `json:"targets"`
+}
+
+type targetSchema struct {
+	Name        string                       `json:"name"`
+	Description string                       `json:"description"`
+	Default     bool                         `json:"default,omitempty"`
+	Phases      map[string]target.Capability `json:"phases"`
 }
 
 var schemaCmd = &cobra.Command{
@@ -91,7 +103,9 @@ var schemaCmd = &cobra.Command{
 					Example:     "l8k schema",
 				},
 			},
-			Phases:                           []string{"discover", "generate", "deploy"},
+			DefaultTarget:                    string(target.Host),
+			Targets:                          targetCapabilitiesSchema(),
+			Phases:                           []string{"discover", "generate", "deploy", "validate"},
 			Fabrics:                          []string{"ethernet", "infiniband"},
 			DeploymentTypes:                  []string{"sriov", "rdma_shared", "host_device"},
 			OutputFormats:                    []string{"text", "json"},
@@ -105,6 +119,11 @@ var schemaCmd = &cobra.Command{
 				"5": "partial_success",
 			},
 			Flags: map[string]flagSchema{
+				"--target": {
+					Type:        "string",
+					Default:     string(target.Host),
+					Description: "Deployment target. Omission preserves the existing host workflow; inspect targets[].phases for availability.",
+				},
 				"--config-dir": {
 					Type:        "string",
 					Description: "Directory containing optional l8k-config.yaml and presets/ overrides",
@@ -261,9 +280,55 @@ var schemaCmd = &cobra.Command{
 				},
 			},
 		}
+		annotateSchemaFlagTargets(&s)
 		data, _ := json.MarshalIndent(s, "", "  ")
 		fmt.Println(string(data))
 	},
+}
+
+func targetCapabilitiesSchema() []targetSchema {
+	descriptors := targetDescriptors()
+	result := make([]targetSchema, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		phases := make(map[string]target.Capability, len(target.PublicPhases()))
+		for _, phase := range target.PublicPhases() {
+			phases[string(phase)] = descriptor.Capability(phase)
+		}
+		result = append(result, targetSchema{
+			Name:        string(descriptor.Name),
+			Description: descriptor.Description,
+			Default:     descriptor.Name == target.Host,
+			Phases:      phases,
+		})
+	}
+	return result
+}
+
+func annotateSchemaFlagTargets(s *schema) {
+	if s == nil {
+		return
+	}
+	for name, spec := range s.Flags {
+		spec.Targets = schemaFlagTargets(name)
+		s.Flags[name] = spec
+	}
+}
+
+func schemaFlagTargets(schemaName string) []string {
+	flagName := strings.TrimPrefix(schemaName, "--")
+	for _, command := range []*cobra.Command{rootCmd, discoverCmd, generateCmd, deployCmd, validateCmd} {
+		flag := command.Flags().Lookup(flagName)
+		if flag == nil {
+			flag = command.PersistentFlags().Lookup(flagName)
+		}
+		if flag == nil || len(flag.Annotations[flagTargetsAnnotation]) == 0 {
+			continue
+		}
+		return append([]string(nil), flag.Annotations[flagTargetsAnnotation]...)
+	}
+	// Commands outside the target-aware lifecycle, such as clean, retain
+	// their existing host semantics until they are explicitly migrated.
+	return []string{string(target.Host)}
 }
 
 func init() {

--- a/pkg/cmd/schema_test.go
+++ b/pkg/cmd/schema_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/target"
+)
+
+func TestSchemaDescribesTargetsAdditively(t *testing.T) {
+	targets := targetCapabilitiesSchema()
+	require.Len(t, targets, 2)
+
+	host := targets[0]
+	assert.Equal(t, string(target.Host), host.Name)
+	assert.True(t, host.Default)
+	dpf := targets[1]
+	assert.Equal(t, string(target.DPF), dpf.Name)
+	assert.False(t, dpf.Default)
+
+	for _, phase := range target.PublicPhases() {
+		assert.Truef(t, host.Phases[string(phase)].Available, "host phase %s", phase)
+		assert.Falsef(t, dpf.Phases[string(phase)].Available, "dpf phase %s", phase)
+		assert.NotEmptyf(t, dpf.Phases[string(phase)].Reason, "dpf phase %s reason", phase)
+	}
+
+}
+
+func TestSchemaFlagsDeclareTargetOwnership(t *testing.T) {
+	s := schema{Flags: map[string]flagSchema{
+		"--target":     {},
+		"--output":     {},
+		"--dry-run":    {},
+		"--fabric":     {},
+		"--kubeconfig": {},
+	}}
+	annotateSchemaFlagTargets(&s)
+	for name, spec := range s.Flags {
+		assert.NotEmptyf(t, spec.Targets, "schema flag %s", name)
+	}
+
+	assert.Equal(t, []string{"host", "dpf"}, s.Flags["--target"].Targets)
+	assert.Equal(t, []string{"host", "dpf"}, s.Flags["--output"].Targets)
+	assert.Equal(t, []string{"host", "dpf"}, s.Flags["--dry-run"].Targets)
+	assert.Equal(t, []string{"host"}, s.Flags["--fabric"].Targets)
+	assert.Equal(t, []string{"host"}, s.Flags["--kubeconfig"].Targets)
+}
+
+func TestAnnotateSchemaFlagTargetsNilSafe(t *testing.T) {
+	require.NotPanics(t, func() { annotateSchemaFlagTargets(nil) })
+}

--- a/pkg/cmd/target_cli.go
+++ b/pkg/cmd/target_cli.go
@@ -1,0 +1,342 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
+	"github.com/nvidia/k8s-launch-kit/pkg/target"
+)
+
+const flagTargetsAnnotation = "launchkit.nvidia.com/targets"
+
+var targetName = string(target.Host)
+
+// flagTargetError reports target-owned flags that were explicitly set for a
+// different target. Defaults never cause this error because validation walks
+// only pflag's Changed set.
+type flagTargetError struct {
+	Selected target.Name
+	Flags    []string
+	Allowed  map[string][]target.Name
+}
+
+func (e *flagTargetError) Error() string {
+	parts := make([]string, 0, len(e.Flags))
+	for _, name := range e.Flags {
+		parts = append(parts, fmt.Sprintf("--%s (targets: %s)", name, joinTargetNames(e.Allowed[name])))
+	}
+	return fmt.Sprintf("flags not valid for target %q: %s", e.Selected, strings.Join(parts, ", "))
+}
+
+func joinTargetNames(names []target.Name) string {
+	values := make([]string, len(names))
+	for index, name := range names {
+		values[index] = string(name)
+	}
+	return strings.Join(values, ", ")
+}
+
+func addTargetFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&targetName,
+		"target",
+		string(target.Host),
+		"Deployment target: host (default) or dpf (reserved; phases are unavailable until the DPF driver is added)",
+	)
+	setFlagGroup(cmd, "target", GroupTarget)
+	setFlagTargetScope(cmd, []target.Name{target.Host, target.DPF}, "target")
+}
+
+// setFlagTargetScope marks flag names with the targets that own their exact
+// semantics. It mirrors setFlagGroup's local-then-persistent lookup because
+// annotations are applied during command construction, before Cobra merges
+// inherited persistent flags.
+func setFlagTargetScope(cmd *cobra.Command, targets []target.Name, names ...string) {
+	values := make([]string, len(targets))
+	for index, name := range targets {
+		values[index] = string(name)
+	}
+	for _, name := range names {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil {
+			flag = cmd.PersistentFlags().Lookup(name)
+		}
+		if flag == nil {
+			continue
+		}
+		if flag.Annotations == nil {
+			flag.Annotations = map[string][]string{}
+		}
+		flag.Annotations[flagTargetsAnnotation] = append([]string(nil), values...)
+	}
+}
+
+func flagTargetScope(flag *pflag.Flag) ([]target.Name, error) {
+	values := flag.Annotations[flagTargetsAnnotation]
+	if len(values) == 0 {
+		return nil, fmt.Errorf("flag --%s has no target ownership metadata", flag.Name)
+	}
+	names := make([]target.Name, 0, len(values))
+	for _, value := range values {
+		name, err := target.ParseName(value)
+		if err != nil {
+			return nil, fmt.Errorf("flag --%s has invalid target metadata: %w", flag.Name, err)
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+func validateExplicitFlagTargets(cmd *cobra.Command, selected target.Name) error {
+	if cmd == nil {
+		return fmt.Errorf("command must not be nil")
+	}
+	invalid := &flagTargetError{Selected: selected, Allowed: map[string][]target.Name{}}
+	var metadataErr error
+	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		if metadataErr != nil {
+			return
+		}
+		// The selector itself is validated by registry lookup below. Its
+		// annotation describes currently advertised targets for help/schema,
+		// not a restriction that should mask UnknownTargetError.
+		if flag.Name == "target" {
+			return
+		}
+		allowed, err := flagTargetScope(flag)
+		if err != nil {
+			metadataErr = err
+			return
+		}
+		for _, name := range allowed {
+			if name == selected {
+				return
+			}
+		}
+		invalid.Flags = append(invalid.Flags, flag.Name)
+		invalid.Allowed[flag.Name] = allowed
+	})
+	if metadataErr != nil {
+		return metadataErr
+	}
+	if len(invalid.Flags) == 0 {
+		return nil
+	}
+	sort.Strings(invalid.Flags)
+	return invalid
+}
+
+type commandTargetDriver struct {
+	descriptor target.Descriptor
+	phase      target.Phase
+	runHost    func()
+}
+
+func (d commandTargetDriver) Descriptor() target.Descriptor { return d.descriptor }
+
+func (d commandTargetDriver) Bind(invocation target.Invocation) (target.Operation, error) {
+	if invocation.Phase != d.phase {
+		return nil, fmt.Errorf("host CLI adapter was bound for phase %q, not %q", d.phase, invocation.Phase)
+	}
+	if d.runHost == nil {
+		return nil, fmt.Errorf("host CLI adapter for phase %q has no operation", d.phase)
+	}
+	return target.OperationFunc(func(context.Context) error {
+		d.runHost()
+		return nil
+	}), nil
+}
+
+type unavailableTargetDriver struct {
+	descriptor target.Descriptor
+}
+
+func (d unavailableTargetDriver) Descriptor() target.Descriptor { return d.descriptor }
+
+func (d unavailableTargetDriver) Bind(invocation target.Invocation) (target.Operation, error) {
+	return nil, &target.PhaseUnavailableError{
+		Name:   invocation.Target,
+		Phase:  invocation.Phase,
+		Reason: d.descriptor.Capability(invocation.Phase).Reason,
+	}
+}
+
+func hostTargetDescriptor() target.Descriptor {
+	available := target.Capability{Available: true}
+	return target.Descriptor{
+		Name:        target.Host,
+		Description: "Kubernetes host networking managed through NVIDIA Network Operator",
+		Phases: map[target.Phase]target.Capability{
+			target.Discover: available,
+			target.Generate: available,
+			target.Deploy:   available,
+			target.Validate: available,
+			target.Pipeline: available,
+		},
+	}
+}
+
+func dpfTargetDescriptor() target.Descriptor {
+	const reason = "the DPF target name and CLI boundary are reserved, but the DPF driver is not available in this build"
+	unavailable := target.Capability{Available: false, Reason: reason}
+	return target.Descriptor{
+		Name:        target.DPF,
+		Description: "DPU-plane provisioning through NVIDIA DPF Operator",
+		Phases: map[target.Phase]target.Capability{
+			target.Discover: unavailable,
+			target.Generate: unavailable,
+			target.Deploy:   unavailable,
+			target.Validate: unavailable,
+			target.Pipeline: unavailable,
+		},
+	}
+}
+
+func targetDescriptors() []target.Descriptor {
+	return []target.Descriptor{hostTargetDescriptor(), dpfTargetDescriptor()}
+}
+
+func bindTargetCommand(cmd *cobra.Command, phase target.Phase, runHost func()) (target.Operation, error) {
+	selected, err := target.ParseName(targetName)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateExplicitFlagTargets(cmd, selected); err != nil {
+		return nil, err
+	}
+
+	registry, err := target.NewRegistry(
+		commandTargetDriver{descriptor: hostTargetDescriptor(), phase: phase, runHost: runHost},
+		unavailableTargetDriver{descriptor: dpfTargetDescriptor()},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("construct target registry: %w", err)
+	}
+
+	var timeout time.Duration
+	switch phase {
+	case target.Pipeline:
+		timeout = deployTimeoutRoot
+	case target.Deploy:
+		timeout = deployTimeout
+	}
+	return registry.Bind(target.Invocation{
+		Target: selected,
+		Phase:  phase,
+		Output: target.OutputOptions{
+			Format:      outputFormat,
+			Quiet:       quietFlag,
+			AutoApprove: yesFlag || outputFormat == "json",
+		},
+		Execution: target.ExecutionOptions{
+			DryRun:  dryRunFlag,
+			Timeout: timeout,
+		},
+	})
+}
+
+func targetPreRun(phase target.Phase) func(*cobra.Command, []string) {
+	return func(cmd *cobra.Command, _ []string) {
+		// The compatibility-first migration deliberately leaves the host Run
+		// body untouched. Binding here proves target/phase availability and
+		// flag ownership before Cobra enters that existing host path. A future
+		// target replaces this no-op host operation with its typed bound
+		// operation when command execution moves behind the common runner.
+		_, err := bindTargetCommand(cmd, phase, func() {})
+		if err != nil {
+			exitWithError(apperrors.NewValidationError(
+				"invalid target invocation",
+				err,
+				targetErrorSuggestion(err),
+			), outputFormat)
+		}
+	}
+}
+
+func targetErrorSuggestion(err error) string {
+	var flags *flagTargetError
+	if errors.As(err, &flags) {
+		return "Remove flags owned by another target, or select --target host for the existing Network Operator workflow"
+	}
+	var unavailable *target.PhaseUnavailableError
+	if errors.As(err, &unavailable) {
+		return "Use --target host for the current workflow; inspect 'l8k schema' for target phase availability"
+	}
+	var unknown *target.UnknownTargetError
+	if errors.As(err, &unknown) {
+		return "Use a target listed by 'l8k schema'"
+	}
+	return "Run 'l8k schema' to inspect target and flag capabilities"
+}
+
+func markRootTargetScopes() {
+	setFlagTargetScope(rootCmd, []target.Name{target.Host, target.DPF},
+		"target", "output", "log-level", "log-file", "yes", "quiet", "dry-run", "deploy", "deploy-timeout")
+	setFlagTargetScope(rootCmd, []target.Name{target.Host},
+		"enabled-plugins", "discover-cluster-config", "save-cluster-config", "user-config",
+		"network-operator-namespace", "network-operator-release", "fabric", "deployment-type",
+		"multirail", "routing", "ignore-arp", "spectrum-x", "multiplane-mode", "number-of-planes",
+		"topology-scheme", "ip-version", "topology-file", "spectrum-x-config",
+		"spectrum-x-configmap-name", "groups", "gpu-type", "node-selector", "collapse-nic-rails",
+		"for", "image-pull-secrets", "save-deployment-files", "network-namespaces",
+		"enable-doca-driver", "workload-manifest", "kubeconfig", "config-dir")
+}
+
+func markDiscoverTargetScopes() {
+	setFlagTargetScope(discoverCmd, []target.Name{target.Host},
+		"kubeconfig", "user-config", "save-cluster-config", "network-operator-namespace",
+		"network-operator-release", "node-selector", "image-pull-secrets", "enabled-plugins",
+		"keep-namespace", "collapse-nic-rails", "fabric", "deployment-type", "multirail",
+		"routing", "ignore-arp", "spectrum-x", "multiplane-mode", "number-of-planes",
+		"topology-scheme", "ip-version", "topology-file", "spectrum-x-config",
+		"spectrum-x-configmap-name")
+}
+
+func markGenerateTargetScopes() {
+	setFlagTargetScope(generateCmd, []target.Name{target.Host, target.DPF}, "deploy", "dry-run")
+	setFlagTargetScope(generateCmd, []target.Name{target.Host},
+		"user-config", "fabric", "deployment-type", "multirail", "routing", "ignore-arp",
+		"spectrum-x", "multiplane-mode", "number-of-planes", "topology-scheme", "ip-version",
+		"topology-file", "spectrum-x-config", "spectrum-x-configmap-name", "groups", "gpu-type",
+		"for", "node-selector", "save-deployment-files", "network-namespaces", "enable-doca-driver",
+		"workload-manifest", "network-operator-namespace", "network-operator-release",
+		"image-pull-secrets", "enabled-plugins", "kubeconfig", "overwrite-existing")
+}
+
+func markDeployTargetScopes() {
+	setFlagTargetScope(deployCmd, []target.Name{target.Host, target.DPF}, "dry-run", "deploy-timeout")
+	setFlagTargetScope(deployCmd, []target.Name{target.Host},
+		"kubeconfig", "deployment-files", "network-operator-namespace", "user-config", "overwrite-existing")
+}
+
+func markValidateTargetScopes() {
+	setFlagTargetScope(validateCmd, []target.Name{target.Host},
+		"kubeconfig", "deployment-files", "user-config", "network-operator-namespace", "connectivity",
+		"keep", "connectivity-timeout", "validation-mode", "validation-checks",
+		"rdma-rping-iterations", "rdma-ib-write-size", "rdma-ib-write-min-bandwidth-gbps",
+		"wait", "report-path")
+}

--- a/pkg/cmd/target_cli_test.go
+++ b/pkg/cmd/target_cli_test.go
@@ -1,0 +1,338 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/target"
+)
+
+func TestSetFlagTargetScope(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	var value string
+	cmd.Flags().StringVar(&value, "value", "", "test value")
+
+	setFlagTargetScope(cmd, []target.Name{target.Host}, "value", "missing")
+
+	flag := cmd.Flags().Lookup("value")
+	require.NotNil(t, flag)
+	assert.Equal(t, []string{"host"}, flag.Annotations[flagTargetsAnnotation])
+	actual, err := flagTargetScope(flag)
+	require.NoError(t, err)
+	assert.Equal(t, []target.Name{target.Host}, actual)
+}
+
+func TestValidateExplicitFlagTargets(t *testing.T) {
+	t.Run("target-agnostic flag", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		var output string
+		cmd.Flags().StringVar(&output, "output", "text", "output")
+		setFlagTargetScope(cmd, []target.Name{target.Host, target.DPF}, "output")
+		require.NoError(t, cmd.ParseFlags([]string{"--output", "json"}))
+		require.NoError(t, validateExplicitFlagTargets(cmd, target.DPF))
+	})
+
+	t.Run("host default is ignored for dpf", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		var connectivity bool
+		cmd.Flags().BoolVar(&connectivity, "connectivity", true, "connectivity")
+		setFlagTargetScope(cmd, []target.Name{target.Host}, "connectivity")
+		require.NoError(t, validateExplicitFlagTargets(cmd, target.DPF))
+	})
+
+	t.Run("explicit false remains explicit", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		var connectivity bool
+		cmd.Flags().BoolVar(&connectivity, "connectivity", true, "connectivity")
+		setFlagTargetScope(cmd, []target.Name{target.Host}, "connectivity")
+		require.NoError(t, cmd.ParseFlags([]string{"--connectivity=false"}))
+
+		err := validateExplicitFlagTargets(cmd, target.DPF)
+		var scopeErr *flagTargetError
+		require.ErrorAs(t, err, &scopeErr)
+		assert.Equal(t, []string{"connectivity"}, scopeErr.Flags)
+		assert.Contains(t, err.Error(), `--connectivity (targets: host)`)
+	})
+
+	t.Run("multiple flags are sorted", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		var alpha, zeta string
+		cmd.Flags().StringVar(&zeta, "zeta", "", "zeta")
+		cmd.Flags().StringVar(&alpha, "alpha", "", "alpha")
+		setFlagTargetScope(cmd, []target.Name{target.Host}, "alpha", "zeta")
+		require.NoError(t, cmd.ParseFlags([]string{"--zeta", "z", "--alpha", "a"}))
+
+		err := validateExplicitFlagTargets(cmd, target.DPF)
+		var scopeErr *flagTargetError
+		require.ErrorAs(t, err, &scopeErr)
+		assert.Equal(t, []string{"alpha", "zeta"}, scopeErr.Flags)
+	})
+
+	t.Run("changed flag must declare ownership", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		var value string
+		cmd.Flags().StringVar(&value, "value", "", "value")
+		require.NoError(t, cmd.ParseFlags([]string{"--value", "set"}))
+		require.ErrorContains(t, validateExplicitFlagTargets(cmd, target.Host), "has no target ownership metadata")
+	})
+
+	t.Run("nil command", func(t *testing.T) {
+		require.ErrorContains(t, validateExplicitFlagTargets(nil, target.Host), "must not be nil")
+	})
+}
+
+func TestTargetAwareCommandsDeclareFlagOwnershipAndHelpGroup(t *testing.T) {
+	commands := []*cobra.Command{rootCmd, discoverCmd, generateCmd, deployCmd, validateCmd}
+	for _, command := range commands {
+		t.Run(command.Name(), func(t *testing.T) {
+			seen := map[string]bool{}
+			visit := func(flag *pflag.Flag) {
+				if flag.Name == "help" || seen[flag.Name] {
+					return
+				}
+				seen[flag.Name] = true
+				_, err := flagTargetScope(flag)
+				assert.NoErrorf(t, err, "%s flag --%s", command.CommandPath(), flag.Name)
+				assert.NotEmptyf(t, flag.Annotations[flagGroupAnnotation],
+					"%s flag --%s has no help group", command.CommandPath(), flag.Name)
+			}
+			command.LocalFlags().VisitAll(visit)
+			command.PersistentFlags().VisitAll(visit)
+			command.InheritedFlags().VisitAll(visit)
+			assert.NotEmpty(t, seen)
+		})
+	}
+}
+
+func TestImportantFlagScopes(t *testing.T) {
+	tests := []struct {
+		command  *cobra.Command
+		flag     string
+		expected []target.Name
+	}{
+		{command: rootCmd, flag: "target", expected: []target.Name{target.Host, target.DPF}},
+		{command: rootCmd, flag: "output", expected: []target.Name{target.Host, target.DPF}},
+		{command: rootCmd, flag: "fabric", expected: []target.Name{target.Host}},
+		{command: discoverCmd, flag: "kubeconfig", expected: []target.Name{target.Host}},
+		{command: generateCmd, flag: "deploy", expected: []target.Name{target.Host, target.DPF}},
+		{command: deployCmd, flag: "dry-run", expected: []target.Name{target.Host, target.DPF}},
+		{command: validateCmd, flag: "connectivity", expected: []target.Name{target.Host}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.command.Name()+"/"+tt.flag, func(t *testing.T) {
+			flag := tt.command.Flags().Lookup(tt.flag)
+			if flag == nil {
+				flag = tt.command.PersistentFlags().Lookup(tt.flag)
+			}
+			require.NotNil(t, flag)
+			actual, err := flagTargetScope(flag)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestBindTargetCommand(t *testing.T) {
+	originalTarget := targetName
+	originalOutput := outputFormat
+	originalDryRun := dryRunFlag
+	t.Cleanup(func() {
+		targetName = originalTarget
+		outputFormat = originalOutput
+		dryRunFlag = originalDryRun
+	})
+
+	newCommand := func() *cobra.Command {
+		command := &cobra.Command{Use: "test"}
+		addTargetFlag(command)
+		return command
+	}
+
+	t.Run("omitted target runs host", func(t *testing.T) {
+		targetName = string(target.Host)
+		command := newCommand()
+		ran := false
+		operation, err := bindTargetCommand(command, target.Generate, func() { ran = true })
+		require.NoError(t, err)
+		require.NoError(t, operation.Run(context.Background()))
+		assert.True(t, ran)
+	})
+
+	t.Run("explicit host runs same operation", func(t *testing.T) {
+		command := newCommand()
+		require.NoError(t, command.ParseFlags([]string{"--target", "host"}))
+		ran := false
+		operation, err := bindTargetCommand(command, target.Generate, func() { ran = true })
+		require.NoError(t, err)
+		require.NoError(t, operation.Run(context.Background()))
+		assert.True(t, ran)
+	})
+
+	t.Run("dpf returns phase capability error", func(t *testing.T) {
+		command := newCommand()
+		require.NoError(t, command.ParseFlags([]string{"--target", "dpf"}))
+		operation, err := bindTargetCommand(command, target.Validate, func() { t.Fatal("host must not run") })
+		var unavailable *target.PhaseUnavailableError
+		require.ErrorAs(t, err, &unavailable)
+		assert.Equal(t, target.DPF, unavailable.Name)
+		assert.Equal(t, target.Validate, unavailable.Phase)
+		assert.Nil(t, operation)
+	})
+
+	t.Run("unknown target reports registered targets", func(t *testing.T) {
+		command := newCommand()
+		require.NoError(t, command.ParseFlags([]string{"--target", "future"}))
+		operation, err := bindTargetCommand(command, target.Discover, func() { t.Fatal("host must not run") })
+		var unknown *target.UnknownTargetError
+		require.ErrorAs(t, err, &unknown)
+		assert.Equal(t, []target.Name{target.DPF, target.Host}, unknown.Supported)
+		assert.Nil(t, operation)
+	})
+}
+
+func TestTargetDescriptors(t *testing.T) {
+	descriptors := targetDescriptors()
+	require.Len(t, descriptors, 2)
+	assert.Equal(t, target.Host, descriptors[0].Name)
+	assert.Equal(t, target.DPF, descriptors[1].Name)
+	for _, phase := range target.PublicPhases() {
+		assert.True(t, descriptors[0].Capability(phase).Available)
+		assert.False(t, descriptors[1].Capability(phase).Available)
+		assert.NotEmpty(t, descriptors[1].Capability(phase).Reason)
+	}
+}
+
+func TestTargetCLIProcess(t *testing.T) {
+	t.Run("schema exposes target and flag capabilities", func(t *testing.T) {
+		output, exitCode := runCLIHelper(t, "schema")
+		require.Equal(t, 0, exitCode)
+		var actual struct {
+			DefaultTarget string `json:"defaultTarget"`
+			Targets       []struct {
+				Name   string                       `json:"name"`
+				Phases map[string]target.Capability `json:"phases"`
+			} `json:"targets"`
+			Flags map[string]flagSchema `json:"flags"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(output), &actual))
+		assert.Equal(t, "host", actual.DefaultTarget)
+		require.Len(t, actual.Targets, 2)
+		assert.Equal(t, "host", actual.Targets[0].Name)
+		assert.Equal(t, "dpf", actual.Targets[1].Name)
+		assert.True(t, actual.Targets[0].Phases["validate"].Available)
+		assert.False(t, actual.Targets[1].Phases["validate"].Available)
+		assert.Equal(t, []string{"host", "dpf"}, actual.Flags["--output"].Targets)
+		assert.Equal(t, []string{"host"}, actual.Flags["--fabric"].Targets)
+	})
+
+	t.Run("omitted and explicit host preserve output and exit code", func(t *testing.T) {
+		omittedOutput, omittedExit := runCLIHelper(t,
+			"generate", "--user-config", "/definitely/missing/config.yaml", "--output", "json")
+		explicitOutput, explicitExit := runCLIHelper(t,
+			"generate", "--target", "host", "--user-config", "/definitely/missing/config.yaml", "--output", "json")
+
+		assert.Equal(t, omittedExit, explicitExit)
+		assert.Equal(t, omittedOutput, explicitOutput)
+		assert.Equal(t, 1, omittedExit)
+		assert.Contains(t, omittedOutput, "cluster config file does not exist")
+	})
+
+	for _, phase := range target.PublicPhases() {
+		t.Run("dpf "+string(phase)+" capability error", func(t *testing.T) {
+			output, exitCode := runCLIHelper(t, string(phase), "--target", "dpf")
+			assert.Equal(t, 2, exitCode)
+			assert.Contains(t, output, `invalid target invocation`)
+			assert.Contains(t, output, `target "dpf" does not implement phase "`+string(phase)+`"`)
+		})
+	}
+
+	t.Run("root dpf pipeline cannot enter host path", func(t *testing.T) {
+		output, exitCode := runCLIHelper(t, "--target", "dpf")
+		assert.Equal(t, 2, exitCode)
+		assert.Contains(t, output, `target "dpf" does not implement phase "pipeline"`)
+	})
+
+	t.Run("explicit false host flag is rejected for dpf", func(t *testing.T) {
+		output, exitCode := runCLIHelper(t, "validate", "--target", "dpf", "--connectivity=false")
+		assert.Equal(t, 2, exitCode)
+		assert.Contains(t, output, `--connectivity (targets: host)`)
+	})
+
+	t.Run("dpf capability errors preserve json output mode", func(t *testing.T) {
+		output, exitCode := runCLIHelper(t, "discover", "--target", "dpf", "--output", "json")
+		assert.Equal(t, 2, exitCode)
+		assert.Contains(t, output, `"code": "VALIDATION_ERROR"`)
+		assert.Contains(t, output, `"success": false`)
+	})
+
+	t.Run("unknown target is distinct from unavailable phase", func(t *testing.T) {
+		output, exitCode := runCLIHelper(t, "discover", "--target", "future")
+		assert.Equal(t, 2, exitCode)
+		assert.Contains(t, output, `unknown target "future"`)
+		assert.Contains(t, output, `registered targets: [dpf host]`)
+	})
+}
+
+func TestTargetCLIHelperProcess(t *testing.T) {
+	if os.Getenv("L8K_TARGET_CLI_HELPER") != "1" {
+		return
+	}
+	separator := -1
+	for index, argument := range os.Args {
+		if argument == "--" {
+			separator = index
+			break
+		}
+	}
+	if separator < 0 || separator+1 >= len(os.Args) {
+		os.Exit(99)
+	}
+	rootCmd.SetArgs(os.Args[separator+1:])
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func runCLIHelper(t *testing.T, args ...string) (string, int) {
+	t.Helper()
+	commandArgs := []string{"-test.run=^TestTargetCLIHelperProcess$", "--"}
+	commandArgs = append(commandArgs, args...)
+	command := exec.Command(os.Args[0], commandArgs...)
+	command.Env = append(os.Environ(), "L8K_TARGET_CLI_HELPER=1")
+	output, err := command.CombinedOutput()
+	if err == nil {
+		return string(output), 0
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("run helper %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output), exitErr.ExitCode()
+}

--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -45,6 +45,7 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
 	"github.com/nvidia/k8s-launch-kit/pkg/presetmatch"
 	"github.com/nvidia/k8s-launch-kit/pkg/presets"
+	"github.com/nvidia/k8s-launch-kit/pkg/target"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 )
 
@@ -124,6 +125,7 @@ connectivity-matrix failure.`,
 
   # Agent mode (JSON output)
   l8k validate --output json 2>/dev/null`,
+	PreRun: targetPreRun(target.Validate),
 	Run: func(cmd *cobra.Command, args []string) {
 		// State accumulated during the run. Captured by reference
 		// in exitWithReport so that EVERY error path — including
@@ -1566,6 +1568,7 @@ func versionStatusText(vc *networkoperatorplugin.VersionCheck) string {
 
 func init() {
 	rootCmd.AddCommand(validateCmd)
+	addTargetFlag(validateCmd)
 
 	validateCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (falls back to $KUBECONFIG, then ~/.kube/config)")
 	validateCmd.Flags().StringVar(&deploymentFiles, "deployment-files", DefaultDeploymentDir, "Directory containing the manifests to verify")
@@ -1604,4 +1607,5 @@ func init() {
 	setFlagGroup(validateCmd, "rdma-ib-write-min-bandwidth-gbps", GroupValidation)
 	setFlagGroup(validateCmd, "wait", GroupValidation)
 	setFlagGroup(validateCmd, "report-path", GroupValidation)
+	markValidateTargetScopes()
 }

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -1,0 +1,295 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package target defines the target-neutral lifecycle boundary used by the
+// Launch Kit CLI. It deliberately contains no Cobra, host configuration, or
+// DPF configuration types. Target-specific CLI adapters bind their typed
+// arguments into an Operation before the common runtime executes it.
+package target
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Name identifies a managed Launch Kit domain.
+type Name string
+
+const (
+	// Host is the existing Network Operator workflow and remains the default.
+	Host Name = "host"
+	// DPF is the DPU-plane workflow. The name is reserved before the driver is
+	// implemented so CLI and automation contracts can evolve additively.
+	DPF Name = "dpf"
+)
+
+var validName = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+
+// ParseName parses a public target name. An omitted value resolves to Host for
+// backwards compatibility. Registry lookup, rather than this parser, decides
+// whether a syntactically valid target is installed.
+func ParseName(value string) (Name, error) {
+	if value == "" {
+		return Host, nil
+	}
+	if strings.TrimSpace(value) != value || !validName.MatchString(value) {
+		return "", fmt.Errorf("invalid target %q: use a lowercase name containing letters, digits, or hyphens", value)
+	}
+	return Name(value), nil
+}
+
+// Phase identifies one lifecycle operation. Pipeline is an internal composite
+// used by the backwards-compatible root command; the public target contract is
+// Discover, Generate, Deploy, and Validate.
+type Phase string
+
+const (
+	Discover Phase = "discover"
+	Generate Phase = "generate"
+	Deploy   Phase = "deploy"
+	Validate Phase = "validate"
+	Pipeline Phase = "pipeline"
+)
+
+var knownPhases = map[Phase]struct{}{
+	Discover: {},
+	Generate: {},
+	Deploy:   {},
+	Validate: {},
+	Pipeline: {},
+}
+
+// PublicPhases returns the stable four-phase lifecycle in execution order.
+func PublicPhases() []Phase {
+	return []Phase{Discover, Generate, Deploy, Validate}
+}
+
+// Capability describes whether a target implements a phase in this build.
+type Capability struct {
+	Available bool   `json:"available"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// Descriptor describes one target without importing its implementation.
+type Descriptor struct {
+	Name        Name                 `json:"name"`
+	Description string               `json:"description"`
+	Phases      map[Phase]Capability `json:"phases"`
+}
+
+// Capability returns the declared capability for phase. Missing phase entries
+// are treated as unavailable, never as implicit no-op support.
+func (d Descriptor) Capability(phase Phase) Capability {
+	capability, ok := d.Phases[phase]
+	if !ok {
+		return Capability{Available: false, Reason: "phase is not declared by the target"}
+	}
+	return capability
+}
+
+func (d Descriptor) validate() error {
+	if d.Name == "" {
+		return fmt.Errorf("target descriptor name must not be empty")
+	}
+	if _, err := ParseName(string(d.Name)); err != nil {
+		return fmt.Errorf("invalid target descriptor name: %w", err)
+	}
+	if d.Phases == nil {
+		return fmt.Errorf("target %q must declare phase capabilities", d.Name)
+	}
+	for phase, capability := range d.Phases {
+		if _, ok := knownPhases[phase]; !ok {
+			return fmt.Errorf("target %q declares unknown phase %q", d.Name, phase)
+		}
+		if !capability.Available && strings.TrimSpace(capability.Reason) == "" {
+			return fmt.Errorf("target %q phase %q is unavailable without a reason", d.Name, phase)
+		}
+	}
+	for _, phase := range PublicPhases() {
+		if _, ok := d.Phases[phase]; !ok {
+			return fmt.Errorf("target %q must declare capability for phase %q", d.Name, phase)
+		}
+	}
+	return nil
+}
+
+// OutputOptions are target-neutral presentation controls.
+type OutputOptions struct {
+	Format      string
+	Quiet       bool
+	AutoApprove bool
+}
+
+// ExecutionOptions are target-neutral phase execution controls.
+type ExecutionOptions struct {
+	DryRun  bool
+	Timeout time.Duration
+}
+
+// Invocation is the target-neutral input presented to a CLI adapter. Config,
+// artifact, and cluster-context arguments stay target-owned until their exact
+// semantics are shared by every driver.
+type Invocation struct {
+	Target    Name
+	Phase     Phase
+	Output    OutputOptions
+	Execution ExecutionOptions
+}
+
+func (i Invocation) validate() error {
+	if i.Target == "" {
+		return fmt.Errorf("target must not be empty")
+	}
+	if _, err := ParseName(string(i.Target)); err != nil {
+		return err
+	}
+	if _, ok := knownPhases[i.Phase]; !ok {
+		return fmt.Errorf("unknown phase %q", i.Phase)
+	}
+	if i.Execution.Timeout < 0 {
+		return fmt.Errorf("phase timeout must not be negative")
+	}
+	return nil
+}
+
+// Operation is a target-specific, fully bound phase request. Implementations
+// capture typed target requests; the runtime never receives a union options
+// structure or Cobra flag set.
+type Operation interface {
+	Run(context.Context) error
+}
+
+// OperationFunc adapts a function to Operation.
+type OperationFunc func(context.Context) error
+
+// Run implements Operation.
+func (f OperationFunc) Run(ctx context.Context) error {
+	if f == nil {
+		return fmt.Errorf("target operation must not be nil")
+	}
+	return f(ctx)
+}
+
+// Driver is the CLI-facing target adapter. Bind validates target-specific
+// requirements, merges target configuration and explicit CLI overrides, and
+// returns an operation that invokes a typed domain driver.
+type Driver interface {
+	Descriptor() Descriptor
+	Bind(Invocation) (Operation, error)
+}
+
+// Registry resolves a target name to its CLI adapter.
+type Registry struct {
+	drivers map[Name]Driver
+}
+
+// NewRegistry creates a deterministic target registry. Invalid descriptors,
+// nil drivers, and duplicate target names fail at construction time.
+func NewRegistry(drivers ...Driver) (*Registry, error) {
+	if len(drivers) == 0 {
+		return nil, fmt.Errorf("target registry must contain at least one driver")
+	}
+	registry := &Registry{drivers: make(map[Name]Driver, len(drivers))}
+	for index, driver := range drivers {
+		if driver == nil {
+			return nil, fmt.Errorf("target driver at index %d must not be nil", index)
+		}
+		descriptor := driver.Descriptor()
+		if err := descriptor.validate(); err != nil {
+			return nil, err
+		}
+		if _, exists := registry.drivers[descriptor.Name]; exists {
+			return nil, fmt.Errorf("target %q is registered more than once", descriptor.Name)
+		}
+		registry.drivers[descriptor.Name] = driver
+	}
+	return registry, nil
+}
+
+// Names returns registered target names in stable order.
+func (r *Registry) Names() []Name {
+	if r == nil {
+		return nil
+	}
+	names := make([]Name, 0, len(r.drivers))
+	for name := range r.drivers {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool { return names[i] < names[j] })
+	return names
+}
+
+// Bind resolves and validates an invocation before asking the selected target
+// adapter to construct its typed operation.
+func (r *Registry) Bind(invocation Invocation) (Operation, error) {
+	if r == nil {
+		return nil, fmt.Errorf("target registry must not be nil")
+	}
+	if err := invocation.validate(); err != nil {
+		return nil, err
+	}
+	driver, ok := r.drivers[invocation.Target]
+	if !ok {
+		return nil, &UnknownTargetError{Name: invocation.Target, Supported: r.Names()}
+	}
+	descriptor := driver.Descriptor()
+	capability := descriptor.Capability(invocation.Phase)
+	if !capability.Available {
+		return nil, &PhaseUnavailableError{
+			Name:   invocation.Target,
+			Phase:  invocation.Phase,
+			Reason: capability.Reason,
+		}
+	}
+	operation, err := driver.Bind(invocation)
+	if err != nil {
+		return nil, err
+	}
+	if operation == nil {
+		return nil, fmt.Errorf("target %q returned a nil operation for phase %q", invocation.Target, invocation.Phase)
+	}
+	return operation, nil
+}
+
+// UnknownTargetError reports a syntactically valid target that has no
+// registered adapter.
+type UnknownTargetError struct {
+	Name      Name
+	Supported []Name
+}
+
+func (e *UnknownTargetError) Error() string {
+	return fmt.Sprintf("unknown target %q; registered targets: %v", e.Name, e.Supported)
+}
+
+// PhaseUnavailableError reports a known target whose selected phase is not
+// implemented in this build.
+type PhaseUnavailableError struct {
+	Name   Name
+	Phase  Phase
+	Reason string
+}
+
+func (e *PhaseUnavailableError) Error() string {
+	if e.Reason == "" {
+		return fmt.Sprintf("target %q does not implement phase %q", e.Name, e.Phase)
+	}
+	return fmt.Sprintf("target %q does not implement phase %q: %s", e.Name, e.Phase, e.Reason)
+}

--- a/pkg/target/target_test.go
+++ b/pkg/target/target_test.go
@@ -1,0 +1,328 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package target
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDriver struct {
+	descriptor Descriptor
+	bind       func(Invocation) (Operation, error)
+}
+
+func (f fakeDriver) Descriptor() Descriptor { return f.descriptor }
+
+func (f fakeDriver) Bind(invocation Invocation) (Operation, error) {
+	if f.bind == nil {
+		return OperationFunc(func(context.Context) error { return nil }), nil
+	}
+	return f.bind(invocation)
+}
+
+func availableDescriptor(name Name, phases ...Phase) Descriptor {
+	capabilities := make(map[Phase]Capability, len(PublicPhases()))
+	for _, phase := range PublicPhases() {
+		capabilities[phase] = Capability{Available: false, Reason: "not implemented in test driver"}
+	}
+	for _, phase := range phases {
+		capabilities[phase] = Capability{Available: true}
+	}
+	return Descriptor{Name: name, Description: string(name), Phases: capabilities}
+}
+
+func TestParseName(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		expected  Name
+		wantError string
+	}{
+		{name: "omitted defaults to host", value: "", expected: Host},
+		{name: "host", value: "host", expected: Host},
+		{name: "dpf", value: "dpf", expected: DPF},
+		{name: "future target syntax", value: "test-target2", expected: "test-target2"},
+		{name: "uppercase rejected", value: "HOST", wantError: "invalid target"},
+		{name: "surrounding whitespace rejected", value: " host", wantError: "invalid target"},
+		{name: "punctuation rejected", value: "dpf/cluster", wantError: "invalid target"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ParseName(tt.value)
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				assert.Empty(t, actual)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestPublicPhasesReturnsStableCopy(t *testing.T) {
+	first := PublicPhases()
+	require.Equal(t, []Phase{Discover, Generate, Deploy, Validate}, first)
+	first[0] = Pipeline
+	assert.Equal(t, Discover, PublicPhases()[0])
+}
+
+func TestDescriptorMissingCapabilityIsUnavailable(t *testing.T) {
+	descriptor := Descriptor{
+		Name: Host,
+		Phases: map[Phase]Capability{
+			Discover: {Available: true},
+		},
+	}
+	assert.True(t, descriptor.Capability(Discover).Available)
+	capability := descriptor.Capability(Generate)
+	assert.False(t, capability.Available)
+	assert.NotEmpty(t, capability.Reason)
+}
+
+func TestNewRegistryRejectsInvalidDrivers(t *testing.T) {
+	tests := []struct {
+		name      string
+		drivers   []Driver
+		wantError string
+	}{
+		{name: "no drivers", wantError: "must contain at least one driver"},
+		{name: "nil driver", drivers: []Driver{nil}, wantError: "must not be nil"},
+		{
+			name:      "empty name",
+			drivers:   []Driver{fakeDriver{descriptor: Descriptor{Phases: map[Phase]Capability{}}}},
+			wantError: "name must not be empty",
+		},
+		{
+			name:      "invalid name",
+			drivers:   []Driver{fakeDriver{descriptor: Descriptor{Name: "DPF", Phases: map[Phase]Capability{}}}},
+			wantError: "invalid target descriptor name",
+		},
+		{
+			name:      "nil phases",
+			drivers:   []Driver{fakeDriver{descriptor: Descriptor{Name: Host}}},
+			wantError: "must declare phase capabilities",
+		},
+		{
+			name: "missing public phase",
+			drivers: []Driver{fakeDriver{descriptor: Descriptor{
+				Name: Host,
+				Phases: map[Phase]Capability{
+					Discover: {Available: true},
+					Generate: {Available: true},
+					Deploy:   {Available: true},
+				},
+			}}},
+			wantError: `must declare capability for phase "validate"`,
+		},
+		{
+			name: "unknown phase",
+			drivers: []Driver{fakeDriver{descriptor: func() Descriptor {
+				descriptor := availableDescriptor(Host)
+				descriptor.Phases["upgrade"] = Capability{Available: true}
+				return descriptor
+			}()}},
+			wantError: "unknown phase",
+		},
+		{
+			name: "unavailable without reason",
+			drivers: []Driver{fakeDriver{descriptor: func() Descriptor {
+				descriptor := availableDescriptor(Host)
+				descriptor.Phases[Discover] = Capability{Available: false}
+				return descriptor
+			}()}},
+			wantError: "unavailable without a reason",
+		},
+		{
+			name: "duplicate",
+			drivers: []Driver{
+				fakeDriver{descriptor: availableDescriptor(Host, Discover)},
+				fakeDriver{descriptor: availableDescriptor(Host, Generate)},
+			},
+			wantError: "registered more than once",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry, err := NewRegistry(tt.drivers...)
+			require.ErrorContains(t, err, tt.wantError)
+			assert.Nil(t, registry)
+		})
+	}
+}
+
+func TestRegistryNamesAreSortedAndDefensive(t *testing.T) {
+	registry, err := NewRegistry(
+		fakeDriver{descriptor: availableDescriptor("zeta", Discover)},
+		fakeDriver{descriptor: availableDescriptor(Host, Discover)},
+		fakeDriver{descriptor: availableDescriptor(DPF, Discover)},
+	)
+	require.NoError(t, err)
+
+	names := registry.Names()
+	require.Equal(t, []Name{DPF, Host, "zeta"}, names)
+	names[0] = "changed"
+	assert.Equal(t, []Name{DPF, Host, "zeta"}, registry.Names())
+	assert.Nil(t, (*Registry)(nil).Names())
+}
+
+func TestRegistryBindAndRun(t *testing.T) {
+	var captured Invocation
+	var ran bool
+	driver := fakeDriver{
+		descriptor: availableDescriptor(Host, Generate),
+		bind: func(invocation Invocation) (Operation, error) {
+			captured = invocation
+			return OperationFunc(func(context.Context) error {
+				ran = true
+				return nil
+			}), nil
+		},
+	}
+	registry, err := NewRegistry(driver)
+	require.NoError(t, err)
+
+	invocation := Invocation{
+		Target: Host,
+		Phase:  Generate,
+		Output: OutputOptions{
+			Format:      "json",
+			Quiet:       true,
+			AutoApprove: true,
+		},
+		Execution: ExecutionOptions{DryRun: true, Timeout: time.Minute},
+	}
+	operation, err := registry.Bind(invocation)
+	require.NoError(t, err)
+	assert.Equal(t, invocation, captured)
+	require.NoError(t, operation.Run(context.Background()))
+	assert.True(t, ran)
+}
+
+func TestRegistryBindErrors(t *testing.T) {
+	bindErr := errors.New("required host argument missing")
+	driver := fakeDriver{
+		descriptor: Descriptor{
+			Name: Host,
+			Phases: map[Phase]Capability{
+				Discover: {Available: true},
+				Generate: {Available: false, Reason: "not built"},
+				Deploy:   {Available: true},
+				Validate: {Available: true},
+			},
+		},
+		bind: func(invocation Invocation) (Operation, error) {
+			switch invocation.Phase {
+			case Discover:
+				return nil, bindErr
+			case Deploy:
+				return nil, nil
+			default:
+				return OperationFunc(func(context.Context) error { return nil }), nil
+			}
+		},
+	}
+	registry, err := NewRegistry(driver)
+	require.NoError(t, err)
+
+	t.Run("nil registry", func(t *testing.T) {
+		operation, bindErr := (*Registry)(nil).Bind(Invocation{Target: Host, Phase: Discover})
+		require.ErrorContains(t, bindErr, "must not be nil")
+		assert.Nil(t, operation)
+	})
+
+	t.Run("invalid invocation", func(t *testing.T) {
+		operation, bindErr := registry.Bind(Invocation{Target: Host, Phase: Discover, Execution: ExecutionOptions{Timeout: -1}})
+		require.ErrorContains(t, bindErr, "must not be negative")
+		assert.Nil(t, operation)
+	})
+
+	t.Run("empty invocation target", func(t *testing.T) {
+		operation, bindErr := registry.Bind(Invocation{Phase: Discover})
+		require.ErrorContains(t, bindErr, "target must not be empty")
+		assert.Nil(t, operation)
+	})
+
+	t.Run("invalid target syntax", func(t *testing.T) {
+		operation, bindErr := registry.Bind(Invocation{Target: "HOST", Phase: Discover})
+		require.ErrorContains(t, bindErr, "invalid target")
+		assert.Nil(t, operation)
+	})
+
+	t.Run("unknown phase", func(t *testing.T) {
+		operation, bindErr := registry.Bind(Invocation{Target: Host, Phase: "upgrade"})
+		require.ErrorContains(t, bindErr, "unknown phase")
+		assert.Nil(t, operation)
+	})
+
+	t.Run("unknown target", func(t *testing.T) {
+		operation, bindErr := registry.Bind(Invocation{Target: DPF, Phase: Discover})
+		var unknown *UnknownTargetError
+		require.ErrorAs(t, bindErr, &unknown)
+		assert.Equal(t, DPF, unknown.Name)
+		assert.Equal(t, []Name{Host}, unknown.Supported)
+		assert.Nil(t, operation)
+	})
+
+	t.Run("unavailable phase", func(t *testing.T) {
+		operation, bindErr := registry.Bind(Invocation{Target: Host, Phase: Generate})
+		var unavailable *PhaseUnavailableError
+		require.ErrorAs(t, bindErr, &unavailable)
+		assert.Equal(t, "not built", unavailable.Reason)
+		assert.Nil(t, operation)
+	})
+
+	t.Run("binder validation", func(t *testing.T) {
+		operation, actualErr := registry.Bind(Invocation{Target: Host, Phase: Discover})
+		require.ErrorIs(t, actualErr, bindErr)
+		assert.Nil(t, operation)
+	})
+
+	t.Run("nil operation", func(t *testing.T) {
+		operation, bindErr := registry.Bind(Invocation{Target: Host, Phase: Deploy})
+		require.ErrorContains(t, bindErr, "returned a nil operation")
+		assert.Nil(t, operation)
+	})
+}
+
+func TestNilOperationFuncReturnsError(t *testing.T) {
+	var operation OperationFunc
+	require.ErrorContains(t, operation.Run(context.Background()), "must not be nil")
+}
+
+func TestTargetErrors(t *testing.T) {
+	assert.Equal(t,
+		`unknown target "future"; registered targets: [dpf host]`,
+		(&UnknownTargetError{Name: "future", Supported: []Name{DPF, Host}}).Error(),
+	)
+	assert.Equal(t,
+		`target "dpf" does not implement phase "discover"`,
+		(&PhaseUnavailableError{Name: DPF, Phase: Discover}).Error(),
+	)
+	assert.Equal(t,
+		`target "dpf" does not implement phase "discover": not built`,
+		(&PhaseUnavailableError{Name: DPF, Phase: Discover, Reason: "not built"}).Error(),
+	)
+}

--- a/skills/k8s-launch-kit-deploy/SKILL.md
+++ b/skills/k8s-launch-kit-deploy/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 
 > **PREREQUISITE:** Read `../k8s-launch-kit-shared/SKILL.md` for install paths, global flags, and output modes.
 
+This workflow uses the default `host` target; `--target host` is equivalent.
+
 Apply previously generated NVIDIA networking manifests to a Kubernetes cluster.
 
 ## Usage

--- a/skills/k8s-launch-kit-discover/SKILL.md
+++ b/skills/k8s-launch-kit-discover/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 
 > **PREREQUISITE:** Read `../k8s-launch-kit-shared/SKILL.md` for install paths, global flags, and output modes.
 
+This workflow uses the default `host` target; `--target host` is equivalent.
+
 Discover cluster hardware and produce a `cluster-config.yaml` describing NICs, GPUs, rails, and node groups.
 
 Three things to know about the saved file:

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 
 > **PREREQUISITE:** Read `../k8s-launch-kit-shared/SKILL.md` for install paths, global flags, and output modes.
 
+This workflow uses the default `host` target; `--target host` is equivalent.
+
 Generate Kubernetes YAML manifests for NVIDIA networking from a cluster config and profile selection.
 
 ## Usage

--- a/skills/k8s-launch-kit-pipeline/SKILL.md
+++ b/skills/k8s-launch-kit-pipeline/SKILL.md
@@ -13,6 +13,10 @@ metadata:
 
 Run discovery + generation + deployment as a single command.
 
+The pipeline operates on the default `host` target. Omitting `--target` keeps
+the established behavior; `--target host` is equivalent. Do not select `dpf`
+until `l8k schema` reports all required DPF phases as available.
+
 ## Usage
 
 The root command chains all phases in one invocation:

--- a/skills/k8s-launch-kit-shared/SKILL.md
+++ b/skills/k8s-launch-kit-shared/SKILL.md
@@ -55,10 +55,23 @@ After installation, `l8k` is available system-wide.
 
 The root command `l8k --discover-cluster-config ...` still works for backward-compatible full-pipeline usage.
 
+## Target selection
+
+`discover`, `generate`, `deploy`, `validate`, and the root pipeline default to
+the `host` target. Existing invocations must omit `--target` unless the user
+explicitly requests it; `--target host` is an equivalent explicit form.
+
+The `dpf` target name is reserved but its phases are not implemented in this
+build. Do not attempt DPF provisioning. Use `l8k schema` and inspect
+`targets[].phases` before selecting any non-host target. Host-only flags such as
+`--fabric`, `--kubeconfig`, and the Network Operator/Spectrum-X flags are
+rejected when explicitly combined with another target.
+
 ## Global Flags
 
 | Flag | Description |
 |------|-------------|
+| `--target <NAME>` | Lifecycle target: `host` (default); `dpf` is currently unavailable |
 | `--kubeconfig <PATH>` | Path to kubeconfig file (optional — falls back to `$KUBECONFIG` env var) |
 | `--user-config <PATH>` | Path to user-supplied l8k-config.yaml |
 | `--output <FORMAT>` | Output format: `text` (default), `json` |

--- a/skills/k8s-launch-kit-validate/SKILL.md
+++ b/skills/k8s-launch-kit-validate/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 
 > **PREREQUISITE:** Read `../k8s-launch-kit-shared/SKILL.md` for install paths, global flags, and exit codes.
 
+This workflow uses the default `host` target; `--target host` is equivalent.
+
 Verify that a previously generated and deployed NVIDIA networking
 deployment is correctly applied and matches the selected Network
 Operator release.


### PR DESCRIPTION
## Summary

- add a target-neutral lifecycle registry with explicit phase capabilities and typed operation binding
- preserve the existing Network Operator workflow as the default `host` target; omitting `--target` and using `--target host` follow the same host path
- classify lifecycle flags by target ownership, reject explicitly supplied foreign-target flags, and expose the same metadata in grouped help and `l8k schema`
- reserve the `dpf` target with clear unavailable-phase errors so it cannot fall through to host behavior before a DPF driver exists
- document the extension boundary and update bundled lifecycle skills

## Compatibility boundary

This PR does not move or reinterpret host configuration, generated artifacts, kubeconfig semantics, or command bodies. Target validation runs before the unchanged host implementation. DPF provisioning is intentionally not implemented here; all four DPF phases remain unavailable in the advertised schema.

Subprocess coverage verifies that omitted-target and explicit-host invocations produce identical output and exit codes on the same host error path.

## Validation

- `CGO_ENABLED=0 go test -count=1 ./...`
- `CGO_ENABLED=0 go test -race -count=1 ./...`
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=0 go build ./...`
- `CGO_ENABLED=0 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0 run ./...`
- `uv run --with mkdocs-material==9.6.20 mkdocs build --strict --clean`
- new `pkg/target` package: 100% statement coverage

Signed-off-by: Alexander Maslennikov <amaslennikov@nvidia.com>
