### PR TITLE
fix: skip hardware fabric default when Spectrum-X forces ethernet

### DIFF
--- a/pkg/resolve/defaults.go
+++ b/pkg/resolve/defaults.go
@@ -81,7 +81,9 @@ func ApplyHardwareDefaults(cfg *config.LaunchKitConfig, opts options.Options) []
 	cfgHasSpectrumX := cfg.Profile.SpectrumX != nil && cfg.Profile.SpectrumX.Enable
 
 	// --fabric ----------------------------------------------------------
-	if cfg.Profile.Fabric == "" && opts.Fabric == "" {
+	// Spectrum-X forces ethernet fabric; skip hardware linkType default
+	// when active so the Spectrum-X branch can default it to ethernet.
+	if cfg.Profile.Fabric == "" && opts.Fabric == "" && !opts.SpectrumX && !cfgHasSpectrumX {
 		fabric, ok, reason := dominantLinkType(cfg.ClusterConfig)
 		log.Log.V(1).Info("HW default: --fabric",
 			"current", cfg.Profile.Fabric, "cliValue", opts.Fabric,


### PR DESCRIPTION
This PR addresses the following issue in `pkg/resolve/defaults.go`: skip hardware fabric default when Spectrum-X forces ethernet.

## Changes
- `pkg/resolve/defaults.go`: skip hardware fabric default when Spectrum-X forces ethernet.

## Details
```diff
--- a/pkg/resolve/defaults.go
+++ b/pkg/resolve/defaults.go
@@ -1,3 +1,5 @@
-	// --fabric ----------------------------------------------------------
-	if cfg.Profile.Fabric == "" && opts.Fabric == "" {
-		fabric, ok, reason := dominantLinkType(cfg.ClusterConfig)
+	// --fabric ----------------------------------------------------------
+	// Spectrum-X forces ethernet fabric; skip hardware linkType default
+	// when active so the Spectrum-X branch can default it to ethernet.
+	if cfg.Profile.Fabric == "" && opts.Fabric == "" && !opts.SpectrumX && !cfgHasSpectrumX {
+		fabric, ok, reason := dominantLinkType(cfg.ClusterConfig)
```

## Tests
- `pkg/resolve/defaults_test.go`

```diff
--- a/pkg/resolve/defaults_test.go
+++ b/pkg/resolve/defaults_test.go
@@ -0,0 +1,66 @@
+func TestApplyHardwareDefaults_SpectrumXSkipsFabricHardwareDefault(t *testing.T) {
+	// An InfiniBand cluster should not leave fabric=infiniband when the
+	// user enabled Spectrum-X on the CLI; the Spectrum-X branch must force
+	// ethernet.
+	cfg := &config.LaunchKitConfig{
+		ClusterConfig: []config.ClusterConfig{
+			{Identifier: "group-1", LinkType: "InfiniBand"},
+		},
+		Profile: &config.Profile{},
+	}
+	opts := options.Options{SpectrumX: true}
+
+	decisions := ApplyHardwareDefaults(cfg, opts)
+
+	if cfg.Profile.Fabric != "ethernet" {
+		t.Errorf("Spectrum-X should force fabric=ethernet, got %q", cfg.Profile.Fabric)
+	}
+
+	found := false
+	for _, d := range decisions {
+		if d.Flag == "--fabric" && d.Value == "ethernet" && d.Reason == "implied by --spectrum-x" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected Spectrum-X fabric default decision, got %v", decisions)
+	}
+}
+
+func TestApplyHardwareDefaults_ConfigSpectrumXSkipsFabricHardwareDefault(t *testing.T) {
+	// Spectrum-X can also come from the config file; hardware default must
+	// still be skipped so fabric is forced to ethernet.
+	cfg := &config.LaunchKitConfig{
+		ClusterConfig: []config.ClusterConfig{
+			{Identifier: "group-1", LinkType: "InfiniBand"},
+		},
+		Profile: &config.Profile{
+			SpectrumX: &config.ProfileSpectrumX{Enable: true},
+		},
+	}
+	opts := options.Options{}
+
+	decisions := ApplyHardwareDefaults(cfg, opts)
+
+	if cfg.Profile.Fabric != "ethernet" {
+		t.Errorf("Spectrum-X should force fabric=ethernet, got %q", cfg.Profile.Fabric)
+	}
+
+	found := false
+	for _, d := range decisions {
+		if d.Flag == "--fabric" && d.Value == "ethernet" && d.Reason == "implied by --spectrum-x" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected Spectrum-X fabric default decision, got %v", decisions)
+	}
+}
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).