### PR TITLE
fix: align swplb resource naming with rail-plane convention

### DIFF
--- a/skills/k8s-launch-kit-generate/references/spectrum-x-modes.md
+++ b/skills/k8s-launch-kit-generate/references/spectrum-x-modes.md
@@ -46,12 +46,12 @@ ovs-network-rail-1
 - **Resource naming**: Per-rail AND per-plane (finest granularity)
 
 ```
-sriov-network-node-policy-plane-0-rail-0
-sriov-network-node-policy-plane-0-rail-1
-sriov-network-node-policy-plane-1-rail-0
-sriov-network-node-policy-plane-1-rail-1
-ovs-network-plane-0-rail-0
-ovs-network-plane-1-rail-0
+sriov-network-node-policy-rail-0-plane-0
+sriov-network-node-policy-rail-0-plane-1
+sriov-network-node-policy-rail-1-plane-0
+sriov-network-node-policy-rail-1-plane-1
+ovs-network-rail-0-plane-0
+ovs-network-rail-0-plane-1
 ```
 
 - **Description**: Software-based distribution of traffic across multiple planes.

--- a/skills/k8s-network-engineer/references/spectrum-x-guide.md
+++ b/skills/k8s-network-engineer/references/spectrum-x-guide.md
@@ -106,12 +106,12 @@ spectrum-x-rail-pool-config-rail-1
 ### Per-Rail-Per-Plane Resources (swplb)
 
 ```
-sriov-network-node-policy-plane-0-rail-0
-sriov-network-node-policy-plane-0-rail-1
-sriov-network-node-policy-plane-1-rail-0
-sriov-network-node-policy-plane-1-rail-1
-ovs-network-plane-0-rail-0
-ovs-network-plane-1-rail-0
+sriov-network-node-policy-rail-0-plane-0
+sriov-network-node-policy-rail-0-plane-1
+sriov-network-node-policy-rail-1-plane-0
+sriov-network-node-policy-rail-1-plane-1
+ovs-network-rail-0-plane-0
+ovs-network-rail-0-plane-1
 ```
 
 ## CIDRPool Configuration


### PR DESCRIPTION
This PR addresses the following issue in `skills/k8s-network-engineer/references/spectrum-x-guide.md` and `skills/k8s-launch-kit-generate/references/spectrum-x-modes.md`: align swplb resource naming with rail-plane convention.

## Changes
- `skills/k8s-network-engineer/references/spectrum-x-guide.md`: align swplb resource naming with rail-plane convention.
- `skills/k8s-launch-kit-generate/references/spectrum-x-modes.md`: align swplb resource naming with rail-plane convention so the generate skill reference matches the network-engineer guide.

## Details
```diff
--- a/skills/k8s-network-engineer/references/spectrum-x-guide.md
+++ b/skills/k8s-network-engineer/references/spectrum-x-guide.md
@@ -1,10 +1,10 @@
 ### Per-Rail-Per-Plane Resources (swplb)
 
 ```
-sriov-network-node-policy-plane-0-rail-0
-sriov-network-node-policy-plane-0-rail-1
-sriov-network-node-policy-plane-1-rail-0
-sriov-network-node-policy-plane-1-rail-1
-ovs-network-plane-0-rail-0
-ovs-network-plane-1-rail-0
+sriov-network-node-policy-rail-0-plane-0
+sriov-network-node-policy-rail-0-plane-1
+sriov-network-node-policy-rail-1-plane-0
+sriov-network-node-policy-rail-1-plane-1
+ovs-network-rail-0-plane-0
+ovs-network-rail-0-plane-1
 ```
```

```diff
--- a/skills/k8s-launch-kit-generate/references/spectrum-x-modes.md
+++ b/skills/k8s-launch-kit-generate/references/spectrum-x-modes.md
@@ -1,10 +1,10 @@
 ```
-sriov-network-node-policy-plane-0-rail-0
-sriov-network-node-policy-plane-0-rail-1
-sriov-network-node-policy-plane-1-rail-0
-sriov-network-node-policy-plane-1-rail-1
-ovs-network-plane-0-rail-0
-ovs-network-plane-1-rail-0
+sriov-network-node-policy-rail-0-plane-0
+sriov-network-node-policy-rail-0-plane-1
+sriov-network-node-policy-rail-1-plane-0
+sriov-network-node-policy-rail-1-plane-1
+ovs-network-rail-0-plane-0
+ovs-network-rail-0-plane-1
 ```
```

## Tests

> No code changes; documentation-only fix. `make test` could not be run in this environment because Go is not installed, but the change is confined to two Markdown reference files.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).