### PR TITLE
fix: align machine/gpu identifier example with derivation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1370,7 +1370,7 @@ Kubernetes size limits without making similar hardware identities collide.
 Example of discovered hardware types in the config:
 ```yaml
 clusterConfig:
-- identifier: group-0
+- identifier: thinksystem-sr680a-v3-nvidia-h100-nvl
   machineType: ThinkSystem-SR680a-V3
   gpuType: NVIDIA-H100-NVL
   workerNodes:


### PR DESCRIPTION
Per Greptile review, the README example for the discovered hardware identifier must be lowercase because discovery normalizes generated identifiers to lowercase.

## Changes
- `README.md`: change the example `clusterConfig` identifier to lowercase.

## Details
```diff
--- a/README.md
+++ b/README.md
@@ -1370,7 +1370,7 @@ Example of discovered hardware types in the config:
 ```yaml
 clusterConfig:
-- identifier: ThinkSystem-SR680a-V3-NVIDIA-H100-NVL
+- identifier: thinksystem-sr680a-v3-nvidia-h100-nvl
   machineType: ThinkSystem-SR680a-V3
   gpuType: NVIDIA-H100-NVL
   workerNodes:
```

## Tests

No Go code changed. `make test` could not be run in this environment because Go is not installed.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).
