### PR TITLE
fix: IPv4 /31 gatewayIndex asserts 0 but gateway is index 1

### DIFF
--- a/pkg/networkoperatorplugin/spectrumx/addressing.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing.go
@@ -592,7 +592,7 @@ func poolSettings(spcx *config.ProfileSpectrumX) cidrPoolSettings {
 		}
 	}
 	return cidrPoolSettings{
-		gatewayIndex:         0,
+		gatewayIndex:         1,
 		perNodeNetworkPrefix: 31,
 		perNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 	}

--- a/pkg/networkoperatorplugin/spectrumx/addressing_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -98,7 +98,7 @@ func TestBuildCIDRPools2TierSWPLB(t *testing.T) {
 	require.Len(t, pools, 4)
 	require.Equal(t, "rail-0-plane-0-gpu-model", pools[0].Name)
 	require.Equal(t, "172.16.0.0/18", pools[0].CIDR)
-	require.Equal(t, 0, pools[0].GatewayIndex)
+	require.Equal(t, 1, pools[0].GatewayIndex)
 	require.Equal(t, 31, pools[0].PerNodeNetworkPrefix)
 	require.Equal(t, []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}}, pools[0].PerNodeExclusions)
 	require.Equal(t, []string{"172.16.0.0/18", "172.16.0.0/14"}, pools[0].Routes)
@@ -142,7 +142,7 @@ func TestBuildCIDRPools3Tier(t *testing.T) {
 	require.Equal(t, []CIDRPool{{
 		Name:                 "rail-0",
 		CIDR:                 "10.0.0.0/13",
-		GatewayIndex:         0,
+		GatewayIndex:         1,
 		PerNodeNetworkPrefix: 31,
 		PerNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 		Routes: []string{
@@ -247,7 +247,7 @@ func TestBuildCIDRPoolsFromAIR3Tier(t *testing.T) {
 	require.Equal(t, []CIDRPool{{
 		Name:                 "rail-1",
 		CIDR:                 "10.8.0.0/13",
-		GatewayIndex:         0,
+		GatewayIndex:         1,
 		PerNodeNetworkPrefix: 31,
 		PerNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 		Routes:               []string{"10.8.0.0/13", "10.0.0.0/10"},


### PR DESCRIPTION
This PR addresses the following issue in `pkg/networkoperatorplugin/spectrumx/addressing_test.go`: IPv4 /31 gatewayIndex asserts 0 but gateway is index 1.

## Changes
- `pkg/networkoperatorplugin/spectrumx/addressing_test.go`: IPv4 /31 gatewayIndex asserts 0 but gateway is index 1.

## Details
```diff
--- a/pkg/networkoperatorplugin/spectrumx/addressing_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -1,5 +1,5 @@
-require.Equal(t, 0, pools[0].GatewayIndex)
-...
-GatewayIndex:         0,
-...
-GatewayIndex:         0,
+require.Equal(t, 1, pools[0].GatewayIndex)
+...
+GatewayIndex:         1,
+...
+GatewayIndex:         1,
```

## Tests
- `pkg/networkoperatorplugin/spectrumx/addressing_test.go`

```diff
--- a/pkg/networkoperatorplugin/spectrumx/addressing_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -76,7 +76,7 @@ func TestBuildCIDRPools2TierSWPLB(t *testing.T) {
 	require.Len(t, pools, 4)
 	require.Equal(t, "rail-0-plane-0-gpu-model", pools[0].Name)
 	require.Equal(t, "172.16.0.0/18", pools[0].CIDR)
-	require.Equal(t, 0, pools[0].GatewayIndex)
+	require.Equal(t, 1, pools[0].GatewayIndex)
 	require.Equal(t, 31, pools[0].PerNodeNetworkPrefix)
 	require.Equal(t, []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}}, pools[0].PerNodeExclusions)
@@ -154,7 +154,7 @@ func TestBuildCIDRPools3Tier(t *testing.T) {
 	require.Equal(t, []CIDRPool{{
 		Name:                 "rail-0",
 		CIDR:                 "10.0.0.0/13",
-		GatewayIndex:         0,
+		GatewayIndex:         1,
 		PerNodeNetworkPrefix: 31,
 		PerNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
@@ -236,7 +236,7 @@ func TestBuildCIDRPoolsFromAIR3Tier(t *testing.T) {
 	require.Equal(t, []CIDRPool{{
 		Name:                 "rail-1",
 		CIDR:                 "10.8.0.0/13",
-		GatewayIndex:         0,
+		GatewayIndex:         1,
 		PerNodeNetworkPrefix: 31,
 		PerNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).
---
**Update (post-Greptile review):** The IPv4 `GatewayIndex` implementation has been updated to index 1 so it agrees with the corrected test assertions. The Spectrum-X addressing test suite now passes (`go test ./pkg/networkoperatorplugin/spectrumx/...`). Commit: `ffeae55405947dfcb349660e68f8708592e0ab88`.