### PR TITLE
fix: swplb resource naming uses plane-first ordering vs rail-first

### DIFF
--- a/skills/k8s-network-engineer/references/spectrum-x-guide.md
+++ b/skills/k8s-network-engineer/references/spectrum-x-guide.md
@@ -106,12 +106,12 @@ spectrum-x-rail-pool-config-rail-1
 ### Per-Rail-Per-Plane Resources (swplb)
 
 ```
-sriov-network-node-policy-plane-0-rail-0
-sriov-network-node-policy-plane-0-rail-1
-sriov-network-node-policy-plane-1-rail-0
-sriov-network-node-policy-plane-1-rail-1
-ovs-network-plane-0-rail-0
-ovs-network-plane-1-rail-0
+sriov-network-node-policy-rail-0-plane-0
+sriov-network-node-policy-rail-0-plane-1
+sriov-network-node-policy-rail-1-plane-0
+sriov-network-node-policy-rail-1-plane-1
+ovs-network-rail-0-plane-0
+ovs-network-rail-0-plane-1
 ```
 
 ## CIDRPool Configuration


### PR DESCRIPTION
This PR addresses the following issue in `skills/k8s-network-engineer/references/spectrum-x-guide.md`: swplb resource naming uses plane-first ordering vs rail-first.

## Changes
- `skills/k8s-network-engineer/references/spectrum-x-guide.md`: swplb resource naming uses plane-first ordering vs rail-first.

## Details
```diff
--- a/skills/k8s-network-engineer/references/spectrum-x-guide.md
+++ b/skills/k8s-network-engineer/references/spectrum-x-guide.md
@@ -1,10 +1,10 @@
-### Per-Rail-Per-Plane Resources (swplb)
-
-```
-sriov-network-node-policy-plane-0-rail-0
-sriov-network-node-policy-plane-0-rail-1
-sriov-network-node-policy-plane-1-rail-0
-sriov-network-node-policy-plane-1-rail-1
-ovs-network-plane-0-rail-0
-ovs-network-plane-1-rail-0
-```
+### Per-Rail-Per-Plane Resources (swplb)
+
+```
+sriov-network-node-policy-rail-0-plane-0
+sriov-network-node-policy-rail-0-plane-1
+sriov-network-node-policy-rail-1-plane-0
+sriov-network-node-policy-rail-1-plane-1
+ovs-network-rail-0-plane-0
+ovs-network-rail-0-plane-1
+```
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).