### PR TITLE
fix: IPv4 poolSettings uses gatewayIndex 0 but leaf is /31 index 1

### DIFF
--- a/pkg/networkoperatorplugin/spectrumx/addressing.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing.go
@@ -592,7 +592,7 @@ func poolSettings(spcx *config.ProfileSpectrumX) cidrPoolSettings {
 		}
 	}
 	return cidrPoolSettings{
-		gatewayIndex:         0,
+		gatewayIndex:         1,
 		perNodeNetworkPrefix: 31,
 		perNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 	}

--- a/pkg/networkoperatorplugin/spectrumx/addressing_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -98,7 +98,7 @@ func TestBuildCIDRPools2TierSWPLB(t *testing.T) {
 	require.Len(t, pools, 4)
 	require.Equal(t, "rail-0-plane-0-gpu-model", pools[0].Name)
 	require.Equal(t, "172.16.0.0/18", pools[0].CIDR)
-	require.Equal(t, 0, pools[0].GatewayIndex)
+	require.Equal(t, 1, pools[0].GatewayIndex)
 	require.Equal(t, 31, pools[0].PerNodeNetworkPrefix)
 	require.Equal(t, []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}}, pools[0].PerNodeExclusions)
 	require.Equal(t, []string{"172.16.0.0/18", "172.16.0.0/14"}, pools[0].Routes)
@@ -142,7 +142,7 @@ func TestBuildCIDRPools3Tier(t *testing.T) {
 	require.Equal(t, []CIDRPool{{
 		Name:                 "rail-0",
 		CIDR:                 "10.0.0.0/13",
-		GatewayIndex:         0,
+		GatewayIndex:         1,
 		PerNodeNetworkPrefix: 31,
 		PerNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 		Routes: []string{
@@ -247,7 +247,7 @@ func TestBuildCIDRPoolsFromAIR3Tier(t *testing.T) {
 	require.Equal(t, []CIDRPool{{
 		Name:                 "rail-1",
 		CIDR:                 "10.8.0.0/13",
-		GatewayIndex:         0,
+		GatewayIndex:         1,
 		PerNodeNetworkPrefix: 31,
 		PerNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 		Routes:               []string{"10.8.0.0/13", "10.0.0.0/10"},


### PR DESCRIPTION
This PR addresses the following issue in `pkg/networkoperatorplugin/spectrumx/addressing.go`: IPv4 poolSettings uses gatewayIndex 0 but leaf is /31 index 1.

## Changes
- `pkg/networkoperatorplugin/spectrumx/addressing.go`: IPv4 poolSettings uses gatewayIndex 0 but leaf is /31 index 1.

## Details
```diff
--- a/pkg/networkoperatorplugin/spectrumx/addressing.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing.go
@@ -1,5 +1,5 @@
-	return cidrPoolSettings{
-		gatewayIndex:         0,
-		perNodeNetworkPrefix: 31,
-		perNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
-	}
+	return cidrPoolSettings{
+		gatewayIndex:         1,
+		perNodeNetworkPrefix: 31,
+		perNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
+	}
```

## Tests
- `pkg/networkoperatorplugin/spectrumx/addressing_test.go`

```diff
--- /dev/null
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -0,0 +1,52 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spectrumx
+
+import (
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+func TestPoolSettingsIPv4GatewayIndex(t *testing.T) {
+	spcx := &config.ProfileSpectrumX{IPVersion: config.SpectrumXIPVersionIPv4}
+	settings := poolSettings(spcx)
+
+	if settings.gatewayIndex != 1 {
+		t.Errorf("IPv4 gatewayIndex = %d, want 1", settings.gatewayIndex)
+	}
+	if settings.perNodeNetworkPrefix != 31 {
+		t.Errorf("IPv4 perNodeNetworkPrefix = %d, want 31", settings.perNodeNetworkPrefix)
+	}
+	if len(settings.perNodeExclusions) != 1 ||
+		settings.perNodeExclusions[0].StartIndex != 1 ||
+		settings.perNodeExclusions[0].EndIndex != 1 {
+		t.Errorf("IPv4 perNodeExclusions = %v, want [{1 1}]", settings.perNodeExclusions)
+	}
+}
+
+func TestPoolSettingsIPv6GatewayIndex(t *testing.T) {
+	spcx := &config.ProfileSpectrumX{IPVersion: config.SpectrumXIPVersionIPv6}
+	settings := poolSettings(spcx)
+
+	if settings.gatewayIndex != 2 {
+		t.Errorf("IPv6 gatewayIndex = %d, want 2", settings.gatewayIndex)
+	}
+	if settings.perNodeNetworkPrefix != 64 {
+		t.Errorf("IPv6 perNodeNetworkPrefix = %d, want 64", settings.perNodeNetworkPrefix)
+	}
+}
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).
---
**Update (post-Greptile review):** The existing IPv4 `BuildCIDRPools` test expectations have been updated to `GatewayIndex: 1` to match the implementation change. The Spectrum-X addressing test suite now passes (`go test ./pkg/networkoperatorplugin/spectrumx/...`). Commit: `db62c58d28baf90bdf09476c1b1bdfb21c017a46`.