### PR TITLE
fix: schema command ignores marshal errors and accepts extra args

### DIFF
--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -69,6 +68,7 @@ var schemaCmd = &cobra.Command{
 	Use:   "schema",
 	Short: "Print tool capabilities as JSON (for AI agents and automation)",
 	Long:  `Output a machine-readable JSON description of l8k's capabilities, flags, and exit codes. Designed for AI agents to programmatically discover what this tool can do.`,
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		s := schema{
 			Version:     Version,
@@ -281,8 +281,12 @@ var schemaCmd = &cobra.Command{
 			},
 		}
 		annotateSchemaFlagTargets(&s)
-		data, _ := json.MarshalIndent(s, "", "  ")
-		fmt.Println(string(data))
+		data, err := json.MarshalIndent(s, "", "  ")
+		if err != nil {
+			cmd.PrintErrln("failed to marshal schema:", err)
+			return
+		}
+		cmd.Println(string(data))
 	},
 }
 


### PR DESCRIPTION
This PR addresses the following issue in `pkg/cmd/schema.go`: schema command ignores marshal errors and accepts extra args.

## Changes
- `pkg/cmd/schema.go`: schema command ignores marshal errors and accepts extra args.

## Details
```diff
--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -1,16 +1,20 @@
-import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/spf13/cobra"
-...
-var schemaCmd = &cobra.Command{
-	Use:   "schema",
-	Short: "Print tool capabilities as JSON (for AI agents and automation)",
-	Long:  `Output a machine-readable JSON description of l8k's capabilities, flags, and exit codes. Designed for AI agents to programmatically discover what this tool can do.`,
-	Run: func(cmd *cobra.Command, args []string) {
-...
-		data, _ := json.MarshalIndent(s, "", "  ")
-		fmt.Println(string(data))
-	},
-}
+import (
+	"encoding/json"
+
+	"github.com/spf13/cobra"
+...
+var schemaCmd = &cobra.Command{
+	Use:   "schema",
+	Short: "Print tool capabilities as JSON (for AI agents and automation)",
+	Long:  `Output a machine-readable JSON description of l8k's capabilities, flags, and exit codes. Designed for AI agents to programmatically discover what this tool can do.`,
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+...
+		data, err := json.MarshalIndent(s, "", "  ")
+		if err != nil {
+			cmd.PrintErrln("failed to marshal schema:", err)
+			return
+		}
+		cmd.Println(string(data))
+	},
+}
```

## Tests
- `pkg/cmd/schema_test.go`

```diff
--- /dev/null
+++ b/pkg/cmd/schema_test.go
@@ -0,0 +1,53 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestSchemaCommand(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	schemaCmd.SetOut(&out)
+	schemaCmd.SetErr(&errOut)
+	schemaCmd.SetArgs([]string{})
+	defer func() {
+		schemaCmd.SetArgs(nil)
+		schemaCmd.SetOut(nil)
+		schemaCmd.SetErr(nil)
+	}()
+
+	if err := schemaCmd.Execute(); err != nil {
+		t.Fatalf("schema command failed: %v", err)
+	}
+	if errOut.Len() != 0 {
+		t.Errorf("unexpected stderr: %s", errOut.String())
+	}
+	output := out.String()
+	if !strings.Contains(output, `"version"`) {
+		t.Errorf("expected version key in output, got %s", output)
+	}
+	if !strings.Contains(output, Version) {
+		t.Errorf("expected version %q in output, got %s", Version, output)
+	}
+}
+
+func TestSchemaCommand_ExtraArgs(t *testing.T) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	schemaCmd.SetOut(&out)
+	schemaCmd.SetErr(&errOut)
+	schemaCmd.SetArgs([]string{"foo"})
+	defer func() {
+		schemaCmd.SetArgs(nil)
+		schemaCmd.SetOut(nil)
+		schemaCmd.SetErr(nil)
+	}()
+
+	if err := schemaCmd.Execute(); err == nil {
+		t.Fatal("expected error for extra args, got nil")
+	} else if !strings.Contains(err.Error(), "foo") {
+		t.Errorf("expected error to mention extra arg, got %v", err)
+	}
+}
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).