### PR TITLE
fix: ambiguous footnote for flags implied by --spectrum-x

### DIFF
--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -49,7 +49,7 @@ to that source file; embedded `--for` generation does not write a config.
 | `--for` | — | preset directory name | Skip discovery: synthesize `clusterConfig` from a topology preset. Requires `--node-selector`. List options with `l8k preset list`. |
 | `--node-selector` | Required with `--for` | `key=val,key2=val2` | Identifies which nodes the synthesized clusterConfig targets at apply time. |
 
-*Not required when `--spectrum-x` is used.
+**Note:** `--fabric` and `--deployment-type` are not required when `--spectrum-x` is used (it implies `ethernet` fabric and `sriov` deployment).
 
 ## Examples
 


### PR DESCRIPTION
This PR addresses the following issue in `skills/k8s-launch-kit-generate/SKILL.md`: ambiguous footnote for flags implied by --spectrum-x.

## Changes
- `skills/k8s-launch-kit-generate/SKILL.md`: ambiguous footnote for flags implied by --spectrum-x.

## Details
```diff
--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -1,1 +1,1 @@
-*Not required when `--spectrum-x` is used.
+**Note:** `--fabric` and `--deployment-type` are not required when `--spectrum-x` is used (it implies `ethernet` fabric and `sriov` deployment).
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).