### PR TITLE
fix: CIDRPool template comment refers to unused .ClusterConfig.PFs

### DIFF
--- a/profiles/spectrum-x-ra2.1/60-cidrpool.yaml
+++ b/profiles/spectrum-x-ra2.1/60-cidrpool.yaml
@@ -1,4 +1,4 @@
-{{- /* .ClusterConfig.PFs keeps this template in per-group render mode. */ -}}
+{{- /* spectrumXCIDRPools generates CIDRPool specs from ClusterConfig. */ -}}
 {{- $pools := spectrumXCIDRPools . .ClusterConfig }}
 {{- range $idx, $pool := $pools }}
 {{ if $idx }}---


### PR DESCRIPTION
This PR addresses the following issue in `profiles/spectrum-x-ra2.1/60-cidrpool.yaml`: CIDRPool template comment refers to unused .ClusterConfig.PFs.

## Changes
- `profiles/spectrum-x-ra2.1/60-cidrpool.yaml`: CIDRPool template comment refers to unused .ClusterConfig.PFs.

## Details
```diff
--- a/profiles/spectrum-x-ra2.1/60-cidrpool.yaml
+++ b/profiles/spectrum-x-ra2.1/60-cidrpool.yaml
@@ -1,2 +1,2 @@
-{{- /* .ClusterConfig.PFs keeps this template in per-group render mode. */ -}}
-{{- $pools := spectrumXCIDRPools . .ClusterConfig }}
+{{- /* spectrumXCIDRPools generates CIDRPool specs from ClusterConfig. */ -}}
+{{- $pools := spectrumXCIDRPools . .ClusterConfig }}
```

## Tests
- `pkg/render/templates_test.go`

```diff
--- /dev/null
+++ b/pkg/render/templates_test.go
@@ -0,0 +1,18 @@
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCIDRPoolTemplateNoMisleadingPFComment(t *testing.T) {
+	p := filepath.Join("..", "..", "profiles", "spectrum-x-ra2.1", "60-cidrpool.yaml")
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("reading template: %v", err)
+	}
+	if strings.Contains(string(b), ".ClusterConfig.PFs") {
+		t.Errorf("CIDRPool template must not reference unused .ClusterConfig.PFs")
+	}
+}
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).