### PR TITLE
fix: add missing t.Helper() to renderSRIOV wrapper

### DIFF
--- a/pkg/networkoperatorplugin/sriov_render_test.go
+++ b/pkg/networkoperatorplugin/sriov_render_test.go
@@ -63,6 +63,7 @@ func loadSRIOVProfile(t *testing.T, dir, fabric, networkTemplate string) *profil
 // multirail mode against a grouping testdata config, exactly as the generate
 // pipeline does.
 func renderSRIOV(t *testing.T, dir, fabric, networkTemplate string) map[string]string {
+	t.Helper()
 	return renderSRIOVWithNamespaces(t, dir, fabric, networkTemplate, nil)
 }
 


### PR DESCRIPTION
This PR addresses the following issue in `pkg/networkoperatorplugin/sriov_render_test.go`: add missing t.Helper() to renderSRIOV wrapper.

## Changes
- `pkg/networkoperatorplugin/sriov_render_test.go`: add missing t.Helper() to renderSRIOV wrapper.

## Details
```diff
--- a/pkg/networkoperatorplugin/sriov_render_test.go
+++ b/pkg/networkoperatorplugin/sriov_render_test.go
@@ -1,3 +1,4 @@
-func renderSRIOV(t *testing.T, dir, fabric, networkTemplate string) map[string]string {
-	return renderSRIOVWithNamespaces(t, dir, fabric, networkTemplate, nil)
-}
+func renderSRIOV(t *testing.T, dir, fabric, networkTemplate string) map[string]string {
+	t.Helper()
+	return renderSRIOVWithNamespaces(t, dir, fabric, networkTemplate, nil)
+}
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).