### PR TITLE
fix: pin ICMP validation to source interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,8 +382,9 @@ desiredNumberScheduled > 0` — a single ContainerCreating-stuck pod fails),
 and run the configured checks (`icmp`, `rping`, and/or `ib_write_bw`) with
 source-bound rail identity. Every profile renders the DaemonSet with a DOCA
 container for RDMA checks and a declared `netshoot` container for ICMP; validate
-applies that manifest without injecting containers at runtime. ICMP uses
-`ping -I <src-iface>`, `rping` uses
+applies that manifest without injecting containers at runtime. ICMP always uses
+`ping -I <src-iface>` for both same-rail and cross-rail probes in every
+validation mode; it never relies on binding only the source IP. `rping` uses
 `-I <src-ip>`, and `ib_write_bw` uses `--bind_source_ip <src-ip>`; every test
 also records a source-qualified `ip route get <dst> from <src>` lookup from the
 netshoot container. When `validation.gpuDirect.enabled` is true, a separate

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -32,7 +32,10 @@ Each generated example DaemonSet declares two validation containers: the DOCA
 container runs `rping`, `ib_write_bw`, and DMA-BUF bandwidth, while the `netshoot` container runs
 ICMP and route checks from the same pod network namespace. Validation applies
 the generated DaemonSet as written; it does not inject a helper container at
-runtime.
+runtime. Every ICMP probe is pinned with `ping -I <src-iface>`, including
+same-rail and cross-rail probes in `quick`, `full`, and `strict` modes. Binding
+only the source IP is intentionally not used because it does not guarantee the
+probe stays on the selected Multus interface.
 
 Manifest-state checks for `NicConfigurationTemplate` and `NicFirmwareTemplate` use the operator-populated `status.nicDevices` list as the matched device set. An empty list, a list that does not yet reflect the current node, NIC type, PCI-address, serial-number, and part-number selectors, a missing named `NicDevice`, a device spec that does not yet reflect the current template payload, or a relevant device condition with a stale `observedGeneration` remains `IN-PROGRESS`. `NicConfigurationTemplate` considers `FirmwareUpdateInProgress` relevant only when the matched device has `spec.firmware`; a stale firmware condition cannot block a configuration-only deployment. Unrelated discovered devices are used only to verify selector freshness; their configuration and firmware state is ignored.
 

--- a/pkg/networkoperatorplugin/connectivity/icmp.go
+++ b/pkg/networkoperatorplugin/connectivity/icmp.go
@@ -48,11 +48,15 @@ func RunICMP(ctx context.Context, restConfig *rest.Config, namespace, pod, conta
 			return r
 		}
 	}
-	cmd := shellWithTimeout(fmt.Sprintf("ping -c 1 -W 1 -I %s %s", shellArg(test.SrcIP), shellArg(test.DstIP)),
+	cmd := shellWithTimeout(icmpCommand(test),
 		commandTimeoutFor(test, icmpCommandTimeout))
 	testLogger(test).V(2).Info("ICMP command", "command", boundedTraceOutput(cmd))
 	res, err := kubeclient.ExecInPod(ctx, restConfig, namespace, pod, container, []string{"/bin/sh", "-c", cmd})
 	r.Stdout, r.Stderr = res.Stdout, res.Stderr
 	finalizeExpectedResult(&r, err == nil, err)
 	return r
+}
+
+func icmpCommand(test PingTest) string {
+	return fmt.Sprintf("ping -c 1 -W 1 -I %s %s", shellArg(test.SrcIface), shellArg(test.DstIP))
 }

--- a/pkg/networkoperatorplugin/connectivity/icmp_test.go
+++ b/pkg/networkoperatorplugin/connectivity/icmp_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package connectivity
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlannedICMPCommandsPinSourceInterfaceInEveryMode(t *testing.T) {
+	pods := []TestPod{
+		mkPod("pod-a", "rail-0", "rail-1"),
+		mkPod("pod-b", "rail-0", "rail-1"),
+	}
+	tests := []struct {
+		name    string
+		mode    Mode
+		routing string
+	}{
+		{name: "quick", mode: ModeQuick, routing: config.RoutingDestinationBased},
+		{name: "full", mode: ModeFull, routing: config.RoutingDestinationBased},
+		{name: "strict source based", mode: ModeStrict, routing: config.RoutingSourceBased},
+		{name: "strict destination based", mode: ModeStrict, routing: config.RoutingDestinationBased},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := PlanWithOptions(pods, tc.mode, tc.routing)
+			require.NotEmpty(t, plan.ICMPSameRail)
+			require.NotEmpty(t, plan.ICMPCrossRail)
+			icmpTests := testsForCheck(plan, CheckICMP)
+
+			for _, test := range icmpTests {
+				expected := fmt.Sprintf("ping -c 1 -W 1 -I %q %q", test.SrcIface, test.DstIP)
+				assert.Equal(t, expected, icmpCommand(test), "%+v", test)
+				assert.NotContains(t, icmpCommand(test), test.SrcIP, "%+v", test)
+			}
+		})
+	}
+}
+
+func TestWrappedICMPCommandPinsInterfaceInTimeoutAndFallbackPaths(t *testing.T) {
+	plan := PlanWithOptions([]TestPod{
+		mkPod("pod-a", "rail-0", "rail-1"),
+		mkPod("pod-b", "rail-0", "rail-1"),
+	}, ModeStrict, config.RoutingSourceBased)
+	require.NotEmpty(t, plan.ICMPCrossRail)
+	test := plan.ICMPCrossRail[0]
+
+	cmd := shellWithTimeout(icmpCommand(test), 5*time.Second)
+
+	assert.Contains(t, cmd, "timeout -s TERM -k 2 5 sh -c "+shellArg(icmpCommand(test)))
+	assert.Contains(t, cmd, "else "+icmpCommand(test)+" & pid=$!")
+	assert.NotContains(t, cmd, test.SrcIP)
+}

--- a/skills/k8s-launch-kit-validate/SKILL.md
+++ b/skills/k8s-launch-kit-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-validate
-version: 1.0.4
+version: 1.0.5
 description: "Use this skill when the user wants to verify that an NVIDIA networking deployment matches the configuration that produced it. Activate for: 'is my deployment correct', 'are all the manifests applied', 'does the network operator version match', 'verify deployment', 'check cluster state against config', or any question about whether the cluster reflects what l8k generated. Wraps the `l8k validate` subcommand."
 metadata:
   requires:
@@ -90,8 +90,10 @@ l8k validate [--user-config <PATH>] [--deployment-files <DIR>] [--kubeconfig <PA
 - `strict`: full matrix. Cross-rail gates by `profile.routing`: `source-based`
   must succeed, `destination-based` must stay isolated.
 
-All checks are source-bound. ICMP uses `ping -I <src-iface>`, `rping` uses
-`-I <src-ip>`, and `ib_write_bw` uses `--bind_source_ip <src-ip>`. GPUDirect
+All checks are source-bound. ICMP always uses `ping -I <src-iface>` for
+same-rail and cross-rail probes in every validation mode; it never binds only
+the source IP. `rping` uses `-I <src-ip>`, and `ib_write_bw` uses
+`--bind_source_ip <src-ip>`. GPUDirect
 adds `--use_cuda=<endpoint-index> --use_cuda_dmabuf` independently on the
 client and server. Treat missing or ambiguous `connectedGPU` topology as a
 failure; never substitute GPU 0. Pull Secrets come from


### PR DESCRIPTION
## Summary

- pin every ICMP validation probe to its planned Multus source interface instead of binding only the source IP
- cover same-rail and cross-rail probes in quick, full, and strict modes, including native and fallback timeout execution
- document the interface-pinning guarantee in the user guide, README, and bundled validation skill

## Root cause

The matrix planner already populated `SrcIface`, and `RunICMP` required it, but the generated `ping` command passed `SrcIP` to `-I`. Source-address binding does not guarantee that a probe uses the intended Multus interface. This is especially visible for non-required cross-rail observations, which do not gate execution on the route-interface check.

## Validation

- `go test ./...`
- `go test -race -count=1 ./pkg/networkoperatorplugin/connectivity`
- `go build ./...`
- `golangci-lint v2.11.0 run ./...`
- `mkdocs build --strict --clean`
- `git diff --check`
