### PR TITLE
fix: RA2.2 README title and versions still refer to 26.1

### DIFF
--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -1,8 +1,8 @@
-# Spectrum-X Multi-Rail Profile
+# Spectrum-X Multi-Rail Profile (RA2.2, Network Operator 26.4)
 
 ## Overview
 
-The Spectrum-X profile provides optimized multi-rail networking with OVS hardware offload, DOCA acceleration, and advanced NIC firmware configuration specifically designed for AI workloads.
+The Spectrum-X RA2.2 profile provides optimized multi-rail networking with OVS hardware offload, DOCA acceleration, and advanced NIC firmware configuration specifically designed for AI workloads.
 
 ## Features
 
@@ -174,7 +174,7 @@ profile:
 ### Prerequisites
 
 1. Kubernetes cluster with SR-IOV capable nodes
-2. NVIDIA Network Operator v26.1.0 or later
+2. NVIDIA Network Operator v26.4.0
 3. ConnectX-8, ConnectX-9, or BlueField-3 SuperNIC adapters
 4. Firmware compatible with Spectrum-X RA2.2
 
@@ -189,7 +189,7 @@ helm repo update
 helm install network-operator nvidia/network-operator \
   --namespace nvidia-network-operator \
   --create-namespace \
-  --version v26.1.0 \
+  --version v26.4.0 \
   -f myValues.yaml \
   --wait
 ```


### PR DESCRIPTION
This PR corrects the documentation in `profiles/spectrum-x-ra2.2/README.md`: RA2.2 README title and versions still refer to 26.1.

## Changes
- `profiles/spectrum-x-ra2.2/README.md`: RA2.2 README title and versions still refer to 26.1.

## Details
```diff
--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -1,5 +1,5 @@
-# Spectrum-X Multi-Rail Profile
+# Spectrum-X Multi-Rail Profile (RA2.2, Network Operator 26.4)

 ## Overview

@@ -1,9 +1,9 @@
 ### Prerequisites

 1. Kubernetes cluster with SR-IOV capable nodes
-2. NVIDIA Network Operator v26.1.0 or later
+2. NVIDIA Network Operator v26.4.0
 3. ConnectX-8, ConnectX-9, or BlueField-3 SuperNIC adapters
 4. Firmware compatible with Spectrum-X RA2.2
```

## Tests
- `profiles/spectrum-x-ra2.2/README.md`

```diff
Add a markdown lint or grep assertion in the profile CI checks that fails if `profiles/spectrum-x-ra2.2/README.md` contains `v26.1.0` or an unqualified `Spectrum-X Multi-Rail Profile` title.
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).