### PR TITLE
fix: IPv4 CIDRPool gatewayIndex is 0 but leaf is second /31 address

### DIFF
--- a/pkg/networkoperatorplugin/spectrumx/addressing.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing.go
@@ -592,7 +592,7 @@ func poolSettings(spcx *config.ProfileSpectrumX) cidrPoolSettings {
 		}
 	}
 	return cidrPoolSettings{
-		gatewayIndex:         0,
+		gatewayIndex:         1,
 		perNodeNetworkPrefix: 31,
 		perNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 	}

--- a/pkg/networkoperatorplugin/spectrumx/addressing_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -98,7 +98,7 @@ func TestBuildCIDRPools2TierSWPLB(t *testing.T) {
 	require.Len(t, pools, 4)
 	require.Equal(t, "rail-0-plane-0-gpu-model", pools[0].Name)
 	require.Equal(t, "172.16.0.0/18", pools[0].CIDR)
-	require.Equal(t, 0, pools[0].GatewayIndex)
+	require.Equal(t, 1, pools[0].GatewayIndex)
 	require.Equal(t, 31, pools[0].PerNodeNetworkPrefix)
 	require.Equal(t, []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}}, pools[0].PerNodeExclusions)
 	require.Equal(t, []string{"172.16.0.0/18", "172.16.0.0/14"}, pools[0].Routes)
@@ -142,7 +142,7 @@ func TestBuildCIDRPools3Tier(t *testing.T) {
 	require.Equal(t, []CIDRPool{{
 		Name:                 "rail-0",
 		CIDR:                 "10.0.0.0/13",
-		GatewayIndex:         0,
+		GatewayIndex:         1,
 		PerNodeNetworkPrefix: 31,
 		PerNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 		Routes: []string{
@@ -247,7 +247,7 @@ func TestBuildCIDRPoolsFromAIR3Tier(t *testing.T) {
 	require.Equal(t, []CIDRPool{{
 		Name:                 "rail-1",
 		CIDR:                 "10.8.0.0/13",
-		GatewayIndex:         0,
+		GatewayIndex:         1,
 		PerNodeNetworkPrefix: 31,
 		PerNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
 		Routes:               []string{"10.8.0.0/13", "10.0.0.0/10"},

--- a/pkg/networkoperatorplugin/spectrumx/pool_settings_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/pool_settings_test.go
@@ -1,0 +1,34 @@
+package spectrumx
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+)
+
+func TestPoolSettingsIPv4GatewayIndex(t *testing.T) {
+	spcx := &config.ProfileSpectrumX{IPVersion: config.SpectrumXIPVersionIPv4}
+	got := poolSettings(spcx)
+	want := cidrPoolSettings{
+		gatewayIndex:         1,
+		perNodeNetworkPrefix: 31,
+		perNodeExclusions:    []PerNodeExclusion{{StartIndex: 1, EndIndex: 1}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("poolSettings(IPv4) = %+v, want %+v", got, want)
+	}
+}
+
+func TestPoolSettingsIPv6Unchanged(t *testing.T) {
+	spcx := &config.ProfileSpectrumX{IPVersion: config.SpectrumXIPVersionIPv6}
+	got := poolSettings(spcx)
+	want := cidrPoolSettings{
+		gatewayIndex:         2,
+		perNodeNetworkPrefix: 64,
+		perNodeExclusions:    []PerNodeExclusion{{StartIndex: 2, EndIndex: 2}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("poolSettings(IPv6) = %+v, want %+v", got, want)
+	}
+}


### PR DESCRIPTION
This PR addresses the following issue in `pkg/networkoperatorplugin/spectrumx/addressing.go`: IPv4 CIDRPool gatewayIndex is 0 but leaf is second /31 address.

## Changes
- `pkg/networkoperatorplugin/spectrumx/addressing.go`: IPv4 CIDRPool gatewayIndex is 0 but leaf is second /31 address.

## Details
See the Files changed tab for the exact diff.

## Tests
- `pkg/networkoperatorplugin/spectrumx/pool_settings_test.go`

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).
---
**Update (post-Greptile review):** The remaining existing IPv4 `BuildCIDRPools` test expectations in `addressing_test.go` have been updated to `GatewayIndex: 1` so the implementation and tests agree. The Spectrum-X addressing test suite now passes (`go test ./pkg/networkoperatorplugin/spectrumx/...`). Commit: `e714cc7464d66d96522c4d45cd9739d591548066`.