### PR TITLE
Add detailed validation connectivity logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Target-Agnostic Execution Flags:
 Target-Agnostic Output & Logging Flags:
   -h, --help               help for l8k
       --log-file string    Write logs to file instead of stderr
-      --log-level string   Enable logging at specified level (debug, info, warn, error)
+      --log-level string   Enable logging at specified level (trace, debug, info, warn, error)
       --output string      Output format: text (default, human-readable) or json (structured, for automation and AI agents) (default "text")
   -q, --quiet              Suppress informational output (errors still shown)
   -y, --yes                Auto-confirm all prompts without interactive input
@@ -446,6 +446,14 @@ the selected checks, their per-command limits, ordered pod-pair batches, a
 bounded setup allowance, cleanup, and a safety margin. The calculated total
 is printed before test execution. Use `--connectivity-timeout <DURATION>` to
 replace it with an explicit end-to-end setup and execution deadline.
+
+For connectivity troubleshooting, add `--log-level debug` to see endpoint
+inventory, plan decisions, source-route cache statistics, stage and RDMA-batch
+progress, pass/fail counts, and elapsed/remaining time. Use `--log-level trace`
+when command evidence is needed: it additionally records bounded route,
+client, and server output for each test. RDMA client stdout/stderr and failed
+server logs are collected before the temporary files are removed. Output
+fields are capped to prevent a noisy command from producing unbounded logs.
 
 A self-contained HTML report lands at `<deployment-files>/k8s-launch-kit-validation-report.html`
 by default (override with `--report-path`, disable with `--report-path=-`).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -44,7 +44,7 @@ flag groups and `l8k schema` for each flag's `targets` list.
 | `--network-operator-namespace` | generate, deploy, clean, validate | host | Override the Network Operator namespace. It is a no-op for discovery. |
 | `--output json` | all | target-agnostic | Emit a single JSON result to stdout for automation. |
 | `--quiet` | root pipeline | target-agnostic | Suppress informational output. |
-| `--log-level` | all | target-agnostic | Enable `debug`, `info`, `warn`, or `error` logging. |
+| `--log-level` | all | target-agnostic | Enable `trace`, `debug`, `info`, `warn`, or `error` logging. `debug` shows structured progress; `trace` also shows bounded command output. |
 | `--log-file` | all | target-agnostic | Write logs to a file instead of `stderr`. |
 
 The current host config and artifact contract is unchanged:
@@ -157,6 +157,11 @@ full deletion boundary.
 | `--report-path` | HTML report path. Use `-` to disable. |
 | `--keep` | Keep the test DaemonSet after validation. |
 | `--wait` | Wait for in-progress manifests to reach a terminal state. |
+
+Use `--log-level debug` with `validate` for structured check, endpoint, route,
+stage, batch, test, cleanup, and report timings. `--log-level trace` also emits
+bounded command stdout/stderr and RDMA server logs. Failed RDMA server logs are
+collected before the validation workload cleanup runs.
 
 ## Preset Flags
 

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -129,6 +129,31 @@ maintenance or CI window. Test DaemonSet and RDMA-process cleanup use short,
 independent best-effort contexts so cleanup is still attempted after either an
 automatic or user-supplied deadline expires.
 
+## Debug and Trace Logs
+
+Use debug logging for structured progress without command output:
+
+```bash
+l8k validate --log-level debug
+```
+
+Debug includes static-check durations, the complete endpoint inventory,
+matrix and timeout planning, source-route executions and cache hits, stage and
+RDMA-batch progress, pass/fail counts, cleanup, report writes, elapsed time,
+and remaining time.
+
+Use trace when a connectivity failure needs command evidence:
+
+```bash
+l8k validate --log-level trace --keep
+```
+
+Trace adds bounded route and ICMP commands, RDMA batch commands, per-test
+client stdout/stderr, and RDMA server logs. Failed RDMA server logs are
+collected before the temporary files and test workload are removed. Each log
+field is capped to keep command output bounded. Add `--keep` only when the
+validation pods must remain available for follow-up inspection.
+
 Disable only the connectivity stage:
 
 ```bash

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -282,7 +282,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "Preview what would be deployed without applying changes to the cluster")
 
 	// Logging flags
-	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "Enable logging at specified level (debug, info, warn, error)")
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "Enable logging at specified level (trace, debug, info, warn, error)")
 	rootCmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Write logs to file instead of stderr")
 
 	// Group the flags into labelled sections in --help output. The phase

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -19,6 +19,7 @@ package log
 import (
 	"flag"
 	"os"
+	"strings"
 
 	"github.com/go-logr/zapr"
 	zzap "go.uber.org/zap"
@@ -31,6 +32,10 @@ import (
 
 const (
 	DebugLevel = int(zapcore.DebugLevel)
+	// TraceLevel is two verbosity steps below info. logr maps V(1) to zap's
+	// debug level (-1) and V(2) to -2, so a dedicated trace level is needed
+	// to make V(2) logs selectable from the CLI.
+	TraceLevel = zapcore.Level(-2)
 )
 
 var (
@@ -101,7 +106,7 @@ func InitLog() {
 			MessageKey:     "msg",
 			StacktraceKey:  "stacktrace",
 			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeLevel:    zapcore.CapitalLevelEncoder,
+			EncodeLevel:    encodeLevel,
 			EncodeTime:     zapcore.RFC3339NanoTimeEncoder,
 			EncodeDuration: zapcore.StringDurationEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
@@ -124,7 +129,7 @@ func InitLog() {
 		MessageKey:     "msg",
 		StacktraceKey:  "stacktrace",
 		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeLevel:    zapcore.CapitalLevelEncoder,
+		EncodeLevel:    encodeLevel,
 		EncodeTime:     zapcore.RFC3339NanoTimeEncoder,
 		EncodeDuration: zapcore.StringDurationEncoder,
 		EncodeCaller:   zapcore.ShortCallerEncoder,
@@ -138,7 +143,7 @@ func InitLog() {
 
 // SetLogLevel sets current logging level to the provided lvl
 func SetLogLevel(lvl string) error {
-	newLevel, err := zapcore.ParseLevel(lvl)
+	newLevel, err := parseLevel(lvl)
 	if err != nil {
 		return err
 	}
@@ -146,7 +151,7 @@ func SetLogLevel(lvl string) error {
 	currLevel := Options.Level.(zzap.AtomicLevel).Level()
 
 	if newLevel != currLevel {
-		log.Log.Info("set log verbose level", "newLevel", newLevel.String(), "currentLevel", currLevel.String())
+		log.Log.Info("set log verbose level", "newLevel", levelName(newLevel), "currentLevel", levelName(currLevel))
 		Options.Level.(zzap.AtomicLevel).SetLevel(newLevel)
 	}
 	return nil
@@ -154,7 +159,29 @@ func SetLogLevel(lvl string) error {
 
 // GetLogLevel returns the current logging level
 func GetLogLevel() string {
-	return Options.Level.(zzap.AtomicLevel).Level().String()
+	return levelName(Options.Level.(zzap.AtomicLevel).Level())
+}
+
+func parseLevel(level string) (zapcore.Level, error) {
+	if strings.EqualFold(strings.TrimSpace(level), "trace") {
+		return TraceLevel, nil
+	}
+	return zapcore.ParseLevel(level)
+}
+
+func levelName(level zapcore.Level) string {
+	if level == TraceLevel {
+		return "trace"
+	}
+	return level.String()
+}
+
+func encodeLevel(level zapcore.Level, encoder zapcore.PrimitiveArrayEncoder) {
+	if level == TraceLevel {
+		encoder.AppendString("TRACE")
+		return
+	}
+	zapcore.CapitalLevelEncoder(level, encoder)
 }
 
 // routeNoiseToControllerRuntimeLogger silences two upstream sources of
@@ -164,7 +191,7 @@ func GetLogLevel() string {
 //     deprecations like "node-role.kubernetes.io/master is deprecated").
 //     The default handler prints to klog; we route it through our
 //     logr.Logger at V(2) so the warnings stay visible under
-//     --log-level=debug but disappear otherwise.
+//     --log-level=trace but disappear otherwise.
 //   - klog itself, which client-go and the helm SDK both initialise.
 //     Without this, klog still prints `I0524 18:40:18.932 warnings.go:110]`
 //     to stderr even when our zap logger is configured to be quiet.
@@ -178,7 +205,7 @@ func routeNoiseToControllerRuntimeLogger() {
 
 // restWarningRouter forwards client-go HTTP-299 warning headers to the
 // controller-runtime logger at V(2). At info-level the calls are no-ops
-// (zap filters them); at debug-level they surface alongside the rest of
+// (zap filters them); at trace-level they surface alongside the rest of
 // our structured logs.
 type restWarningRouter struct{}
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestParseLevel(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  zapcore.Level
+	}{
+		{name: "trace", input: "trace", want: TraceLevel},
+		{name: "trace is case insensitive", input: " TRACE ", want: TraceLevel},
+		{name: "debug", input: "debug", want: zapcore.DebugLevel},
+		{name: "info", input: "info", want: zapcore.InfoLevel},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseLevel(tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseLevelRejectsUnknownValue(t *testing.T) {
+	_, err := parseLevel("verbose")
+	require.Error(t, err)
+}
+
+func TestLevelName(t *testing.T) {
+	assert.Equal(t, "trace", levelName(TraceLevel))
+	assert.Equal(t, "debug", levelName(zapcore.DebugLevel))
+}
+
+func TestEncodeLevelNamesTrace(t *testing.T) {
+	encoder := zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+		LevelKey:    "level",
+		EncodeLevel: encodeLevel,
+	})
+	buffer, err := encoder.EncodeEntry(zapcore.Entry{Level: TraceLevel}, nil)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"level":"TRACE"}`, buffer.String())
+}

--- a/pkg/networkoperatorplugin/connectivity/connectivity.go
+++ b/pkg/networkoperatorplugin/connectivity/connectivity.go
@@ -131,6 +131,7 @@ type DaemonSetReport struct {
 // All UI output flows through `uiOutput` (caller passes
 // ui.FromContext(ctx)). Logs go to controller-runtime's logr.
 func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, uiOutput ui.Output, opts Options) (*MatrixResult, error) {
+	runStarted := time.Now()
 	if opts.Timeout < 0 {
 		return nil, fmt.Errorf("connectivity timeout must be greater than or equal to zero")
 	}
@@ -145,6 +146,18 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 		opts.IBWriteSize = 65536
 	}
 
+	logger := connectivityLogger()
+	logger.V(1).Info("connectivity run started",
+		"manifestDir", opts.ManifestDir,
+		"mode", opts.Mode,
+		"routing", opts.Routing,
+		"checks", opts.Checks,
+		"requestedTimeout", opts.Timeout.String(),
+		"automaticTimeout", opts.Timeout == 0,
+		"keep", opts.Keep)
+	defer func() {
+		logger.V(1).Info("connectivity run finished", "duration", time.Since(runStarted).Round(time.Millisecond).String())
+	}()
 	uiOutput.Section("Connectivity matrix")
 	if len(opts.Checks) == 0 {
 		return &MatrixResult{
@@ -160,6 +173,7 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 		runCtx, runCancel = context.WithTimeout(ctx, opts.Timeout)
 		setupTimeout = opts.Timeout
 		uiOutput.Info("Connectivity timeout set by user: %s", opts.Timeout)
+		logger.V(1).Info("connectivity timeout configured", "timeout", opts.Timeout.String(), "source", "user")
 	}
 	defer runCancel()
 
@@ -174,10 +188,14 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 
 	hasICMP := checksContain(opts.Checks, CheckICMP)
 	hasRDMA := checksContain(opts.Checks, CheckRPing) || checksContain(opts.Checks, CheckIBWriteBW) || checksContain(opts.Checks, CheckGPUDirectDMABuf)
+	loadStarted := time.Now()
 	objs, refs, err := LoadExampleDaemonSets(opts.ManifestDir)
 	if err != nil {
 		return nil, err
 	}
+	logger.V(1).Info("example DaemonSet manifests loaded",
+		"count", len(objs),
+		"duration", time.Since(loadStarted).Round(time.Millisecond).String())
 	if len(objs) == 0 {
 		return &MatrixResult{
 			Skipped: &MatrixSkip{Reason: "no example DaemonSet manifests found under " + opts.ManifestDir},
@@ -198,38 +216,57 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 	defer func() {
 		if opts.Keep {
 			uiOutput.Info("--keep set: leaving %d test DaemonSet(s) running", len(refs))
+			logger.V(1).Info("connectivity cleanup skipped", "reason", "keep enabled", "daemonSets", len(refs))
 			return
 		}
 		// Use a fresh context for cleanup; the main ctx may have
 		// already been cancelled / timed out.
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), matrixCleanupTimeout)
 		defer cleanupCancel()
+		cleanupStarted := time.Now()
 		for _, ref := range refs {
+			deleteStarted := time.Now()
 			if err := DeleteDaemonSet(cleanupCtx, c, ref); err != nil {
 				uiOutput.Warning("cleanup: %v", err)
 				log.Log.V(1).Info("cleanup error", "error", err.Error())
+				continue
 			}
+			logger.V(1).Info("test DaemonSet deleted",
+				"namespace", ref.Namespace, "name", ref.Name,
+				"duration", time.Since(deleteStarted).Round(time.Millisecond).String())
 		}
+		logger.V(1).Info("connectivity cleanup completed",
+			"daemonSets", len(refs),
+			"duration", time.Since(cleanupStarted).Round(time.Millisecond).String())
 	}()
 
 	applyAndCollectPods := func(runCtx context.Context, objs []*unstructured.Unstructured, refs []DaemonSetRef) ([]testPodWithDS, error) {
 		for i, obj := range objs {
 			ref := refs[i]
 			uiOutput.Info("Applying %s/%s (from %s)", ref.Namespace, ref.Name, ref.SourceFile)
+			started := time.Now()
 			if err := ApplyDaemonSet(runCtx, c, obj); err != nil {
 				return nil, fmt.Errorf("apply daemonset %s/%s: %w", ref.Namespace, ref.Name, err)
 			}
+			logger.V(1).Info("test DaemonSet applied",
+				"namespace", ref.Namespace, "name", ref.Name, "sourceFile", ref.SourceFile,
+				"duration", time.Since(started).Round(time.Millisecond).String())
 		}
 
 		// Wait for each DS to roll out, then enumerate its pods.
 		out := make([]testPodWithDS, 0)
 		for _, ref := range refs {
 			uiOutput.Info("Waiting for DaemonSet %s/%s to roll out", ref.Namespace, ref.Name)
+			started := time.Now()
 			rollout, err := WaitForRollout(runCtx, c, ref, setupTimeout)
 			if err != nil {
 				return out, err
 			}
 			uiOutput.Success("DaemonSet %s/%s ready (%d/%d pods)", ref.Namespace, ref.Name, rollout.Ready, rollout.Desired)
+			logger.V(1).Info("test DaemonSet rollout completed",
+				"namespace", ref.Namespace, "name", ref.Name,
+				"ready", rollout.Ready, "desired", rollout.Desired,
+				"duration", time.Since(started).Round(time.Millisecond).String())
 			pods, err := ListPods(runCtx, c, ref)
 			if err != nil {
 				return out, err
@@ -274,12 +311,20 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			}
 			if discoverRDMA {
 				tp.RDMADevsByRail = DiscoverRDMADevices(runCtx, restConfig, p.pod.Namespace, p.pod.Name, p.ref.RDMAContainer, ifaceByRail)
-				log.Log.V(1).Info("RDMA device discovery",
-					"pod", p.pod.Name, "rails", tp.RailOrder,
-					"rdmaDevsByRail", tp.RDMADevsByRail)
 			}
 			tp.InterfacesByRail = ifaceByRail
 			PopulateGPUTopology(&tp, opts.ClusterConfig)
+			logger.V(1).Info("connectivity endpoint discovered",
+				"namespace", tp.Namespace,
+				"pod", tp.Name,
+				"node", tp.Node,
+				"rails", tp.RailOrder,
+				"ipsByRail", tp.IPsByRail,
+				"interfacesByRail", tp.InterfacesByRail,
+				"rdmaDevicesByRail", tp.RDMADevsByRail,
+				"gpuIndicesByRail", tp.GPUIndicesByRail,
+				"icmpContainer", p.ref.ICMPContainer,
+				"rdmaContainer", p.ref.RDMAContainer)
 			testPods = append(testPods, tp)
 		}
 		return testPods
@@ -306,6 +351,7 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 	plan := PlanWithOptions(testPods, opts.Mode, opts.Routing)
 	if plan.Skip != nil {
 		uiOutput.Warning("Matrix skipped: %s", plan.Skip.Reason)
+		logger.V(1).Info("connectivity plan skipped", "reason", plan.Skip.Reason, "pods", len(testPods))
 		result.Skipped = plan.Skip
 		return result, nil
 	}
@@ -315,6 +361,15 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 	if automaticTimeout {
 		budget := automaticTimeoutBudget(plan, opts.Checks)
 		uiOutput.Info("Connectivity timeout automatically calculated from %d planned tests: %s total budget", budget.PlannedTests, budget.Total)
+		logger.V(1).Info("connectivity timeout calculated",
+			"source", "matrixPlan",
+			"plannedTests", budget.PlannedTests,
+			"setup", budget.Setup.String(),
+			"tests", budget.Tests.String(),
+			"safetyMargin", budget.SafetyMargin.String(),
+			"cleanup", budget.Cleanup.String(),
+			"execution", budget.executionTimeout().String(),
+			"total", budget.Total.String())
 		setupCancel()
 		executionCtx, executionCancel = context.WithTimeout(ctx, budget.executionTimeout())
 	}
@@ -322,6 +377,19 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 
 	totalSameRail := len(plan.RDMASameRail)
 	totalCrossRail := len(plan.RDMACrossRail)
+	logger.V(1).Info("connectivity plan built",
+		"mode", opts.Mode,
+		"routing", opts.Routing,
+		"crossRailExpectation", crossRailExpectation(opts.Mode, opts.Routing),
+		"pods", len(testPods),
+		"icmpSameRail", len(plan.ICMPSameRail),
+		"icmpCrossRail", len(plan.ICMPCrossRail),
+		"rpingSameRail", len(plan.RDMASameRail),
+		"rpingCrossRail", len(plan.RDMACrossRail),
+		"ibWriteBwSameRail", len(plan.RDMABwSameRail),
+		"ibWriteBwCrossRail", len(plan.RDMABwCrossRail),
+		"gpuDirectSameRail", len(plan.GPUDirectDMABufSameRail),
+		"gpuDirectCrossRail", len(plan.GPUDirectDMABufCrossRail))
 	plannedTests := 0
 	if checksContain(opts.Checks, CheckICMP) {
 		uiOutput.Info("Plan: %d same-rail ICMP + %d cross-rail ICMP",
@@ -401,6 +469,7 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			},
 		},
 	}
+	routes := routeCache{}
 	for _, stage := range stages {
 		if !checksContain(opts.Checks, stage.check) {
 			continue
@@ -410,34 +479,44 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			continue
 		}
 		uiOutput.Info("Stage: %s — %d test(s)", stage.label, len(tests))
-		if stage.check != CheckICMP {
-			tests = checkSourceRoutes(executionCtx, restConfig, namespaceByPod, icmpContainerByPod, tests)
-		}
-		if stage.check == CheckRPing {
-			result.PingResults = append(result.PingResults,
-				RunRPingBatches(executionCtx, restConfig, namespaceByPod, rdmaContainerByPod, tests, opts.RPingIterations)...)
-			continue
-		}
-		if stage.check == CheckIBWriteBW {
-			result.PingResults = append(result.PingResults,
-				RunIbWriteBwBatches(executionCtx, restConfig, namespaceByPod, rdmaContainerByPod, tests, opts.IBWriteSize, opts.IBWriteMinBandwidthGbps)...)
-			continue
-		}
-		if stage.check == CheckGPUDirectDMABuf {
-			result.PingResults = append(result.PingResults,
-				RunGPUDirectDMABufBatches(executionCtx, restConfig, namespaceByPod, rdmaContainerByPod, tests, opts.IBWriteSize, opts.IBWriteMinBandwidthGbps)...)
-			continue
-		}
-		for _, t := range tests {
-			if namespaceByPod[t.SrcPod] == "" || namespaceByPod[t.DstPod] == "" || icmpContainerByPod[t.SrcPod] == "" {
-				result.PingResults = append(result.PingResults, PingResult{
-					Test: t,
-					Err:  fmt.Errorf("no namespace/container lookup for pod pair (%s, %s)", t.SrcPod, t.DstPod),
-				})
-				continue
+		stageStarted := time.Now()
+		logger.V(1).Info("connectivity stage started",
+			"stage", stage.check, "tests", len(tests), "remainingTimeout", remainingTimeout(executionCtx))
+		tests = checkSourceRoutes(executionCtx, restConfig, namespaceByPod, icmpContainerByPod, tests, routes)
+		stageResults := make([]PingResult, 0, len(tests))
+		switch stage.check {
+		case CheckRPing:
+			stageResults = RunRPingBatches(executionCtx, restConfig, namespaceByPod, rdmaContainerByPod, tests, opts.RPingIterations)
+		case CheckIBWriteBW:
+			stageResults = RunIbWriteBwBatches(executionCtx, restConfig, namespaceByPod, rdmaContainerByPod, tests, opts.IBWriteSize, opts.IBWriteMinBandwidthGbps)
+		case CheckGPUDirectDMABuf:
+			stageResults = RunGPUDirectDMABufBatches(executionCtx, restConfig, namespaceByPod, rdmaContainerByPod, tests, opts.IBWriteSize, opts.IBWriteMinBandwidthGbps)
+		default:
+			for i, t := range tests {
+				testStarted := time.Now()
+				testLogger(t).V(1).Info("connectivity test started", "index", i+1, "total", len(tests))
+				var testResult PingResult
+				if namespaceByPod[t.SrcPod] == "" || namespaceByPod[t.DstPod] == "" || icmpContainerByPod[t.SrcPod] == "" {
+					testResult = PingResult{
+						Test: t,
+						Err:  fmt.Errorf("no namespace/container lookup for pod pair (%s, %s)", t.SrcPod, t.DstPod),
+					}
+				} else {
+					testResult = stage.run(t)
+				}
+				logConnectivityTestResult(testResult, i+1, len(tests), time.Since(testStarted))
+				stageResults = append(stageResults, testResult)
 			}
-			result.PingResults = append(result.PingResults, stage.run(t))
 		}
+		result.PingResults = append(result.PingResults, stageResults...)
+		passed, failed := resultCounts(stageResults)
+		logger.V(1).Info("connectivity stage completed",
+			"stage", stage.check,
+			"tests", len(stageResults),
+			"passed", passed,
+			"failed", failed,
+			"duration", time.Since(stageStarted).Round(time.Millisecond).String(),
+			"remainingTimeout", remainingTimeout(executionCtx))
 	}
 
 	// Summary.
@@ -449,6 +528,11 @@ func RunMatrix(ctx context.Context, c client.Client, restConfig *rest.Config, ui
 			result.Summary.Failed++
 		}
 	}
+	logger.V(1).Info("connectivity matrix completed",
+		"tests", result.Summary.TotalTests,
+		"passed", result.Summary.Passed,
+		"failed", result.Summary.Failed,
+		"duration", time.Since(runStarted).Round(time.Millisecond).String())
 	// Render the per-rail grid before the final summary line so
 	// operators see the full picture, then the rolled-up counts at
 	// the bottom.
@@ -473,7 +557,19 @@ func normalizeChecks(checks []Check) []Check {
 	return out
 }
 
-func checkSourceRoutes(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest) []PingTest {
+type routeCacheKey struct {
+	namespace string
+	pod       string
+	container string
+	srcIP     string
+	dstIP     string
+}
+
+type routeCache map[routeCacheKey]RouteCheck
+
+func checkSourceRoutes(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, cache routeCache) []PingTest {
+	started := time.Now()
+	checks, hits, failures := 0, 0, 0
 	out := append([]PingTest(nil), tests...)
 	for i := range out {
 		if out[i].Expectation != ExpectRequired {
@@ -483,15 +579,69 @@ func checkSourceRoutes(ctx context.Context, restConfig *rest.Config, namespaceBy
 		container := containerByPod[out[i].SrcPod]
 		if namespace == "" || container == "" {
 			out[i].sourceRouteErr = fmt.Errorf("no netshoot namespace/container lookup for source pod %s", out[i].SrcPod)
+			failures++
 			continue
 		}
-		out[i].sourceRoute = checkRoute(ctx, restConfig, namespace, out[i].SrcPod, container, out[i])
+		key := routeCacheKey{
+			namespace: namespace,
+			pod:       out[i].SrcPod,
+			container: container,
+			srcIP:     out[i].SrcIP,
+			dstIP:     out[i].DstIP,
+		}
+		if cached, ok := cache[key]; ok {
+			out[i].sourceRoute = cached
+			hits++
+			testLogger(out[i]).V(2).Info("source route cache hit",
+				"routeDev", cached.Dev, "routeOutput", boundedTraceOutput(cached.Output), "routeError", cached.Err)
+		} else {
+			checks++
+			out[i].sourceRoute = checkRoute(ctx, restConfig, namespace, out[i].SrcPod, container, out[i])
+			// Reuse deterministic route results, but allow a later stage to
+			// retry transient pod-exec/API failures.
+			if out[i].sourceRoute.Err == "" || out[i].sourceRoute.Err == routeSkipErr {
+				cache[key] = out[i].sourceRoute
+			}
+		}
 		if routeMismatch(out[i].sourceRoute, out[i]) {
 			out[i].sourceRouteErr = fmt.Errorf("source route selected dev %q, expected %q (route: %s)",
 				out[i].sourceRoute.Dev, out[i].SrcIface, out[i].sourceRoute.Output)
+			failures++
 		}
 	}
+	connectivityLogger().V(1).Info("source route checks completed",
+		"tests", len(tests), "executed", checks, "cacheHits", hits, "failures", failures,
+		"duration", time.Since(started).Round(time.Millisecond).String())
 	return out
+}
+
+func resultCounts(results []PingResult) (passed, failed int) {
+	for _, result := range results {
+		if result.OK {
+			passed++
+		} else {
+			failed++
+		}
+	}
+	return passed, failed
+}
+
+func logConnectivityTestResult(result PingResult, index, total int, duration time.Duration) {
+	errText := ""
+	if result.Err != nil {
+		errText = result.Err.Error()
+	}
+	testLogger(result.Test).V(1).Info("connectivity test completed",
+		"index", index, "total", total,
+		"passed", result.OK, "observedConnected", result.ObservedOK,
+		"duration", duration.Round(time.Millisecond).String(), "error", errText)
+	testLogger(result.Test).V(2).Info("connectivity test output",
+		"stdout", boundedTraceOutput(result.Stdout),
+		"stderr", boundedTraceOutput(result.Stderr),
+		"serverLog", boundedTraceOutput(result.ServerLog),
+		"routeCommand", boundedTraceOutput(result.Route.Command),
+		"routeOutput", boundedTraceOutput(result.Route.Output),
+		"routeError", result.Route.Err)
 }
 
 func checksContain(checks []Check, want Check) bool {

--- a/pkg/networkoperatorplugin/connectivity/icmp.go
+++ b/pkg/networkoperatorplugin/connectivity/icmp.go
@@ -26,13 +26,21 @@ import (
 
 func RunICMP(ctx context.Context, restConfig *rest.Config, namespace, pod, container string, test PingTest) PingResult {
 	r := initResult(test)
+	if r.Err != nil {
+		finalizeExpectedResult(&r, false, r.Err)
+		return r
+	}
 	if test.SrcIface == "" {
 		r.Err = fmt.Errorf("icmp needs source interface for rail %q", test.SrcRail)
 		finalizeExpectedResult(&r, false, r.Err)
 		return r
 	}
 	if r.Expectation == ExpectRequired {
-		r.Route = checkRoute(ctx, restConfig, namespace, pod, container, test)
+		// RunMatrix pre-computes and caches required source routes across
+		// stages. Keep the standalone runner behavior for direct callers.
+		if r.Route.Command == "" {
+			r.Route = checkRoute(ctx, restConfig, namespace, pod, container, test)
+		}
 		if routeMismatch(r.Route, test) {
 			r.Err = fmt.Errorf("source route selected dev %q, expected %q (route: %s)",
 				r.Route.Dev, test.SrcIface, r.Route.Output)
@@ -42,6 +50,7 @@ func RunICMP(ctx context.Context, restConfig *rest.Config, namespace, pod, conta
 	}
 	cmd := shellWithTimeout(fmt.Sprintf("ping -c 1 -W 1 -I %s %s", shellArg(test.SrcIP), shellArg(test.DstIP)),
 		commandTimeoutFor(test, icmpCommandTimeout))
+	testLogger(test).V(2).Info("ICMP command", "command", boundedTraceOutput(cmd))
 	res, err := kubeclient.ExecInPod(ctx, restConfig, namespace, pod, container, []string{"/bin/sh", "-c", cmd})
 	r.Stdout, r.Stderr = res.Stdout, res.Stderr
 	finalizeExpectedResult(&r, err == nil, err)

--- a/pkg/networkoperatorplugin/connectivity/observability.go
+++ b/pkg/networkoperatorplugin/connectivity/observability.go
@@ -1,0 +1,78 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connectivity
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const traceOutputLimit = 4096
+
+func connectivityLogger() logr.Logger {
+	return log.Log.WithName("connectivity")
+}
+
+func testLogger(test PingTest) logr.Logger {
+	return connectivityLogger().WithValues(
+		"family", resultFamily(test.Kind),
+		"crossRail", test.Kind.IsCrossRail(),
+		"expectation", test.Expectation,
+		"srcPod", test.SrcPod,
+		"srcNode", test.SrcNode,
+		"srcRail", test.SrcRail,
+		"srcIP", test.SrcIP,
+		"srcIface", test.SrcIface,
+		"srcRDMADev", test.SrcRDMADev,
+		"dstPod", test.DstPod,
+		"dstNode", test.DstNode,
+		"dstRail", test.DstRail,
+		"dstIP", test.DstIP,
+		"dstIface", test.DstIface,
+		"dstRDMADev", test.DstRDMADev,
+	)
+}
+
+func boundedTraceOutput(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) <= traceOutputLimit {
+		return value
+	}
+	cut := traceOutputLimit
+	for cut > 0 && !utf8.RuneStart(value[cut]) {
+		cut--
+	}
+	return fmt.Sprintf("%s... [truncated %d bytes]", value[:cut], len(value)-cut)
+}
+
+func remainingTimeout(ctx context.Context) string {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return "unbounded"
+	}
+	remaining := time.Until(deadline)
+	if remaining < 0 {
+		remaining = 0
+	}
+	return remaining.Round(time.Millisecond).String()
+}

--- a/pkg/networkoperatorplugin/connectivity/rdma.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma.go
@@ -376,7 +376,7 @@ func runRPingBatch(ctx context.Context, restConfig *rest.Config, namespaceByPod,
 		}
 		finalizeExpectedResult(&results[i], false, fmt.Errorf("rping exited with code %d", cell.rc))
 	}
-	attachRDMAServerLogs(restConfig, serverNamespace, first.DstPod, serverContainer,
+	attachRDMAServerLogs(tctx, restConfig, serverNamespace, first.DstPod, serverContainer,
 		"/tmp/l8k-rping-server", results)
 	return results
 }
@@ -453,7 +453,7 @@ func parseRPingBatchResults(stdout string) map[int]rdmaBatchCell {
 }
 
 func rdmaBatchTimeoutFor(tests []PingTest) time.Duration {
-	timeout := 15 * time.Second
+	timeout := 15*time.Second + rdmaServerLogTimeout
 	for _, test := range tests {
 		timeout += commandTimeoutFor(test, rpingCommandTimeout) + rdmaBatchSettleDelayFor([]PingTest{test})
 	}
@@ -706,7 +706,7 @@ func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceBy
 			finalizeExpectedResult(&results[i], observedOK, observedErr)
 		}
 	}
-	attachRDMAServerLogs(restConfig, serverNamespace, first.DstPod, serverContainer,
+	attachRDMAServerLogs(tctx, restConfig, serverNamespace, first.DstPod, serverContainer,
 		"/tmp/l8k-ibwritebw-server", results)
 	return results
 }
@@ -877,7 +877,7 @@ func ibWriteBwBatchPort(index int) int {
 }
 
 func ibWriteBwBatchTimeoutFor(tests []PingTest) time.Duration {
-	timeout := 20 * time.Second
+	timeout := 20*time.Second + rdmaServerLogTimeout
 	for _, test := range tests {
 		timeout += commandTimeoutFor(test, ibWriteBwCommandTimeout) + rdmaBatchSettleDelayFor([]PingTest{test})
 	}
@@ -921,7 +921,7 @@ func logRDMABatchResults(results []PingResult, batch, batches int) {
 	}
 }
 
-func attachRDMAServerLogs(restConfig *rest.Config, namespace, pod, container, pathPrefix string, results []PingResult) {
+func attachRDMAServerLogs(ctx context.Context, restConfig *rest.Config, namespace, pod, container, pathPrefix string, results []PingResult) {
 	indices := make([]int, 0, len(results))
 	traceEnabled := connectivityLogger().V(2).Enabled()
 	for i := range results {
@@ -933,7 +933,7 @@ func attachRDMAServerLogs(restConfig *rest.Config, namespace, pod, container, pa
 		return
 	}
 
-	logs, err := collectRDMAServerLogs(restConfig, namespace, pod, container, pathPrefix, indices)
+	logs, err := collectRDMAServerLogs(ctx, restConfig, namespace, pod, container, pathPrefix, indices)
 	if err != nil {
 		connectivityLogger().V(1).Info("RDMA server log collection failed",
 			"namespace", namespace, "pod", pod, "container", container,
@@ -947,15 +947,15 @@ func attachRDMAServerLogs(restConfig *rest.Config, namespace, pod, container, pa
 	}
 }
 
-func collectRDMAServerLogs(restConfig *rest.Config, namespace, pod, container, pathPrefix string, indices []int) (map[int]string, error) {
+func collectRDMAServerLogs(ctx context.Context, restConfig *rest.Config, namespace, pod, container, pathPrefix string, indices []int) (map[int]string, error) {
 	var command strings.Builder
 	for _, index := range indices {
 		fmt.Fprintf(&command, "echo %s %d; tail -c %d %s-%d.log 2>/dev/null; echo; echo %s %d; ",
 			rdmaServerLogMarker, index, rdmaServerLogLimit, pathPrefix, index, rdmaServerLogEndMarker, index)
 	}
-	// The client/batch context may already have expired. Use a fresh, tightly
-	// bounded context so failure evidence is collected before deferred cleanup.
-	tctx, cancel := context.WithTimeout(context.Background(), rdmaServerLogTimeout)
+	// The batch timeout reserves this collection window. Derive from the batch
+	// context so diagnostics cannot run beyond the advertised matrix deadline.
+	tctx, cancel := context.WithTimeout(ctx, rdmaServerLogTimeout)
 	defer cancel()
 	res, err := kubeclient.ExecInPod(tctx, restConfig, namespace, pod, container, []string{"/bin/sh", "-c", command.String()})
 	if err != nil {

--- a/pkg/networkoperatorplugin/connectivity/rdma.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma.go
@@ -41,11 +41,24 @@ const rdmaServerSettleDelay = 2 * time.Second
 // Options.Timeout.
 const rdmaTestTimeout = 90 * time.Second
 
-const rpingBatchResultMarker = "__L8K_RPING_RESULT__"
+const (
+	rpingBatchResultMarker = "__L8K_RPING_RESULT__"
+	rpingBatchStdoutMarker = "__L8K_RPING_STDOUT__"
+	rpingBatchStderrMarker = "__L8K_RPING_STDERR__"
+	rpingBatchEndMarker    = "__L8K_RPING_END__"
+)
 
 const (
 	ibWriteBwBatchResultMarker = "__L8K_IBWRITEBW_RESULT__"
+	ibWriteBwBatchStdoutMarker = "__L8K_IBWRITEBW_STDOUT__"
+	ibWriteBwBatchStderrMarker = "__L8K_IBWRITEBW_STDERR__"
 	ibWriteBwBatchEndMarker    = "__L8K_IBWRITEBW_END__"
+)
+
+const (
+	rdmaServerLogMarker    = "__L8K_RDMA_SERVER_LOG__"
+	rdmaServerLogEndMarker = "__L8K_RDMA_SERVER_LOG_END__"
+	rdmaServerLogLimit     = 16 * 1024
 )
 
 // railNameIndex extracts the numeric rail index from a rail key like
@@ -97,6 +110,7 @@ func railIndex(rail string) int {
 // rail. Returns map[rail]→<rdmaDev>; rails whose interface couldn't
 // be resolved are absent from the map.
 func DiscoverRDMADevices(ctx context.Context, restConfig *rest.Config, namespace, pod, container string, ifaceByRail map[string]string) map[string]string {
+	started := time.Now()
 	out := map[string]string{}
 	if len(ifaceByRail) == 0 {
 		return out
@@ -149,8 +163,19 @@ func DiscoverRDMADevices(ctx context.Context, restConfig *rest.Config, namespace
 	if b.Len() == 0 {
 		return out
 	}
+	connectivityLogger().V(2).Info("RDMA device discovery command",
+		"namespace", namespace, "pod", pod, "container", container,
+		"command", boundedTraceOutput(b.String()))
 	res, err := kubeclient.ExecInPod(ctx, restConfig, namespace, pod, container, []string{"/bin/sh", "-c", b.String()})
 	if err != nil {
+		connectivityLogger().V(1).Info("RDMA device discovery failed",
+			"namespace", namespace, "pod", pod, "container", container,
+			"interfacesByRail", ifaceByRail,
+			"duration", time.Since(started).Round(time.Millisecond).String(),
+			"error", err.Error())
+		connectivityLogger().V(2).Info("RDMA device discovery output",
+			"namespace", namespace, "pod", pod,
+			"stdout", boundedTraceOutput(res.Stdout), "stderr", boundedTraceOutput(res.Stderr))
 		return out
 	}
 	for _, line := range strings.Split(res.Stdout, "\n") {
@@ -168,6 +193,13 @@ func DiscoverRDMADevices(ctx context.Context, restConfig *rest.Config, namespace
 			out[rail] = dev
 		}
 	}
+	connectivityLogger().V(1).Info("RDMA device discovery completed",
+		"namespace", namespace, "pod", pod, "container", container,
+		"interfacesByRail", ifaceByRail, "rdmaDevicesByRail", out,
+		"duration", time.Since(started).Round(time.Millisecond).String())
+	connectivityLogger().V(2).Info("RDMA device discovery output",
+		"namespace", namespace, "pod", pod,
+		"stdout", boundedTraceOutput(res.Stdout), "stderr", boundedTraceOutput(res.Stderr))
 	return out
 }
 
@@ -238,8 +270,25 @@ func RunRPingBatches(ctx context.Context, restConfig *rest.Config, namespaceByPo
 	}
 	groups := groupRPingTests(tests)
 	out := make([]PingResult, 0, len(tests))
-	for _, group := range groups {
-		out = append(out, runRPingBatch(ctx, restConfig, namespaceByPod, containerByPod, group, iterations)...)
+	for i, group := range groups {
+		started := time.Now()
+		first := group[0]
+		connectivityLogger().V(1).Info("RDMA batch started",
+			"family", "rping", "batch", i+1, "batches", len(groups),
+			"tests", len(group), "completedTests", len(out), "totalTests", len(tests),
+			"srcPod", first.SrcPod, "dstPod", first.DstPod,
+			"remainingTimeout", remainingTimeout(ctx))
+		batchResults := runRPingBatch(ctx, restConfig, namespaceByPod, containerByPod, group, iterations)
+		out = append(out, batchResults...)
+		passed, failed := resultCounts(batchResults)
+		connectivityLogger().V(1).Info("RDMA batch completed",
+			"family", "rping", "batch", i+1, "batches", len(groups),
+			"tests", len(batchResults), "passed", passed, "failed", failed,
+			"completedTests", len(out), "totalTests", len(tests),
+			"srcPod", first.SrcPod, "dstPod", first.DstPod,
+			"duration", time.Since(started).Round(time.Millisecond).String(),
+			"remainingTimeout", remainingTimeout(ctx))
+		logRDMABatchResults(batchResults, i+1, len(groups))
 	}
 	return out
 }
@@ -275,6 +324,9 @@ func runRPingBatch(ctx context.Context, restConfig *rest.Config, namespaceByPod,
 	defer cancel()
 
 	serverCmd := rpingBatchServerCommand(tests)
+	connectivityLogger().V(2).Info("RDMA batch server command",
+		"family", "rping", "srcPod", first.SrcPod, "dstPod", first.DstPod,
+		"tests", len(tests), "command", boundedTraceOutput(serverCmd))
 	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, serverNamespace, first.DstPod, serverContainer, []string{"/bin/sh", "-c", serverCmd})
 	if err != nil {
 		batchErr := fmt.Errorf("rping batch server start: %w (stderr: %s)", err, srvRes.Stderr)
@@ -296,16 +348,19 @@ func runRPingBatch(ctx context.Context, restConfig *rest.Config, namespaceByPod,
 	}
 
 	clientCmd := rpingBatchClientCommand(tests, iterations)
+	connectivityLogger().V(2).Info("RDMA batch client command",
+		"family", "rping", "srcPod", first.SrcPod, "dstPod", first.DstPod,
+		"tests", len(tests), "iterations", iterations, "command", boundedTraceOutput(clientCmd))
 	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, clientNamespace, first.SrcPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
-	rcByIndex := parseRPingBatchResults(cliRes.Stdout)
+	parsed := parseRPingBatchResults(cliRes.Stdout)
 	for i := range results {
-		results[i].Stdout = cliRes.Stdout
-		results[i].Stderr = cliRes.Stderr
 		if results[i].Err != nil {
 			continue
 		}
-		rc, ok := rcByIndex[i]
+		cell, ok := parsed[i]
 		if !ok {
+			results[i].Stdout = cliRes.Stdout
+			results[i].Stderr = cliRes.Stderr
 			err := cliErr
 			if err == nil {
 				err = fmt.Errorf("rping batch missing result for test %d", i)
@@ -313,12 +368,16 @@ func runRPingBatch(ctx context.Context, restConfig *rest.Config, namespaceByPod,
 			finalizeExpectedResult(&results[i], false, err)
 			continue
 		}
-		if rc == 0 {
+		results[i].Stdout = cell.stdout
+		results[i].Stderr = cell.stderr
+		if cell.rc == 0 {
 			finalizeExpectedResult(&results[i], true, nil)
 			continue
 		}
-		finalizeExpectedResult(&results[i], false, fmt.Errorf("rping exited with code %d", rc))
+		finalizeExpectedResult(&results[i], false, fmt.Errorf("rping exited with code %d", cell.rc))
 	}
+	attachRDMAServerLogs(restConfig, serverNamespace, first.DstPod, serverContainer,
+		"/tmp/l8k-rping-server", results)
 	return results
 }
 
@@ -369,8 +428,12 @@ func rpingBatchClientCommand(tests []PingTest, iterations int) string {
 			continue
 		}
 		fmt.Fprintf(&b,
-			"run_with_timeout %d rping -c -I %s -a %s -p %d -C %d -v >/tmp/l8k-rping-client-%d.out 2>/tmp/l8k-rping-client-%d.err; rc=$?; echo %s %d $rc; ",
-			timeoutSeconds, shellArg(test.SrcIP), shellArg(test.DstIP), rpingBatchPort(i), iterations, i, i, rpingBatchResultMarker, i)
+			"run_with_timeout %d rping -c -I %s -a %s -p %d -C %d -v >/tmp/l8k-rping-client-%d.out 2>/tmp/l8k-rping-client-%d.err; rc=$?; "+
+				"echo %s %d $rc; echo %s %d; cat /tmp/l8k-rping-client-%d.out 2>/dev/null; echo; "+
+				"echo %s %d; cat /tmp/l8k-rping-client-%d.err 2>/dev/null; echo; echo %s %d; ",
+			timeoutSeconds, shellArg(test.SrcIP), shellArg(test.DstIP), rpingBatchPort(i), iterations, i, i,
+			rpingBatchResultMarker, i, rpingBatchStdoutMarker, i, i,
+			rpingBatchStderrMarker, i, i, rpingBatchEndMarker, i)
 	}
 	b.WriteString("exit 0")
 	return b.String()
@@ -380,21 +443,13 @@ func rpingBatchPort(index int) int {
 	return 9999 + index
 }
 
-func parseRPingBatchResults(stdout string) map[int]int {
-	out := map[int]int{}
-	for _, line := range strings.Split(stdout, "\n") {
-		fields := strings.Fields(strings.TrimSpace(line))
-		if len(fields) != 3 || fields[0] != rpingBatchResultMarker {
-			continue
-		}
-		idx, err1 := strconv.Atoi(fields[1])
-		rc, err2 := strconv.Atoi(fields[2])
-		if err1 != nil || err2 != nil {
-			continue
-		}
-		out[idx] = rc
-	}
-	return out
+func parseRPingBatchResults(stdout string) map[int]rdmaBatchCell {
+	return parseRDMABatchResults(stdout, rdmaBatchMarkers{
+		result: rpingBatchResultMarker,
+		stdout: rpingBatchStdoutMarker,
+		stderr: rpingBatchStderrMarker,
+		end:    rpingBatchEndMarker,
+	})
 }
 
 func rdmaBatchTimeoutFor(tests []PingTest) time.Duration {
@@ -516,8 +571,29 @@ func runIbWriteBwBatches(ctx context.Context, restConfig *rest.Config, namespace
 	}
 	groups := groupRPingTests(tests)
 	out := make([]PingResult, 0, len(tests))
-	for _, group := range groups {
-		out = append(out, runIbWriteBwBatch(ctx, restConfig, namespaceByPod, containerByPod, group, size, minBandwidthGbps, gpuDirect)...)
+	family := "ib_write_bw"
+	if gpuDirect {
+		family = "gpudirect_dmabuf"
+	}
+	for i, group := range groups {
+		started := time.Now()
+		first := group[0]
+		connectivityLogger().V(1).Info("RDMA batch started",
+			"family", family, "batch", i+1, "batches", len(groups),
+			"tests", len(group), "completedTests", len(out), "totalTests", len(tests),
+			"srcPod", first.SrcPod, "dstPod", first.DstPod,
+			"remainingTimeout", remainingTimeout(ctx))
+		batchResults := runIbWriteBwBatch(ctx, restConfig, namespaceByPod, containerByPod, group, size, minBandwidthGbps, gpuDirect)
+		out = append(out, batchResults...)
+		passed, failed := resultCounts(batchResults)
+		connectivityLogger().V(1).Info("RDMA batch completed",
+			"family", family, "batch", i+1, "batches", len(groups),
+			"tests", len(batchResults), "passed", passed, "failed", failed,
+			"completedTests", len(out), "totalTests", len(tests),
+			"srcPod", first.SrcPod, "dstPod", first.DstPod,
+			"duration", time.Since(started).Round(time.Millisecond).String(),
+			"remainingTimeout", remainingTimeout(ctx))
+		logRDMABatchResults(batchResults, i+1, len(groups))
 	}
 	return out
 }
@@ -563,6 +639,13 @@ func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceBy
 	defer cancel()
 
 	serverCmd := ibWriteBwBatchServerCommandMode(tests, size, gpuDirect)
+	family := "ib_write_bw"
+	if gpuDirect {
+		family = "gpudirect_dmabuf"
+	}
+	connectivityLogger().V(2).Info("RDMA batch server command",
+		"family", family, "srcPod", first.SrcPod, "dstPod", first.DstPod,
+		"tests", len(tests), "size", size, "command", boundedTraceOutput(serverCmd))
 	srvRes, err := kubeclient.ExecInPod(tctx, restConfig, serverNamespace, first.DstPod, serverContainer, []string{"/bin/sh", "-c", serverCmd})
 	if err != nil {
 		batchErr := fmt.Errorf("ib_write_bw batch server start: %w (stderr: %s)", err, srvRes.Stderr)
@@ -588,15 +671,19 @@ func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceBy
 	}
 
 	clientCmd := ibWriteBwBatchClientCommandMode(tests, size, gpuDirect)
+	connectivityLogger().V(2).Info("RDMA batch client command",
+		"family", family, "srcPod", first.SrcPod, "dstPod", first.DstPod,
+		"tests", len(tests), "size", size, "command", boundedTraceOutput(clientCmd))
 	cliRes, cliErr := kubeclient.ExecInPod(tctx, restConfig, clientNamespace, first.SrcPod, clientContainer, []string{"/bin/sh", "-c", clientCmd})
 	parsed := parseIbWriteBwBatchResults(cliRes.Stdout)
 	for i := range results {
-		results[i].Stderr = cliRes.Stderr
 		if results[i].Err != nil {
 			continue
 		}
 		cell, ok := parsed[i]
 		if !ok {
+			results[i].Stdout = cliRes.Stdout
+			results[i].Stderr = cliRes.Stderr
 			err := cliErr
 			if err == nil {
 				err = fmt.Errorf("ib_write_bw batch missing result for test %d", i)
@@ -605,6 +692,7 @@ func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceBy
 			continue
 		}
 		results[i].Stdout = cell.stdout
+		results[i].Stderr = cell.stderr
 		bw, msgRate, parseOK := parseIbWriteBwOutput(cell.stdout)
 		results[i].BandwidthGbps = bw
 		results[i].MsgRateMpps = msgRate
@@ -618,6 +706,8 @@ func runIbWriteBwBatch(ctx context.Context, restConfig *rest.Config, namespaceBy
 			finalizeExpectedResult(&results[i], observedOK, observedErr)
 		}
 	}
+	attachRDMAServerLogs(restConfig, serverNamespace, first.DstPod, serverContainer,
+		"/tmp/l8k-ibwritebw-server", results)
 	return results
 }
 
@@ -655,9 +745,14 @@ func ibWriteBwBatchClientCommandMode(tests []PingTest, size int, gpuDirect bool)
 			continue
 		}
 		fmt.Fprintf(&b,
-			"run_with_timeout %d ib_write_bw -d %s -R -s %d --report_gbits -p %d --bind_source_ip %s%s %s >%s 2>%s; rc=$?; echo %s %d $rc; cat %s 2>/dev/null; echo %s %d; ",
+			"run_with_timeout %d ib_write_bw -d %s -R -s %d --report_gbits -p %d --bind_source_ip %s%s %s >%s 2>%s; rc=$?; "+
+				"echo %s %d $rc; echo %s %d; cat %s 2>/dev/null; echo; echo %s %d; cat %s 2>/dev/null; echo; echo %s %d; ",
 			timeoutSeconds, shellArg(test.SrcRDMADev), size, ibWriteBwBatchPort(i), shellArg(test.SrcIP), cudaDMABufArgs(gpuDirect, test.SrcGPUIndex), shellArg(test.DstIP),
-			outFile, errFile, ibWriteBwBatchResultMarker, i, outFile, ibWriteBwBatchEndMarker, i)
+			outFile, errFile,
+			ibWriteBwBatchResultMarker, i,
+			ibWriteBwBatchStdoutMarker, i, outFile,
+			ibWriteBwBatchStderrMarker, i, errFile,
+			ibWriteBwBatchEndMarker, i)
 	}
 	b.WriteString("exit 0")
 	return b.String()
@@ -685,44 +780,95 @@ func gpudirectPreconditionError(test PingTest) error {
 		test.SrcGPUIndex, test.DstGPUIndex, test.SrcNode, test.SrcRail, test.DstNode, test.DstRail)
 }
 
-type ibWriteBwBatchCell struct {
+type rdmaBatchCell struct {
 	rc     int
 	stdout string
+	stderr string
 }
 
-func parseIbWriteBwBatchResults(stdout string) map[int]ibWriteBwBatchCell {
-	out := map[int]ibWriteBwBatchCell{}
-	var current *int
-	var b strings.Builder
-	for _, line := range strings.Split(stdout, "\n") {
+type rdmaBatchMarkers struct {
+	result string
+	stdout string
+	stderr string
+	end    string
+}
+
+func parseIbWriteBwBatchResults(stdout string) map[int]rdmaBatchCell {
+	return parseRDMABatchResults(stdout, rdmaBatchMarkers{
+		result: ibWriteBwBatchResultMarker,
+		stdout: ibWriteBwBatchStdoutMarker,
+		stderr: ibWriteBwBatchStderrMarker,
+		end:    ibWriteBwBatchEndMarker,
+	})
+}
+
+func parseRDMABatchResults(output string, markers rdmaBatchMarkers) map[int]rdmaBatchCell {
+	out := map[int]rdmaBatchCell{}
+	currentIndex := -1
+	currentStream := ""
+	var stdout, stderr strings.Builder
+	flush := func() {
+		if currentIndex < 0 {
+			return
+		}
+		cell, ok := out[currentIndex]
+		if !ok {
+			return
+		}
+		cell.stdout = strings.TrimSpace(stdout.String())
+		cell.stderr = strings.TrimSpace(stderr.String())
+		out[currentIndex] = cell
+	}
+	reset := func(index int) {
+		currentIndex = index
+		currentStream = ""
+		stdout.Reset()
+		stderr.Reset()
+	}
+	for _, line := range strings.Split(output, "\n") {
 		fields := strings.Fields(strings.TrimSpace(line))
-		if len(fields) == 3 && fields[0] == ibWriteBwBatchResultMarker {
+		if len(fields) == 3 && fields[0] == markers.result {
 			idx, err1 := strconv.Atoi(fields[1])
 			rc, err2 := strconv.Atoi(fields[2])
 			if err1 == nil && err2 == nil {
-				out[idx] = ibWriteBwBatchCell{rc: rc}
-				current = &idx
-				b.Reset()
+				flush()
+				out[idx] = rdmaBatchCell{rc: rc}
+				reset(idx)
 			}
 			continue
 		}
-		if len(fields) == 2 && fields[0] == ibWriteBwBatchEndMarker {
+		if len(fields) == 2 && fields[0] == markers.stdout {
 			idx, err := strconv.Atoi(fields[1])
-			if err == nil {
-				if cell, ok := out[idx]; ok {
-					cell.stdout = strings.TrimSpace(b.String())
-					out[idx] = cell
-				}
+			if err == nil && idx == currentIndex {
+				currentStream = "stdout"
 			}
-			current = nil
-			b.Reset()
 			continue
 		}
-		if current != nil {
-			b.WriteString(line)
-			b.WriteByte('\n')
+		if len(fields) == 2 && fields[0] == markers.stderr {
+			idx, err := strconv.Atoi(fields[1])
+			if err == nil && idx == currentIndex {
+				currentStream = "stderr"
+			}
+			continue
+		}
+		if len(fields) == 2 && fields[0] == markers.end {
+			idx, err := strconv.Atoi(fields[1])
+			if err == nil && idx == currentIndex {
+				flush()
+			}
+			reset(-1)
+			continue
+		}
+		switch currentStream {
+		case "stdout":
+			stdout.WriteString(line)
+			stdout.WriteByte('\n')
+		case "stderr":
+			stderr.WriteString(line)
+			stderr.WriteByte('\n')
 		}
 	}
+	flush()
 	return out
 }
 
@@ -747,6 +893,116 @@ func bandwidthVerdict(bw, minBandwidthGbps float64) (bool, error) {
 	default:
 		return true, nil
 	}
+}
+
+func logRDMABatchResults(results []PingResult, batch, batches int) {
+	for i, result := range results {
+		errText := ""
+		if result.Err != nil {
+			errText = result.Err.Error()
+		}
+		if !result.OK {
+			testLogger(result.Test).V(1).Info("RDMA test failed",
+				"batch", batch, "batches", batches, "batchTest", i+1,
+				"observedConnected", result.ObservedOK, "error", errText,
+				"clientStdoutBytes", len(result.Stdout),
+				"clientStderrBytes", len(result.Stderr),
+				"serverLogBytes", len(result.ServerLog))
+		}
+		testLogger(result.Test).V(2).Info("RDMA test output",
+			"batch", batch, "batches", batches, "batchTest", i+1,
+			"passed", result.OK, "observedConnected", result.ObservedOK, "error", errText,
+			"clientStdout", boundedTraceOutput(result.Stdout),
+			"clientStderr", boundedTraceOutput(result.Stderr),
+			"serverLog", boundedTraceOutput(result.ServerLog),
+			"routeCommand", boundedTraceOutput(result.Route.Command),
+			"routeOutput", boundedTraceOutput(result.Route.Output),
+			"routeError", result.Route.Err)
+	}
+}
+
+func attachRDMAServerLogs(restConfig *rest.Config, namespace, pod, container, pathPrefix string, results []PingResult) {
+	indices := make([]int, 0, len(results))
+	traceEnabled := connectivityLogger().V(2).Enabled()
+	for i := range results {
+		if traceEnabled || !results[i].OK {
+			indices = append(indices, i)
+		}
+	}
+	if len(indices) == 0 {
+		return
+	}
+
+	logs, err := collectRDMAServerLogs(restConfig, namespace, pod, container, pathPrefix, indices)
+	if err != nil {
+		connectivityLogger().V(1).Info("RDMA server log collection failed",
+			"namespace", namespace, "pod", pod, "container", container,
+			"pathPrefix", pathPrefix, "indices", indices, "error", err.Error())
+		return
+	}
+	for i, serverLog := range logs {
+		if i >= 0 && i < len(results) {
+			results[i].ServerLog = serverLog
+		}
+	}
+}
+
+func collectRDMAServerLogs(restConfig *rest.Config, namespace, pod, container, pathPrefix string, indices []int) (map[int]string, error) {
+	var command strings.Builder
+	for _, index := range indices {
+		fmt.Fprintf(&command, "echo %s %d; tail -c %d %s-%d.log 2>/dev/null; echo; echo %s %d; ",
+			rdmaServerLogMarker, index, rdmaServerLogLimit, pathPrefix, index, rdmaServerLogEndMarker, index)
+	}
+	// The client/batch context may already have expired. Use a fresh, tightly
+	// bounded context so failure evidence is collected before deferred cleanup.
+	tctx, cancel := context.WithTimeout(context.Background(), rdmaServerLogTimeout)
+	defer cancel()
+	res, err := kubeclient.ExecInPod(tctx, restConfig, namespace, pod, container, []string{"/bin/sh", "-c", command.String()})
+	if err != nil {
+		return nil, fmt.Errorf("collect RDMA server logs: %w (stderr: %s)", err, boundedTraceOutput(res.Stderr))
+	}
+	return parseRDMAServerLogs(res.Stdout), nil
+}
+
+func parseRDMAServerLogs(output string) map[int]string {
+	out := map[int]string{}
+	current := -1
+	var contents strings.Builder
+	flush := func() {
+		if current >= 0 {
+			out[current] = strings.TrimSpace(contents.String())
+		}
+	}
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) == 2 && fields[0] == rdmaServerLogMarker {
+			flush()
+			index, err := strconv.Atoi(fields[1])
+			if err != nil {
+				current = -1
+				contents.Reset()
+				continue
+			}
+			current = index
+			contents.Reset()
+			continue
+		}
+		if len(fields) == 2 && fields[0] == rdmaServerLogEndMarker {
+			index, err := strconv.Atoi(fields[1])
+			if err == nil && index == current {
+				flush()
+			}
+			current = -1
+			contents.Reset()
+			continue
+		}
+		if current >= 0 {
+			contents.WriteString(line)
+			contents.WriteByte('\n')
+		}
+	}
+	flush()
+	return out
 }
 
 // killRDMAServer is best-effort cleanup. We try the captured PID

--- a/pkg/networkoperatorplugin/connectivity/rdma_test.go
+++ b/pkg/networkoperatorplugin/connectivity/rdma_test.go
@@ -101,19 +101,69 @@ func TestParseIbWriteBwOutput(t *testing.T) {
 
 func TestParseIbWriteBwBatchResults(t *testing.T) {
 	stdout := ibWriteBwBatchResultMarker + ` 0 0
+` + ibWriteBwBatchStdoutMarker + ` 0
 banner
  65536      5000             194.39             193.21		   0.368459
+` + ibWriteBwBatchStderrMarker + ` 0
+harmless warning
 ` + ibWriteBwBatchEndMarker + ` 0
 ` + ibWriteBwBatchResultMarker + ` 1 124
+` + ibWriteBwBatchStdoutMarker + ` 1
 timeout text
+` + ibWriteBwBatchStderrMarker + ` 1
+connection timed out
 ` + ibWriteBwBatchEndMarker + ` 1
 `
 	got := parseIbWriteBwBatchResults(stdout)
 	require.Len(t, got, 2)
 	assert.Equal(t, 0, got[0].rc)
 	assert.Contains(t, got[0].stdout, "194.39")
+	assert.Equal(t, "harmless warning", got[0].stderr)
 	assert.Equal(t, 124, got[1].rc)
 	assert.Contains(t, got[1].stdout, "timeout text")
+	assert.Equal(t, "connection timed out", got[1].stderr)
+}
+
+func TestParseRPingBatchResultsKeepsPerCellOutput(t *testing.T) {
+	output := rpingBatchResultMarker + ` 0 0
+` + rpingBatchStdoutMarker + ` 0
+ping data verified
+` + rpingBatchStderrMarker + ` 0
+` + rpingBatchEndMarker + ` 0
+` + rpingBatchResultMarker + ` 1 1
+` + rpingBatchStdoutMarker + ` 1
+client output
+` + rpingBatchStderrMarker + ` 1
+RDMA_CM_EVENT_REJECTED
+` + rpingBatchEndMarker + ` 1
+`
+
+	got := parseRPingBatchResults(output)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, 0, got[0].rc)
+	assert.Equal(t, "ping data verified", got[0].stdout)
+	assert.Empty(t, got[0].stderr)
+	assert.Equal(t, 1, got[1].rc)
+	assert.Equal(t, "client output", got[1].stdout)
+	assert.Equal(t, "RDMA_CM_EVENT_REJECTED", got[1].stderr)
+}
+
+func TestParseRDMAServerLogs(t *testing.T) {
+	output := rdmaServerLogMarker + ` 1
+server listening
+connection rejected
+` + rdmaServerLogEndMarker + ` 1
+` + rdmaServerLogMarker + ` 3
+empty peer response
+` + rdmaServerLogEndMarker + ` 3
+`
+
+	got := parseRDMAServerLogs(output)
+
+	require.Len(t, got, 2)
+	assert.Contains(t, got[1], "connection rejected")
+	assert.Equal(t, "empty peer response", got[3])
 }
 
 func TestRDMABatchClientCommandsDoNotRequireIPTooling(t *testing.T) {
@@ -131,11 +181,15 @@ func TestRDMABatchClientCommandsDoNotRequireIPTooling(t *testing.T) {
 	assert.NotContains(t, rpingCmd, "ipcmd")
 	assert.NotContains(t, rpingCmd, "route get")
 	assert.Contains(t, rpingCmd, `-p 9999`)
+	assert.Contains(t, rpingCmd, rpingBatchStdoutMarker+" 0")
+	assert.Contains(t, rpingCmd, rpingBatchStderrMarker+" 0")
 
 	ibCmd := ibWriteBwBatchClientCommand([]PingTest{test}, 65536)
 	assert.NotContains(t, ibCmd, "ipcmd")
 	assert.NotContains(t, ibCmd, "route get")
 	assert.Contains(t, ibCmd, ibWriteBwBatchResultMarker+" 0 $rc")
+	assert.Contains(t, ibCmd, ibWriteBwBatchStdoutMarker+" 0")
+	assert.Contains(t, ibCmd, ibWriteBwBatchStderrMarker+" 0")
 }
 
 func TestGPUDirectDMABufCommandsUseEndpointGPUIndices(t *testing.T) {

--- a/pkg/networkoperatorplugin/connectivity/result.go
+++ b/pkg/networkoperatorplugin/connectivity/result.go
@@ -49,7 +49,10 @@ type PingResult struct {
 	MinBandwidthGbps float64 // ib_write_bw families only; 0 when no threshold was applied
 	Stdout           string
 	Stderr           string
-	Err              error `json:"-"`
+	// ServerLog is populated for failed RDMA batch cells before the
+	// temporary in-pod server log is removed during cleanup.
+	ServerLog string `json:"ServerLog,omitempty"`
+	Err       error  `json:"-"`
 }
 
 func (r PingResult) MarshalJSON() ([]byte, error) {

--- a/pkg/networkoperatorplugin/connectivity/source.go
+++ b/pkg/networkoperatorplugin/connectivity/source.go
@@ -88,6 +88,7 @@ func rdmaSettleDelayFor(test PingTest) time.Duration {
 }
 
 func checkRoute(ctx context.Context, restConfig *rest.Config, namespace, pod, container string, test PingTest) RouteCheck {
+	started := time.Now()
 	cmd := fmt.Sprintf(
 		`ipcmd=""; for p in ip /sbin/ip /usr/sbin/ip /bin/ip /usr/bin/ip; do `+
 			`if command -v "$p" >/dev/null 2>&1 || [ -x "$p" ]; then ipcmd="$p"; break; fi; `+
@@ -98,6 +99,7 @@ func checkRoute(ctx context.Context, restConfig *rest.Config, namespace, pod, co
 	out := RouteCheck{Command: cmd}
 	if test.SrcIP == "" || test.DstIP == "" {
 		out.Err = "missing source or destination IP"
+		testLogger(test).V(1).Info("source route check failed", "error", out.Err)
 		return out
 	}
 	tctx, cancel := context.WithTimeout(ctx, routeCheckTimeout)
@@ -106,16 +108,26 @@ func checkRoute(ctx context.Context, restConfig *rest.Config, namespace, pod, co
 	out.Output = strings.TrimSpace(strings.Join([]string{res.Stdout, res.Stderr}, "\n"))
 	if err != nil {
 		out.Err = err.Error()
+		testLogger(test).V(1).Info("source route check failed",
+			"duration", time.Since(started).Round(time.Millisecond).String(), "error", out.Err)
+		testLogger(test).V(2).Info("source route check output",
+			"command", boundedTraceOutput(cmd), "output", boundedTraceOutput(out.Output))
 		return out
 	}
 	if strings.Contains(out.Output, routeSkipMarker) {
 		out.Err = routeSkipErr
+		testLogger(test).V(1).Info("source route check skipped",
+			"duration", time.Since(started).Round(time.Millisecond).String(), "reason", out.Err)
 		return out
 	}
 	if m := routeDevRe.FindStringSubmatch(out.Output); len(m) == 2 {
 		out.Dev = m[1]
 	}
 	out.OK = out.Dev != ""
+	testLogger(test).V(2).Info("source route check completed",
+		"duration", time.Since(started).Round(time.Millisecond).String(),
+		"routeDev", out.Dev, "routeOK", out.OK,
+		"command", boundedTraceOutput(cmd), "output", boundedTraceOutput(out.Output))
 	return out
 }
 

--- a/pkg/networkoperatorplugin/connectivity/source_test.go
+++ b/pkg/networkoperatorplugin/connectivity/source_test.go
@@ -17,6 +17,9 @@
 package connectivity
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,4 +40,46 @@ func TestShellWithTimeoutUsesMinimumOneSecond(t *testing.T) {
 
 	assert.Contains(t, cmd, `timeout -s TERM -k 2 1 sh -c "true"`)
 	assert.Contains(t, cmd, `sleep 1;`)
+}
+
+func TestCheckSourceRoutesReusesCachedRoute(t *testing.T) {
+	test := PingTest{
+		Kind: ICMPSameRail, SrcPod: "pod-a", DstPod: "pod-b",
+		SrcIP: "192.0.2.10", DstIP: "192.0.2.20", SrcIface: "net1",
+		Expectation: ExpectRequired,
+	}
+	key := routeCacheKey{
+		namespace: "default", pod: "pod-a", container: "netshoot",
+		srcIP: test.SrcIP, dstIP: test.DstIP,
+	}
+	cache := routeCache{key: {
+		Command: "ip route get", Output: "192.0.2.20 dev net1 src 192.0.2.10", Dev: "net1", OK: true,
+	}}
+
+	got := checkSourceRoutes(context.Background(), nil,
+		map[string]string{"pod-a": "default"}, map[string]string{"pod-a": "netshoot"}, []PingTest{test}, cache)
+
+	assert.Len(t, got, 1)
+	assert.Equal(t, "net1", got[0].sourceRoute.Dev)
+	assert.NoError(t, got[0].sourceRouteErr)
+}
+
+func TestBoundedTraceOutput(t *testing.T) {
+	input := strings.Repeat("x", traceOutputLimit+100)
+	got := boundedTraceOutput(input)
+
+	assert.Less(t, len(got), len(input))
+	assert.Contains(t, got, "truncated 100 bytes")
+}
+
+func TestRunICMPPreservesPrecomputedRouteError(t *testing.T) {
+	test := PingTest{
+		Kind: ICMPSameRail, SrcIface: "net1", Expectation: ExpectRequired,
+		sourceRouteErr: errors.New("route lookup failed"),
+	}
+
+	result := RunICMP(context.Background(), nil, "default", "pod-a", "netshoot", test)
+
+	assert.False(t, result.OK)
+	assert.EqualError(t, result.Err, "route lookup failed")
 }

--- a/pkg/networkoperatorplugin/connectivity/timeout.go
+++ b/pkg/networkoperatorplugin/connectivity/timeout.go
@@ -23,6 +23,7 @@ const (
 	automaticSafetyMinimum       = 30 * time.Second
 	matrixCleanupTimeout         = 30 * time.Second
 	rdmaServerCleanupTimeout     = 3 * time.Second
+	rdmaServerLogTimeout         = 5 * time.Second
 	routeCheckTimeout            = 10 * time.Second
 	nonRequiredCommandTimeout    = 5 * time.Second
 	icmpCommandTimeout           = 5 * time.Second
@@ -45,10 +46,12 @@ func (b timeoutBudget) executionTimeout() time.Duration {
 }
 
 // automaticTimeoutBudget mirrors the serial execution graph in RunMatrix.
-// Route probes run before each selected RDMA family, RDMA commands are grouped
-// by ordered pod pair, and ICMP tests run one-by-one. Keeping the calculation
-// beside the command timeout constants makes the default deadline grow with
-// the actual plan instead of relying on a fixed cluster-size assumption.
+// Route probes are budgeted per selected family as a conservative upper bound;
+// RunMatrix reuses identical route results across families. RDMA commands are
+// grouped by ordered pod pair, and ICMP tests run one-by-one. Keeping the
+// calculation beside the command timeout constants makes the default deadline
+// grow with the actual plan instead of relying on a fixed cluster-size
+// assumption.
 func automaticTimeoutBudget(plan MatrixPlan, checks []Check) timeoutBudget {
 	checks = normalizeChecks(checks)
 	budget := timeoutBudget{

--- a/pkg/networkoperatorplugin/connectivity/timeout_test.go
+++ b/pkg/networkoperatorplugin/connectivity/timeout_test.go
@@ -45,11 +45,11 @@ func TestAutomaticTimeoutBudgetMirrorsSelectedExecutionPlan(t *testing.T) {
 
 	assert.Equal(t, 12, budget.PlannedTests)
 	assert.Equal(t, automaticSetupTimeout, budget.Setup)
-	assert.Equal(t, 5*time.Minute+51*time.Second, budget.Tests)
-	assert.Equal(t, 35*time.Second+100*time.Millisecond, budget.SafetyMargin)
-	assert.Equal(t, 6*time.Minute+26*time.Second+100*time.Millisecond, budget.executionTimeout())
+	assert.Equal(t, 6*time.Minute+21*time.Second, budget.Tests)
+	assert.Equal(t, 38*time.Second+100*time.Millisecond, budget.SafetyMargin)
+	assert.Equal(t, 6*time.Minute+59*time.Second+100*time.Millisecond, budget.executionTimeout())
 	assert.Equal(t, matrixCleanupTimeout, budget.Cleanup)
-	assert.Equal(t, 16*time.Minute+56*time.Second+100*time.Millisecond, budget.Total)
+	assert.Equal(t, 17*time.Minute+29*time.Second+100*time.Millisecond, budget.Total)
 }
 
 func TestAutomaticTimeoutBudgetIncludesOnlySelectedChecks(t *testing.T) {
@@ -108,7 +108,7 @@ func TestAutomaticTimeoutBudgetForThreeNodeFourRailQuickMatrix(t *testing.T) {
 	})
 
 	assert.Equal(t, 144, budget.PlannedTests)
-	assert.Equal(t, 2*time.Hour+10*time.Minute+24*time.Second, budget.Total)
+	assert.Equal(t, 2*time.Hour+12*time.Minute+3*time.Second, budget.Total)
 }
 
 func TestAutomaticTimeoutBudgetUsesDefaultChecksAndNoSafetyForEmptyPlan(t *testing.T) {

--- a/pkg/networkoperatorplugin/preflight/strays.go
+++ b/pkg/networkoperatorplugin/preflight/strays.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -125,8 +126,13 @@ func CheckStrayCRs(ctx context.Context, in Inputs) Result {
 			// Tolerate "no matches for kind ...List" — the cluster
 			// may not have this CRD (older operator release). Log
 			// once at debug and move on.
+			reason := "list_failed"
+			if meta.IsNoMatchError(err) || strings.Contains(err.Error(), "no matches for kind") {
+				reason = "crd_not_installed"
+			}
 			log.Log.V(1).Info("stray-CR list skipped",
-				"kind", kind.GVK.Kind, "scope", scopeLabel(kind), "error", err.Error())
+				"kind", kind.GVK.Kind, "apiVersion", kind.GVK.GroupVersion().String(),
+				"scope", scopeLabel(kind), "reason", reason, "error", err.Error())
 			continue
 		}
 		for i := range list.Items {

--- a/pkg/networkoperatorplugin/validate.go
+++ b/pkg/networkoperatorplugin/validate.go
@@ -190,6 +190,10 @@ func ValidateManifests(ctx context.Context, c client.Client, manifestDir string)
 		if ext != ".yaml" && ext != ".yml" {
 			continue
 		}
+		if strings.EqualFold(e.Name(), "values.yaml") || strings.EqualFold(e.Name(), "values.yml") {
+			log.Log.V(1).Info("Skipping Helm values file", "file", e.Name())
+			continue
+		}
 		if isExampleManifest(e.Name()) {
 			log.Log.V(1).Info("Skipping example manifest", "file", e.Name())
 			continue

--- a/pkg/networkoperatorplugin/validate_test.go
+++ b/pkg/networkoperatorplugin/validate_test.go
@@ -19,7 +19,10 @@ package networkoperatorplugin
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,15 +99,25 @@ func TestHelmReleaseNameFromSecret(t *testing.T) {
 
 func TestIsExampleManifest(t *testing.T) {
 	tests := map[string]bool{
-		"50-example-daemonset.yaml":          true,
-		"40-example-pod.yaml":                true,
-		"30-EXAMPLE-something.yaml":          true,
-		"10-nicclusterpolicy.yaml":           false,
-		"11-nicnodepolicy-group-0.yaml":      false,
-		"30-sriovnetworknodepolicy.yaml":     false,
-		"35-nicinterfacenametemplate.yaml":   false,
+		"50-example-daemonset.yaml":        true,
+		"40-example-pod.yaml":              true,
+		"30-EXAMPLE-something.yaml":        true,
+		"10-nicclusterpolicy.yaml":         false,
+		"11-nicnodepolicy-group-0.yaml":    false,
+		"30-sriovnetworknodepolicy.yaml":   false,
+		"35-nicinterfacenametemplate.yaml": false,
 	}
 	for in, want := range tests {
 		assert.Equalf(t, want, isExampleManifest(in), "isExampleManifest(%q)", in)
 	}
+}
+
+func TestValidateManifestsSkipsHelmValues(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "values.yaml"), []byte("operator:\n  tag: v26.7.0\n"), 0o600))
+
+	results, err := ValidateManifests(context.Background(), nil, dir)
+
+	require.NoError(t, err)
+	assert.Empty(t, results)
 }

--- a/pkg/target/host/paths.go
+++ b/pkg/target/host/paths.go
@@ -161,7 +161,9 @@ func UserConfigPathForGenerate(input UserConfigInput) string {
 }
 
 // LoadUserConfig loads the resolved Host config and applies release and
-// namespace overlays used by standalone deploy and validate.
+// namespace overlays used by standalone deploy and validate. When parsing
+// succeeds but a release overlay fails, it returns the parsed config together
+// with the error so validation can retain that evidence in a partial report.
 func LoadUserConfig(input UserConfigInput, opts options.Options) (*config.LaunchKitConfig, string, error) {
 	path, err := UserConfigPathFor(input)
 	if err != nil {
@@ -178,7 +180,7 @@ func LoadUserConfig(input UserConfigInput, opts options.Options) (*config.Launch
 		return nil, path, fmt.Errorf("user-config %s is empty", path)
 	}
 	if err := networkoperatorplugin.ApplyNetworkOperatorRelease(opts, cfg); err != nil {
-		return nil, path, fmt.Errorf("apply release catalog: %w", err)
+		return cfg, path, fmt.Errorf("apply release catalog: %w", err)
 	}
 	if opts.NetworkOperatorNamespace != "" {
 		if cfg.NetworkOperator == nil {

--- a/pkg/target/host/paths_test.go
+++ b/pkg/target/host/paths_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/options"
 )
 
 func TestResolveKubeconfigPrecedence(t *testing.T) {
@@ -76,4 +78,25 @@ func TestUserConfigPathForUsesExplicitAndDeploymentFallback(t *testing.T) {
 	actual, err = UserConfigPathFor(UserConfigInput{DeploymentFiles: deployment})
 	require.NoError(t, err)
 	assert.Equal(t, configPath, actual)
+}
+
+func TestLoadUserConfigRetainsParsedConfigWhenReleaseOverlayFails(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cluster-config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`networkOperator:
+  selectedRelease: "99.9"
+  namespace: custom-network-operator
+clusterConfig:
+  - identifier: retained-report-group
+`), 0o600))
+
+	cfg, actualPath, err := LoadUserConfig(UserConfigInput{Explicit: path}, options.Options{})
+
+	require.ErrorContains(t, err, `unsupported network operator release "99.9"`)
+	assert.Equal(t, path, actualPath)
+	require.NotNil(t, cfg)
+	require.NotNil(t, cfg.NetworkOperator)
+	assert.Equal(t, "99.9", cfg.NetworkOperator.SelectedRelease)
+	assert.Equal(t, "custom-network-operator", cfg.NetworkOperator.Namespace)
+	require.Len(t, cfg.ClusterConfig, 1)
+	assert.Equal(t, "retained-report-group", cfg.ClusterConfig[0].Identifier)
 }

--- a/pkg/target/host/validate.go
+++ b/pkg/target/host/validate.go
@@ -143,11 +143,16 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 		NetworkOperatorNamespace: request.OperatorNamespace,
 	})
 	cfgPath = loadedCfgPath
+	// Preserve successfully parsed user input in partial reports even when a
+	// release-catalog overlay fails. Operational validation still follows the
+	// existing soft-failure path below and skips config-derived version checks.
+	if cfg != nil {
+		reportConfig = cfg
+	}
 	if cfgErr != nil {
 		log.Log.V(1).Info("user-config not loaded; version check will be skipped",
 			"path", cfgPath, "error", cfgErr.Error())
 	} else if cfg != nil {
-		reportConfig = cfg
 		if cfg.NetworkOperator != nil && cfg.NetworkOperator.Namespace != "" {
 			operatorNamespace = cfg.NetworkOperator.Namespace
 		}

--- a/pkg/target/host/validate.go
+++ b/pkg/target/host/validate.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"k8s.io/client-go/rest"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -64,6 +65,7 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 		reportClient      ctrlclient.Client
 		reportRestConfig  *rest.Config
 		reportManifestDir string
+		reportConfig      *config.LaunchKitConfig
 		cfgPath           string
 		operatorNamespace = defaultOperatorNamespace
 	)
@@ -87,7 +89,7 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 		writeHTMLReportIfWanted(context.Background(), reportClient, reportRestConfig,
 			reportManifestDir, request.DeploymentFiles,
 			operatorNamespace, versionCheck, componentCheck, helmValuesCheck, strayCheck, results, &matrix, &warnings,
-			presetResults, overall, cfgPath, request.OutputFormat,
+			presetResults, overall, reportConfig, request.OutputFormat,
 			request.ReportPath, request.Version, request.Kubeconfig)
 		return err
 	}
@@ -145,6 +147,7 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 		log.Log.V(1).Info("user-config not loaded; version check will be skipped",
 			"path", cfgPath, "error", cfgErr.Error())
 	} else if cfg != nil {
+		reportConfig = cfg
 		if cfg.NetworkOperator != nil && cfg.NetworkOperator.Namespace != "" {
 			operatorNamespace = cfg.NetworkOperator.Namespace
 		}
@@ -204,7 +207,10 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 	ctx := operationContext
 
 	var vcErr error
+	checkStarted := time.Now()
 	versionCheck, vcErr = networkoperatorplugin.CheckHelmReleaseVersion(ctx, k8sClient, operatorNamespace, selectedRelease)
+	log.Log.V(1).Info("validation check completed", "check", "helm release version",
+		"success", vcErr == nil, "duration", time.Since(checkStarted).Round(time.Millisecond).String())
 	if vcErr != nil {
 		return exitWithReport(apperrors.NewClusterError(
 			"version check failed",
@@ -220,7 +226,10 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 	// already covers the dominant "wrong operator version"
 	// case. The per-component breakdown is most useful when
 	// catching out-of-band kubectl edits or partial upgrades.
+	checkStarted = time.Now()
 	ccCheck, ccErr := networkoperatorplugin.CheckComponentVersions(ctx, k8sClient, operatorNamespace, selectedRelease)
+	log.Log.V(1).Info("validation check completed", "check", "component versions",
+		"success", ccErr == nil, "duration", time.Since(checkStarted).Round(time.Millisecond).String())
 	if ccErr != nil {
 		log.Log.V(1).Info("component-version check failed", "error", ccErr.Error())
 	}
@@ -236,7 +245,10 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 	if b, err := os.ReadFile(valuesPath); err == nil {
 		generatedValuesYAML = b
 	}
+	checkStarted = time.Now()
 	hvCheck, hvErr := networkoperatorplugin.CheckHelmReleaseValues(ctx, restConfig, operatorNamespace, generatedValuesYAML)
+	log.Log.V(1).Info("validation check completed", "check", "Helm values drift",
+		"success", hvErr == nil, "duration", time.Since(checkStarted).Round(time.Millisecond).String())
 	if hvErr != nil {
 		log.Log.V(1).Info("helm-values check failed", "error", hvErr.Error())
 	}
@@ -247,6 +259,7 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 	// NOT render. Surfaces as a soft fail — the verdict picks it up,
 	// the HTML report lists every offender, and the user can sweep
 	// them with `l8k deploy --overwrite-existing`.
+	checkStarted = time.Now()
 	genRefs, scanErr := preflight.ScanGeneratedManifests(manifestDir)
 	if scanErr != nil {
 		log.Log.V(1).Info("stray-CR scan failed", "error", scanErr.Error())
@@ -256,10 +269,17 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 		OperatorNamespace:  operatorNamespace,
 		GeneratedManifests: genRefs,
 	})
+	log.Log.V(1).Info("validation check completed", "check", "stray custom resources",
+		"success", scanErr == nil, "mismatches", len(stray.Mismatches),
+		"duration", time.Since(checkStarted).Round(time.Millisecond).String())
 	strayCheck = &stray
 
 	var valErr error
+	checkStarted = time.Now()
 	results, valErr = networkoperatorplugin.ValidateManifests(ctx, k8sClient, manifestDir)
+	log.Log.V(1).Info("validation check completed", "check", "manifest readiness",
+		"success", valErr == nil, "objects", len(results),
+		"duration", time.Since(checkStarted).Round(time.Millisecond).String())
 	if valErr != nil {
 		return exitWithReport(apperrors.NewGeneralError(
 			"manifest validation failed",
@@ -290,7 +310,7 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 		emitVerdictBanner(overall, request.OutputFormat)
 		writeHTMLReportIfWanted(ctx, k8sClient, restConfig, manifestDir, request.DeploymentFiles,
 			operatorNamespace, versionCheck, componentCheck, helmValuesCheck, strayCheck, results, &matrix, &warnings,
-			presetResults, overall, cfgPath, request.OutputFormat,
+			presetResults, overall, reportConfig, request.OutputFormat,
 			request.ReportPath, request.Version, request.Kubeconfig)
 	}
 
@@ -343,7 +363,7 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 			return exitWithReport(apperrors.NewClusterError(
 				"connectivity matrix failed",
 				err,
-				"See log output for the failing step; re-run with --keep to inspect the test DaemonSet",
+				"Re-run with --log-level trace for bounded command output; add --keep to inspect the test DaemonSet",
 			))
 		}
 		if request.OutputFormat == "json" {

--- a/pkg/target/host/validate_helpers.go
+++ b/pkg/target/host/validate_helpers.go
@@ -357,7 +357,7 @@ func writeHTMLReportIfWanted(
 	warnings *[]string,
 	presetResults []presetmatch.Result,
 	overall connectivity.OverallVerdict,
-	userCfgPath string,
+	loadedConfig *config.LaunchKitConfig,
 	outputFormat string,
 	reportPath string,
 	version string,
@@ -373,6 +373,11 @@ func writeHTMLReportIfWanted(
 	if path == "" {
 		return
 	}
+	reportStarted := time.Now()
+	if info, err := os.Stat(path); err == nil {
+		log.Log.V(1).Info("validation report will be overwritten",
+			"path", path, "previousSizeBytes", info.Size(), "previousModifiedAt", info.ModTime())
+	}
 
 	data := connectivity.ReportData{
 		Verdict: overall,
@@ -383,8 +388,8 @@ func writeHTMLReportIfWanted(
 			APIServerVersion:  probeAPIServerVersion(restConfig),
 			OperatorNamespace: operatorNamespace,
 		},
-		Profile:        loadProfileInfo(userCfgPath, manifestDir),
-		NodeGroups:     loadNodeGroups(userCfgPath, presetResults),
+		Profile:        loadProfileInfo(manifestDir, loadedConfig),
+		NodeGroups:     loadNodeGroups(presetResults, loadedConfig),
 		Nodes:          listNodesForReport(ctx, c),
 		Release:        versionCheck,
 		ComponentCheck: componentCheck,
@@ -411,6 +416,8 @@ func writeHTMLReportIfWanted(
 		return
 	}
 	abs, _ := filepath.Abs(path)
+	log.Log.V(1).Info("validation report written",
+		"path", abs, "duration", time.Since(reportStarted).Round(time.Millisecond).String())
 	if outputFormat == "json" {
 		_ = json.NewEncoder(os.Stdout).Encode(map[string]any{"reportPath": abs})
 	} else {
@@ -451,31 +458,26 @@ func probeAPIServerVersion(restConfig *rest.Config) string {
 	return info.GitVersion
 }
 
-// loadProfileInfo reads the profile section out of cluster-config.yaml
-// (when present) and projects it into the report's ProfileInfo. When
-// the config doesn't carry an explicit `profile:` block (which is
-// normal — `l8k discover` writes only `clusterConfig:` and
-// `networkOperator:`), this falls back to inferring the profile from
-// the Kinds present in the rendered deployment manifests.
-func loadProfileInfo(userCfgPath, manifestDir string) connectivity.ProfileInfo {
-	if userCfgPath != "" {
-		if cfg, err := config.LoadFullConfig(userCfgPath, log.Log); err == nil && cfg != nil && cfg.Profile != nil {
-			info := connectivity.ProfileInfo{
-				Fabric:         cfg.Profile.Fabric,
-				DeploymentType: cfg.Profile.Deployment,
-				Multirail:      cfg.Profile.Multirail,
-			}
-			if cfg.Profile.SpectrumX != nil && cfg.Profile.SpectrumX.Enable {
-				info.SpectrumX = &connectivity.ProfileSpectrumX{
-					Version:        cfg.Profile.SpectrumX.SPCXVersion,
-					MultiplaneMode: cfg.Profile.SpectrumX.MultiplaneMode,
-					NumberOfPlanes: cfg.Profile.SpectrumX.NumberOfPlanes,
-				}
-			}
-			return info
+// loadProfileInfo projects the already-loaded profile into the report. When
+// the config doesn't carry an explicit profile block, it falls back to the
+// Kinds present in the rendered deployment manifests.
+func loadProfileInfo(manifestDir string, cfg *config.LaunchKitConfig) connectivity.ProfileInfo {
+	if cfg == nil || cfg.Profile == nil {
+		return inferProfileFromManifests(manifestDir)
+	}
+	info := connectivity.ProfileInfo{
+		Fabric:         cfg.Profile.Fabric,
+		DeploymentType: cfg.Profile.Deployment,
+		Multirail:      cfg.Profile.Multirail,
+	}
+	if cfg.Profile.SpectrumX != nil && cfg.Profile.SpectrumX.Enable {
+		info.SpectrumX = &connectivity.ProfileSpectrumX{
+			Version:        cfg.Profile.SpectrumX.SPCXVersion,
+			MultiplaneMode: cfg.Profile.SpectrumX.MultiplaneMode,
+			NumberOfPlanes: cfg.Profile.SpectrumX.NumberOfPlanes,
 		}
 	}
-	return inferProfileFromManifests(manifestDir)
+	return info
 }
 
 // inferProfileFromManifests walks the deployment-files directory and
@@ -615,9 +617,9 @@ func splitYAMLDocs(s string) []string {
 	return docs
 }
 
-// loadNodeGroups projects every cluster-config.yaml `clusterConfig[]`
-// entry into a NodeGroupInfo for the report. Empty result when the
-// config wasn't found / parsed — the section just renders empty.
+// loadNodeGroups projects every cluster-config.yaml `clusterConfig[]` entry
+// from the already-loaded config into a NodeGroupInfo for the report. Empty
+// result when the config wasn't found or parsed.
 //
 // presetResults carries the runtime-fresh per-group preset match
 // (computed by presetmatch.MatchAll at validate-time). Its
@@ -628,12 +630,8 @@ func splitYAMLDocs(s string) []string {
 // stored snapshot when the runtime entry is absent keeps the older
 // flow working (e.g. validate run without l8k discover access to
 // the cluster).
-func loadNodeGroups(userCfgPath string, presetResults []presetmatch.Result) []connectivity.NodeGroupInfo {
-	if userCfgPath == "" {
-		return nil
-	}
-	cfg, err := config.LoadFullConfig(userCfgPath, log.Log)
-	if err != nil || cfg == nil {
+func loadNodeGroups(presetResults []presetmatch.Result, cfg *config.LaunchKitConfig) []connectivity.NodeGroupInfo {
+	if cfg == nil {
 		return nil
 	}
 	// Build a per-group index of fresh match results so the

--- a/skills/k8s-launch-kit-shared/SKILL.md
+++ b/skills/k8s-launch-kit-shared/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-shared
-version: 1.0.1
+version: 1.0.2
 description: "k8s-launch-kit (l8k) CLI: Shared patterns for binary location, global flags, output formatting, exit codes, and error handling. Read this before using any other k8s-launch-kit skill."
 ---
 
@@ -85,6 +85,7 @@ package ownership, artifacts, or external integration boundaries.
 | `--output <FORMAT>` | Output format: `text` (default), `json` |
 | `--yes` / `-y` | Auto-confirm all prompts (root command only — **not available on subcommands**; `--output json` auto-confirms) |
 | `--quiet` / `-q` | Suppress informational output (errors still shown) |
+| `--log-level <LEVEL>` | Enable logs at `trace`, `debug`, `info`, `warn`, or `error`. Debug shows structured progress; trace also shows bounded command output. |
 | `--network-operator-namespace <NS>` | Override network operator namespace (default: `nvidia-network-operator`). **No-op for `l8k discover`** — discover always bootstraps into `nvidia-k8s-launch-kit`; the flag still applies to `l8k generate` / `l8k deploy` / `l8k clean` / `l8k validate`. |
 | `--network-namespaces <NS,...>` | Comma-separated namespaces for the secondary-network CRs + example test DaemonSets; one copy rendered per namespace (shared resources like IPPools/NodePolicies are NOT duplicated). Default: `default` |
 | `--node-selector <LABELS>` | Restrict to nodes matching labels (comma-separated, ANDed) |

--- a/skills/k8s-launch-kit-troubleshoot/SKILL.md
+++ b/skills/k8s-launch-kit-troubleshoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-troubleshoot
-version: 1.1.0
+version: 1.1.1
 description: "Use this skill when the user has problems with NVIDIA Network Operator on Kubernetes, or wants to analyze a sosreport diagnostic dump. Activate for: OFED driver crashes, SR-IOV pods failing, NicClusterPolicy errors, network operator pod issues, RDMA not working, NIC configuration failures, pods stuck in CrashLoopBackOff or ContainerCreating with network annotations, VF allocation issues, or when the user mentions 'troubleshoot', 'debug', 'sosreport', 'diagnose', or describes any NVIDIA networking failure -- even if they don't explicitly ask for troubleshooting."
 metadata:
   requires:
@@ -16,9 +16,21 @@ Debug NVIDIA Network Operator issues on Kubernetes, with or without a sosreport.
 ## l8k Troubleshooting Commands
 
 ```bash
+# Show validation endpoints, planning, route-cache statistics, stage/batch
+# progress, timings, and failed RDMA evidence.
+l8k validate --kubeconfig <PATH> --deployment-files <DIR> --log-level debug
+
+# Add bounded route command output, RDMA client stdout/stderr, and server logs.
+l8k validate --kubeconfig <PATH> --deployment-files <DIR> --log-level trace --keep
+
 # Collect a diagnostic dump from the cluster
 l8k sosreport [--kubeconfig <PATH>] --output-dir ./sosreport
 ```
+
+Start with `debug`. Escalate to `trace` when a route, ICMP, rping, or
+ib_write_bw failure needs command output. Trace fields are bounded; failed RDMA
+server logs are collected before cleanup. Add `--keep` only when the workload
+must remain available for follow-up `kubectl exec` inspection.
 
 `l8k sosreport` gathers cluster state, CRDs, operator logs, and per-node NIC info into a structured directory for offline analysis. Use the diagnostic commands and triage workflow below to interpret the dump.
 

--- a/skills/k8s-launch-kit-validate/SKILL.md
+++ b/skills/k8s-launch-kit-validate/SKILL.md
@@ -29,7 +29,7 @@ Operator release.
    version expected by `networkOperator.selectedRelease` in
    `cluster-config.yaml` (looked up in l8k's embedded release catalog).
 2. **Manifest state.** Every YAML manifest under
-   `--deployment-files` (skipping any file with "example" in its name)
+   `--deployment-files` (skipping example workloads and Helm `values.yaml`)
    is fetched from the cluster and classified by the per-Kind resource-state
    registry. `NicConfigurationTemplate` and `NicFirmwareTemplate` wait for
    the operator-populated `status.nicDevices` list to reflect current node,
@@ -79,6 +79,7 @@ l8k validate [--user-config <PATH>] [--deployment-files <DIR>] [--kubeconfig <PA
 | `--rdma-rping-iterations` | `validation.rdma.rpingIterations` | rping client iteration count |
 | `--rdma-ib-write-size` | `validation.rdma.ibWriteSize` | ib_write_bw message size |
 | `--rdma-ib-write-min-bandwidth-gbps` | `validation.rdma.ibWriteMinBandwidthGbps` | Minimum peak Gbps; `0` disables bandwidth gating |
+| `--log-level` | disabled | `debug` for structured progress and timing; `trace` also includes bounded command output |
 
 ## Connectivity Modes
 
@@ -115,7 +116,19 @@ l8k validate --user-config ./cluster-config.yaml \
 
 # Agent mode (single JSON object on stdout, logs on stderr)
 l8k validate --output json 2>/dev/null | jq '.summary'
+
+# Diagnose stage or batch progress without raw command output
+l8k validate --log-level debug
+
+# Capture bounded route, ICMP, RDMA client, and RDMA server evidence
+l8k validate --log-level trace --keep
 ```
+
+Debug logs show the endpoint inventory, plan, source-route cache statistics,
+static checks, stages, RDMA batches, cleanup, report writes, elapsed time, and
+remaining timeout. Trace adds bounded commands and per-test stdout/stderr.
+Failed RDMA server logs are collected before the temporary files and test
+workload are removed. Add `--keep` only when follow-up pod inspection is needed.
 
 ## Output
 


### PR DESCRIPTION
## Summary

- add a trace log level so V(2) output is selectable while keeping structured progress at debug
- log validation check timings, connectivity endpoints and plan, timeout budget, route-cache statistics, stage progress, RDMA batch progress, cleanup, and report writes
- return per-cell RDMA client stdout/stderr and collect failed server logs before cleanup; trace output is capped per field
- cache deterministic source-route checks across connectivity families and skip Helm values.yaml during manifest validation
- update README, user/reference documentation, and bundled validation/troubleshooting skills

## Validation

- go test ./...
- go test -race -count=1 ./pkg/log ./pkg/networkoperatorplugin/connectivity ./pkg/networkoperatorplugin ./pkg/networkoperatorplugin/preflight ./pkg/target/host
- go vet ./...
- CGO_ENABLED=0 go build ./...
- golangci-lint v2.11: 0 issues
- build/l8k --log-level trace version --output json