### PR TITLE
fix: SR-IOV profile test asserts wrong ARP ignore sysctl key

### DIFF
--- a/pkg/networkoperatorplugin/sriov_render_test.go
+++ b/pkg/networkoperatorplugin/sriov_render_test.go
@@ -419,6 +419,7 @@ func TestNonSpectrumXProfilesRenderMetaPlugins(t *testing.T) {
 				metaPlugins := specString(t, doc, "metaPlugins")
 				require.Contains(t, metaPlugins, `"type": "tuning"`)
 				require.Contains(t, metaPlugins, `"net.ipv4.conf.all.arp_ignore": "1"`)
+				require.Contains(t, metaPlugins, `"net.ipv4.conf.IFNAME.arp_ignore": "1"`)
 				require.Contains(t, metaPlugins, `"net.ipv4.conf.IFNAME.arp_announce": "2"`)
 				require.Contains(t, metaPlugins, `"type": "sbr"`)
 				require.Less(t,


### PR DESCRIPTION
This PR addresses the following issue in `pkg/networkoperatorplugin/sriov_render_test.go`: SR-IOV profile test asserts wrong ARP ignore sysctl key.

## Changes
- `pkg/networkoperatorplugin/sriov_render_test.go`: assert both the global (`net.ipv4.conf.all.arp_ignore`) and interface-scoped (`net.ipv4.conf.IFNAME.arp_ignore`) ARP-ignore sysctl keys for non-Spectrum-X profiles.

## Details
Greptile noted that replacing the global `arp_ignore` assertion with the interface-scoped key left the global renderer output untested. The fix now asserts both entries so a regression removing either would fail the profile test.

```diff
--- a/pkg/networkoperatorplugin/sriov_render_test.go
+++ b/pkg/networkoperatorplugin/sriov_render_test.go
@@ -418,6 +418,7 @@ func TestNonSpectrumXProfilesRenderMetaPlugins(t *testing.T) {
 			for _, doc := range docs {
 				metaPlugins := specString(t, doc, "metaPlugins")
 				require.Contains(t, metaPlugins, `"type": "tuning"`)
+				require.Contains(t, metaPlugins, `"net.ipv4.conf.all.arp_ignore": "1"`)
 				require.Contains(t, metaPlugins, `"net.ipv4.conf.IFNAME.arp_ignore": "1"`)
 				require.Contains(t, metaPlugins, `"net.ipv4.conf.IFNAME.arp_announce": "2"`)
 				require.Contains(t, metaPlugins, `"type": "sbr"`)
```

## Tests
```
go test ./pkg/networkoperatorplugin/... -run TestNonSpectrumXProfilesRenderMetaPlugins -count=1 -v
```
Result: PASS

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).