### PR TITLE
fix: group generation example uses wrong flag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,12 +568,12 @@ embedded config used by `--for` when no file is selected is not written.
 
 ### Generate Deployment Files for a Specific Node Group
 
-In heterogeneous clusters, discovery produces multiple node groups. Use `--group` to generate manifests for a single group:
+In heterogeneous clusters, discovery produces multiple node groups. Use `--groups` to generate manifests for a single group:
 
 ```bash
 l8k generate --user-config ./config.yaml \
     --fabric infiniband --deployment-type sriov --multirail \
-    --group group-0 \
+    --groups group-0 \
     --save-deployment-files ./deployments
 ```
 


### PR DESCRIPTION
This PR corrects the documentation in `README.md`: group generation example uses wrong flag name.

## Changes
- `README.md`: group generation example uses wrong flag name.

## Details
```diff
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-### Generate Deployment Files for a Specific Node Group
-
-In heterogeneous clusters, discovery produces multiple node groups. Use `--group` to generate manifests for a single group:
-
-```bash
-l8k generate --user-config ./config.yaml \
-    --fabric infiniband --deployment-type sriov --multirail \
-    --group group-0 \
-    --save-deployment-files ./deployments
-```
+### Generate Deployment Files for a Specific Node Group
+
+In heterogeneous clusters, discovery produces multiple node groups. Use `--groups` to generate manifests for a single group:
+
+```bash
+l8k generate --user-config ./config.yaml \
+    --fabric infiniband --deployment-type sriov --multirail \
+    --groups group-0 \
+    --save-deployment-files ./deployments
+```
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).