### PR TITLE
fix: RA2.2 README points to non-existent 90-pod.yaml manifest

### DIFF
--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -225,10 +225,10 @@ kubectl apply -f ./output/network-operator/
 
 ## Testing
 
-Deploy the test pod to verify the configuration:
+Deploy the example DaemonSet to verify the configuration:
 
 ```bash
-kubectl apply -f 90-pod.yaml
+kubectl apply -f ./output/network-operator/90-example-daemonset.yaml
 ```
 
 Check the pod has access to all rails:


### PR DESCRIPTION
This PR corrects the documentation in `profiles/spectrum-x-ra2.2/README.md`: RA2.2 README points to non-existent 90-pod.yaml manifest.

## Changes
- `profiles/spectrum-x-ra2.2/README.md`: RA2.2 README points to non-existent 90-pod.yaml manifest.

## Details
```diff
--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -1,10 +1,10 @@

 ## Testing

-Deploy the test pod to verify the configuration:
+Deploy the example DaemonSet to verify the configuration:

 ```bash
-kubectl apply -f 90-pod.yaml
+kubectl apply -f ./output/network-operator/90-example-daemonset.yaml
 ```

 Check the pod has access to all rails:
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).