### PR TITLE
fix: Per-group generation example uses non-existent --group flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,12 +568,12 @@ embedded config used by `--for` when no file is selected is not written.
 
 ### Generate Deployment Files for a Specific Node Group
 
-In heterogeneous clusters, discovery produces multiple node groups. Use `--group` to generate manifests for a single group:
+In heterogeneous clusters, discovery produces multiple node groups. Use `--groups` to generate manifests for a single group:
 
 ```bash
 l8k generate --user-config ./config.yaml \
     --fabric infiniband --deployment-type sriov --multirail \
-    --group group-0 \
+    --groups group-0 \
     --save-deployment-files ./deployments
 ```
 


### PR DESCRIPTION
This PR corrects the documentation in `README.md`: Per-group generation example uses non-existent --group flag.

## Changes
- `README.md`: Per-group generation example uses non-existent --group flag.

## Details
```diff
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-### Generate Deployment Files for a Specific Node Group
-
-In heterogeneous clusters, discovery produces multiple node groups. Use `--group` to generate manifests for a single group:
-
-```bash
-l8k generate --user-config ./config.yaml \
-    --fabric infiniband --deployment-type sriov --multirail \
-    --group group-0 \
-    --save-deployment-files ./deployments
-```
+### Generate Deployment Files for a Specific Node Group
+
+In heterogeneous clusters, discovery produces multiple node groups. Use `--groups` to generate manifests for a single group:
+
+```bash
+l8k generate --user-config ./config.yaml \
+    --fabric infiniband --deployment-type sriov --multirail \
+    --groups group-0 \
+    --save-deployment-files ./deployments
+```
```

## Tests
- `pkg/readme/readme_test.go`

```diff
package readme_test

import (
	"os"
	"path/filepath"
	"runtime"
	"strings"
	"testing"
)

// TestGroupExampleUsesPluralFlag ensures the per-group generate example in
// README.md uses the documented --groups flag instead of the non-existent
// --group flag.
func TestGroupExampleUsesPluralFlag(t *testing.T) {
	_, file, _, ok := runtime.Caller(0)
	if !ok {
		t.Fatal("failed to determine test file path")
	}

	// Walk up from pkg/readme/readme_test.go to the repository root.
	dir := filepath.Dir(file)
	for i := 0; i < 2; i++ {
		dir = filepath.Dir(dir)
	}

	readme := filepath.Join(dir, "README.md")
	b, err := os.ReadFile(readme)
	if err != nil {
		t.Fatalf("reading README.md: %v", err)
	}
	content := string(b)

	if strings.Contains(content, "Use `--group`") {
		t.Errorf("README.md prose references non-existent --group flag; use --groups")
	}
	if strings.Contains(content, "--group group-0") {
		t.Errorf("README.md per-group example uses non-existent --group flag; use --groups")
	}
}
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).