### PR TITLE
fix: reject SPC-X-only fields when spectrumX.enable is false

### DIFF
--- a/pkg/resolve/validate.go
+++ b/pkg/resolve/validate.go
@@ -61,6 +61,15 @@ func ValidateResolvedConfig(cfg *config.LaunchKitConfig) error {
 		if cfg.Profile.SpectrumX.TopologyFile != "" {
 			return fmt.Errorf("topologyFile is set but spectrumX.enable=false; remove the field or set --spectrum-x")
 		}
+		if cfg.Profile.SpectrumX.SPCXVersion != "" {
+			return fmt.Errorf("spcxVersion is set but spectrumX.enable=false; remove the field or set --spectrum-x")
+		}
+		if cfg.Profile.SpectrumX.Profile != "" {
+			return fmt.Errorf("profile is set but spectrumX.enable=false; remove the field or set --spectrum-x")
+		}
+		if cfg.Profile.SpectrumX.ConfigMapName != "" {
+			return fmt.Errorf("configMapName is set but spectrumX.enable=false; remove the field or set --spectrum-x")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR addresses the following issue in `pkg/resolve/validate.go`: reject SPC-X-only fields when spectrumX.enable is false.

## Changes
- `pkg/resolve/validate.go`: reject SPC-X-only fields when spectrumX.enable is false.

## Details
```diff
--- a/pkg/resolve/validate.go
+++ b/pkg/resolve/validate.go
@@ -1,4 +1,13 @@
-		if cfg.Profile.SpectrumX.TopologyFile != "" {
-			return fmt.Errorf("topologyFile is set but spectrumX.enable=false; remove the field or set --spectrum-x")
-		}
-	}
+		if cfg.Profile.SpectrumX.TopologyFile != "" {
+			return fmt.Errorf("topologyFile is set but spectrumX.enable=false; remove the field or set --spectrum-x")
+		}
+		if cfg.Profile.SpectrumX.SPCXVersion != "" {
+			return fmt.Errorf("spcxVersion is set but spectrumX.enable=false; remove the field or set --spectrum-x")
+		}
+		if cfg.Profile.SpectrumX.Profile != "" {
+			return fmt.Errorf("profile is set but spectrumX.enable=false; remove the field or set --spectrum-x")
+		}
+		if cfg.Profile.SpectrumX.ConfigMapName != "" {
+			return fmt.Errorf("configMapName is set but spectrumX.enable=false; remove the field or set --spectrum-x")
+		}
+	}
```

## Tests
- `pkg/resolve/validate_test.go`

```diff
func TestValidateResolvedConfig_InverseCohortSpectrumXOnlyFields(t *testing.T) {
	base := func() *config.LaunchKitConfig {
		return &config.LaunchKitConfig{
			Profile: &config.Profile{
				SpectrumX: &config.SpectrumX{Enable: false},
			},
		}
	}

	cases := []struct {
		name string
		set  func(*config.SpectrumX)
		want string
	}{
		{"multiplaneMode", func(s *config.SpectrumX) { s.MultiplaneMode = "hardware" },
			"multiplaneMode is set but spectrumX.enable=false; remove the field or set --spectrum-x"},
		{"numberOfPlanes", func(s *config.SpectrumX) { s.NumberOfPlanes = 2 },
			"numberOfPlanes is set but spectrumX.enable=false; remove the field or set --spectrum-x"},
		{"topologyType", func(s *config.SpectrumX) { s.TopologyType = "dragonfly+" },
			"topologyType is set but spectrumX.enable=false; remove the field or set --spectrum-x"},
		{"ipVersion", func(s *config.SpectrumX) { s.IPVersion = "ipv6" },
			"ipVersion is set but spectrumX.enable=false; remove the field or set --spectrum-x"},
		{"topologyFile", func(s *config.SpectrumX) { s.TopologyFile = "/tmp/topo.yaml" },
			"topologyFile is set but spectrumX.enable=false; remove the field or set --spectrum-x"},
		{"spcxVersion", func(s *config.SpectrumX) { s.SPCXVersion = "1.0.0" },
			"spcxVersion is set but spectrumX.enable=false; remove the field or set --spectrum-x"},
		{"profile", func(s *config.SpectrumX) { s.Profile = "ra2.1" },
			"profile is set but spectrumX.enable=false; remove the field or set --spectrum-x"},
		{"configMapName", func(s *config.SpectrumX) { s.ConfigMapName = "spcx-profile" },
			"configMapName is set but spectrumX.enable=false; remove the field or set --spectrum-x"},
	}

	for _, tc := range cases {
		t.Run(tc.name, func(t *testing.T) {
			cfg := base()
			tc.set(cfg.Profile.SpectrumX)
			if err := ValidateResolvedConfig(cfg); err == nil {
				t.Fatalf("expected error for %s", tc.name)
			} else if err.Error() != tc.want {
				t.Fatalf("unexpected error: got %q, want %q", err.Error(), tc.want)
			}
		})
	}
}
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).