### PR TITLE
fix: RA2.2 README still references Network Operator v26.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
           go test -coverprofile=coverage.out ./...
           go tool cover -func=coverage.out
 
+      - name: Run shell regression tests
+        run: make shell-tests
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ PCI_IDS_NVIDIA=pkg/networkoperatorplugin/internal/pciids/nvidia.ids
 NIC_CONFIG_CRDS_DIR=pkg/nicconfigdaemon/assets/crds
 NIC_CONFIG_OPERATOR_MODULE=github.com/Mellanox/nic-configuration-operator
 
-.PHONY: all build clean test coverage deps lint docker-build docker-build-local docker-run update-readme download-sosreport update-pci-ids sync-network-operator-releases sync-nic-config-crds release release-snapshot help
+.PHONY: all build clean test shell-tests coverage deps lint docker-build docker-build-local docker-run update-readme download-sosreport update-pci-ids sync-network-operator-releases sync-nic-config-crds release release-snapshot help
 
 ## Build the binary
 build:
@@ -73,6 +73,14 @@ clean:
 ## Run tests
 test:
 	$(GOTEST) -v ./...
+
+## Run shell regression tests
+shell-tests:
+	@for script in tests/*.sh; do \
+		[ -f "$$script" ] || continue; \
+		echo "Running $$script..."; \
+		bash "$$script"; \
+	done
 
 ## Run tests with coverage
 coverage:
@@ -137,7 +145,7 @@ dev-install: build
 dev-setup: deps lint-check test
 
 ## CI pipeline
-ci: deps lint test build
+ci: deps lint test shell-tests build
 
 ## Update README with help section
 update-readme: build

--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -174,7 +174,7 @@ profile:
 ### Prerequisites
 
 1. Kubernetes cluster with SR-IOV capable nodes
-2. NVIDIA Network Operator v26.1.0 or later
+2. NVIDIA Network Operator v26.4.0 or later
 3. ConnectX-8, ConnectX-9, or BlueField-3 SuperNIC adapters
 4. Firmware compatible with Spectrum-X RA2.2
 
@@ -189,7 +189,7 @@ helm repo update
 helm install network-operator nvidia/network-operator \
   --namespace nvidia-network-operator \
   --create-namespace \
-  --version v26.1.0 \
+  --version v26.4.0 \
   -f myValues.yaml \
   --wait
 ```

--- a/tests/test_spectrum_x_readme_versions.sh
+++ b/tests/test_spectrum_x_readme_versions.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+README="profiles/spectrum-x-ra2.2/README.md"
+
+# RA2.2 must not reference the RA2.1 Network Operator version
+if grep -q 'v26\.1\.0' "$README"; then
+  echo "ERROR: $README still references Network Operator v26.1.0 (RA2.1)" >&2
+  exit 1
+fi
+
+# RA2.2 requires Network Operator 26.4+
+if ! grep -q 'v26\.4\.0' "$README"; then
+  echo "ERROR: $README does not reference the required Network Operator v26.4.0" >&2
+  exit 1
+fi
+
+echo "OK: $README references the correct Network Operator version for RA2.2"


### PR DESCRIPTION
This PR corrects the documentation in `profiles/spectrum-x-ra2.2/README.md`: RA2.2 README still references Network Operator v26.1.0.

## Changes
- `profiles/spectrum-x-ra2.2/README.md`: update the prerequisite and Helm installation example to Network Operator v26.4.0.
- `tests/test_spectrum_x_readme_versions.sh`: add a regression check that fails if the README references v26.1.0 or omits v26.4.0.
- `Makefile`: add a `shell-tests` target and include it in the `ci` target so the regression check runs locally.
- `.github/workflows/ci.yml`: add a "Run shell regression tests" step to the test job so the check runs in CI.

## Details
```diff
--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -1,3 +1,3 @@
-2. NVIDIA Network Operator v26.1.0 or later
-...
-  --version v26.1.0 \\
+2. NVIDIA Network Operator v26.4.0 or later
+...
+  --version v26.4.0 \\
```

## Tests
```
make shell-tests
```
Result: PASS

```
go test ./pkg/networkoperatorplugin/... -count=1
```
Result: PASS

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).