### PR TITLE
fix: use spectrumXTestConfig helper in TestBuildCIDRPoolsFromAIR2Tier

### DIFF
--- a/pkg/networkoperatorplugin/spectrumx/addressing_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -188,16 +188,8 @@ func TestBuildCIDRPoolsFromAIR2Tier(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &config.LaunchKitConfig{
-				Profile: &config.Profile{SpectrumX: &config.ProfileSpectrumX{
-					Enable:         true,
-					TopologyType:   config.SpectrumXTopology2Tier,
-					IPVersion:      config.SpectrumXIPVersionIPv4,
-					TopologyFile:   topologyPath,
-					MultiplaneMode: tt.mode,
-					NumberOfPlanes: 4,
-				}},
-			}
+			cfg := spectrumXTestConfig(topologyPath, tt.mode)
+			cfg.Profile.SpectrumX.NumberOfPlanes = 4
 			pools, err := BuildCIDRPools(cfg, config.ClusterConfig{
 				WorkerNodes: []string{"worker-su01-rack01-h01", "worker-su01-rack01-h02"},
 				PFs:         []config.PFConfig{{Traffic: "east-west", Rail: &rail}},


### PR DESCRIPTION
This PR addresses the following issue in `pkg/networkoperatorplugin/spectrumx/addressing_test.go`: use spectrumXTestConfig helper in TestBuildCIDRPoolsFromAIR2Tier.

## Changes
- `pkg/networkoperatorplugin/spectrumx/addressing_test.go`: use spectrumXTestConfig helper in TestBuildCIDRPoolsFromAIR2Tier.

## Details
```diff
--- a/pkg/networkoperatorplugin/spectrumx/addressing_test.go
+++ b/pkg/networkoperatorplugin/spectrumx/addressing_test.go
@@ -1,10 +1,2 @@
-			cfg := &config.LaunchKitConfig{
-				Profile: &config.Profile{SpectrumX: &config.ProfileSpectrumX{
-					Enable:         true,
-					TopologyType:   config.SpectrumXTopology2Tier,
-					IPVersion:      config.SpectrumXIPVersionIPv4,
-					TopologyFile:   topologyPath,
-					MultiplaneMode: tt.mode,
-					NumberOfPlanes: 4,
-				}},
-			}
+			cfg := spectrumXTestConfig(topologyPath, tt.mode)
+			cfg.Profile.SpectrumX.NumberOfPlanes = 4
```

## Tests
- `pkg/networkoperatorplugin/spectrumx/addressing_test.go`

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).