### PR TITLE
fix: IPv4 CIDRPool GatewayIndex points to host instead of leaf

### DIFF
--- a/pkg/networkoperatorplugin/spectrumx/addressing.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing.go
@@ -592,7 +592,7 @@ func poolSettings(spcx *config.ProfileSpectrumX) cidrPoolSettings {
 		}
 	}
 	return cidrPoolSettings{
-		gatewayIndex:         0,
+		gatewayIndex:         1,
 		perNodeNetworkPrefix: 31,
 		perNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 	}

--- a/pkg/networkoperatorplugin/spectrumx/addressing_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -98,7 +98,7 @@ func TestBuildCIDRPools2TierSWPLB(t *testing.T) {
 	require.Len(t, pools, 4)
 	require.Equal(t, "rail-0-plane-0-gpu-model", pools[0].Name)
 	require.Equal(t, "172.16.0.0/18", pools[0].CIDR)
-	require.Equal(t, 0, pools[0].GatewayIndex)
+	require.Equal(t, 1, pools[0].GatewayIndex)
 	require.Equal(t, 31, pools[0].PerNodeNetworkPrefix)
 	require.Equal(t, []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}}, pools[0].PerNodeExclusions)
 	require.Equal(t, []string{"172.16.0.0/18", "172.16.0.0/14"}, pools[0].Routes)
@@ -142,7 +142,7 @@ func TestBuildCIDRPools3Tier(t *testing.T) {
 	require.Equal(t, []CIDRPool{{
 		Name:                 "rail-0",
 		CIDR:                 "10.0.0.0/13",
-		GatewayIndex:         0,
+		GatewayIndex:         1,
 		PerNodeNetworkPrefix: 31,
 		PerNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 		Routes: []string{
@@ -247,7 +247,7 @@ func TestBuildCIDRPoolsFromAIR3Tier(t *testing.T) {
 	require.Equal(t, []CIDRPool{{
 		Name:                 "rail-1",
 		CIDR:                 "10.8.0.0/13",
-		GatewayIndex:         0,
+		GatewayIndex:         1,
 		PerNodeNetworkPrefix: 31,
 		PerNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 		Routes:               []string{"10.8.0.0/13", "10.0.0.0/10"},


### PR DESCRIPTION
This PR addresses the following issue in `pkg/networkoperatorplugin/spectrumx/addressing.go`: IPv4 CIDRPool GatewayIndex points to host instead of leaf.

## Changes
- `pkg/networkoperatorplugin/spectrumx/addressing.go`: IPv4 CIDRPool GatewayIndex points to host instead of leaf.

## Details
```diff
--- a/pkg/networkoperatorplugin/spectrumx/addressing.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing.go
@@ -1,14 +1,14 @@
-func poolSettings(spcx *config.ProfileSpectrumX) cidrPoolSettings {
-	if isIPv6(spcx) {
-		return cidrPoolSettings{
-			gatewayIndex:         2,
-			perNodeNetworkPrefix: 64,
-			perNodeExclusions:    []PerNodeExclusion{{StartIndex: 2, EndIndex: 2}},
-		}
-	}
-	return cidrPoolSettings{
-		gatewayIndex:         0,
-		perNodeNetworkPrefix: 31,
-		perNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
-	}
-}
+func poolSettings(spcx *config.ProfileSpectrumX) cidrPoolSettings {
+	if isIPv6(spcx) {
+		return cidrPoolSettings{
+			gatewayIndex:         2,
+			perNodeNetworkPrefix: 64,
+			perNodeExclusions:    []PerNodeExclusion{{StartIndex: 2, EndIndex: 2}},
+		}
+	}
+	return cidrPoolSettings{
+		gatewayIndex:         1,
+		perNodeNetworkPrefix: 31,
+		perNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
+	}
+}
```

## Tests
- `pkg/networkoperatorplugin/spectrumx/addressing_test.go`

```diff
--- /dev/null
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -0,0 +1,19 @@
+package spectrumx
+
+import (
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+func TestPoolSettingsIPv4GatewayIndex(t *testing.T) {
+	spcx := &config.ProfileSpectrumX{IPVersion: config.SpectrumXIPVersionIPv4}
+	got := poolSettings(spcx)
+	if got.gatewayIndex != 1 {
+		t.Errorf("IPv4 poolSettings gatewayIndex = %d, want 1", got.gatewayIndex)
+	}
+}
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).
---
**Update (post-Greptile review):** The IPv4 `GatewayIndex` implementation and the existing `BuildCIDRPools` test expectations have been made consistent (index 1). The Spectrum-X addressing test suite now passes (`go test ./pkg/networkoperatorplugin/spectrumx/...`). Commit: `b2c2956ad05cdff0c24a0a2d82a38c80b87b0457`.