### PR TITLE
fix: clarify cryptic top-of-template comment

### DIFF
--- a/profiles/spectrum-x-ra2.1/60-cidrpool.yaml
+++ b/profiles/spectrum-x-ra2.1/60-cidrpool.yaml
@@ -1,4 +1,4 @@
-{{- /* .ClusterConfig.PFs keeps this template in per-group render mode. */ -}}
+{{- /* Renders nv-ipam CIDRPool CRDs for each PF group. Per-group render mode is enabled by .ClusterConfig.PFs. */ -}}
 {{- $pools := spectrumXCIDRPools . .ClusterConfig }}
 {{- range $idx, $pool := $pools }}
 {{ if $idx }}---


### PR DESCRIPTION
This PR addresses the following issue in `profiles/spectrum-x-ra2.1/60-cidrpool.yaml`: clarify cryptic top-of-template comment.

## Changes
- `profiles/spectrum-x-ra2.1/60-cidrpool.yaml`: clarify cryptic top-of-template comment.

## Details
```diff
--- a/profiles/spectrum-x-ra2.1/60-cidrpool.yaml
+++ b/profiles/spectrum-x-ra2.1/60-cidrpool.yaml
@@ -1,1 +1,1 @@
-{{- /* .ClusterConfig.PFs keeps this template in per-group render mode. */ -}}
+{{- /* Renders nv-ipam CIDRPool CRDs for each PF group. Per-group render mode is enabled by .ClusterConfig.PFs. */ -}}
```

## Tests
- `profiles/spectrum-x-ra2.1/60-cidrpool_test.go`

```diff
package spectrumx

import (
	"strings"
	"testing"
)

// TestCIDRPoolsTemplateRenders verifies that the comment change does not
// break template rendering and that the output still produces CIDRPool CRDs.
func TestCIDRPoolsTemplateRenders(t *testing.T) {
	rendered, err := renderTemplate("profiles/spectrum-x-ra2.1/60-cidrpool.yaml", minimalClusterConfig())
	if err != nil {
		t.Fatalf("rendering cidrpool template: %v", err)
	}

	if !strings.Contains(rendered, "apiVersion: nv-ipam.nvidia.com/v1alpha1") {
		t.Errorf("rendered output missing expected nv-ipam apiVersion")
	}
	if !strings.Contains(rendered, "kind: CIDRPool") {
		t.Errorf("rendered output missing expected CIDRPool kind")
	}
}
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).