### PR TITLE
fix: add missing t.Helper() to renderProfile wrapper

### DIFF
--- a/pkg/networkoperatorplugin/sriov_render_test.go
+++ b/pkg/networkoperatorplugin/sriov_render_test.go
@@ -166,6 +166,7 @@ func loadProfileFromDir(t *testing.T, dir string) *profiles.Profile {
 // renderProfile renders a whole profile (its real template set) against the
 // mixed-same-type grouping config in multirail mode.
 func renderProfile(t *testing.T, dir, fabric, deployment string) map[string]string {
+	t.Helper()
 	return renderProfileWithProfile(t, dir, &config.Profile{Fabric: fabric, Deployment: deployment, Multirail: true})
 }
 


### PR DESCRIPTION
This PR addresses the following issue in `pkg/networkoperatorplugin/sriov_render_test.go`: add missing t.Helper() to renderProfile wrapper.

## Changes
- `pkg/networkoperatorplugin/sriov_render_test.go`: add missing t.Helper() to renderProfile wrapper.

## Details
```diff
--- a/pkg/networkoperatorplugin/sriov_render_test.go
+++ b/pkg/networkoperatorplugin/sriov_render_test.go
@@ -1,3 +1,4 @@
-func renderProfile(t *testing.T, dir, fabric, deployment string) map[string]string {
-	return renderProfileWithProfile(t, dir, &config.Profile{Fabric: fabric, Deployment: deployment, Multirail: true})
-}
+func renderProfile(t *testing.T, dir, fabric, deployment string) map[string]string {
+	t.Helper()
+	return renderProfileWithProfile(t, dir, &config.Profile{Fabric: fabric, Deployment: deployment, Multirail: true})
+}
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).