### PR TITLE
fix: Rename profilesConfiguredInCmd to allProfilesConfiguredInCmd

### DIFF
--- a/pkg/app/generate.go
+++ b/pkg/app/generate.go
@@ -66,10 +66,10 @@ func (l *Launcher) executeGeneration(configPath string) error {
 		}
 	}
 
-	profilesConfiguredInCmd := true
+	allProfilesConfiguredInCmd := true
 	for _, plugin := range l.plugins {
 		if !plugin.ProfileConfiguredInCmd(l.options) {
-			profilesConfiguredInCmd = false
+			allProfilesConfiguredInCmd = false
 			break
 		}
 	}
@@ -134,7 +134,7 @@ func (l *Launcher) executeGeneration(configPath string) error {
 	// is unverified, defaults skip). Deployment + Multirail always
 	// default.
 	if fullConfig.Profile == nil || fullConfig.Profile.Fabric == "" {
-		if !profilesConfiguredInCmd && len(fullConfig.ClusterConfig) == 0 {
+		if !allProfilesConfiguredInCmd && len(fullConfig.ClusterConfig) == 0 {
 			l.ui.Info("Profiles not configured, skipping deployment file generation")
 			l.logger.Info("Profiles are not configured for every plugin, skipping deployment files generation")
 			return nil


### PR DESCRIPTION
This PR addresses the following issue in `pkg/app/generate.go`: Rename profilesConfiguredInCmd to allProfilesConfiguredInCmd.

## Changes
- `pkg/app/generate.go`: Rename profilesConfiguredInCmd to allProfilesConfiguredInCmd.

## Details
```diff
--- a/pkg/app/generate.go
+++ b/pkg/app/generate.go
@@ -1,7 +1,7 @@
-	profilesConfiguredInCmd := true
-	for _, plugin := range l.plugins {
-		if !plugin.ProfileConfiguredInCmd(l.options) {
-			profilesConfiguredInCmd = false
-			break
-		}
-	}
+	allProfilesConfiguredInCmd := true
+	for _, plugin := range l.plugins {
+		if !plugin.ProfileConfiguredInCmd(l.options) {
+			allProfilesConfiguredInCmd = false
+			break
+		}
+	}
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).