### PR TITLE
fix: RA2.2 README test command references missing 90-pod.yaml

### DIFF
--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -225,16 +225,17 @@ kubectl apply -f ./output/network-operator/
 
 ## Testing
 
-Deploy the test pod to verify the configuration:
+Deploy the example workload to verify the configuration:
 
 ```bash
-kubectl apply -f 90-pod.yaml
+kubectl apply -f ./output/network-operator/90-example-daemonset.yaml
 ```
 
-Check the pod has access to all rails:
+Check that a DaemonSet pod has access to all rails (replace `<pod-name>` with the
+name of an actual pod created by the DaemonSet):
 
 ```bash
-kubectl exec -it spectrum-x-multirail-test-pod -- sh -c "ip addr show && rdma link"
+kubectl exec -it <pod-name> -- sh -c "ip addr show && rdma link"
 ```
 
 ## Multi-Rail Topology Examples


### PR DESCRIPTION
This PR corrects the documentation in `profiles/spectrum-x-ra2.2/README.md`: RA2.2 README test command references missing 90-pod.yaml.

## Changes
- `profiles/spectrum-x-ra2.2/README.md`: RA2.2 README test command references missing 90-pod.yaml.

## Details
bash
-kubectl apply -f 90-pod.yaml
+kubectl apply -f ./output/network-operator/90-example-daemonset.yaml
 ```

-Check the pod has access to all rails:
+Check that a DaemonSet pod has access to all rails (replace `<pod-name>` with the
+name of an actual pod created by the DaemonSet):

 ```bash
-kubectl exec -it spectrum-x-multirail-test-pod -- sh -c "ip addr show && rdma link"
+kubectl exec -it <pod-name> -- sh -c "ip addr show && rdma link"
 ```
```

## Tests
- `profiles/spectrum-x-ra2.2/README.md`

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).