### PR TITLE
fix: add RA2.2 version to profile title

### DIFF
--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -1,4 +1,4 @@
-# Spectrum-X Multi-Rail Profile
+# Spectrum-X Multi-Rail Profile (RA2.2)
 
 ## Overview
 


### PR DESCRIPTION
This PR corrects the documentation in `profiles/spectrum-x-ra2.2/README.md`: add RA2.2 version to profile title.

## Changes
- `profiles/spectrum-x-ra2.2/README.md`: add RA2.2 version to profile title.

## Details
```diff
--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -1,1 +1,1 @@
-# Spectrum-X Multi-Rail Profile
+# Spectrum-X Multi-Rail Profile (RA2.2)
```

## Tests
- `profiles/spectrum-x-ra2.2/README_test.go`

```diff
package spectrum_x_ra2_2

import (
	"os"
	"strings"
	"testing"
)

func TestReadmeTitleIncludesRA2_2(t *testing.T) {
	b, err := os.ReadFile("README.md")
	if err != nil {
		t.Fatalf("failed to read README.md: %v", err)
	}
	firstLine := strings.Split(string(b), "\n")[0]
	if !strings.Contains(firstLine, "Spectrum-X Multi-Rail Profile") {
		t.Errorf("README title does not contain expected base text: %q", firstLine)
	}
	if !strings.Contains(firstLine, "RA2.2") {
		t.Errorf("README title should identify RA2.2 profile: %q", firstLine)
	}
}
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).