### PR TITLE
fix: validate pod==0 for 2-tier IPv4 Spectrum-X allocation

### DIFF
--- a/pkg/networkoperatorplugin/spectrumx/addressing.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing.go
@@ -419,6 +419,9 @@ func ipv4HostLeafMiddleOctets(spcx *config.ProfileSpectrumX, plane, rail, pod, s
 		if su < 0 || su > 63 {
 			return 0, 0, fmt.Errorf("su %d exceeds the supported 6-bit SU field", su)
 		}
+		if pod != 0 {
+			return 0, 0, fmt.Errorf("pod %d must be zero for 2-tier IPv4 allocation", pod)
+		}
 		if planeAware {
 			if plane < 0 || plane > 3 {
 				return 0, 0, fmt.Errorf("plane %d exceeds the supported 2-bit plane field", plane)


### PR DESCRIPTION
This PR addresses the following issue in `pkg/networkoperatorplugin/spectrumx/addressing.go`: validate pod==0 for 2-tier IPv4 Spectrum-X allocation.

## Changes
- `pkg/networkoperatorplugin/spectrumx/addressing.go`: validate pod==0 for 2-tier IPv4 Spectrum-X allocation.

## Details
```diff
--- a/pkg/networkoperatorplugin/spectrumx/addressing.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing.go
@@ -1,5 +1,8 @@
-	case config.SpectrumXTopology2Tier:
-		if su < 0 || su > 63 {
-			return 0, 0, fmt.Errorf("su %d exceeds the supported 6-bit SU field", su)
-		}
-		if planeAware {
+	case config.SpectrumXTopology2Tier:
+		if su < 0 || su > 63 {
+			return 0, 0, fmt.Errorf("su %d exceeds the supported 6-bit SU field", su)
+		}
+		if pod != 0 {
+			return 0, 0, fmt.Errorf("pod %d must be zero for 2-tier IPv4 allocation", pod)
+		}
+		if planeAware {
```

## Tests
- `pkg/networkoperatorplugin/spectrumx/addressing_2tier_test.go`

```diff
--- /dev/null
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_2tier_test.go
@@ -0,0 +1,37 @@
+package spectrumx
+
+import (
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+func TestAllocateIPv4HostLeaf_2TierPodValidation(t *testing.T) {
+	spcx := &config.ProfileSpectrumX{
+		IPVersion:    config.SpectrumXIPVersionIPv4,
+		TopologyType: config.SpectrumXTopology2Tier,
+	}
+
+	cases := []struct {
+		name string
+		mode string
+	}{
+		{"non-plane-aware", ""},
+		{"plane-aware-swplb", "swplb"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spcx.MultiplaneMode = tc.mode
+			if _, _, err := allocateIPv4HostLeaf(spcx, 0, 0, 1, 0, 0); err == nil {
+				t.Fatal("expected error for non-zero pod in 2-tier IPv4 allocation")
+			} else if want := "pod 1 must be zero for 2-tier IPv4 allocation"; err.Error() != want {
+				t.Fatalf("unexpected error: got %q, want %q", err.Error(), want)
+			}
+
+			if _, _, err := allocateIPv4HostLeaf(spcx, 0, 0, 0, 0, 0); err != nil {
+				t.Fatalf("unexpected error for pod=0 with mode %q: %v", tc.mode, err)
+			}
+		})
+	}
+}
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).