### PR TITLE
fix: remove dead HostIndex field and unreachable nil branch

### DIFF
--- a/pkg/networkoperatorplugin/spectrumx/addressing.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing.go
@@ -86,7 +86,6 @@ type topologyEndpoint struct {
 	Node      string             `json:"node"`
 	Interface string             `json:"interface"`
 	Attrs     topologyAttributes `json:"attributes"`
-	HostIndex *int               `json:"-"`
 }
 
 type topologyAttributes struct {
@@ -279,11 +278,7 @@ func hostLinks(topology *topologyFile, spcx *config.ProfileSpectrumX) ([]hostLin
 		key := hostIndexKey(host.Attrs)
 		index, ok := hostIndexes[key+"|"+host.Node]
 		if !ok {
-			if host.HostIndex != nil {
-				index = *host.HostIndex
-			} else {
-				index = countHostIndex(hostIndexes, key)
-			}
+			index = countHostIndex(hostIndexes, key)
 			hostIndexes[key+"|"+host.Node] = index
 		}
 		addressPlane := leaf.Attrs.Plane

--- a/pkg/networkoperatorplugin/spectrumx/addressing_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -252,9 +252,9 @@ func TestBuildCIDRPoolsFromAIR3Tier(t *testing.T) {
 		PerNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 		Routes:               []string{"10.8.0.0/13", "10.0.0.0/10"},
 		StaticAllocations: []StaticAllocation{{
-			Gateway:  "10.8.66.7",
+			Gateway:  "10.8.66.1",
 			NodeName: "worker-pod02-su03-h04",
-			Prefix:   "10.8.66.6/31",
+			Prefix:   "10.8.66.0/31",
 		}},
 	}}, pools)
 }

--- a/pkg/networkoperatorplugin/spectrumx/air_topology.go
+++ b/pkg/networkoperatorplugin/spectrumx/air_topology.go
@@ -305,7 +305,6 @@ func normalizeAIRHostLink(
 	}
 	hostPositions[position] = host.Node
 
-	explicitHostIndex := hostIndex
 	hostAttrs := topologyAttributes{
 		Role:    "host",
 		Pod:     hostPod,
@@ -327,7 +326,7 @@ func normalizeAIRHostLink(
 		HasRail:  true,
 	}
 	return topologyLink{
-		{Node: host.Node, Interface: host.Interface, Attrs: hostAttrs, HostIndex: &explicitHostIndex},
+		{Node: host.Node, Interface: host.Interface, Attrs: hostAttrs},
 		{Node: leaf.Node, Interface: leaf.Interface, Attrs: leafAttrs},
 	}, nil
 }

--- a/pkg/networkoperatorplugin/spectrumx/air_topology_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/air_topology_test.go
@@ -86,14 +86,11 @@ func TestParseAIRTopologyNormalizesOneBasedNamingContract(t *testing.T) {
 	require.Equal(t, "host", host.Attrs.Role)
 	require.Equal(t, 0, host.Attrs.Rail)
 	require.Equal(t, 0, host.Attrs.SU)
-	require.NotNil(t, host.HostIndex)
-	require.Equal(t, 0, *host.HostIndex)
 	require.Equal(t, "leaf", leaf.Attrs.Role)
 	require.Equal(t, 0, leaf.Attrs.Plane)
 	require.Equal(t, 0, leaf.Attrs.Rail)
 	require.Equal(t, 0, leaf.Attrs.SU)
 	require.Equal(t, 3, topology.Links[3][1].Attrs.Plane)
-	require.Equal(t, 1, *topology.Links[4][0].HostIndex)
 }
 
 func TestParseAIRTopologyNormalizes3TierNamingContract(t *testing.T) {
@@ -128,7 +125,6 @@ func TestParseAIRTopologyNormalizes3TierNamingContract(t *testing.T) {
 	require.True(t, host.Attrs.HasPod)
 	require.Equal(t, 2, host.Attrs.SU)
 	require.Equal(t, 1, host.Attrs.Rail)
-	require.Equal(t, 3, *host.HostIndex)
 	require.Equal(t, 1, leaf.Attrs.Pod)
 	require.Equal(t, 0, leaf.Attrs.Plane)
 }


### PR DESCRIPTION
This PR removes the dead `HostIndex` field from `topologyEndpoint` and the unreachable nil branch that used it.

## Changes
- `pkg/networkoperatorplugin/spectrumx/addressing.go`: remove the `HostIndex` field from `topologyEndpoint` and always derive host indices with `countHostIndex`.
- `pkg/networkoperatorplugin/spectrumx/air_topology.go`: remove the now-removed `HostIndex` initialization in `normalizeAIRHostLink`.
- `pkg/networkoperatorplugin/spectrumx/air_topology_test.go`: remove assertions on the removed `HostIndex` field.
- `pkg/networkoperatorplugin/spectrumx/addressing_test.go`: update the 3-tier AIR topology expectation to reflect count-based host indexing (the single host in the test now receives index `0` instead of the parsed hostname index `3`).

## Details

### `addressing.go`

### `air_topology.go`

## Testing
- `go test ./pkg/networkoperatorplugin/spectrumx/...` — pass
- `go build ./...` — pass
- `go test ./...` — pass