### PR TITLE
fix: reuse parseDocs helper to avoid YAML split/unmarshal duplication

### DIFF
--- a/pkg/networkoperatorplugin/sriov_render_test.go
+++ b/pkg/networkoperatorplugin/sriov_render_test.go
@@ -118,7 +118,7 @@ func parseDocs(t *testing.T, name, content string) []map[string]any {
 		}
 		var doc map[string]any
 		err := yaml.UnmarshalStrict([]byte(raw), &doc)
-		require.NoErrorf(t, err, "file %s doc %d is not valid YAML:\n%s", name, i, raw)
+		require.NoErrorf(t, err, "file %s doc %d is not valid YAML (likely a glued separator):\n%s", name, i, raw)
 		docs = append(docs, doc)
 	}
 	return docs
@@ -222,22 +222,13 @@ func TestProfileManifestsAreValidMultiDocYAML(t *testing.T) {
 				if wantDocs == 0 {
 					continue // values-like file with no Kind
 				}
-				gotDocs := 0
-				for _, raw := range splitYAMLDocuments(content) {
-					if strings.TrimSpace(raw) == "" {
-						continue
-					}
-					var doc map[string]any
-					require.NoErrorf(t, yaml.UnmarshalStrict([]byte(raw), &doc),
-						"%s contains a document that is not valid YAML (likely a glued separator):\n%s", name, raw)
-					gotDocs++
-				}
-				require.Equalf(t, wantDocs, gotDocs,
+				docs := parseDocs(t, name, content)
+				require.Equalf(t, wantDocs, len(docs),
 					"%s: expected %d documents (one per `kind:`), got %d — a glued `---` separator merges documents",
-					name, wantDocs, gotDocs)
+					name, wantDocs, len(docs))
 				if strings.Contains(name, "20-ippool") {
 					sawIPPool = true
-					require.Equal(t, 8, gotDocs, "multirail IPPool must emit one valid doc per rail")
+					require.Equal(t, 8, len(docs), "multirail IPPool must emit one valid doc per rail")
 				}
 			}
 			require.True(t, sawIPPool, "expected an IPPool manifest in profile %s", p.dir)


### PR DESCRIPTION
This PR addresses the following issue in `pkg/networkoperatorplugin/sriov_render_test.go`: reuse parseDocs helper to avoid YAML split/unmarshal duplication.

## Changes
- `pkg/networkoperatorplugin/sriov_render_test.go`: consolidate strict multi-document YAML parsing in the existing `parseDocs` helper while preserving the failing document index in error messages.

## Details
Greptile noted that the refactor removed the document index from `parseDocs` diagnostics, making it harder to locate the failing document in malformed multi-document YAML. The index is restored while keeping the helper reuse.

```diff
--- a/pkg/networkoperatorplugin/sriov_render_test.go
+++ b/pkg/networkoperatorplugin/sriov_render_test.go
@@ -112,13 +112,13 @@ func metaString(t *testing.T, doc map[string]any, key string) string {
 func parseDocs(t *testing.T, name, content string) []map[string]any {
 	t.Helper()
 	var docs []map[string]any
-	for _, raw := range splitYAMLDocuments(content) {
+	for i, raw := range splitYAMLDocuments(content) {
 		if strings.TrimSpace(raw) == "" {
 			continue
 		}
 		var doc map[string]any
 		err := yaml.UnmarshalStrict([]byte(raw), &doc)
-		require.NoErrorf(t, err, "%s contains a document that is not valid YAML (likely a glued separator):\n%s", name, raw)
+		require.NoErrorf(t, err, "file %s doc %d is not valid YAML (likely a glued separator):\n%s", name, i, raw)
 		docs = append(docs, doc)
 	}
 	return docs
```

## Tests
```
go test ./pkg/networkoperatorplugin -count=1 -v
```
Result: PASS

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).