### PR TITLE
fix: update test manifest path to match generated file

### DIFF
--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -225,16 +225,17 @@ kubectl apply -f ./output/network-operator/
 
 ## Testing
 
-Deploy the test pod to verify the configuration:
+Deploy the test DaemonSet to verify the configuration:
 
 ```bash
-kubectl apply -f 90-pod.yaml
+kubectl apply -f ./output/network-operator/90-example-daemonset.yaml
 ```
 
-Check the pod has access to all rails:
+Check that a DaemonSet pod has access to all rails (replace `<pod-name>` with the
+name of an actual pod created by the DaemonSet):
 
 ```bash
-kubectl exec -it spectrum-x-multirail-test-pod -- sh -c "ip addr show && rdma link"
+kubectl exec -it <pod-name> -- sh -c "ip addr show && rdma link"
 ```
 
 ## Multi-Rail Topology Examples


### PR DESCRIPTION
This PR corrects the documentation in `profiles/spectrum-x-ra2.2/README.md`: update test manifest path to match generated file.

## Changes
- `profiles/spectrum-x-ra2.2/README.md`: update test manifest path to match generated file.

## Details
```diff
--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -1,13 +1,14 @@
 ## Testing
 
-Deploy the test pod to verify the configuration:
+Deploy the test DaemonSet to verify the configuration:
 
 ```bash
-kubectl apply -f 90-pod.yaml
+kubectl apply -f ./output/network-operator/90-example-daemonset.yaml
 ```
 
-Check the pod has access to all rails:
+Check that a DaemonSet pod has access to all rails (replace `<pod-name>` with the
+name of an actual pod created by the DaemonSet):
 
 ```bash
-kubectl exec -it spectrum-x-multirail-test-pod -- sh -c "ip addr show && rdma link"
+kubectl exec -it <pod-name> -- sh -c "ip addr show && rdma link"
 ```
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).
