### PR TITLE
fix: update stale Network Operator version for RA2.2 profile

### DIFF
--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -1,4 +1,4 @@
-# Spectrum-X Multi-Rail Profile
+# Spectrum-X Multi-Rail Profile (RA2.2)
 
 ## Overview
 
@@ -174,7 +174,7 @@ profile:
 ### Prerequisites
 
 1. Kubernetes cluster with SR-IOV capable nodes
-2. NVIDIA Network Operator v26.1.0 or later
+2. NVIDIA Network Operator v26.4.1 or later
 3. ConnectX-8, ConnectX-9, or BlueField-3 SuperNIC adapters
 4. Firmware compatible with Spectrum-X RA2.2
 
@@ -189,7 +189,7 @@ helm repo update
 helm install network-operator nvidia/network-operator \
   --namespace nvidia-network-operator \
   --create-namespace \
-  --version v26.1.0 \
+  --version v26.4.1 \
   -f myValues.yaml \
   --wait
 ```


### PR DESCRIPTION
This PR corrects the documentation in `profiles/spectrum-x-ra2.2/README.md`: update stale Network Operator version for RA2.2 profile.

## Changes
- `profiles/spectrum-x-ra2.2/README.md`: update stale Network Operator version for RA2.2 profile.

## Details
See the Files changed tab for the exact diff.

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).