### PR TITLE
feat: add GPUDirect DMA-BUF validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,13 +363,22 @@ container for RDMA checks and a declared `netshoot` container for ICMP; validate
 applies that manifest without injecting containers at runtime. ICMP uses
 `ping -I <src-iface>`, `rping` uses
 `-I <src-ip>`, and `ib_write_bw` uses `--bind_source_ip <src-ip>`; every test
-also records a source-qualified `ip route get <dst> from <src>` lookup. The
+also records a source-qualified `ip route get <dst> from <src>` lookup from the
+netshoot container. When `validation.gpuDirect.enabled` is true, a separate
+DMA-BUF bandwidth stage repeats the selected `ib_write_bw` matrix with
+`--use_cuda=<endpoint-index> --use_cuda_dmabuf`. Source and destination CUDA
+indices are resolved independently from each node's per-PF `connectedGPU`
+topology; missing or ambiguous mappings fail explicitly instead of falling
+back to GPU 0. The
 matrix is on by default (`--connectivity=false` to skip) and cleans up the
 test DaemonSet unless `--keep` is set. Fresh `l8k discover` output includes
 the default validation block:
 
 ```yaml
 validation:
+  gpuDirect:
+    enabled: false
+    gpuResourceType: nvidia.com/gpu
   connectivity: true
   mode: strict
   checks:
@@ -381,6 +390,16 @@ validation:
     ibWriteSize: 65536
     ibWriteMinBandwidthGbps: 100
 ```
+
+Discovery always writes `gpuDirect.enabled`: it is `true` only when every
+worker in every discovered group can satisfy the topology-derived
+`gpuResourceType` request for its render bucket, and `false` otherwise. Users
+can edit the result before generation. When enabled, generated validation DaemonSets use
+the release-specific full-runtime DOCA image, propagate
+`networkOperator.imagePullSecrets`, and request the GPU prefix required by the
+largest discovered `GPU<N>` index in the primary DOCA container. The netshoot
+container never requests GPUs. The named pull Secret must exist in every
+validation workload namespace.
 
 Validation modes control cross-rail coverage and gating:
 
@@ -681,7 +700,7 @@ The tool resolves configuration and profile paths in order: local directory firs
 
 ### Network Operator release selection
 
-Use `--network-operator-release <MAJOR.MINOR>` (or `networkOperator.selectedRelease` in the config file) to pick a Network Operator release line by name instead of hand-editing image tags. Supported releases live in an embedded catalog ([pkg/networkoperatorplugin/releases/releases.yaml](pkg/networkoperatorplugin/releases/releases.yaml)); each entry maps a release key to image tags and repositories for the operator, DOCA driver, and—where the release deploys it—the independently versioned xPlane service. Selecting a release populates `networkOperator.{version,componentVersion,repository}` and `docaDriver.version` from the catalog, while Spectrum-X profiles resolve `spectrumXOperator.xPlane.{repository,version}` from the same entry. Explicit values in `l8k-config.yaml` are overridden when a release is set.
+Use `--network-operator-release <MAJOR.MINOR>` (or `networkOperator.selectedRelease` in the config file) to pick a Network Operator release line by name instead of hand-editing image tags. Supported releases live in an embedded catalog ([pkg/networkoperatorplugin/releases/releases.yaml](pkg/networkoperatorplugin/releases/releases.yaml)); each entry maps a release key to image tags and repositories for the operator, DOCA driver, full-runtime validation workload, and—where the release deploys it—the independently versioned xPlane service. Selecting a release populates `networkOperator.{version,componentVersion,repository}` and `docaDriver.version` from the catalog, while validation workloads and Spectrum-X profiles resolve their image coordinates from the same entry. Explicit values in `l8k-config.yaml` are overridden when a release is set.
 
 ```bash
 # Pick a release on the CLI

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -134,7 +134,7 @@ full deletion boundary.
 | --- | --- |
 | `--connectivity` | Enable or disable data-plane connectivity checks. |
 | `--validation-mode` | `quick`, `full`, or `strict`. |
-| `--validation-checks` | Comma-separated list of `icmp`, `rping`, and `ib_write_bw`. |
+| `--validation-checks` | Comma-separated list of `icmp`, `rping`, and `ib_write_bw`. Enabled GPUDirect DMA-BUF validation follows the `ib_write_bw` selection. |
 | `--connectivity-timeout` | Wall-clock budget for connectivity workload rollout and test execution. |
 | `--rdma-rping-iterations` | Override `validation.rdma.rpingIterations`. |
 | `--rdma-ib-write-size` | Override `validation.rdma.ibWriteSize`. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -47,7 +47,7 @@ Supported release lines are currently:
 - `26.4`
 - `26.7`
 
-The release line fills Network Operator versions, component image tags, DOCA driver version, repositories, Helm repository URL, and version-gated template behavior. Spectrum-X releases also carry a manually maintained xPlane repository and version used in `spectrumXOperator.xPlane` instead of reusing the generic component tag.
+The release line fills Network Operator versions, component image tags, DOCA driver version, full-runtime validation image, repositories, Helm repository URL, and version-gated template behavior. Spectrum-X releases also carry a manually maintained xPlane repository and version used in `spectrumXOperator.xPlane` instead of reusing the generic component tag.
 
 ## Network Operator
 
@@ -92,6 +92,9 @@ Secondary-network CRs and example workloads render once per network namespace. S
 
 ```yaml
 validation:
+  gpuDirect:
+    enabled: false
+    gpuResourceType: nvidia.com/gpu
   connectivity: true
   mode: strict
   checks:
@@ -106,12 +109,22 @@ validation:
 
 | Field | Meaning |
 | --- | --- |
+| `gpuDirect.enabled` | Run a separate CUDA DMA-BUF `ib_write_bw` matrix when `ib_write_bw` is selected. Discovery always writes this boolean and enables it only when every discovered worker can satisfy its render bucket's topology-derived `gpuResourceType` request. |
+| `gpuDirect.gpuResourceType` | Qualified Kubernetes extended resource requested by the primary validation container. Defaults to `nvidia.com/gpu`. |
 | `connectivity` | Enables the data-plane stage. Static acceptance checks always run. |
 | `mode` | `quick`, `full`, or `strict`. |
 | `checks` | Any combination of `icmp`, `rping`, and `ib_write_bw`; an empty list disables all connectivity test families. |
 | `rdma.rpingIterations` | Client iterations for each `rping` test. |
 | `rdma.ibWriteSize` | Message size passed to `ib_write_bw`. |
 | `rdma.ibWriteMinBandwidthGbps` | Minimum observed peak bandwidth. Set `0` to disable the bandwidth gate. |
+
+GPU resource counts are not added to `clusterConfig`. Generation derives the
+request needed to expose the discovered `GPU<N>` indices from the existing PF
+topology. The DMA-BUF runner resolves source and destination indices separately
+from `connectedGPU` (and reports `connectedGPUPCIAddress` when available); an
+unresolved or ambiguous NIC/GPU association is a failed validation result.
+`networkOperator.imagePullSecrets` is copied to the validation Pod spec, so
+each named Secret must exist in every generated network namespace.
 
 ## DOCA Driver
 

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -24,12 +24,12 @@ When `--user-config` is omitted, Launch Kit checks `./cluster-config.yaml`, the 
 | Component versions | Version-bearing sections of `NicClusterPolicy` and `NicNodePolicy` match the selected release catalog. |
 | Manifest state | Each generated CR is classified as `READY`, `IN-PROGRESS`, `ERROR`, or `MISSING`. |
 | Preflight | Stray CRs and Helm value drift that can make the apply path ambiguous. |
-| Connectivity | ICMP, `rping`, and `ib_write_bw` checks between generated test DaemonSet pods. |
+| Connectivity | ICMP, `rping`, host-memory `ib_write_bw`, and optional GPUDirect DMA-BUF bandwidth checks between generated test DaemonSet pods. |
 
 Connectivity is skipped when manifests are missing, errored, or still in progress.
 
 Each generated example DaemonSet declares two validation containers: the DOCA
-container runs `rping` and `ib_write_bw`, while the `netshoot` container runs
+container runs `rping`, `ib_write_bw`, and DMA-BUF bandwidth, while the `netshoot` container runs
 ICMP and route checks from the same pod network namespace. Validation applies
 the generated DaemonSet as written; it does not inject a helper container at
 runtime.
@@ -58,6 +58,9 @@ Fresh discovery writes:
 
 ```yaml
 validation:
+  gpuDirect:
+    enabled: false
+    gpuResourceType: nvidia.com/gpu
   connectivity: true
   mode: strict
   checks:
@@ -69,6 +72,26 @@ validation:
     ibWriteSize: 65536
     ibWriteMinBandwidthGbps: 100
 ```
+
+`gpuDirect.enabled` is never omitted. Discovery sets it to `true` only when
+every worker in every discovered group can satisfy its render bucket's
+topology-derived `gpuResourceType` request; otherwise it writes `false`. You may
+change the value before generation. GPUDirect runs as a distinct result family whenever
+it is enabled and `ib_write_bw` is selected.
+
+The generated validation DaemonSet selects its full-runtime DOCA image from
+the Network Operator release catalog and copies
+`networkOperator.imagePullSecrets` into the Pod spec. Create those Secrets in
+every network namespace used by validation. Only the DOCA container requests
+the configured GPU resource.
+
+For each test, Launch Kit maps the source rail and destination rail to their
+own `connectedGPU` value from discovery or the selected topology preset. It
+then passes `--use_cuda=<source-index> --use_cuda_dmabuf` to the client and
+`--use_cuda=<destination-index> --use_cuda_dmabuf` to the server. Missing or
+ambiguous mappings fail; GPU 0 is never assumed. Text, JSON, and HTML output
+keep DMA-BUF results separate and include indices, PCI addresses when known,
+bandwidth, threshold, and errors.
 
 Override per run:
 

--- a/hack/sync-network-operator-releases/sync_test.go
+++ b/hack/sync-network-operator-releases/sync_test.go
@@ -84,6 +84,9 @@ type catalogReleaseValues struct {
 	DOCADriver struct {
 		Version string `yaml:"version"`
 	} `yaml:"docaDriver"`
+	Validation struct {
+		Image string `yaml:"image"`
+	} `yaml:"validation"`
 }
 
 func TestSyncCatalogUpdatesAllReleasesAndFallsBackForLatest(t *testing.T) {
@@ -141,6 +144,7 @@ func TestSyncCatalogUpdatesAllReleasesAndFallsBackForLatest(t *testing.T) {
 	assert.Equal(t, stableOperatorRepository, stable.NetworkOperator.OperatorRepository)
 	assert.Equal(t, stableHelmRepoURL, stable.NetworkOperator.HelmRepoURL)
 	assert.Equal(t, "doca3.3.0-26.01-1.0.0.0-6", stable.DOCADriver.Version)
+	assert.Equal(t, "registry.example/validation:26.1", stable.Validation.Image)
 
 	latest := catalog.Releases["26.7"]
 	assert.Equal(t, "v26.7.0-rc.1", latest.NetworkOperator.Version)
@@ -149,6 +153,7 @@ func TestSyncCatalogUpdatesAllReleasesAndFallsBackForLatest(t *testing.T) {
 	assert.Equal(t, stagingOperatorRepository, latest.NetworkOperator.OperatorRepository)
 	assert.Equal(t, stagingHelmRepoURL, latest.NetworkOperator.HelmRepoURL)
 	assert.Equal(t, "doca3.5.0-26.07-0.5.1.0-0", latest.DOCADriver.Version)
+	assert.Equal(t, "registry.example/validation:26.7", latest.Validation.Image)
 
 	beforeSecondRun := append([]byte(nil), updated...)
 	secondResult, err := syncCatalog(context.Background(), syncOptions{
@@ -328,6 +333,8 @@ releases:
       helmRepoURL: https://helm.ngc.nvidia.com/nvidia
     docaDriver:
       version: doca3.3.0-26.01-1.0.0.0-0
+    validation:
+      image: registry.example/validation:26.1
   "26.7":
     networkOperator:
       version: v26.7.0-beta.4
@@ -337,6 +344,8 @@ releases:
       helmRepoURL: https://helm.ngc.nvidia.com/nvstaging/mellanox
     docaDriver:
       version: doca3.5.0-26.07-0.4.2.0-0
+    validation:
+      image: registry.example/validation:26.7
 `
 }
 

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -237,7 +237,7 @@ var schemaCmd = &cobra.Command{
 				"--validation-checks": {
 					Type:        "[]string",
 					Default:     "inherit from validation.checks",
-					Description: "Comma-separated checks to run during validate connectivity: icmp, rping, ib_write_bw.",
+					Description: "Comma-separated checks to run during validate connectivity: icmp, rping, ib_write_bw. Enabled GPUDirect DMA-BUF validation follows ib_write_bw.",
 				},
 				"--validation-mode": {
 					Type:        "string",

--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -210,6 +210,7 @@ connectivity-matrix failure.`,
 		selectedRelease := ""
 		profileRouting := config.RoutingDestinationBased
 		validationCfg := config.DefaultValidationConfig()
+		var clusterConfig []config.ClusterConfig
 		cfg, cfgPath, cfgErr := loadUserConfig(options.Options{
 			ConfigDir:                configDir,
 			NetworkOperatorNamespace: networkOperatorNamespace,
@@ -228,6 +229,7 @@ connectivity-matrix failure.`,
 				profileRouting = cfg.Profile.Routing
 			}
 			validationCfg = config.NormalizeValidationConfig(cfg.Validation)
+			clusterConfig = cfg.ClusterConfig
 			for _, g := range cfg.ClusterConfig {
 				if len(g.PresetDeviation) == 0 {
 					continue
@@ -409,6 +411,7 @@ connectivity-matrix failure.`,
 				RPingIterations:         validationCfg.RDMA.RPingIterations,
 				IBWriteSize:             validationCfg.RDMA.IBWriteSize,
 				IBWriteMinBandwidthGbps: *validationCfg.RDMA.IBWriteMinBandwidthGbps,
+				ClusterConfig:           clusterConfig,
 			})
 			matrix = m
 			if err != nil {
@@ -502,7 +505,20 @@ func connectivityChecksFromConfig(validationCfg *config.ValidationConfig) []conn
 			checks = append(checks, connectivity.CheckIBWriteBW)
 		}
 	}
+	if validationCfg.GPUDirect.Enabled &&
+		checksContainConfig(validationCfg.Checks, config.ValidationCheckIBWriteBW) {
+		checks = append(checks, connectivity.CheckGPUDirectDMABuf)
+	}
 	return checks
+}
+
+func checksContainConfig(checks []string, want string) bool {
+	for _, check := range checks {
+		if check == want {
+			return true
+		}
+	}
+	return false
 }
 
 // hasPresetDeviation reports whether any group deviated from its

--- a/pkg/cmd/validate_config_test.go
+++ b/pkg/cmd/validate_config_test.go
@@ -92,6 +92,18 @@ func TestApplyValidateFlagOverrides(t *testing.T) {
 		assert.Equal(t, []connectivity.Check{connectivity.CheckICMP}, connectivityChecksFromConfig(cfg))
 	})
 
+	t.Run("enabled GPUDirect follows ib_write_bw selection", func(t *testing.T) {
+		cfg := config.NormalizeValidationConfig(&config.ValidationConfig{
+			Checks:    []string{config.ValidationCheckIBWriteBW},
+			GPUDirect: config.ValidationGPUDirectConfig{Enabled: true, GPUResourceType: "example.com/gpu"},
+		})
+		assert.Equal(t,
+			[]connectivity.Check{connectivity.CheckIBWriteBW, connectivity.CheckGPUDirectDMABuf},
+			connectivityChecksFromConfig(cfg))
+		cfg.Checks = []string{config.ValidationCheckRPing}
+		assert.Equal(t, []connectivity.Check{connectivity.CheckRPing}, connectivityChecksFromConfig(cfg))
+	})
+
 	t.Run("zero minimum bandwidth override disables bandwidth gating", func(t *testing.T) {
 		resetValidateOverrideGlobals(t)
 		cmd := newValidateOverrideTestCmd()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"gopkg.in/yaml.v2"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 )
 
 // defaultConfigYAML is the canonical baseline l8k configuration baked into the
@@ -196,11 +197,16 @@ type LaunchKitConfig struct {
 	// CurrentNetworkNamespace is transient render state. The renderer sets it
 	// to one NetworkNamespaces entry while producing that namespace's copy;
 	// it is never part of the persisted configuration schema.
-	CurrentNetworkNamespace string            `yaml:"-"`
-	Workload                *WorkloadConfig   `yaml:"workload,omitempty"`
-	Validation              *ValidationConfig `yaml:"validation,omitempty"`
-	Profile                 *Profile          `yaml:"profile,omitempty"`
-	ClusterConfig           []ClusterConfig   `yaml:"clusterConfig,omitempty"`
+	CurrentNetworkNamespace string `yaml:"-"`
+	// ValidationGPUResourceCount is transient render state. The renderer
+	// computes the largest GPU prefix required across every source group in a
+	// DaemonSet render bucket so endpoint-specific CUDA indices remain visible
+	// after compatible groups are merged. It is never persisted in user config.
+	ValidationGPUResourceCount int               `yaml:"-"`
+	Workload                   *WorkloadConfig   `yaml:"workload,omitempty"`
+	Validation                 *ValidationConfig `yaml:"validation,omitempty"`
+	Profile                    *Profile          `yaml:"profile,omitempty"`
+	ClusterConfig              []ClusterConfig   `yaml:"clusterConfig,omitempty"`
 }
 
 type NetworkOperatorConfig struct {
@@ -417,16 +423,28 @@ const (
 	DefaultValidationRPingIterations = 5
 	DefaultValidationIBWriteSize     = 65536
 	DefaultValidationIBWriteMinGbps  = 100
+	DefaultGPUResourceType           = "nvidia.com/gpu"
 )
 
 // ValidationConfig controls `l8k validate` data-plane checks. Static manifest
-// and version checks always run; Connectivity gates the example-DaemonSet RDMA
-// matrix. Checks selects which RDMA families to run.
+// and version checks always run; Connectivity gates the example-DaemonSet data
+// plane matrix. Checks selects the base families, while GPUDirect enables the
+// DMA-BUF variant of ib_write_bw.
 type ValidationConfig struct {
-	Connectivity *bool                 `yaml:"connectivity,omitempty"`
-	Mode         string                `yaml:"mode,omitempty"`
-	Checks       []string              `yaml:"checks,omitempty"`
-	RDMA         *ValidationRDMAConfig `yaml:"rdma,omitempty"`
+	Connectivity *bool                     `yaml:"connectivity,omitempty"`
+	Mode         string                    `yaml:"mode,omitempty"`
+	Checks       []string                  `yaml:"checks,omitempty"`
+	RDMA         *ValidationRDMAConfig     `yaml:"rdma,omitempty"`
+	GPUDirect    ValidationGPUDirectConfig `yaml:"gpuDirect"`
+}
+
+// ValidationGPUDirectConfig controls the CUDA DMA-BUF variant of the
+// ib_write_bw matrix. Enabled is deliberately non-optional: discovery writes
+// its decision to the generated config and users may override that value
+// before generation or validation.
+type ValidationGPUDirectConfig struct {
+	Enabled         bool   `yaml:"enabled"`
+	GPUResourceType string `yaml:"gpuResourceType"`
 }
 
 type ValidationRDMAConfig struct {
@@ -452,6 +470,10 @@ func DefaultValidationConfig() *ValidationConfig {
 			RPingIterations:         DefaultValidationRPingIterations,
 			IBWriteSize:             DefaultValidationIBWriteSize,
 			IBWriteMinBandwidthGbps: defaultFloat64(DefaultValidationIBWriteMinGbps),
+		},
+		GPUDirect: ValidationGPUDirectConfig{
+			Enabled:         false,
+			GPUResourceType: DefaultGPUResourceType,
 		},
 	}
 }
@@ -483,6 +505,10 @@ func NormalizeValidationConfig(v *ValidationConfig) *ValidationConfig {
 	}
 	if v.RDMA.IBWriteMinBandwidthGbps == nil {
 		v.RDMA.IBWriteMinBandwidthGbps = defaultFloat64(DefaultValidationIBWriteMinGbps)
+	}
+	v.GPUDirect.GPUResourceType = strings.TrimSpace(v.GPUDirect.GPUResourceType)
+	if v.GPUDirect.GPUResourceType == "" {
+		v.GPUDirect.GPUResourceType = DefaultGPUResourceType
 	}
 	return v
 }
@@ -516,6 +542,13 @@ func ValidateValidationConfig(v *ValidationConfig) error {
 	}
 	if v.RDMA != nil && v.RDMA.IBWriteMinBandwidthGbps != nil && *v.RDMA.IBWriteMinBandwidthGbps < 0 {
 		return fmt.Errorf("validation.rdma.ibWriteMinBandwidthGbps must be greater than or equal to 0")
+	}
+	resourceType := v.GPUDirect.GPUResourceType
+	if !strings.Contains(resourceType, "/") {
+		return fmt.Errorf("validation.gpuDirect.gpuResourceType must be a qualified extended resource name, got %q", resourceType)
+	}
+	if errs := k8svalidation.IsQualifiedName(resourceType); len(errs) > 0 {
+		return fmt.Errorf("validation.gpuDirect.gpuResourceType %q is invalid: %s", resourceType, strings.Join(errs, "; "))
 	}
 	for _, check := range v.Checks {
 		switch check {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 func TestGeneratedGroupIdentityIsBounded(t *testing.T) {
@@ -121,6 +122,8 @@ profile:
 		assert.Equal(t, ValidationModeStrict, config.Validation.Mode)
 		assert.Equal(t, []string{ValidationCheckICMP, ValidationCheckRPing, ValidationCheckIBWriteBW}, config.Validation.Checks)
 		require.NotNil(t, config.Validation.RDMA)
+		assert.False(t, config.Validation.GPUDirect.Enabled)
+		assert.Equal(t, DefaultGPUResourceType, config.Validation.GPUDirect.GPUResourceType)
 		assert.Equal(t, DefaultValidationRPingIterations, config.Validation.RDMA.RPingIterations)
 		assert.Equal(t, DefaultValidationIBWriteSize, config.Validation.RDMA.IBWriteSize)
 		require.NotNil(t, config.Validation.RDMA.IBWriteMinBandwidthGbps)
@@ -181,6 +184,8 @@ func TestDefaultLaunchKitConfig(t *testing.T) {
 	assert.Equal(t, ValidationModeStrict, cfg.Validation.Mode)
 	assert.Equal(t, []string{ValidationCheckICMP, ValidationCheckRPing, ValidationCheckIBWriteBW}, cfg.Validation.Checks)
 	require.NotNil(t, cfg.Validation.RDMA)
+	assert.False(t, cfg.Validation.GPUDirect.Enabled)
+	assert.Equal(t, DefaultGPUResourceType, cfg.Validation.GPUDirect.GPUResourceType)
 	assert.Equal(t, DefaultValidationRPingIterations, cfg.Validation.RDMA.RPingIterations)
 	assert.Equal(t, DefaultValidationIBWriteSize, cfg.Validation.RDMA.IBWriteSize)
 	require.NotNil(t, cfg.Validation.RDMA.IBWriteMinBandwidthGbps)
@@ -198,6 +203,21 @@ func TestDefaultLaunchKitConfig(t *testing.T) {
 }
 
 func TestValidationConfig(t *testing.T) {
+	t.Run("always serializes explicit GPUDirect fields", func(t *testing.T) {
+		data, err := yaml.Marshal(DefaultValidationConfig())
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "gpuDirect:\n  enabled: false\n  gpuResourceType: nvidia.com/gpu")
+	})
+
+	t.Run("does not serialize transient GPU render count", func(t *testing.T) {
+		cfg, err := DefaultLaunchKitConfig()
+		require.NoError(t, err)
+		cfg.ValidationGPUResourceCount = 8
+		data, err := yaml.Marshal(cfg)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "validationGPUResourceCount")
+	})
+
 	t.Run("explicit empty checks stays empty", func(t *testing.T) {
 		cfg := NormalizeValidationConfig(&ValidationConfig{Checks: []string{}})
 		require.NotNil(t, cfg)
@@ -228,6 +248,17 @@ func TestValidationConfig(t *testing.T) {
 		cfg := NormalizeValidationConfig(&ValidationConfig{RDMA: &ValidationRDMAConfig{IBWriteMinBandwidthGbps: &zero}})
 		require.NotNil(t, cfg.RDMA.IBWriteMinBandwidthGbps)
 		assert.Equal(t, 0.0, *cfg.RDMA.IBWriteMinBandwidthGbps)
+	})
+
+	t.Run("defaults and validates GPU resource type", func(t *testing.T) {
+		cfg := NormalizeValidationConfig(&ValidationConfig{GPUDirect: ValidationGPUDirectConfig{Enabled: true}})
+		assert.True(t, cfg.GPUDirect.Enabled)
+		assert.Equal(t, DefaultGPUResourceType, cfg.GPUDirect.GPUResourceType)
+		require.NoError(t, ValidateValidationConfig(cfg))
+		cfg.GPUDirect.GPUResourceType = "gpu"
+		err := ValidateValidationConfig(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "qualified extended resource")
 	})
 }
 

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -39,6 +39,11 @@ networkNamespaces: [default]
 #   manifest: /path/to/my-deployment.yaml  # Custom workload manifest (replaces default example DaemonSet)
 
 validation:
+  gpuDirect:
+    # Discovery sets enabled=true only when every discovered worker node can
+    # satisfy the topology-derived request for gpuResourceType.
+    enabled: false
+    gpuResourceType: nvidia.com/gpu
   # connectivity gates the data-plane validation stage. Static manifest,
   # Helm release, component-version, and preflight checks always run.
   connectivity: true

--- a/pkg/networkoperatorplugin/connectivity/connectivity.go
+++ b/pkg/networkoperatorplugin/connectivity/connectivity.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -34,9 +35,10 @@ import (
 type Check string
 
 const (
-	CheckICMP      Check = "icmp"
-	CheckRPing     Check = "rping"
-	CheckIBWriteBW Check = "ib_write_bw"
+	CheckICMP            Check = "icmp"
+	CheckRPing           Check = "rping"
+	CheckIBWriteBW       Check = "ib_write_bw"
+	CheckGPUDirectDMABuf Check = "gpudirect_dmabuf"
 )
 
 // Options control the matrix run end-to-end. The l8k validate CLI
@@ -70,6 +72,10 @@ type Options struct {
 	// IBWriteMinBandwidthGbps is the minimum peak bandwidth that must be
 	// observed for an ib_write_bw test to pass. 0 disables threshold gating.
 	IBWriteMinBandwidthGbps float64
+	// ClusterConfig supplies the node/rail to connected-GPU topology used by
+	// the DMA-BUF test. GPUDirect is selected by including
+	// CheckGPUDirectDMABuf in Checks.
+	ClusterConfig []config.ClusterConfig
 }
 
 // MatrixResult is the aggregate output of one connectivity run. It's
@@ -79,7 +85,8 @@ type MatrixResult struct {
 	// one per merged group.
 	DaemonSets []DaemonSetReport
 	// PingResults is the flat list of every executed connectivity test
-	// (icmp + rping + ib_write_bw, same-rail + cross-rail).
+	// (icmp + rping + host-memory ib_write_bw + GPUDirect DMA-BUF,
+	// same-rail + cross-rail).
 	PingResults []PingResult
 	// Skipped is non-nil when fewer than 2 schedulable test pods
 	// were available across all DaemonSets. The matrix is treated
@@ -149,7 +156,7 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 	uiOutput.Info("Loading example DaemonSet manifests from %s", opts.ManifestDir)
 
 	hasICMP := checksContain(opts.Checks, CheckICMP)
-	hasRDMA := checksContain(opts.Checks, CheckRPing) || checksContain(opts.Checks, CheckIBWriteBW)
+	hasRDMA := checksContain(opts.Checks, CheckRPing) || checksContain(opts.Checks, CheckIBWriteBW) || checksContain(opts.Checks, CheckGPUDirectDMABuf)
 	objs, refs, err := LoadExampleDaemonSets(opts.ManifestDir)
 	if err != nil {
 		return nil, err
@@ -159,10 +166,10 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			Skipped: &MatrixSkip{Reason: "no example DaemonSet manifests found under " + opts.ManifestDir},
 		}, nil
 	}
-	if hasICMP {
+	if hasICMP || hasRDMA {
 		for _, ref := range refs {
 			if ref.ICMPContainer == "" {
-				return nil, fmt.Errorf("example DaemonSet %s/%s from %s does not declare the %q ICMP helper container",
+				return nil, fmt.Errorf("example DaemonSet %s/%s from %s does not declare the %q ICMP/route helper container",
 					ref.Namespace, ref.Name, ref.SourceFile, icmpTestContainerName)
 			}
 		}
@@ -255,6 +262,7 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 					"rdmaDevsByRail", tp.RDMADevsByRail)
 			}
 			tp.InterfacesByRail = ifaceByRail
+			PopulateGPUTopology(&tp, opts.ClusterConfig)
 			testPods = append(testPods, tp)
 		}
 		return testPods
@@ -303,6 +311,11 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			len(plan.RDMABwSameRail), len(plan.RDMABwCrossRail))
 		plannedTests += len(plan.RDMABwSameRail) + len(plan.RDMABwCrossRail)
 	}
+	if checksContain(opts.Checks, CheckGPUDirectDMABuf) {
+		uiOutput.Info("Plan: %d same-rail GPUDirect DMA-BUF + %d cross-rail GPUDirect DMA-BUF",
+			len(plan.GPUDirectDMABufSameRail), len(plan.GPUDirectDMABufCrossRail))
+		plannedTests += len(plan.GPUDirectDMABufSameRail) + len(plan.GPUDirectDMABufCrossRail)
+	}
 	// Defensive: Plan() can return a zero-test plan without setting
 	// Skip (e.g. ≥2 schedulable pods but Plan's same-rail loop emits
 	// nothing). Two possible causes, both surface here:
@@ -347,6 +360,11 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			tests: append(append([]PingTest{}, plan.RDMABwSameRail...), plan.RDMABwCrossRail...),
 		},
 		{
+			check: CheckGPUDirectDMABuf,
+			label: "GPUDirect RDMA bandwidth (DMA-BUF)",
+			tests: append(append([]PingTest{}, plan.GPUDirectDMABufSameRail...), plan.GPUDirectDMABufCrossRail...),
+		},
+		{
 			check: CheckICMP,
 			label: "Layer 3 ping (ICMP)",
 			tests: append(append([]PingTest{}, plan.ICMPSameRail...), plan.ICMPCrossRail...),
@@ -365,6 +383,9 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			continue
 		}
 		uiOutput.Info("Stage: %s — %d test(s)", stage.label, len(tests))
+		if stage.check != CheckICMP {
+			tests = checkSourceRoutes(ctx, restConfig, namespaceByPod, icmpContainerByPod, tests)
+		}
 		if stage.check == CheckRPing {
 			result.PingResults = append(result.PingResults,
 				RunRPingBatches(ctx, restConfig, namespaceByPod, rdmaContainerByPod, tests, opts.RPingIterations)...)
@@ -373,6 +394,11 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 		if stage.check == CheckIBWriteBW {
 			result.PingResults = append(result.PingResults,
 				RunIbWriteBwBatches(ctx, restConfig, namespaceByPod, rdmaContainerByPod, tests, opts.IBWriteSize, opts.IBWriteMinBandwidthGbps)...)
+			continue
+		}
+		if stage.check == CheckGPUDirectDMABuf {
+			result.PingResults = append(result.PingResults,
+				RunGPUDirectDMABufBatches(ctx, restConfig, namespaceByPod, rdmaContainerByPod, tests, opts.IBWriteSize, opts.IBWriteMinBandwidthGbps)...)
 			continue
 		}
 		for _, t := range tests {
@@ -416,6 +442,27 @@ func normalizeChecks(checks []Check) []Check {
 		}
 		seen[check] = true
 		out = append(out, check)
+	}
+	return out
+}
+
+func checkSourceRoutes(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest) []PingTest {
+	out := append([]PingTest(nil), tests...)
+	for i := range out {
+		if out[i].Expectation != ExpectRequired {
+			continue
+		}
+		namespace := namespaceByPod[out[i].SrcPod]
+		container := containerByPod[out[i].SrcPod]
+		if namespace == "" || container == "" {
+			out[i].sourceRouteErr = fmt.Errorf("no netshoot namespace/container lookup for source pod %s", out[i].SrcPod)
+			continue
+		}
+		out[i].sourceRoute = checkRoute(ctx, restConfig, namespace, out[i].SrcPod, container, out[i])
+		if routeMismatch(out[i].sourceRoute, out[i]) {
+			out[i].sourceRouteErr = fmt.Errorf("source route selected dev %q, expected %q (route: %s)",
+				out[i].sourceRoute.Dev, out[i].SrcIface, out[i].sourceRoute.Output)
+		}
 	}
 	return out
 }
@@ -538,14 +585,17 @@ func emitSummary(uiOutput ui.Output, result *MatrixResult) {
 	}
 }
 
-// stageLabelOf returns the human-friendly label for a test kind used
-// in failure-line prefixes ("icmp", "rping", "ib_write_bw").
+// stageLabelOf returns the human-friendly family label for a test kind used
+// in failure-line prefixes.
 func stageLabelOf(k PingTestKind) string {
 	if k.IsICMP() {
 		return "icmp"
 	}
 	if k.IsRDMABw() {
 		return "ib_write_bw"
+	}
+	if k.IsGPUDirectDMABuf() {
+		return "gpudirect_dmabuf"
 	}
 	return "rping"
 }

--- a/pkg/networkoperatorplugin/connectivity/matrix.go
+++ b/pkg/networkoperatorplugin/connectivity/matrix.go
@@ -18,7 +18,10 @@ package connectivity
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 )
@@ -63,6 +66,11 @@ type TestPod struct {
 	// InterfacesByRail is "<rail>" → pod netdev name (e.g. "net1").
 	// Every runner uses this to pin or verify the source interface.
 	InterfacesByRail map[string]string
+	// GPUIndicesByRail and GPUPCIAddressesByRail describe the host GPU
+	// connected to each NIC/rail. They come from discovered or preset PF
+	// topology and are intentionally endpoint-specific.
+	GPUIndicesByRail      map[string]int
+	GPUPCIAddressesByRail map[string]string
 	// RailOrder is the deterministic iteration order over IPsByRail
 	// — needed because Go map iteration is randomized and the cross
 	// -rail canary picks "rail 0" vs "rail 1" by position.
@@ -70,7 +78,7 @@ type TestPod struct {
 }
 
 // PingTest is one src→dst test the matrix will execute. Kind tags the
-// test bucket. ICMP and two RDMA test families are scheduled in stages by the
+// test bucket. ICMP and three RDMA test families are scheduled in stages by the
 // orchestrator:
 //
 //   - Kind = RDMAPingSameRail / RDMAPingCrossRail — `rping -c -a
@@ -81,6 +89,9 @@ type TestPod struct {
 //     <dev> -R --report_gbits [<server-ip>]` against an
 //     `ib_write_bw -d <dev> -R --report_gbits` server. Measures
 //     bandwidth in Gbps.
+//   - Kind = GPUDirectDMABufSameRail / GPUDirectDMABufCrossRail — the
+//     same bandwidth matrix with endpoint-specific CUDA buffers exported
+//     through DMA-BUF.
 //
 // SrcPod/DstPod carry the actual k8s pod names — needed by the
 // orchestrator to issue the SPDY exec against the right pod. SrcNode/
@@ -90,26 +101,33 @@ type TestPod struct {
 // SrcRDMADev / DstRDMADev carry the per-pod RDMA device names so the
 // test runner can pass `-d <dev>` for ib_write_bw.
 type PingTest struct {
-	Kind        PingTestKind
-	SrcPod      string
-	DstPod      string
-	SrcNode     string
-	DstNode     string
-	Rail        string // for same-rail tests; "<srcRail>→<dstRail>" for cross
-	SrcIP       string
-	DstIP       string
-	SrcRail     string
-	DstRail     string
-	SrcIface    string
-	DstIface    string
-	SrcRDMADev  string
-	DstRDMADev  string
-	Expectation Expectation
+	Kind             PingTestKind
+	SrcPod           string
+	DstPod           string
+	SrcNode          string
+	DstNode          string
+	Rail             string // for same-rail tests; "<srcRail>→<dstRail>" for cross
+	SrcIP            string
+	DstIP            string
+	SrcRail          string
+	DstRail          string
+	SrcIface         string
+	DstIface         string
+	SrcRDMADev       string
+	DstRDMADev       string
+	SrcGPUIndex      int
+	DstGPUIndex      int
+	SrcGPUPCIAddress string
+	DstGPUPCIAddress string
+	Expectation      Expectation
+	sourceRoute      RouteCheck
+	sourceRouteErr   error
 }
 
 // PingTestKind enumerates the buckets the matrix renders into. Order
 // follows the orchestrator's staged-execution flow: rping first
-// (QP-establishment canary), ib_write_bw second (bandwidth).
+// (QP-establishment canary), host-memory ib_write_bw second, then the
+// GPUDirect DMA-BUF bandwidth family.
 type PingTestKind int
 
 const (
@@ -119,6 +137,8 @@ const (
 	RDMAPingCrossRail
 	RDMABwSameRail
 	RDMABwCrossRail
+	GPUDirectDMABufSameRail
+	GPUDirectDMABufCrossRail
 )
 
 func (k PingTestKind) IsICMP() bool {
@@ -137,10 +157,14 @@ func (k PingTestKind) IsRDMABw() bool {
 	return k == RDMABwSameRail || k == RDMABwCrossRail
 }
 
+func (k PingTestKind) IsGPUDirectDMABuf() bool {
+	return k == GPUDirectDMABufSameRail || k == GPUDirectDMABufCrossRail
+}
+
 // IsCrossRail reports whether the test kind is one of the cross-rail
 // canary variants (regardless of family).
 func (k PingTestKind) IsCrossRail() bool {
-	return k == ICMPCrossRail || k == RDMAPingCrossRail || k == RDMABwCrossRail
+	return k == ICMPCrossRail || k == RDMAPingCrossRail || k == RDMABwCrossRail || k == GPUDirectDMABufCrossRail
 }
 
 // MatrixSkip captures the soft-skip case where fewer than 2 schedulable
@@ -159,13 +183,15 @@ type MatrixSkip struct {
 // silently dropped: there's no `-d <dev>` to pass and the test
 // would fail with a confusing error.
 type MatrixPlan struct {
-	ICMPSameRail    []PingTest
-	ICMPCrossRail   []PingTest
-	RDMASameRail    []PingTest
-	RDMACrossRail   []PingTest
-	RDMABwSameRail  []PingTest
-	RDMABwCrossRail []PingTest
-	Skip            *MatrixSkip
+	ICMPSameRail             []PingTest
+	ICMPCrossRail            []PingTest
+	RDMASameRail             []PingTest
+	RDMACrossRail            []PingTest
+	RDMABwSameRail           []PingTest
+	RDMABwCrossRail          []PingTest
+	GPUDirectDMABufSameRail  []PingTest
+	GPUDirectDMABufCrossRail []PingTest
+	Skip                     *MatrixSkip
 }
 
 // Plan builds the test plan from the given pods. The matrix generation
@@ -244,6 +270,9 @@ func PlanWithOptions(pods []TestPod, mode Mode, routing string) MatrixPlan {
 				bwT := base
 				bwT.Kind = RDMABwSameRail
 				plan.RDMABwSameRail = append(plan.RDMABwSameRail, bwT)
+				gpuT := withGPUEndpoints(base, src, dst, rail, rail)
+				gpuT.Kind = GPUDirectDMABufSameRail
+				plan.GPUDirectDMABufSameRail = append(plan.GPUDirectDMABufSameRail, gpuT)
 			}
 			for _, pair := range crossRailPairs(src, dst, mode, i, j) {
 				srcRail, dstRail := pair.srcRail, pair.dstRail
@@ -279,11 +308,142 @@ func PlanWithOptions(pods []TestPod, mode Mode, routing string) MatrixPlan {
 				bwC := base
 				bwC.Kind = RDMABwCrossRail
 				plan.RDMABwCrossRail = append(plan.RDMABwCrossRail, bwC)
+				gpuC := withGPUEndpoints(base, src, dst, srcRail, dstRail)
+				gpuC.Kind = GPUDirectDMABufCrossRail
+				plan.GPUDirectDMABufCrossRail = append(plan.GPUDirectDMABufCrossRail, gpuC)
 			}
 		}
 	}
 
 	return plan
+}
+
+func withGPUEndpoints(test PingTest, src, dst TestPod, srcRail, dstRail string) PingTest {
+	test.SrcGPUIndex = -1
+	test.DstGPUIndex = -1
+	if index, ok := src.GPUIndicesByRail[srcRail]; ok {
+		test.SrcGPUIndex = index
+		test.SrcGPUPCIAddress = src.GPUPCIAddressesByRail[srcRail]
+	}
+	if index, ok := dst.GPUIndicesByRail[dstRail]; ok {
+		test.DstGPUIndex = index
+		test.DstGPUPCIAddress = dst.GPUPCIAddressesByRail[dstRail]
+	}
+	return test
+}
+
+var (
+	railIndexRE  = regexp.MustCompile(`(?:^|-)rail-([0-9]+)(?:-|$)`)
+	planeIndexRE = regexp.MustCompile(`(?:^|-)plane-([0-9]+)(?:-|$)`)
+	gpuIndexRE   = regexp.MustCompile(`^GPU([0-9]+)$`)
+)
+
+// PopulateGPUTopology resolves each pod rail to the connected host GPU from
+// the original discovery groups. A mapping is accepted only when it is
+// unambiguous. Missing topology stays absent so the GPUDirect runner can emit
+// an explicit failed precondition instead of silently selecting GPU0.
+func PopulateGPUTopology(pod *TestPod, groups []config.ClusterConfig) {
+	if pod == nil {
+		return
+	}
+	pod.GPUIndicesByRail = map[string]int{}
+	pod.GPUPCIAddressesByRail = map[string]string{}
+	group := groupForNode(pod.Node, groups)
+	if group == nil {
+		return
+	}
+	for _, railName := range pod.RailOrder {
+		pf, ok := pfForNetworkRail(group.PFs, railName)
+		if !ok {
+			continue
+		}
+		match := gpuIndexRE.FindStringSubmatch(strings.TrimSpace(pf.ConnectedGPU))
+		if len(match) != 2 {
+			continue
+		}
+		index, err := strconv.Atoi(match[1])
+		if err != nil {
+			continue
+		}
+		pod.GPUIndicesByRail[railName] = index
+		pod.GPUPCIAddressesByRail[railName] = pf.ConnectedGPUPCIAddress
+	}
+}
+
+func groupForNode(node string, groups []config.ClusterConfig) *config.ClusterConfig {
+	match := -1
+	for i := range groups {
+		for _, worker := range groups[i].WorkerNodes {
+			if worker == node {
+				if match >= 0 && match != i {
+					return nil
+				}
+				match = i
+				break
+			}
+		}
+	}
+	if match >= 0 {
+		return &groups[match]
+	}
+	if len(groups) == 1 {
+		return &groups[0]
+	}
+	return nil
+}
+
+func pfForNetworkRail(pfs []config.PFConfig, network string) (config.PFConfig, bool) {
+	railMatch := railIndexRE.FindStringSubmatch(network)
+	rail := -1
+	if len(railMatch) == 2 {
+		rail, _ = strconv.Atoi(railMatch[1])
+	}
+	candidates := make([]config.PFConfig, 0)
+	for _, pf := range pfs {
+		if pf.Traffic != "east-west" {
+			continue
+		}
+		if rail >= 0 && (pf.Rail == nil || *pf.Rail != rail) {
+			continue
+		}
+		candidates = append(candidates, pf)
+	}
+	if rail < 0 {
+		railSet := map[int]bool{}
+		for _, pf := range candidates {
+			if pf.Rail != nil {
+				railSet[*pf.Rail] = true
+			}
+		}
+		if len(railSet) > 1 {
+			return config.PFConfig{}, false
+		}
+	}
+	if len(candidates) == 0 {
+		return config.PFConfig{}, false
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].PciAddress < candidates[j].PciAddress })
+	if planeMatch := planeIndexRE.FindStringSubmatch(network); len(planeMatch) == 2 {
+		plane, _ := strconv.Atoi(planeMatch[1])
+		if plane >= 0 && plane < len(candidates) {
+			return candidates[plane], true
+		}
+		// Collapsed topology can retain one master PF per NIC while the
+		// generated network exposes multiple firmware planes. Those planes
+		// still share the NIC's connected GPU.
+		if len(candidates) == 1 {
+			return candidates[0], true
+		}
+		return config.PFConfig{}, false
+	}
+	firstGPU := candidates[0].ConnectedGPU
+	firstPCI := candidates[0].ConnectedGPUPCIAddress
+	for _, pf := range candidates[1:] {
+		if pf.ConnectedGPU != firstGPU || pf.ConnectedGPUPCIAddress != firstPCI {
+			return config.PFConfig{}, false
+		}
+	}
+	return candidates[0], true
 }
 
 type railPair struct {

--- a/pkg/networkoperatorplugin/connectivity/matrix_test.go
+++ b/pkg/networkoperatorplugin/connectivity/matrix_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,15 +31,19 @@ import (
 // IP/interface data.
 func mkPod(name string, rails ...string) TestPod {
 	tp := TestPod{
-		Name:             name,
-		IPsByRail:        map[string]string{},
-		RDMADevsByRail:   map[string]string{},
-		InterfacesByRail: map[string]string{},
+		Name:                  name,
+		IPsByRail:             map[string]string{},
+		RDMADevsByRail:        map[string]string{},
+		InterfacesByRail:      map[string]string{},
+		GPUIndicesByRail:      map[string]int{},
+		GPUPCIAddressesByRail: map[string]string{},
 	}
 	for i, rail := range rails {
 		tp.IPsByRail[rail] = fakeIP(name, rail)
 		tp.RDMADevsByRail[rail] = fakeRDMADev(name, rail)
 		tp.InterfacesByRail[rail] = fakeIface(i)
+		tp.GPUIndicesByRail[rail] = i + 2
+		tp.GPUPCIAddressesByRail[rail] = fmt.Sprintf("0000:%02x:00.0", i+1)
 		tp.RailOrder = append(tp.RailOrder, rail)
 	}
 	return tp
@@ -119,10 +124,12 @@ func TestPlan_TwoPodsOneRail(t *testing.T) {
 	// rping tests and 2 ib_write_bw tests.
 	assert.Len(t, plan.RDMASameRail, 2)
 	assert.Len(t, plan.RDMABwSameRail, 2)
+	assert.Len(t, plan.GPUDirectDMABufSameRail, 2)
 	assert.Len(t, plan.ICMPSameRail, 2)
 	// Cross-rail canary requires ≥2 rails per pod — skipped here.
 	assert.Empty(t, plan.RDMACrossRail)
 	assert.Empty(t, plan.RDMABwCrossRail)
+	assert.Empty(t, plan.GPUDirectDMABufCrossRail)
 	assert.Empty(t, plan.ICMPCrossRail)
 
 	// Check direction coverage: both A→B and B→A appear in the rping
@@ -141,6 +148,69 @@ func TestPlan_TwoPodsOneRail(t *testing.T) {
 		assert.NotEmpty(t, tt.SrcIface, "%+v", tt)
 		assert.NotEmpty(t, tt.DstIface, "%+v", tt)
 	}
+}
+
+func TestPopulateGPUTopologyUsesNodeRailAndPlane(t *testing.T) {
+	rail0, rail1 := 0, 1
+	groups := []config.ClusterConfig{{
+		WorkerNodes: []string{"node-a"},
+		PFs: []config.PFConfig{
+			{Traffic: "east-west", Rail: &rail0, PciAddress: "0000:01:00.0", ConnectedGPU: "GPU4", ConnectedGPUPCIAddress: "0000:41:00.0"},
+			{Traffic: "east-west", Rail: &rail0, PciAddress: "0000:01:00.1", ConnectedGPU: "GPU5", ConnectedGPUPCIAddress: "0000:51:00.0"},
+			{Traffic: "east-west", Rail: &rail1, PciAddress: "0000:02:00.0", ConnectedGPU: "GPU7", ConnectedGPUPCIAddress: "0000:71:00.0"},
+		},
+	}}
+	pod := TestPod{Node: "node-a", RailOrder: []string{"rail-0-plane-0", "rail-0-plane-1", "rail-1"}}
+	PopulateGPUTopology(&pod, groups)
+	assert.Equal(t, 4, pod.GPUIndicesByRail["rail-0-plane-0"])
+	assert.Equal(t, 5, pod.GPUIndicesByRail["rail-0-plane-1"])
+	assert.Equal(t, 7, pod.GPUIndicesByRail["rail-1"])
+	assert.Equal(t, "0000:71:00.0", pod.GPUPCIAddressesByRail["rail-1"])
+}
+
+func TestPlanGPUDirectUsesEndpointSpecificGPUIndices(t *testing.T) {
+	src := mkPod("pod-a", "rail-0")
+	dst := mkPod("pod-b", "rail-0")
+	src.GPUIndicesByRail["rail-0"] = 4
+	src.GPUPCIAddressesByRail["rail-0"] = "0000:41:00.0"
+	dst.GPUIndicesByRail["rail-0"] = 7
+	dst.GPUPCIAddressesByRail["rail-0"] = "0000:71:00.0"
+
+	plan := Plan([]TestPod{src, dst})
+	require.Len(t, plan.GPUDirectDMABufSameRail, 2)
+	forward := plan.GPUDirectDMABufSameRail[0]
+	assert.Equal(t, "pod-a", forward.SrcPod)
+	assert.Equal(t, "pod-b", forward.DstPod)
+	assert.Equal(t, 4, forward.SrcGPUIndex)
+	assert.Equal(t, 7, forward.DstGPUIndex)
+	assert.Equal(t, "0000:41:00.0", forward.SrcGPUPCIAddress)
+	assert.Equal(t, "0000:71:00.0", forward.DstGPUPCIAddress)
+}
+
+func TestPopulateGPUTopologyDoesNotFallbackForAmbiguousRail(t *testing.T) {
+	rail0 := 0
+	groups := []config.ClusterConfig{{WorkerNodes: []string{"node-a"}, PFs: []config.PFConfig{
+		{Traffic: "east-west", Rail: &rail0, PciAddress: "0000:01:00.0", ConnectedGPU: "GPU1"},
+		{Traffic: "east-west", Rail: &rail0, PciAddress: "0000:02:00.0", ConnectedGPU: "GPU2"},
+	}}}
+	pod := TestPod{Node: "node-a", RailOrder: []string{"rail-0"}}
+	PopulateGPUTopology(&pod, groups)
+	assert.NotContains(t, pod.GPUIndicesByRail, "rail-0")
+}
+
+func TestPopulateGPUTopologyDoesNotChooseFirstAmbiguousNodeGroup(t *testing.T) {
+	rail0 := 0
+	groups := []config.ClusterConfig{
+		{WorkerNodes: []string{"node-a"}, PFs: []config.PFConfig{{
+			Traffic: "east-west", Rail: &rail0, PciAddress: "0000:01:00.0", ConnectedGPU: "GPU1",
+		}}},
+		{WorkerNodes: []string{"node-a"}, PFs: []config.PFConfig{{
+			Traffic: "east-west", Rail: &rail0, PciAddress: "0000:02:00.0", ConnectedGPU: "GPU6",
+		}}},
+	}
+	pod := TestPod{Node: "node-a", RailOrder: []string{"rail-0"}}
+	PopulateGPUTopology(&pod, groups)
+	assert.NotContains(t, pod.GPUIndicesByRail, "rail-0")
 }
 
 func TestPlan_TwoPodsTwoRails_IncludesCrossRailCanary(t *testing.T) {

--- a/pkg/networkoperatorplugin/connectivity/rdma.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma.go
@@ -41,12 +41,7 @@ const rdmaServerSettleDelay = 2 * time.Second
 // Options.Timeout.
 const rdmaTestTimeout = 90 * time.Second
 
-const (
-	rpingBatchResultMarker     = "__L8K_RPING_RESULT__"
-	rdmaBatchRouteResultMarker = "__L8K_ROUTE_RESULT__"
-	rdmaBatchRouteEndMarker    = "__L8K_ROUTE_END__"
-	rdmaBatchRouteFailCode     = 201
-)
+const rpingBatchResultMarker = "__L8K_RPING_RESULT__"
 
 const (
 	ibWriteBwBatchResultMarker = "__L8K_IBWRITEBW_RESULT__"
@@ -191,6 +186,9 @@ func RunRPing(ctx context.Context, restConfig *rest.Config, serverNamespace stri
 		iterations = 5
 	}
 	r := initResult(test)
+	if r.Err != nil {
+		return r
+	}
 
 	tctx, cancel := context.WithTimeout(ctx, rdmaTestTimeout)
 	defer cancel()
@@ -248,10 +246,17 @@ func RunRPingBatches(ctx context.Context, restConfig *rest.Config, namespaceByPo
 
 func runRPingBatch(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, iterations int) []PingResult {
 	results := make([]PingResult, len(tests))
+	runnable := false
 	for i, test := range tests {
 		results[i] = initResult(test)
+		if results[i].Err == nil {
+			runnable = true
+		}
 	}
 	if len(tests) == 0 {
+		return results
+	}
+	if !runnable {
 		return results
 	}
 
@@ -293,24 +298,11 @@ func runRPingBatch(ctx context.Context, restConfig *rest.Config, namespaceByPod,
 	clientCmd := rpingBatchClientCommand(tests, iterations)
 	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, clientNamespace, first.SrcPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
 	rcByIndex := parseRPingBatchResults(cliRes.Stdout)
-	routeByIndex := parseRDMABatchRouteResults(cliRes.Stdout, tests)
 	for i := range results {
 		results[i].Stdout = cliRes.Stdout
 		results[i].Stderr = cliRes.Stderr
-		if results[i].Expectation == ExpectRequired {
-			route, ok := routeByIndex[i]
-			if !ok {
-				err := fmt.Errorf("rping batch missing source-route check for test %d", i)
-				finalizeExpectedResult(&results[i], false, err)
-				continue
-			}
-			results[i].Route = route
-			if routeMismatch(route, tests[i]) {
-				err := fmt.Errorf("source route selected dev %q, expected %q (route: %s)",
-					route.Dev, tests[i].SrcIface, route.Output)
-				finalizeExpectedResult(&results[i], false, err)
-				continue
-			}
+		if results[i].Err != nil {
+			continue
 		}
 		rc, ok := rcByIndex[i]
 		if !ok {
@@ -355,7 +347,7 @@ func rpingBatchServerCommand(tests []PingTest) string {
 	var b strings.Builder
 	b.WriteString("pkill rping 2>/dev/null || true; rm -f /tmp/l8k-rping-server-*.log; ")
 	for i, test := range tests {
-		if test.DstIP == "" {
+		if test.DstIP == "" || test.sourceRouteErr != nil {
 			continue
 		}
 		fmt.Fprintf(&b, "nohup rping -s -a %s -p %d -v >/tmp/l8k-rping-server-%d.log 2>&1 & ",
@@ -373,12 +365,11 @@ func rpingBatchClientCommand(tests []PingTest, iterations int) string {
 		if timeoutSeconds <= 0 {
 			timeoutSeconds = 1
 		}
-		appendRDMABatchRouteGuard(&b, i, test,
-			fmt.Sprintf("echo %s %d %d", rpingBatchResultMarker, i, rdmaBatchRouteFailCode))
+		if test.sourceRouteErr != nil {
+			continue
+		}
 		fmt.Fprintf(&b,
-			`if [ "$route_ok" = "1" ]; then `+
-				"run_with_timeout %d rping -c -I %s -a %s -p %d -C %d -v >/tmp/l8k-rping-client-%d.out 2>/tmp/l8k-rping-client-%d.err; rc=$?; echo %s %d $rc; "+
-				`fi; `,
+			"run_with_timeout %d rping -c -I %s -a %s -p %d -C %d -v >/tmp/l8k-rping-client-%d.out 2>/tmp/l8k-rping-client-%d.err; rc=$?; echo %s %d $rc; ",
 			timeoutSeconds, shellArg(test.SrcIP), shellArg(test.DstIP), rpingBatchPort(i), iterations, i, i, rpingBatchResultMarker, i)
 	}
 	b.WriteString("exit 0")
@@ -402,80 +393,6 @@ func parseRPingBatchResults(stdout string) map[int]int {
 			continue
 		}
 		out[idx] = rc
-	}
-	return out
-}
-
-func appendRDMABatchRouteGuard(b *strings.Builder, index int, test PingTest, failCommand string) {
-	b.WriteString("route_ok=1; ")
-	if test.Expectation != ExpectRequired {
-		return
-	}
-	routeFile := fmt.Sprintf("/tmp/l8k-route-%d.out", index)
-	fmt.Fprintf(b,
-		`route_file=%s; ipcmd=""; for p in ip /sbin/ip /usr/sbin/ip /bin/ip /usr/bin/ip; do `+
-			`if command -v "$p" >/dev/null 2>&1 || [ -x "$p" ]; then ipcmd="$p"; break; fi; `+
-			`done; `+
-			`route_missing=0; if [ -z "$ipcmd" ]; then echo %s >"$route_file"; route_rc=0; route_missing=1; `+
-			`else "$ipcmd" -o route get %s from %s >"$route_file" 2>&1; route_rc=$?; fi; `+
-			`route_dev=$(sed -n 's/.* dev \([^ ]*\).*/\1/p' "$route_file" | head -n1); `+
-			`echo %s %d $route_rc; cat "$route_file" 2>/dev/null; echo %s %d; `+
-			`if [ "$route_missing" != "1" ] && { [ "$route_rc" != "0" ] || [ "$route_dev" != %s ]; }; then route_ok=0; %s; fi; `,
-		shellArg(routeFile), shellArg(routeSkipMarker), shellArg(test.DstIP), shellArg(test.SrcIP),
-		rdmaBatchRouteResultMarker, index, rdmaBatchRouteEndMarker, index, shellArg(test.SrcIface), failCommand)
-}
-
-func parseRDMABatchRouteResults(stdout string, tests []PingTest) map[int]RouteCheck {
-	out := map[int]RouteCheck{}
-	var current *int
-	var b strings.Builder
-	rcByIndex := map[int]int{}
-	for _, line := range strings.Split(stdout, "\n") {
-		fields := strings.Fields(strings.TrimSpace(line))
-		if len(fields) == 3 && fields[0] == rdmaBatchRouteResultMarker {
-			idx, idxErr := strconv.Atoi(fields[1])
-			rc, rcErr := strconv.Atoi(fields[2])
-			if idxErr != nil || rcErr != nil {
-				current = nil
-				b.Reset()
-				continue
-			}
-			current = &idx
-			rcByIndex[idx] = rc
-			b.Reset()
-			continue
-		}
-		if len(fields) == 2 && fields[0] == rdmaBatchRouteEndMarker {
-			idx, err := strconv.Atoi(fields[1])
-			if err == nil && current != nil && idx == *current {
-				output := strings.TrimSpace(b.String())
-				route := RouteCheck{
-					Output: output,
-					OK:     rcByIndex[idx] == 0,
-				}
-				if idx >= 0 && idx < len(tests) {
-					route.Command = fmt.Sprintf("ip -o route get %s from %s", tests[idx].DstIP, tests[idx].SrcIP)
-				}
-				if strings.Contains(output, routeSkipMarker) {
-					route.Err = routeSkipErr
-					route.OK = false
-				}
-				if m := routeDevRe.FindStringSubmatch(output); len(m) == 2 {
-					route.Dev = m[1]
-				}
-				if route.Dev == "" {
-					route.OK = false
-				}
-				out[idx] = route
-			}
-			current = nil
-			b.Reset()
-			continue
-		}
-		if current != nil {
-			b.WriteString(line)
-			b.WriteByte('\n')
-		}
 	}
 	return out
 }
@@ -513,6 +430,9 @@ func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, serverNamespace 
 	}
 	r := initResult(test)
 	r.MinBandwidthGbps = minBandwidthGbps
+	if r.Err != nil {
+		return r
+	}
 	if test.SrcRDMADev == "" || test.DstRDMADev == "" {
 		r.Err = fmt.Errorf("ib_write_bw needs RDMA device names; got src=%q dst=%q", test.SrcRDMADev, test.DstRDMADev)
 		return r
@@ -580,27 +500,50 @@ func RunIbWriteBw(ctx context.Context, restConfig *rest.Config, serverNamespace 
 // listeners can be started with one server-side exec before the client pod runs
 // the tests sequentially in one client-side exec.
 func RunIbWriteBwBatches(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, size int, minBandwidthGbps float64) []PingResult {
+	return runIbWriteBwBatches(ctx, restConfig, namespaceByPod, containerByPod, tests, size, minBandwidthGbps, false)
+}
+
+// RunGPUDirectDMABufBatches executes the bandwidth matrix with CUDA buffers
+// exported through DMA-BUF. Each endpoint uses the GPU index resolved for its
+// own NIC/rail topology.
+func RunGPUDirectDMABufBatches(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, size int, minBandwidthGbps float64) []PingResult {
+	return runIbWriteBwBatches(ctx, restConfig, namespaceByPod, containerByPod, tests, size, minBandwidthGbps, true)
+}
+
+func runIbWriteBwBatches(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, size int, minBandwidthGbps float64, gpuDirect bool) []PingResult {
 	if size <= 0 {
 		size = 65536
 	}
 	groups := groupRPingTests(tests)
 	out := make([]PingResult, 0, len(tests))
 	for _, group := range groups {
-		out = append(out, runIbWriteBwBatch(ctx, restConfig, namespaceByPod, containerByPod, group, size, minBandwidthGbps)...)
+		out = append(out, runIbWriteBwBatch(ctx, restConfig, namespaceByPod, containerByPod, group, size, minBandwidthGbps, gpuDirect)...)
 	}
 	return out
 }
 
-func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, size int, minBandwidthGbps float64) []PingResult {
+func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, size int, minBandwidthGbps float64, gpuDirect bool) []PingResult {
 	results := make([]PingResult, len(tests))
+	runnable := false
 	for i, test := range tests {
 		results[i] = initResult(test)
 		results[i].MinBandwidthGbps = minBandwidthGbps
 		if test.SrcRDMADev == "" || test.DstRDMADev == "" {
 			results[i].Err = fmt.Errorf("ib_write_bw needs RDMA device names; got src=%q dst=%q", test.SrcRDMADev, test.DstRDMADev)
 		}
+		if gpuDirect {
+			if err := gpudirectPreconditionError(test); err != nil {
+				results[i].Err = err
+			}
+		}
+		if results[i].Err == nil {
+			runnable = true
+		}
 	}
 	if len(tests) == 0 {
+		return results
+	}
+	if !runnable {
 		return results
 	}
 	first := tests[0]
@@ -609,7 +552,9 @@ func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceBy
 	if serverNamespace == "" || serverContainer == "" || clientNamespace == "" || clientContainer == "" {
 		err := fmt.Errorf("no namespace/container lookup for ib_write_bw pod pair (%s, %s)", first.SrcPod, first.DstPod)
 		for i := range results {
-			results[i].Err = err
+			if results[i].Err == nil {
+				results[i].Err = err
+			}
 		}
 		return results
 	}
@@ -617,12 +562,14 @@ func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceBy
 	tctx, cancel := context.WithTimeout(ctx, ibWriteBwBatchTimeoutFor(tests))
 	defer cancel()
 
-	serverCmd := ibWriteBwBatchServerCommand(tests, size)
+	serverCmd := ibWriteBwBatchServerCommandMode(tests, size, gpuDirect)
 	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, serverNamespace, first.DstPod, serverContainer, []string{"/bin/sh", "-c", serverCmd})
 	if err != nil {
 		batchErr := fmt.Errorf("ib_write_bw batch server start: %w (stderr: %s)", err, srvRes.Stderr)
 		for i := range results {
-			results[i].Err = batchErr
+			if results[i].Err == nil {
+				results[i].Err = batchErr
+			}
 		}
 		return results
 	}
@@ -632,35 +579,21 @@ func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceBy
 	case <-tctx.Done():
 		batchErr := fmt.Errorf("ib_write_bw batch settle wait: %w", tctx.Err())
 		for i := range results {
-			results[i].Err = batchErr
+			if results[i].Err == nil {
+				results[i].Err = batchErr
+			}
 		}
 		return results
 	case <-time.After(rdmaBatchSettleDelayFor(tests)):
 	}
 
-	clientCmd := ibWriteBwBatchClientCommand(tests, size)
+	clientCmd := ibWriteBwBatchClientCommandMode(tests, size, gpuDirect)
 	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, clientNamespace, first.SrcPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
 	parsed := parseIbWriteBwBatchResults(cliRes.Stdout)
-	routeByIndex := parseRDMABatchRouteResults(cliRes.Stdout, tests)
 	for i := range results {
 		results[i].Stderr = cliRes.Stderr
 		if results[i].Err != nil {
 			continue
-		}
-		if results[i].Expectation == ExpectRequired {
-			route, ok := routeByIndex[i]
-			if !ok {
-				err := fmt.Errorf("ib_write_bw batch missing source-route check for test %d", i)
-				finalizeExpectedResult(&results[i], false, err)
-				continue
-			}
-			results[i].Route = route
-			if routeMismatch(route, tests[i]) {
-				err := fmt.Errorf("source route selected dev %q, expected %q (route: %s)",
-					route.Dev, tests[i].SrcIface, route.Output)
-				finalizeExpectedResult(&results[i], false, err)
-				continue
-			}
 		}
 		cell, ok := parsed[i]
 		if !ok {
@@ -688,23 +621,27 @@ func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceBy
 	return results
 }
 
-func ibWriteBwBatchServerCommand(tests []PingTest, size int) string {
+func ibWriteBwBatchServerCommandMode(tests []PingTest, size int, gpuDirect bool) string {
 	var b strings.Builder
 	b.WriteString("pkill ib_write_bw 2>/dev/null || true; rm -f /tmp/l8k-ibwritebw-server-*.log; ")
 	for i, test := range tests {
-		if test.DstRDMADev == "" || test.DstIP == "" {
+		if !ibWriteBwRunnable(test, gpuDirect) {
 			continue
 		}
 		port := ibWriteBwBatchPort(i)
 		fmt.Fprintf(&b,
-			"nohup ib_write_bw -d %s -R -s %d --report_gbits -p %d --bind_source_ip %s >/tmp/l8k-ibwritebw-server-%d.log 2>&1 & ",
-			shellArg(test.DstRDMADev), size, port, shellArg(test.DstIP), i)
+			"nohup ib_write_bw -d %s -R -s %d --report_gbits -p %d --bind_source_ip %s%s >/tmp/l8k-ibwritebw-server-%d.log 2>&1 & ",
+			shellArg(test.DstRDMADev), size, port, shellArg(test.DstIP), cudaDMABufArgs(gpuDirect, test.DstGPUIndex), i)
 	}
 	b.WriteString("echo ready")
 	return b.String()
 }
 
 func ibWriteBwBatchClientCommand(tests []PingTest, size int) string {
+	return ibWriteBwBatchClientCommandMode(tests, size, false)
+}
+
+func ibWriteBwBatchClientCommandMode(tests []PingTest, size int, gpuDirect bool) string {
 	var b strings.Builder
 	b.WriteString(`run_with_timeout() { seconds="$1"; shift; if command -v timeout >/dev/null 2>&1; then timeout --kill-after=2s "${seconds}s" "$@"; else "$@" & pid=$!; (sleep "$seconds"; kill -TERM "$pid" 2>/dev/null; sleep 2; kill -KILL "$pid" 2>/dev/null) & watchdog=$!; wait "$pid"; rc=$?; kill "$watchdog" 2>/dev/null; wait "$watchdog" 2>/dev/null; return "$rc"; fi; }; `)
 	for i, test := range tests {
@@ -714,17 +651,38 @@ func ibWriteBwBatchClientCommand(tests []PingTest, size int) string {
 		}
 		outFile := fmt.Sprintf("/tmp/l8k-ibwritebw-client-%d.out", i)
 		errFile := fmt.Sprintf("/tmp/l8k-ibwritebw-client-%d.err", i)
-		appendRDMABatchRouteGuard(&b, i, test,
-			fmt.Sprintf("echo %s %d %d; echo %s %d", ibWriteBwBatchResultMarker, i, rdmaBatchRouteFailCode, ibWriteBwBatchEndMarker, i))
+		if !ibWriteBwRunnable(test, gpuDirect) {
+			continue
+		}
 		fmt.Fprintf(&b,
-			`if [ "$route_ok" = "1" ]; then `+
-				"run_with_timeout %d ib_write_bw -d %s -R -s %d --report_gbits -p %d --bind_source_ip %s %s >%s 2>%s; rc=$?; echo %s %d $rc; cat %s 2>/dev/null; echo %s %d; "+
-				`fi; `,
-			timeoutSeconds, shellArg(test.SrcRDMADev), size, ibWriteBwBatchPort(i), shellArg(test.SrcIP), shellArg(test.DstIP),
+			"run_with_timeout %d ib_write_bw -d %s -R -s %d --report_gbits -p %d --bind_source_ip %s%s %s >%s 2>%s; rc=$?; echo %s %d $rc; cat %s 2>/dev/null; echo %s %d; ",
+			timeoutSeconds, shellArg(test.SrcRDMADev), size, ibWriteBwBatchPort(i), shellArg(test.SrcIP), cudaDMABufArgs(gpuDirect, test.SrcGPUIndex), shellArg(test.DstIP),
 			outFile, errFile, ibWriteBwBatchResultMarker, i, outFile, ibWriteBwBatchEndMarker, i)
 	}
 	b.WriteString("exit 0")
 	return b.String()
+}
+
+func cudaDMABufArgs(enabled bool, gpuIndex int) string {
+	if !enabled {
+		return ""
+	}
+	return fmt.Sprintf(" --use_cuda=%d --use_cuda_dmabuf", gpuIndex)
+}
+
+func ibWriteBwRunnable(test PingTest, gpuDirect bool) bool {
+	if test.sourceRouteErr != nil || test.SrcRDMADev == "" || test.DstRDMADev == "" || test.SrcIP == "" || test.DstIP == "" {
+		return false
+	}
+	return !gpuDirect || (test.SrcGPUIndex >= 0 && test.DstGPUIndex >= 0)
+}
+
+func gpudirectPreconditionError(test PingTest) error {
+	if test.SrcGPUIndex >= 0 && test.DstGPUIndex >= 0 {
+		return nil
+	}
+	return fmt.Errorf("GPUDirect DMA-BUF needs unambiguous connected GPU indices for both endpoints; got src=%d dst=%d (srcNode=%s srcRail=%s dstNode=%s dstRail=%s)",
+		test.SrcGPUIndex, test.DstGPUIndex, test.SrcNode, test.SrcRail, test.DstNode, test.DstRail)
 }
 
 type ibWriteBwBatchCell struct {

--- a/pkg/networkoperatorplugin/connectivity/rdma_test.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma_test.go
@@ -17,6 +17,9 @@
 package connectivity
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -113,52 +116,101 @@ timeout text
 	assert.Contains(t, got[1].stdout, "timeout text")
 }
 
-func TestParseRDMABatchRouteResults(t *testing.T) {
-	tests := []PingTest{
-		{SrcIP: "192.168.0.10", DstIP: "192.168.0.20"},
-		{SrcIP: "192.168.4.10", DstIP: "192.168.0.20"},
-	}
-	stdout := rdmaBatchRouteResultMarker + ` 0 0
-192.168.0.20 from 192.168.0.10 dev net1 src 192.168.0.10
-` + rdmaBatchRouteEndMarker + ` 0
-` + rdmaBatchRouteResultMarker + ` 1 127
-` + routeSkipMarker + `
-` + rdmaBatchRouteEndMarker + ` 1
-`
-	got := parseRDMABatchRouteResults(stdout, tests)
-	require.Len(t, got, 2)
-	assert.True(t, got[0].OK)
-	assert.Equal(t, "net1", got[0].Dev)
-	assert.Equal(t, "ip -o route get 192.168.0.20 from 192.168.0.10", got[0].Command)
-	assert.False(t, got[1].OK)
-	assert.Equal(t, "ip command not found in validation container", got[1].Err)
-	assert.False(t, routeMismatch(got[1], PingTest{SrcIface: "net2"}))
-}
-
-func TestRDMABatchClientCommandsIncludeSourceRouteGuard(t *testing.T) {
+func TestRDMABatchClientCommandsDoNotRequireIPTooling(t *testing.T) {
 	test := PingTest{
 		SrcIP:       "192.168.0.10",
 		DstIP:       "192.168.0.20",
 		SrcIface:    "net1",
 		SrcRDMADev:  "mlx5_1",
+		DstRDMADev:  "mlx5_2",
 		Expectation: ExpectRequired,
 	}
 
 	rpingCmd := rpingBatchClientCommand([]PingTest{test}, 5)
-	assert.Contains(t, rpingCmd, rdmaBatchRouteResultMarker)
-	assert.Contains(t, rpingCmd, "ipcmd")
-	assert.Contains(t, rpingCmd, "route get")
-	assert.Contains(t, rpingCmd, rpingBatchResultMarker+" 0 201")
-	assert.Contains(t, rpingCmd, `if [ "$route_ok" = "1" ]; then run_with_timeout`)
+	assert.NotContains(t, rpingCmd, "route get")
+	assert.NotContains(t, rpingCmd, "ipcmd")
+	assert.NotContains(t, rpingCmd, "route get")
 	assert.Contains(t, rpingCmd, `-p 9999`)
-	assert.NotContains(t, rpingCmd, "continue")
 
 	ibCmd := ibWriteBwBatchClientCommand([]PingTest{test}, 65536)
-	assert.Contains(t, ibCmd, rdmaBatchRouteResultMarker)
-	assert.Contains(t, ibCmd, "route get")
-	assert.Contains(t, ibCmd, ibWriteBwBatchResultMarker+" 0 201")
-	assert.Contains(t, ibCmd, `if [ "$route_ok" = "1" ]; then run_with_timeout`)
-	assert.NotContains(t, ibCmd, "continue")
+	assert.NotContains(t, ibCmd, "ipcmd")
+	assert.NotContains(t, ibCmd, "route get")
+	assert.Contains(t, ibCmd, ibWriteBwBatchResultMarker+" 0 $rc")
+}
+
+func TestGPUDirectDMABufCommandsUseEndpointGPUIndices(t *testing.T) {
+	test := PingTest{
+		SrcIP: "192.168.0.10", DstIP: "192.168.0.20",
+		SrcRDMADev: "mlx5_1", DstRDMADev: "mlx5_9",
+		SrcGPUIndex: 4, DstGPUIndex: 7,
+	}
+	server := ibWriteBwBatchServerCommandMode([]PingTest{test}, 65536, true)
+	client := ibWriteBwBatchClientCommandMode([]PingTest{test}, 65536, true)
+	assert.Contains(t, server, "--use_cuda=7 --use_cuda_dmabuf")
+	assert.NotContains(t, server, "--use_cuda=4")
+	assert.Contains(t, client, "--use_cuda=4 --use_cuda_dmabuf")
+	assert.NotContains(t, client, "--use_cuda=7")
+}
+
+func TestGPUDirectDMABufRejectsMissingTopologyWithoutGPUZeroFallback(t *testing.T) {
+	err := gpudirectPreconditionError(PingTest{
+		SrcGPUIndex: -1, DstGPUIndex: 3,
+		SrcNode: "worker-a", DstNode: "worker-b",
+		SrcRail: "rail-0", DstRail: "rail-0",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "src=-1 dst=3")
+	assert.Contains(t, err.Error(), "worker-a")
+	assert.NotContains(t, err.Error(), "assuming GPU0")
+}
+
+func TestRunGPUDirectDMABufBatchesFailsMissingTopologyBeforeExec(t *testing.T) {
+	results := RunGPUDirectDMABufBatches(context.Background(), nil, nil, nil, []PingTest{{
+		Kind:   GPUDirectDMABufSameRail,
+		SrcPod: "pod-a", DstPod: "pod-b", SrcNode: "worker-a", DstNode: "worker-b",
+		SrcRail: "rail-0", DstRail: "rail-0", SrcIP: "192.0.2.1", DstIP: "192.0.2.2",
+		SrcRDMADev: "mlx5_0", DstRDMADev: "mlx5_1", SrcGPUIndex: -1, DstGPUIndex: 7,
+	}}, 65536, 100)
+	require.Len(t, results, 1)
+	require.Error(t, results[0].Err)
+	assert.Contains(t, results[0].Err.Error(), "src=-1 dst=7")
+	assert.Equal(t, 100.0, results[0].MinBandwidthGbps)
+	assert.False(t, results[0].OK)
+}
+
+func TestRunGPUDirectDMABufBatchesPreservesTopologyErrorInMixedBatch(t *testing.T) {
+	tests := []PingTest{
+		{
+			Kind: GPUDirectDMABufSameRail, SrcPod: "pod-a", DstPod: "pod-b",
+			SrcNode: "worker-a", DstNode: "worker-b", SrcRail: "rail-0", DstRail: "rail-0",
+			SrcIP: "192.0.2.1", DstIP: "192.0.2.2", SrcRDMADev: "mlx5_0", DstRDMADev: "mlx5_1",
+			SrcGPUIndex: -1, DstGPUIndex: 7,
+		},
+		{
+			Kind: GPUDirectDMABufSameRail, SrcPod: "pod-a", DstPod: "pod-b",
+			SrcNode: "worker-a", DstNode: "worker-b", SrcRail: "rail-1", DstRail: "rail-1",
+			SrcIP: "198.51.100.1", DstIP: "198.51.100.2", SrcRDMADev: "mlx5_2", DstRDMADev: "mlx5_3",
+			SrcGPUIndex: 4, DstGPUIndex: 7,
+		},
+	}
+	results := RunGPUDirectDMABufBatches(context.Background(), nil, nil, nil, tests, 65536, 100)
+	require.Len(t, results, 2)
+	require.Error(t, results[0].Err)
+	assert.Contains(t, results[0].Err.Error(), "src=-1 dst=7")
+	require.Error(t, results[1].Err)
+	assert.Contains(t, results[1].Err.Error(), "no namespace/container lookup")
+}
+
+func TestGPUDirectResultJSONIncludesFamilyAndError(t *testing.T) {
+	data, err := json.Marshal(PingResult{
+		Test: PingTest{Kind: GPUDirectDMABufSameRail, SrcGPUIndex: 4, DstGPUIndex: 7},
+		Err:  fmt.Errorf("DMA-BUF unavailable"),
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"Family":"gpudirect_dmabuf"`)
+	assert.Contains(t, string(data), `"Error":"DMA-BUF unavailable"`)
+	assert.Contains(t, string(data), `"SrcGPUIndex":4`)
+	assert.Contains(t, string(data), `"DstGPUIndex":7`)
 }
 
 func TestRPingBatchServerCommandRunsOneListenerPerTest(t *testing.T) {
@@ -191,4 +243,7 @@ func TestPingTestKind_Predicates(t *testing.T) {
 	assert.True(t, RDMABwCrossRail.IsCrossRail())
 	assert.False(t, RDMAPingSameRail.IsCrossRail())
 	assert.False(t, RDMABwSameRail.IsCrossRail())
+	assert.True(t, GPUDirectDMABufSameRail.IsGPUDirectDMABuf())
+	assert.True(t, GPUDirectDMABufCrossRail.IsCrossRail())
+	assert.False(t, GPUDirectDMABufSameRail.IsRDMABw())
 }

--- a/pkg/networkoperatorplugin/connectivity/report.go
+++ b/pkg/networkoperatorplugin/connectivity/report.go
@@ -405,6 +405,9 @@ func reportFuncMap() template.FuncMap {
 			if fam == "icmp" {
 				return "Layer 3 ping (ICMP)"
 			}
+			if fam == "gpudirect_dmabuf" {
+				return "GPUDirect RDMA bandwidth (DMA-BUF)"
+			}
 			return "RDMA ping (rping)"
 		},
 		// cellClass returns the CSS class for a matrix cell based
@@ -447,7 +450,7 @@ func reportFuncMap() template.FuncMap {
 				}
 				return "✗ connected"
 			}
-			if fam == "ibbw" {
+			if fam == "ibbw" || fam == "gpudirect_dmabuf" {
 				if observedOK(r) && r.BandwidthGbps > 0 {
 					return fmt.Sprintf("✓ %.1f Gbps", r.BandwidthGbps)
 				}
@@ -478,6 +481,21 @@ func reportFuncMap() template.FuncMap {
 				return t.DstNode
 			}
 			return t.DstPod
+		},
+		"gpudirectResults": func(results []PingResult) []PingResult {
+			out := make([]PingResult, 0)
+			for _, result := range results {
+				if result.Test.Kind.IsGPUDirectDMABuf() {
+					out = append(out, result)
+				}
+			}
+			return out
+		},
+		"errorText": func(err error) string {
+			if err == nil {
+				return ""
+			}
+			return err.Error()
 		},
 	}
 }
@@ -511,17 +529,22 @@ func htmlFamilyOf(k PingTestKind) string {
 	if k.IsRDMABw() {
 		return "ibbw"
 	}
+	if k.IsGPUDirectDMABuf() {
+		return "gpudirect_dmabuf"
+	}
 	return "rping"
 }
 
 // htmlFamilyRank gives a stable ordering of families in the rendered
-// report — ICMP before rping (QP establishment) before ib_write_bw (bandwidth).
+// report — ICMP, rping, host-memory ib_write_bw, then GPUDirect DMA-BUF.
 func htmlFamilyRank(fam string) int {
 	switch fam {
 	case "icmp":
 		return 0
 	case "ibbw":
 		return 2
+	case "gpudirect_dmabuf":
+		return 3
 	default:
 		return 1
 	}

--- a/pkg/networkoperatorplugin/connectivity/report.html.tmpl
+++ b/pkg/networkoperatorplugin/connectivity/report.html.tmpl
@@ -942,6 +942,27 @@ footer strong { color: var(--text-muted); }
           </tbody>
         </table>
       {{- end}}
+
+      {{- $gpuResults := gpudirectResults .Matrix.PingResults}}
+      {{- if $gpuResults}}
+      <div class="matrix-rail">GPUDirect DMA-BUF endpoint details</div>
+      <table class="matrix-table">
+        <thead><tr><th>Source</th><th>Source GPU</th><th>Destination</th><th>Destination GPU</th><th>Bandwidth</th><th>Minimum</th><th>Error</th></tr></thead>
+        <tbody>
+        {{- range $gpuResults}}
+          <tr>
+            <td>{{srcLabel .Test}} [{{.Test.SrcRail}}]</td>
+            <td>GPU{{.Test.SrcGPUIndex}} {{.Test.SrcGPUPCIAddress}}</td>
+            <td>{{dstLabel .Test}} [{{.Test.DstRail}}]</td>
+            <td>GPU{{.Test.DstGPUIndex}} {{.Test.DstGPUPCIAddress}}</td>
+            <td>{{printf "%.1f" .BandwidthGbps}} Gbps</td>
+            <td>{{printf "%.1f" .MinBandwidthGbps}} Gbps</td>
+            <td>{{errorText .Err}}</td>
+          </tr>
+        {{- end}}
+        </tbody>
+      </table>
+      {{- end}}
       {{- else}}
       <p class="empty">No ping tests executed.</p>
       {{- end}}

--- a/pkg/networkoperatorplugin/connectivity/report_test.go
+++ b/pkg/networkoperatorplugin/connectivity/report_test.go
@@ -19,6 +19,7 @@ package connectivity
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -299,4 +300,28 @@ func TestRenderHTML_HandlesNilOptionalFields(t *testing.T) {
 	require.NoError(t, RenderHTML(&buf, data))
 	assert.Contains(t, buf.String(), "<html")
 	assert.Contains(t, buf.String(), "Connectivity testing was not run")
+}
+
+func TestRenderHTML_GPUDirectFamilyIncludesEndpointEvidence(t *testing.T) {
+	data := ReportData{
+		Cluster: ClusterInfo{L8kVersion: "v0", GeneratedAt: time.Now()},
+		Matrix: &MatrixResult{PingResults: []PingResult{{
+			Test: PingTest{
+				Kind:    GPUDirectDMABufSameRail,
+				SrcNode: "worker-a", DstNode: "worker-b", Rail: "rail-0", SrcRail: "rail-0", DstRail: "rail-0",
+				SrcGPUIndex: 4, DstGPUIndex: 7,
+				SrcGPUPCIAddress: "0000:41:00.0", DstGPUPCIAddress: "0000:71:00.0",
+			},
+			BandwidthGbps: 91.25, MinBandwidthGbps: 100, Err: fmt.Errorf("below minimum"),
+		}}},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, RenderHTML(&buf, data))
+	html := buf.String()
+	assert.Contains(t, html, "GPUDirect RDMA bandwidth (DMA-BUF)")
+	assert.Contains(t, html, "GPU4 0000:41:00.0")
+	assert.Contains(t, html, "GPU7 0000:71:00.0")
+	assert.Contains(t, html, "91.2 Gbps")
+	assert.Contains(t, html, "100.0 Gbps")
+	assert.Contains(t, html, "below minimum")
 }

--- a/pkg/networkoperatorplugin/connectivity/result.go
+++ b/pkg/networkoperatorplugin/connectivity/result.go
@@ -16,6 +16,8 @@
 
 package connectivity
 
+import "encoding/json"
+
 type RouteCheck struct {
 	Command string
 	Output  string
@@ -25,11 +27,11 @@ type RouteCheck struct {
 }
 
 // PingResult carries the outcome of one src→dst matrix test. The
-// matrix currently runs rping and ib_write_bw — fields specific to a
-// kind stay zero for tests of the other kind:
+// matrix runs ICMP, rping, host-memory ib_write_bw, and GPUDirect DMA-BUF;
+// fields specific to a kind stay zero for other kinds:
 //
 //   - rping: OK + Err + Stdout/Stderr; BandwidthGbps stays at 0.
-//   - ib_write_bw: OK + Err + Stdout/Stderr + BandwidthGbps +
+//   - both ib_write_bw families: OK + Err + Stdout/Stderr + BandwidthGbps +
 //     MsgRateMpps populated by parseIbWriteBwOutput. MinBandwidthGbps
 //     records the configured passing threshold when set.
 //
@@ -42,10 +44,38 @@ type PingResult struct {
 	ObservedOK       bool
 	Expectation      Expectation
 	Route            RouteCheck
-	BandwidthGbps    float64 // ib_write_bw only; 0 when n/a
-	MsgRateMpps      float64 // ib_write_bw only; 0 when n/a
-	MinBandwidthGbps float64 // ib_write_bw only; 0 when no threshold was applied
+	BandwidthGbps    float64 // ib_write_bw families only; 0 when n/a
+	MsgRateMpps      float64 // ib_write_bw families only; 0 when n/a
+	MinBandwidthGbps float64 // ib_write_bw families only; 0 when no threshold was applied
 	Stdout           string
 	Stderr           string
-	Err              error
+	Err              error `json:"-"`
+}
+
+func (r PingResult) MarshalJSON() ([]byte, error) {
+	type alias PingResult
+	errorText := ""
+	if r.Err != nil {
+		errorText = r.Err.Error()
+	}
+	return json.Marshal(struct {
+		alias
+		Family string `json:"Family"`
+		Error  string `json:"Error,omitempty"`
+	}{alias: alias(r), Family: resultFamily(r.Test.Kind), Error: errorText})
+}
+
+func resultFamily(kind PingTestKind) string {
+	switch {
+	case kind.IsICMP():
+		return "icmp"
+	case kind.IsRDMAPing():
+		return "rping"
+	case kind.IsRDMABw():
+		return "ib_write_bw"
+	case kind.IsGPUDirectDMABuf():
+		return "gpudirect_dmabuf"
+	default:
+		return "unknown"
+	}
 }

--- a/pkg/networkoperatorplugin/connectivity/source.go
+++ b/pkg/networkoperatorplugin/connectivity/source.go
@@ -38,7 +38,12 @@ func initResult(test PingTest) PingResult {
 	if exp == "" {
 		exp = ExpectRequired
 	}
-	return PingResult{Test: test, Expectation: exp}
+	return PingResult{
+		Test:        test,
+		Expectation: exp,
+		Route:       test.sourceRoute,
+		Err:         test.sourceRouteErr,
+	}
 }
 
 func shellArg(s string) string {

--- a/pkg/networkoperatorplugin/connectivity/text_report.go
+++ b/pkg/networkoperatorplugin/connectivity/text_report.go
@@ -56,7 +56,7 @@ func RenderMatrixText(uiOutput ui.Output, result *MatrixResult) {
 	// (QP-establishment canary) before ib_write_bw (bandwidth).
 	byRail, byCross, nodes, rails := groupResultsByKind(result.PingResults)
 
-	families := []kindFamily{familyICMP, familyRPing, familyIbBw}
+	families := []kindFamily{familyICMP, familyRPing, familyIbBw, familyGPUDirectDMABuf}
 	for _, rail := range rails {
 		for _, fam := range families {
 			grid, ok := byRail[rail][fam]
@@ -82,10 +82,31 @@ func RenderMatrixText(uiOutput ui.Output, result *MatrixResult) {
 			uiOutput.Info("%s", line)
 		}
 	}
+
+	var gpuResults []PingResult
+	for _, r := range result.PingResults {
+		if r.Test.Kind.IsGPUDirectDMABuf() {
+			gpuResults = append(gpuResults, r)
+		}
+	}
+	if len(gpuResults) > 0 {
+		uiOutput.Info("")
+		uiOutput.Info("GPUDirect DMA-BUF endpoint details:")
+		for _, r := range gpuResults {
+			status := cellBody(&r, familyGPUDirectDMABuf)
+			if r.Err != nil {
+				status += ": " + r.Err.Error()
+			}
+			uiOutput.Info("  %s GPU%d (%s) [%s] → %s GPU%d (%s) [%s]: %s; threshold %.1f Gbps",
+				axisLabel(r.Test.SrcNode, r.Test.SrcPod), r.Test.SrcGPUIndex, r.Test.SrcGPUPCIAddress, r.Test.SrcRail,
+				axisLabel(r.Test.DstNode, r.Test.DstPod), r.Test.DstGPUIndex, r.Test.DstGPUPCIAddress, r.Test.DstRail,
+				status, r.MinBandwidthGbps)
+		}
+	}
 }
 
-// kindFamily collapses the four PingTestKind values down to the two
-// families the renderer cares about: rping and ib_write_bw. The
+// kindFamily collapses same/cross-rail PingTestKind values into the four
+// families the renderer presents. The
 // same-rail / cross-rail axis is handled separately (per-rail grid vs
 // cross-rail list).
 type kindFamily int
@@ -94,6 +115,7 @@ const (
 	familyICMP kindFamily = iota
 	familyRPing
 	familyIbBw
+	familyGPUDirectDMABuf
 )
 
 func kindFamilyOf(k PingTestKind) kindFamily {
@@ -103,12 +125,18 @@ func kindFamilyOf(k PingTestKind) kindFamily {
 	if k.IsRDMABw() {
 		return familyIbBw
 	}
+	if k.IsGPUDirectDMABuf() {
+		return familyGPUDirectDMABuf
+	}
 	return familyRPing
 }
 
 func familyTitle(f kindFamily) string {
 	if f == familyIbBw {
 		return "RDMA bandwidth (ib_write_bw)"
+	}
+	if f == familyGPUDirectDMABuf {
+		return "GPUDirect RDMA bandwidth (DMA-BUF)"
 	}
 	if f == familyICMP {
 		return "Layer 3 ping (ICMP)"
@@ -296,7 +324,7 @@ func cellBody(r *PingResult, fam kindFamily) string {
 		}
 		return "✗ connected"
 	}
-	if fam == familyIbBw {
+	if fam == familyIbBw || fam == familyGPUDirectDMABuf {
 		if observedOK(r) && r.BandwidthGbps > 0 {
 			return fmt.Sprintf("✓ %.1f Gbps", r.BandwidthGbps)
 		}

--- a/pkg/networkoperatorplugin/connectivity/text_report_test.go
+++ b/pkg/networkoperatorplugin/connectivity/text_report_test.go
@@ -201,6 +201,26 @@ func TestRenderMatrixText_EmptyResultsIsNoOp(t *testing.T) {
 	assert.Empty(t, out.lines)
 }
 
+func TestRenderMatrixText_GPUDirectFamilyIncludesEndpointDetails(t *testing.T) {
+	result := &MatrixResult{PingResults: []PingResult{{
+		Test: PingTest{
+			Kind:    GPUDirectDMABufSameRail,
+			SrcNode: "worker-a", DstNode: "worker-b", Rail: "rail-0", SrcRail: "rail-0", DstRail: "rail-0",
+			SrcGPUIndex: 4, DstGPUIndex: 7,
+			SrcGPUPCIAddress: "0000:41:00.0", DstGPUPCIAddress: "0000:71:00.0",
+		},
+		OK: true, ObservedOK: true, BandwidthGbps: 191.25, MinBandwidthGbps: 100,
+	}}}
+	out := &captureOutput{}
+	RenderMatrixText(out, result)
+	joined := strings.Join(out.lines, "\n")
+	assert.Contains(t, joined, "GPUDirect RDMA bandwidth (DMA-BUF)")
+	assert.Contains(t, joined, "worker-a GPU4 (0000:41:00.0)")
+	assert.Contains(t, joined, "worker-b GPU7 (0000:71:00.0)")
+	assert.Contains(t, joined, "191.2 Gbps")
+	assert.Contains(t, joined, "threshold 100.0 Gbps")
+}
+
 func TestShortPodName(t *testing.T) {
 	t.Run("short name unchanged", func(t *testing.T) {
 		assert.Equal(t, "sriov-test-abc", shortPodName("sriov-test-abc"))

--- a/pkg/networkoperatorplugin/discovery/discover.go
+++ b/pkg/networkoperatorplugin/discovery/discover.go
@@ -356,6 +356,27 @@ func DiscoverClusterConfig(ctx context.Context, c client.Client, restConfig *res
 	// the group's Identifier + NodeSelector are aligned with that value.
 	applyMachineLabelToGroups(ctx, c, cfg.ClusterConfig)
 
+	// Persist the automatic GPUDirect decision in the generated config. The
+	// test is enabled only when the configured extended GPU resource can
+	// satisfy the topology-derived request on every worker represented by every
+	// discovered group.
+	// Discovery does not persist per-group GPU quantities; the boolean is the
+	// complete discovery output for this feature and remains user-editable.
+	cfg.Validation = config.NormalizeValidationConfig(cfg.Validation)
+	nodeList := &corev1.NodeList{}
+	if err := c.List(ctx, nodeList); err != nil {
+		cfg.Validation.GPUDirect.Enabled = false
+		uiOutput.Warning("Could not inspect GPU resources on cluster nodes; GPUDirect DMA-BUF validation disabled: %v", err)
+	} else {
+		resourceType := cfg.Validation.GPUDirect.GPUResourceType
+		cfg.Validation.GPUDirect.Enabled = gpuDirectAvailableOnAllGroupNodes(cfg.ClusterConfig, nodeList.Items, resourceType)
+		if cfg.Validation.GPUDirect.Enabled {
+			uiOutput.Info("Enabled GPUDirect DMA-BUF validation: every discovered worker can satisfy its topology-derived %s request", resourceType)
+		} else {
+			uiOutput.Info("GPUDirect DMA-BUF validation disabled: %s cannot satisfy the topology-derived request on every discovered worker", resourceType)
+		}
+	}
+
 	// Phase summary — counts surfaced at info level so the default UX shows
 	// progress without requiring --log-level=debug.
 	totalEW, totalNS, presetMatches, deviationGroups, labelled := 0, 0, 0, 0, 0
@@ -387,6 +408,68 @@ func DiscoverClusterConfig(ctx context.Context, c client.Client, restConfig *res
 		"machineLabelledGroups", labelled)
 
 	return nil
+}
+
+func gpuDirectAvailableOnAllGroupNodes(groups []config.ClusterConfig, nodes []corev1.Node, resourceType string) bool {
+	if len(groups) == 0 || resourceType == "" {
+		return false
+	}
+	nodeByName := make(map[string]*corev1.Node, len(nodes))
+	for i := range nodes {
+		nodeByName[nodes[i].Name] = &nodes[i]
+	}
+	requiredByGroup := gpuDirectResourceCountsByGroup(groups)
+	foundWorker := false
+	for i := range groups {
+		if len(groups[i].WorkerNodes) == 0 {
+			return false
+		}
+		for _, nodeName := range groups[i].WorkerNodes {
+			foundWorker = true
+			node := nodeByName[nodeName]
+			if node == nil {
+				return false
+			}
+			quantity, ok := node.Status.Allocatable[corev1.ResourceName(resourceType)]
+			if !ok || quantity.CmpInt64(int64(requiredByGroup[i])) < 0 {
+				return false
+			}
+		}
+	}
+	return foundWorker
+}
+
+type gpuDirectRenderBucket struct {
+	gpuType     string
+	eastWestPFs int
+	unique      int
+}
+
+// gpuDirectResourceCountsByGroup mirrors the renderer's merge key
+// (gpuType, east-west PF count). Every node selected by one merged DaemonSet
+// must satisfy that bucket's largest topology-derived GPU prefix.
+func gpuDirectResourceCountsByGroup(groups []config.ClusterConfig) []int {
+	keys := make([]gpuDirectRenderBucket, len(groups))
+	maxByBucket := make(map[gpuDirectRenderBucket]int, len(groups))
+	for i := range groups {
+		key := gpuDirectRenderBucket{
+			gpuType:     groups[i].GPUType,
+			eastWestPFs: len(pfutil.FilterEastWestPFs(groups[i].PFs)),
+		}
+		if key.gpuType == "" {
+			key.unique = i + 1
+		}
+		keys[i] = key
+		count := pfutil.GPUResourceCountForPFs(groups[i].PFs)
+		if count > maxByBucket[key] {
+			maxByBucket[key] = count
+		}
+	}
+	required := make([]int, len(groups))
+	for i := range groups {
+		required[i] = maxByBucket[keys[i]]
+	}
+	return required
 }
 
 func resolvePresetCatalog(opts Options) (*presets.Catalog, error) {

--- a/pkg/networkoperatorplugin/discovery/discover_test.go
+++ b/pkg/networkoperatorplugin/discovery/discover_test.go
@@ -23,10 +23,52 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestGPUDirectAvailableOnAllGroupNodes(t *testing.T) {
+	groups := []config.ClusterConfig{
+		{WorkerNodes: []string{"node-a", "node-b"}},
+		{WorkerNodes: []string{"node-c"}},
+	}
+	node := func(name, quantity string) corev1.Node {
+		return corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}, Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{corev1.ResourceName("example.com/gpu"): resource.MustParse(quantity)},
+		}}
+	}
+	nodes := []corev1.Node{node("node-a", "8"), node("node-b", "1"), node("node-c", "2")}
+	assert.True(t, gpuDirectAvailableOnAllGroupNodes(groups, nodes, "example.com/gpu"))
+	nodes[1].Status.Allocatable[corev1.ResourceName("example.com/gpu")] = resource.MustParse("0")
+	assert.False(t, gpuDirectAvailableOnAllGroupNodes(groups, nodes, "example.com/gpu"))
+	assert.False(t, gpuDirectAvailableOnAllGroupNodes(groups, nodes[:2], "example.com/gpu"))
+	assert.False(t, gpuDirectAvailableOnAllGroupNodes(nil, nodes, "example.com/gpu"))
+
+	t.Run("merged bucket requires its largest topology prefix on every worker", func(t *testing.T) {
+		rail0 := 0
+		mergedGroups := []config.ClusterConfig{
+			{GPUType: "same-gpu", WorkerNodes: []string{"node-a"}, PFs: []config.PFConfig{{
+				Traffic: "east-west", Rail: &rail0, ConnectedGPU: "GPU1",
+			}}},
+			{GPUType: "same-gpu", WorkerNodes: []string{"node-c"}, PFs: []config.PFConfig{{
+				Traffic: "east-west", Rail: &rail0, ConnectedGPU: "GPU7",
+			}}},
+		}
+		limitedNodes := []corev1.Node{node("node-a", "2"), node("node-c", "8")}
+		assert.False(t, gpuDirectAvailableOnAllGroupNodes(mergedGroups, limitedNodes, "example.com/gpu"))
+		limitedNodes[0].Status.Allocatable[corev1.ResourceName("example.com/gpu")] = resource.MustParse("8")
+		assert.True(t, gpuDirectAvailableOnAllGroupNodes(mergedGroups, limitedNodes, "example.com/gpu"))
+
+		mergedGroups[1].GPUType = "different-gpu"
+		limitedNodes[0].Status.Allocatable[corev1.ResourceName("example.com/gpu")] = resource.MustParse("2")
+		assert.True(t, gpuDirectAvailableOnAllGroupNodes(mergedGroups, limitedNodes, "example.com/gpu"),
+			"separate render buckets must retain their own request sizes")
+	})
+}
 
 func TestCheckDaemonSetPodsReady_NoPodsFound(t *testing.T) {
 	scheme := runtime.NewScheme()

--- a/pkg/networkoperatorplugin/example_daemonset_test.go
+++ b/pkg/networkoperatorplugin/example_daemonset_test.go
@@ -17,6 +17,7 @@
 package networkoperatorplugin
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +26,7 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/stretchr/testify/require"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func TestExampleDaemonSetTemplatesDeclareICMPHelper(t *testing.T) {
@@ -51,6 +53,114 @@ func TestExampleDaemonSetTemplatesDeclareICMPHelper(t *testing.T) {
 			require.Equal(t, daemonSetBranches, strings.Count(body, helperCommand))
 		})
 	}
+}
+
+func TestExampleDaemonSetTemplatesDeclareReleaseImagePullSecretsAndGPURequests(t *testing.T) {
+	templates, err := filepath.Glob(filepath.Join("..", "..", "profiles", "*", "*-example-daemonset.yaml"))
+	require.NoError(t, err)
+	require.NotEmpty(t, templates)
+
+	for _, templatePath := range templates {
+		t.Run(filepath.Base(filepath.Dir(templatePath)), func(t *testing.T) {
+			content, err := os.ReadFile(templatePath)
+			require.NoError(t, err)
+			body := string(content)
+			branches := strings.Count(body, "kind: DaemonSet")
+			require.Equal(t, branches, strings.Count(body, "image: {{validationImage $.NetworkOperator}}"))
+			require.Equal(t, branches, strings.Count(body, "imagePullSecrets:"))
+			require.GreaterOrEqual(t, strings.Count(body, "{{$.Validation.GPUDirect.GPUResourceType}}"), branches*2,
+				"every primary container branch must request and limit the configured GPU resource")
+		})
+	}
+}
+
+func TestRenderedExampleDaemonSetGPUDirectResources(t *testing.T) {
+	ctrllog.SetLogger(zap.New(zap.UseDevMode(true)))
+	cfg, err := config.LoadFullConfig(filepath.Join("testdata", "grouping", "mixed-same-type.yaml"), ctrllog.Log)
+	require.NoError(t, err)
+	cfg.Profile = &config.Profile{Fabric: "ethernet", Deployment: "sriov", Multirail: true}
+	cfg.NetworkOperator.SelectedRelease = "26.4"
+	cfg.NetworkOperator.ImagePullSecrets = []string{"yes"}
+	cfg.Validation.GPUDirect.Enabled = true
+	cfg.Validation.GPUDirect.GPUResourceType = "example.com/gpu"
+	require.GreaterOrEqual(t, len(cfg.ClusterConfig), 2)
+	for groupIndex := range cfg.ClusterConfig {
+		gpuIndex := 1
+		if groupIndex > 0 {
+			gpuIndex = 7
+		}
+		for pfIndex := range cfg.ClusterConfig[groupIndex].PFs {
+			cfg.ClusterConfig[groupIndex].PFs[pfIndex].ConnectedGPU = fmt.Sprintf("GPU%d", gpuIndex)
+		}
+	}
+	rendered, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(loadProfileFromDir(t, "sriov-ethernet-rdma"), cfg)
+	require.NoError(t, err)
+	manifestName, manifest := fileMatching(t, rendered, "example-daemonset")
+	docs := parseDocs(t, manifestName, manifest)
+	require.Len(t, docs, 1)
+	podSpec := requireMap(t, requireMap(t, requireMap(t, docs[0], "spec"), "template"), "spec")
+	pullSecrets, ok := podSpec["imagePullSecrets"].([]any)
+	require.True(t, ok)
+	require.Equal(t, map[string]any{"name": "yes"}, pullSecrets[0], "pull secret names must remain YAML strings")
+	containers, ok := podSpec["containers"].([]any)
+	require.True(t, ok)
+	primary := containers[0].(map[string]any)
+	require.Equal(t, "nvcr.io/nvidia/doca/doca:full-rt-cuda13.0.0-3.4.0-runtime-host", primary["image"])
+	resources := requireMap(t, primary, "resources")
+	requests := requireMap(t, resources, "requests")
+	limits := requireMap(t, resources, "limits")
+	require.Equal(t, "8", requests["example.com/gpu"], "merged DaemonSet must cover the highest source-group GPU index")
+	require.Equal(t, "8", limits["example.com/gpu"])
+	helper := containers[1].(map[string]any)
+	_, hasHelperResources := helper["resources"]
+	require.False(t, hasHelperResources)
+
+	cfg.Validation.GPUDirect.Enabled = false
+	rendered, err = (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(loadProfileFromDir(t, "sriov-ethernet-rdma"), cfg)
+	require.NoError(t, err)
+	manifestName, manifest = fileMatching(t, rendered, "example-daemonset")
+	docs = parseDocs(t, manifestName, manifest)
+	podSpec = requireMap(t, requireMap(t, requireMap(t, docs[0], "spec"), "template"), "spec")
+	containers = podSpec["containers"].([]any)
+	primary = containers[0].(map[string]any)
+	requests = requireMap(t, requireMap(t, primary, "resources"), "requests")
+	_, hasGPURequest := requests["example.com/gpu"]
+	require.False(t, hasGPURequest, "disabled GPUDirect must not request a GPU")
+}
+
+func TestRenderedSpectrumXDRAExampleDaemonSetGPUDirectResources(t *testing.T) {
+	ctrllog.SetLogger(zap.New(zap.UseDevMode(true)))
+	cfg, err := config.LoadFullConfig(filepath.Join("testdata", "grouping", "mixed-same-type.yaml"), ctrllog.Log)
+	require.NoError(t, err)
+	topologyFile := writeSpectrumXTopology(t, cfg, 2)
+	cfg.Profile = &config.Profile{
+		Fabric: "ethernet", Deployment: "sriov", Multirail: true,
+		SpectrumX: &config.ProfileSpectrumX{
+			Enable: true, SPCXVersion: "RA2.3", MultiplaneMode: "swplb",
+			NumberOfPlanes: 2, TopologyType: config.SpectrumXTopology2Tier,
+			TopologyFile: topologyFile, UseDRA: true,
+		},
+	}
+	cfg.NetworkOperator.SelectedRelease = "26.7"
+	cfg.Validation.GPUDirect.Enabled = true
+	for groupIndex := range cfg.ClusterConfig {
+		for pfIndex := range cfg.ClusterConfig[groupIndex].PFs {
+			cfg.ClusterConfig[groupIndex].PFs[pfIndex].ConnectedGPU = "GPU7"
+		}
+	}
+	rendered, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(loadProfileFromDir(t, "spectrum-x"), cfg)
+	require.NoError(t, err)
+	manifestName, manifest := fileMatching(t, rendered, "example-daemonset")
+	docs := parseDocs(t, manifestName, manifest)
+	require.Len(t, docs, 1)
+	podSpec := requireMap(t, requireMap(t, requireMap(t, docs[0], "spec"), "template"), "spec")
+	containers := podSpec["containers"].([]any)
+	primary := containers[0].(map[string]any)
+	require.Equal(t, "nvcr.io/nvstaging/doca/doca:full-rt-cuda13.0.0-3.5.0-runtime-host-dev", primary["image"])
+	resources := requireMap(t, primary, "resources")
+	require.NotEmpty(t, resources["claims"])
+	require.Equal(t, "8", requireMap(t, resources, "requests")["nvidia.com/gpu"])
+	require.Equal(t, "8", requireMap(t, resources, "limits")["nvidia.com/gpu"])
 }
 
 func TestRenderedExampleDaemonSetsDeclareICMPHelper(t *testing.T) {
@@ -148,6 +258,113 @@ func TestRenderedSpectrumXExampleDaemonSetsDeclareICMPHelper(t *testing.T) {
 			require.Equal(t, "nicolaka/netshoot:latest", helper["image"])
 		})
 	}
+}
+
+func TestRenderedGPUDirectResourcesAcrossEveryProfileBranch(t *testing.T) {
+	standardProfiles := []struct {
+		dir        string
+		fabric     string
+		deployment string
+	}{
+		{dir: "sriov-ethernet-rdma", fabric: "ethernet", deployment: "sriov"},
+		{dir: "sriov-ib-rdma", fabric: "infiniband", deployment: "sriov"},
+		{dir: "host-device-rdma", fabric: "ethernet", deployment: "host_device"},
+		{dir: "macvlan-rdma-shared", fabric: "ethernet", deployment: "rdma_shared"},
+		{dir: "ipoib-rdma-shared", fabric: "infiniband", deployment: "rdma_shared"},
+	}
+	for _, profile := range standardProfiles {
+		for _, multirail := range []bool{false, true} {
+			name := fmt.Sprintf("%s/multirail=%t", profile.dir, multirail)
+			t.Run(name, func(t *testing.T) {
+				cfg := gpudirectRenderConfig(t, &config.Profile{
+					Fabric: profile.fabric, Deployment: profile.deployment, Multirail: multirail,
+				}, "26.4", 2)
+				assertRenderedGPUDirectExample(t, profile.dir, cfg,
+					"nvcr.io/nvidia/doca/doca:full-rt-cuda13.0.0-3.4.0-runtime-host", "3")
+			})
+		}
+	}
+
+	spectrumProfiles := []struct {
+		name, dir, version, release, mode string
+		planes                            int
+	}{
+		{name: "ra2.1-none", dir: "spectrum-x-ra2.1", version: "RA2.1", release: "26.1", mode: "none", planes: 1},
+		{name: "ra2.1-uniplane", dir: "spectrum-x-ra2.1", version: "RA2.1", release: "26.1", mode: "uniplane", planes: 1},
+		{name: "ra2.1-hwplb", dir: "spectrum-x-ra2.1", version: "RA2.1", release: "26.1", mode: "hwplb", planes: 2},
+		{name: "ra2.1-swplb", dir: "spectrum-x-ra2.1", version: "RA2.1", release: "26.1", mode: "swplb", planes: 2},
+		{name: "ra2.2-none", dir: "spectrum-x-ra2.2", version: "RA2.2", release: "26.4", mode: "none", planes: 1},
+		{name: "ra2.2-uniplane", dir: "spectrum-x-ra2.2", version: "RA2.2", release: "26.4", mode: "uniplane", planes: 1},
+		{name: "ra2.2-hwplb", dir: "spectrum-x-ra2.2", version: "RA2.2", release: "26.4", mode: "hwplb", planes: 4},
+		{name: "ra2.2-swplb", dir: "spectrum-x-ra2.2", version: "RA2.2", release: "26.4", mode: "swplb", planes: 2},
+		{name: "ra2.3-none", dir: "spectrum-x", version: "RA2.3", release: "26.7", mode: "none", planes: 1},
+		{name: "ra2.3-uniplane", dir: "spectrum-x", version: "RA2.3", release: "26.7", mode: "uniplane", planes: 1},
+		{name: "ra2.3-hwplb", dir: "spectrum-x", version: "RA2.3", release: "26.7", mode: "hwplb", planes: 4},
+		{name: "ra2.3-swplb", dir: "spectrum-x", version: "RA2.3", release: "26.7", mode: "swplb", planes: 2},
+	}
+	for _, profile := range spectrumProfiles {
+		t.Run(profile.name, func(t *testing.T) {
+			cfg := gpudirectRenderConfig(t, nil, profile.release, 2)
+			topologyFile := writeSpectrumXTopology(t, cfg, profile.planes)
+			cfg.Profile = &config.Profile{
+				Fabric: "ethernet", Deployment: "sriov", Multirail: true,
+				SpectrumX: &config.ProfileSpectrumX{
+					Enable: true, SPCXVersion: profile.version, MultiplaneMode: profile.mode,
+					NumberOfPlanes: profile.planes, TopologyType: config.SpectrumXTopology2Tier,
+					TopologyFile: topologyFile,
+				},
+			}
+			image := "nvcr.io/nvidia/doca/doca:full-rt-cuda13.0.0-3.4.0-runtime-host"
+			if profile.release == "26.1" {
+				image = "nvcr.io/nvidia/doca/doca:full-rt-cuda13.0.0-3.2.3-runtime-host"
+			}
+			if profile.release == "26.7" {
+				image = "nvcr.io/nvstaging/doca/doca:full-rt-cuda13.0.0-3.5.0-runtime-host-dev"
+			}
+			assertRenderedGPUDirectExample(t, profile.dir, cfg, image, "3")
+		})
+	}
+}
+
+func gpudirectRenderConfig(t *testing.T, profile *config.Profile, release string, gpuIndex int) *config.LaunchKitConfig {
+	t.Helper()
+	ctrllog.SetLogger(zap.New(zap.UseDevMode(true)))
+	cfg, err := config.LoadFullConfig(filepath.Join("testdata", "grouping", "mixed-same-type.yaml"), ctrllog.Log)
+	require.NoError(t, err)
+	cfg.Profile = profile
+	cfg.NetworkOperator.SelectedRelease = release
+	cfg.NetworkOperator.ImagePullSecrets = []string{"yes"}
+	cfg.Validation.GPUDirect.Enabled = true
+	cfg.Validation.GPUDirect.GPUResourceType = "example.com/gpu"
+	for groupIndex := range cfg.ClusterConfig {
+		for pfIndex := range cfg.ClusterConfig[groupIndex].PFs {
+			cfg.ClusterConfig[groupIndex].PFs[pfIndex].ConnectedGPU = fmt.Sprintf("GPU%d", gpuIndex)
+		}
+	}
+	return cfg
+}
+
+func assertRenderedGPUDirectExample(t *testing.T, profileDir string, cfg *config.LaunchKitConfig, image, count string) {
+	t.Helper()
+	rendered, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(loadProfileFromDir(t, profileDir), cfg)
+	require.NoError(t, err)
+	manifestName, manifest := fileMatching(t, rendered, "example-daemonset")
+	docs := parseDocs(t, manifestName, manifest)
+	require.Len(t, docs, 1)
+	podSpec := requireMap(t, requireMap(t, requireMap(t, docs[0], "spec"), "template"), "spec")
+	pullSecrets, ok := podSpec["imagePullSecrets"].([]any)
+	require.True(t, ok)
+	require.Equal(t, map[string]any{"name": "yes"}, pullSecrets[0])
+	containers, ok := podSpec["containers"].([]any)
+	require.True(t, ok)
+	require.Len(t, containers, 2)
+	primary := containers[0].(map[string]any)
+	require.Equal(t, image, primary["image"])
+	resources := requireMap(t, primary, "resources")
+	require.Equal(t, count, requireMap(t, resources, "requests")["example.com/gpu"])
+	require.Equal(t, count, requireMap(t, resources, "limits")["example.com/gpu"])
+	_, helperHasResources := containers[1].(map[string]any)["resources"]
+	require.False(t, helperHasResources)
 }
 
 func requireMap(t *testing.T, parent map[string]any, key string) map[string]any {

--- a/pkg/networkoperatorplugin/internal/pfutil/pfutil.go
+++ b/pkg/networkoperatorplugin/internal/pfutil/pfutil.go
@@ -26,6 +26,7 @@ package pfutil
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
@@ -43,6 +44,32 @@ func FilterEastWestPFs(pfs []config.PFConfig) []config.PFConfig {
 		}
 	}
 	return filtered
+}
+
+var connectedGPUIndexRE = regexp.MustCompile(`^GPU([0-9]+)$`)
+
+// GPUResourceCountForPFs returns the number of GPU devices a validation Pod
+// must request to keep every topology-derived CUDA ordinal addressable. The
+// device plugin exposes requested devices as a zero-based CUDA prefix, so a PF
+// connected to GPU7 requires eight devices. Missing topology falls back to one
+// device; validation then reports the unresolved endpoint instead of assuming
+// GPU0.
+func GPUResourceCountForPFs(pfs []config.PFConfig) int {
+	maxIndex := -1
+	for _, pf := range FilterEastWestPFs(pfs) {
+		match := connectedGPUIndexRE.FindStringSubmatch(strings.TrimSpace(pf.ConnectedGPU))
+		if len(match) != 2 {
+			continue
+		}
+		index, err := strconv.Atoi(match[1])
+		if err == nil && index > maxIndex {
+			maxIndex = index
+		}
+	}
+	if maxIndex < 0 {
+		return 1
+	}
+	return maxIndex + 1
 }
 
 // PciBusDevicePrefix returns the "domain:bus:device" portion of a PCI

--- a/pkg/networkoperatorplugin/internal/pfutil/pfutil_test.go
+++ b/pkg/networkoperatorplugin/internal/pfutil/pfutil_test.go
@@ -49,6 +49,18 @@ func TestIsDualPortModel(t *testing.T) {
 	}
 }
 
+func TestGPUResourceCountForPFs(t *testing.T) {
+	rail0 := 0
+	pfs := []config.PFConfig{
+		{Traffic: "north-south", ConnectedGPU: "GPU15"},
+		{Traffic: "east-west", Rail: &rail0, ConnectedGPU: "GPU2"},
+		{Traffic: "east-west", Rail: &rail0, ConnectedGPU: "GPU7"},
+		{Traffic: "east-west", Rail: &rail0, ConnectedGPU: "unknown"},
+	}
+	assert.Equal(t, 8, GPUResourceCountForPFs(pfs))
+	assert.Equal(t, 1, GPUResourceCountForPFs(nil))
+}
+
 func TestCollapsePFsToOnePerNIC(t *testing.T) {
 	t.Run("multi-plane NIC collapses to master", func(t *testing.T) {
 		// Two PFs on one NIC (same bus:device), no port-count keyword in model

--- a/pkg/networkoperatorplugin/releases/releases.go
+++ b/pkg/networkoperatorplugin/releases/releases.go
@@ -43,13 +43,15 @@ import (
 var releasesYAML []byte
 
 // Release describes a single Network Operator minor release: image tags for
-// the operator, DOCA driver, and independently versioned xPlane service.
+// the operator, DOCA driver, validation workload, and independently versioned
+// xPlane service.
 // Keyed by MAJOR.MINOR (e.g. "26.4") in the embedded catalog — patch bumps
 // update the values in place.
 type Release struct {
 	NetworkOperator ReleaseNetworkOperator `yaml:"networkOperator"`
 	DOCADriver      ReleaseDOCADriver      `yaml:"docaDriver"`
 	XPlane          ReleaseXPlane          `yaml:"xPlane"`
+	Validation      ReleaseValidation      `yaml:"validation"`
 }
 
 type ReleaseNetworkOperator struct {
@@ -78,6 +80,10 @@ type ReleaseDOCADriver struct {
 type ReleaseXPlane struct {
 	Repository string `yaml:"repository"`
 	Version    string `yaml:"version"`
+}
+
+type ReleaseValidation struct {
+	Image string `yaml:"image"`
 }
 
 type releasesFile struct {

--- a/pkg/networkoperatorplugin/releases/releases.yaml
+++ b/pkg/networkoperatorplugin/releases/releases.yaml
@@ -25,6 +25,8 @@ releases:
       helmRepoURL: https://helm.ngc.nvidia.com/nvidia
     docaDriver:
       version: doca3.3.0-26.01-1.0.0.0-6
+    validation:
+      image: nvcr.io/nvidia/doca/doca:full-rt-cuda13.0.0-3.2.3-runtime-host
   "26.4":
     networkOperator:
       version: v26.4.1
@@ -37,6 +39,8 @@ releases:
     xPlane:
       repository: nvcr.io/nvidia/doca
       version: doca-3.4.0
+    validation:
+      image: nvcr.io/nvidia/doca/doca:full-rt-cuda13.0.0-3.4.0-runtime-host
   "26.7":
     networkOperator:
       version: v26.7.0-rc.1
@@ -49,3 +53,5 @@ releases:
     xPlane:
       repository: nvcr.io/nvstaging/doca
       version: 3.5.0032
+    validation:
+      image: nvcr.io/nvstaging/doca/doca:full-rt-cuda13.0.0-3.5.0-runtime-host-dev

--- a/pkg/networkoperatorplugin/releases/releases_test.go
+++ b/pkg/networkoperatorplugin/releases/releases_test.go
@@ -32,6 +32,20 @@ func TestLookupRelease_Known(t *testing.T) {
 		assert.NotEmpty(t, r.NetworkOperator.ComponentVersion, "key %s: networkOperator.componentVersion", key)
 		assert.NotEmpty(t, r.NetworkOperator.Repository, "key %s: networkOperator.repository", key)
 		assert.NotEmpty(t, r.DOCADriver.Version, "key %s: docaDriver.version", key)
+		assert.NotEmpty(t, r.Validation.Image, "key %s: validation.image", key)
+	}
+}
+
+func TestLookupRelease_ValidationImages(t *testing.T) {
+	want := map[string]string{
+		"26.1": "nvcr.io/nvidia/doca/doca:full-rt-cuda13.0.0-3.2.3-runtime-host",
+		"26.4": "nvcr.io/nvidia/doca/doca:full-rt-cuda13.0.0-3.4.0-runtime-host",
+		"26.7": "nvcr.io/nvstaging/doca/doca:full-rt-cuda13.0.0-3.5.0-runtime-host-dev",
+	}
+	for key, image := range want {
+		release, ok := LookupRelease(key)
+		require.True(t, ok)
+		assert.Equal(t, image, release.Validation.Image)
 	}
 }
 

--- a/pkg/networkoperatorplugin/render_plan.go
+++ b/pkg/networkoperatorplugin/render_plan.go
@@ -423,6 +423,9 @@ func renderForScope(
 			nsCfg := withRenderNamespaces(cfg, ns, nsList)
 			for i, plan := range plans {
 				renderCfg := withClusterConfig(nsCfg, []config.ClusterConfig{plan.Merged}, subnetsAt(planSubnets, i))
+				if kind == "DaemonSet" {
+					renderCfg.ValidationGPUResourceCount = gpuResourceCountForGroups(plan.Sources)
+				}
 				rendered, err := ProcessTemplate(templatePath, renderCfg, "")
 				if err != nil {
 					return nil, err

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -103,6 +103,8 @@ var templateFuncs = template.FuncMap{
 	// hand-authored configs.
 	"xPlaneRepository": xPlaneRepository,
 	"xPlaneVersion":    xPlaneVersion,
+	"validationImage":  validationImage,
+	"gpuResourceCount": gpuResourceCount,
 	// secondaryNetworkMetaPlugins renders the metaPlugins literal-block body
 	// shared by non-Spectrum-X secondary-network CRs. Keep tuning before sbr:
 	// tuning fixes per-interface ARP ownership before sbr installs
@@ -1084,6 +1086,53 @@ func xPlaneVersion(networkOperator *config.NetworkOperatorConfig) string {
 		return release.XPlane.Version
 	}
 	return networkOperator.ComponentVersion
+}
+
+func validationImage(networkOperator *config.NetworkOperatorConfig) string {
+	if networkOperator != nil {
+		if release, ok := releases.LookupRelease(networkOperator.SelectedRelease); ok && release.Validation.Image != "" {
+			return release.Validation.Image
+		}
+		if version, err := semver.NewVersion(strings.TrimPrefix(networkOperator.Version, "v")); err == nil {
+			key := fmt.Sprintf("%d.%d", version.Major(), version.Minor())
+			if release, ok := releases.LookupRelease(key); ok && release.Validation.Image != "" {
+				return release.Validation.Image
+			}
+		}
+	}
+	keys := releases.SupportedReleases()
+	if len(keys) == 0 {
+		return ""
+	}
+	latest, _ := releases.LookupRelease(keys[len(keys)-1])
+	return latest.Validation.Image
+}
+
+// gpuResourceCount requests the visible GPU prefix needed to preserve the
+// host GPU indices recorded in connectedGPU. The renderer supplies an
+// aggregate count for merged DaemonSet buckets; direct ProcessTemplate callers
+// fall back to the current group's PFs. For example, topology that uses GPU0
+// and GPU4 requests five devices so --use_cuda=4 remains addressable. Missing
+// topology still requests one GPU to make the runtime available; the validator
+// reports an explicit topology error instead of assuming GPU0.
+func gpuResourceCount(aggregate int, pfs []config.PFConfig) int {
+	if aggregate > 0 {
+		return aggregate
+	}
+	return pfutil.GPUResourceCountForPFs(pfs)
+}
+
+func gpuResourceCountForGroups(groups []config.ClusterConfig) int {
+	maxCount := 0
+	for _, group := range groups {
+		if count := pfutil.GPUResourceCountForPFs(group.PFs); count > maxCount {
+			maxCount = count
+		}
+	}
+	if maxCount == 0 {
+		return 1
+	}
+	return maxCount
 }
 
 // mergeCompatibleGroups merges ClusterConfig groups that share the same gpuType

--- a/profiles/host-device-rdma/40-example-daemonset.yaml
+++ b/profiles/host-device-rdma/40-example-daemonset.yaml
@@ -16,6 +16,12 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Hostdev.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}{{- end}}{{- end}}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if .ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -44,19 +50,25 @@ spec:
       {{- end }}
       containers:
       - name: test-container
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK"]
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
             nvidia.com/{{$.Hostdev.ResourceName}}_rail_{{$pf.Rail}}: '1'
             {{- end}}
             {{- end}}
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
             nvidia.com/{{$.Hostdev.ResourceName}}_rail_{{$pf.Rail}}: '1'
@@ -85,6 +97,12 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: {{.Hostdev.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if .ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -113,15 +131,21 @@ spec:
       {{- end }}
       containers:
       - name: test-container
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK"]
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             nvidia.com/{{.Hostdev.ResourceName}}: '1'
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             nvidia.com/{{.Hostdev.ResourceName}}: '1'
       - name: netshoot
         image: nicolaka/netshoot:latest

--- a/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
@@ -16,6 +16,12 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Ipoib.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}{{- end}}{{- end}}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if .ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -44,19 +50,25 @@ spec:
       {{- end }}
       containers:
       - name: test-container
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK"]
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
             rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
             {{- end}}
             {{- end}}
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
             rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
@@ -86,6 +98,12 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: {{.Ipoib.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if $.ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -114,15 +132,21 @@ spec:
       {{- end }}
       containers:
       - name: test-container
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK"]
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             rdma/{{.RdmaShared.ResourceName}}: 1
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             rdma/{{.RdmaShared.ResourceName}}: 1
       - name: netshoot
         image: nicolaka/netshoot:latest

--- a/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
@@ -16,6 +16,12 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Macvlan.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}{{- end}}{{- end}}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if .ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -44,19 +50,25 @@ spec:
       {{- end }}
       containers:
       - name: test-container
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK"]
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
             rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
             {{- end}}
             {{- end}}
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
             rdma/{{$.RdmaShared.ResourceName}}_rail_{{$pf.Rail}}: 1
@@ -86,6 +98,12 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: {{.Macvlan.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if $.ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -114,15 +132,21 @@ spec:
       {{- end }}
       containers:
       - name: test-container
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK"]
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             rdma/{{.RdmaShared.ResourceName}}: 1
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             rdma/{{.RdmaShared.ResourceName}}: 1
       - name: netshoot
         image: nicolaka/netshoot:latest

--- a/profiles/spectrum-x-ra2.1/90-example-daemonset.yaml
+++ b/profiles/spectrum-x-ra2.1/90-example-daemonset.yaml
@@ -18,6 +18,12 @@ spec:
         {{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $railIdx := untilStep 0 $railCount 1 }}{{- if $swplb }}{{- range $planeIdx := untilStep 0 $planes 1 }}{{- if not $first }},{{ end }}{{- $first = false }}rail-{{$railIdx}}-plane-{{$planeIdx}}{{- end }}{{- else }}{{- if not $first }},{{ end }}{{- $first = false }}rail-{{$railIdx}}{{- end }}{{- end }}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if or .ClusterConfig.SourceMachineLabels .ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -46,12 +52,15 @@ spec:
       {{- end }}
       containers:
       - name: spectrum-x-test
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         securityContext:
           capabilities:
             add: ["IPC_LOCK", "NET_RAW"]
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $railIdx := untilStep 0 $railCount 1 }}
             {{- if $swplb }}
             {{- range $planeIdx := untilStep 0 $planes 1 }}
@@ -62,6 +71,9 @@ spec:
             {{- end }}
             {{- end }}
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $railIdx := untilStep 0 $railCount 1 }}
             {{- if $swplb }}
             {{- range $planeIdx := untilStep 0 $planes 1 }}
@@ -71,19 +83,7 @@ spec:
             nvidia.com/rail_{{$railIdx}}: "1"
             {{- end }}
             {{- end }}
-        command:
-        - sh
-        - -c
-        - |
-          echo "Spectrum-X Multi-Rail Test DaemonSet"
-          echo "Available network interfaces:"
-          ip addr show
-          echo ""
-          echo "RDMA devices:"
-          rdma link
-          echo ""
-          echo "Sleeping indefinitely for manual testing..."
-          sleep infinity
+        command: ["/bin/bash", "-c", "sleep infinity"]
       - name: netshoot
         image: nicolaka/netshoot:latest
         command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]

--- a/profiles/spectrum-x-ra2.2/90-example-daemonset.yaml
+++ b/profiles/spectrum-x-ra2.2/90-example-daemonset.yaml
@@ -18,6 +18,12 @@ spec:
         {{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $railIdx := untilStep 0 $railCount 1 }}{{- if $swplb }}{{- range $planeIdx := untilStep 0 $planes 1 }}{{- if not $first }},{{ end }}{{- $first = false }}rail-{{$railIdx}}-plane-{{$planeIdx}}{{- end }}{{- else }}{{- if not $first }},{{ end }}{{- $first = false }}rail-{{$railIdx}}{{- end }}{{- end }}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if or .ClusterConfig.SourceMachineLabels .ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -46,7 +52,7 @@ spec:
       {{- end }}
       containers:
       - name: spectrum-x-test
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         securityContext:
           capabilities:
             add: ["IPC_LOCK", "NET_RAW"]
@@ -62,9 +68,18 @@ spec:
           - name: rail-{{$railIdx}}
             {{- end }}
             {{- end }}
+          {{- if $.Validation.GPUDirect.Enabled }}
+          requests:
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+          limits:
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+          {{- end }}
         {{- else }}
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $railIdx := untilStep 0 $railCount 1 }}
             {{- if $swplb }}
             {{- range $planeIdx := untilStep 0 $planes 1 }}
@@ -75,6 +90,9 @@ spec:
             {{- end }}
             {{- end }}
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $railIdx := untilStep 0 $railCount 1 }}
             {{- if $swplb }}
             {{- range $planeIdx := untilStep 0 $planes 1 }}
@@ -85,19 +103,7 @@ spec:
             {{- end }}
             {{- end }}
         {{- end }}
-        command:
-        - sh
-        - -c
-        - |
-          echo "Spectrum-X Multi-Rail Test DaemonSet"
-          echo "Available network interfaces:"
-          ip addr show
-          echo ""
-          echo "RDMA devices:"
-          rdma link
-          echo ""
-          echo "Sleeping indefinitely for manual testing..."
-          sleep infinity
+        command: ["/bin/bash", "-c", "sleep infinity"]
       - name: netshoot
         image: nicolaka/netshoot:latest
         command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]

--- a/profiles/spectrum-x/90-example-daemonset.yaml
+++ b/profiles/spectrum-x/90-example-daemonset.yaml
@@ -18,6 +18,12 @@ spec:
         {{- $swplb := eq .Profile.SpectrumX.MultiplaneMode "swplb" }}
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $railIdx := untilStep 0 $railCount 1 }}{{- if $swplb }}{{- range $planeIdx := untilStep 0 $planes 1 }}{{- if not $first }},{{ end }}{{- $first = false }}rail-{{$railIdx}}-plane-{{$planeIdx}}{{- end }}{{- else }}{{- if not $first }},{{ end }}{{- $first = false }}rail-{{$railIdx}}{{- end }}{{- end }}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if or .ClusterConfig.SourceMachineLabels .ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -46,7 +52,7 @@ spec:
       {{- end }}
       containers:
       - name: spectrum-x-test
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         securityContext:
           capabilities:
             add: ["IPC_LOCK", "NET_RAW"]
@@ -62,9 +68,18 @@ spec:
           - name: rail-{{$railIdx}}
             {{- end }}
             {{- end }}
+          {{- if $.Validation.GPUDirect.Enabled }}
+          requests:
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+          limits:
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+          {{- end }}
         {{- else }}
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $railIdx := untilStep 0 $railCount 1 }}
             {{- if $swplb }}
             {{- range $planeIdx := untilStep 0 $planes 1 }}
@@ -75,6 +90,9 @@ spec:
             {{- end }}
             {{- end }}
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $railIdx := untilStep 0 $railCount 1 }}
             {{- if $swplb }}
             {{- range $planeIdx := untilStep 0 $planes 1 }}
@@ -85,19 +103,7 @@ spec:
             {{- end }}
             {{- end }}
         {{- end }}
-        command:
-        - sh
-        - -c
-        - |
-          echo "Spectrum-X Multi-Rail Test DaemonSet"
-          echo "Available network interfaces:"
-          ip addr show
-          echo ""
-          echo "RDMA devices:"
-          rdma link
-          echo ""
-          echo "Sleeping indefinitely for manual testing..."
-          sleep infinity
+        command: ["/bin/bash", "-c", "sleep infinity"]
       - name: netshoot
         image: nicolaka/netshoot:latest
         command: ["/bin/bash", "-c", "trap 'exit 0' TERM INT; while true; do while wait -n 2>/dev/null; do :; done; sleep 1 & wait $! || true; done"]

--- a/profiles/sriov-ethernet-rdma/60-example-daemonset.yaml
+++ b/profiles/sriov-ethernet-rdma/60-example-daemonset.yaml
@@ -16,6 +16,12 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}{{- end}}{{- end}}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if .ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -44,19 +50,25 @@ spec:
       {{- end }}
       containers:
       - name: test-container
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK"]
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
             nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
             {{- end}}
             {{- end}}
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
             nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
@@ -85,6 +97,12 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if $.ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -113,15 +131,21 @@ spec:
       {{- end }}
       containers:
       - name: test-container
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK"]
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             nvidia.com/{{.Sriov.ResourceName}}: '1'
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             nvidia.com/{{.Sriov.ResourceName}}: '1'
       - name: netshoot
         image: nicolaka/netshoot:latest

--- a/profiles/sriov-ib-rdma/60-example-daemonset.yaml
+++ b/profiles/sriov-ib-rdma/60-example-daemonset.yaml
@@ -16,6 +16,12 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: {{ $first := true }}{{- range $i, $pf := .ClusterConfig.PFs}}{{- if eq $pf.Traffic "east-west"}}{{- if not $first}},{{end}}{{- $first = false}}{{$.Sriov.NetworkName}}-rail-{{$pf.Rail}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}{{- end}}{{- end}}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if .ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -44,19 +50,25 @@ spec:
       {{- end }}
       containers:
       - name: test-container
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK"]
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
             nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
             {{- end}}
             {{- end}}
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             {{- range $i, $pf := .ClusterConfig.PFs}}
             {{- if eq $pf.Traffic "east-west"}}
             nvidia.com/{{$.Sriov.ResourceName}}_rail_{{$pf.Rail}}: '1'
@@ -85,6 +97,12 @@ spec:
       annotations:
         k8s.v1.cni.cncf.io/networks: {{.Sriov.NetworkName}}{{suffix $.ClusterConfig.Identifier}}{{nsSuffix $.NetworkNamespaces $.CurrentNetworkNamespace}}
     spec:
+      {{- if $.NetworkOperator.ImagePullSecrets }}
+      imagePullSecrets:
+        {{- range $.NetworkOperator.ImagePullSecrets }}
+      - name: "{{ . }}"
+        {{- end }}
+      {{- end }}
       {{- if $.ClusterConfig.NodeSelector }}
       affinity:
         nodeAffinity:
@@ -113,15 +131,21 @@ spec:
       {{- end }}
       containers:
       - name: test-container
-        image: nvcr.io/nvidia/doca/doca:3.3.0-full-rt-host
+        image: {{validationImage $.NetworkOperator}}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
             add: ["IPC_LOCK"]
         resources:
           requests:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             nvidia.com/{{.Sriov.ResourceName}}: '1'
           limits:
+            {{- if $.Validation.GPUDirect.Enabled }}
+            "{{$.Validation.GPUDirect.GPUResourceType}}": "{{gpuResourceCount $.ValidationGPUResourceCount $.ClusterConfig.PFs}}"
+            {{- end }}
             nvidia.com/{{.Sriov.ResourceName}}: '1'
       - name: netshoot
         image: nicolaka/netshoot:latest

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -337,6 +337,13 @@ profile:
 # Controls l8k validate data-plane checks.
 # ============================================================================
 validation:
+  gpuDirect:
+    # bool | always present; discovery writes true only when every worker can
+    # satisfy its render bucket's topology-derived gpuResourceType request.
+    enabled: false
+    # string | qualified extended resource | default: nvidia.com/gpu
+    gpuResourceType: nvidia.com/gpu
+
   # bool | default: true
   # Run the example DaemonSet connectivity matrix.
   connectivity: true

--- a/skills/k8s-launch-kit-discover/SKILL.md
+++ b/skills/k8s-launch-kit-discover/SKILL.md
@@ -158,6 +158,11 @@ is not written; the GPU label is still written when `gpuType` alone is resolved.
   in the config file) for private registries.
 - Network Operator does **NOT** need to be pre-installed.
 
+Discovery also always writes `validation.gpuDirect.enabled`. It is true only
+when every worker in every discovered group can satisfy its render bucket's
+topology-derived `validation.gpuDirect.gpuResourceType` request; otherwise it
+is false. Do not add GPU counts or resource maps under `clusterConfig`.
+
 ## Tips
 
 - Profile precedence is `hardware/default < existing YAML < explicit CLI`.

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -111,6 +111,13 @@ read `references/profile-decision-tree.md`.
 
 Generated YAMLs are written to the output directory under `network-operator/`. Each profile also emits a `values.yaml` (Helm values for the `nvidia/network-operator` chart) alongside the CR manifests:
 
+When `validation.gpuDirect.enabled` is true, every generated example
+DaemonSet requests `validation.gpuDirect.gpuResourceType` only on its primary
+DOCA container. The request exposes the highest `GPU<N>` referenced by PF
+topology, the image comes from the selected release's `validation.image`, and
+`networkOperator.imagePullSecrets` is copied to the Pod spec. Do not inject
+these fields later at validation runtime.
+
 ```
 output/
 └── network-operator/

--- a/skills/k8s-launch-kit-validate/SKILL.md
+++ b/skills/k8s-launch-kit-validate/SKILL.md
@@ -38,8 +38,10 @@ Operator release.
    `READY`, `IN-PROGRESS`, `ERROR`, or `MISSING`.
 3. **Connectivity matrix.** By default, `l8k validate` applies the generated
    example DaemonSet, waits for ready pods, and runs source-bound `icmp`,
-   `rping`, and `ib_write_bw` tests. Profile templates declare both validation
-   containers: DOCA for the RDMA checks and `netshoot` for ICMP and route
+   `rping`, and `ib_write_bw` tests. When `validation.gpuDirect.enabled` is
+   true and `ib_write_bw` is selected, a distinct DMA-BUF bandwidth family
+   uses the connected GPU index for each source and destination rail. Profile templates declare both validation
+   containers: the release-specific full-runtime DOCA image for the RDMA checks and `netshoot` for ICMP and route
    checks. Validate applies the generated DaemonSet without runtime container
    injection. The default mode is `strict`.
 
@@ -82,7 +84,11 @@ l8k validate [--user-config <PATH>] [--deployment-files <DIR>] [--kubeconfig <PA
   must succeed, `destination-based` must stay isolated.
 
 All checks are source-bound. ICMP uses `ping -I <src-iface>`, `rping` uses
-`-I <src-ip>`, and `ib_write_bw` uses `--bind_source_ip <src-ip>`.
+`-I <src-ip>`, and `ib_write_bw` uses `--bind_source_ip <src-ip>`. GPUDirect
+adds `--use_cuda=<endpoint-index> --use_cuda_dmabuf` independently on the
+client and server. Treat missing or ambiguous `connectedGPU` topology as a
+failure; never substitute GPU 0. Pull Secrets come from
+`networkOperator.imagePullSecrets` and must exist in every validation namespace.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- add an explicit `validation.gpuDirect` configuration block with a configurable `gpuResourceType`; discovery writes only `enabled`, setting it true only when every worker can satisfy the topology-derived GPU request for its render bucket
- catalog release-specific full-runtime DOCA images and render them in every validation DaemonSet, propagate Network Operator image pull secrets, and request the GPU prefix needed for topology-derived CUDA indices only on the primary container
- run GPUDirect as a separate `gpudirect_dmabuf` bandwidth family when enabled and `ib_write_bw` is selected, using independent source and destination GPU indices from PF topology and failing unresolved or ambiguous mappings instead of assuming GPU 0
- keep route diagnostics in the netshoot helper because the full-runtime images do not contain `ip` or `rdma`, and surface GPU indices, PCI addresses, bandwidth, threshold, and errors in text, JSON, and HTML reports
- update user/reference documentation and bundled Launch Kit skills

This follows NVIDIA's [GPUDirect RDMA with DMA-BUF guidance](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-operator-rdma.html).

## Validation

- `CGO_ENABLED=0 make build`
- `CGO_ENABLED=0 go test ./... -count=1`
- `CGO_ENABLED=0 go vet ./...`
- rendered CLI smoke tests for merged, namespace-different, and heterogeneous grouping fixtures
- rendered tests across all standard profile branches and Spectrum-X RA2.1/RA2.2/RA2.3 modes, including DRA
- ran all three catalog images as `linux/amd64` and verified `rping`, `ib_write_bw`, and `--use_cuda_dmabuf`
- CI: Build, Test, Lint, Docs, and CodeQL passed on the previous revision; the amended review fix is rerunning the same checks
