### PR TITLE
fix: RA2.3 README test command references missing 90-pod.yaml

### DIFF
--- a/profiles/spectrum-x/README.md
+++ b/profiles/spectrum-x/README.md
@@ -242,16 +242,22 @@ kubectl apply -f ./output/network-operator/
 
 ## Testing
 
-Deploy the test pod to verify the configuration:
+Deploy the example DaemonSet to verify the configuration:
 
 ```bash
-kubectl apply -f 90-pod.yaml
+kubectl apply -f ./output/network-operator/90-example-daemonset-<identifier>.yaml
 ```
 
-Check the pod has access to all rails:
+Wait for the DaemonSet to be ready, then run a command in one of its pods.
+Because Kubernetes object names are bounded to 63 characters, the DaemonSet
+name inside the manifest may differ from the filename identifier when the
+group identifier is long. Extract the actual name from the rendered manifest
+(replace `<identifier>` with the group identifier from your generated filename):
 
 ```bash
-kubectl exec -it spectrum-x-multirail-test-pod -- sh -c "ip addr show && rdma link"
+DS_NAME=$(sed -n 's/^  name: //p' ./output/network-operator/90-example-daemonset-<identifier>.yaml | head -n1)
+kubectl rollout status daemonset/$DS_NAME
+kubectl exec -it daemonset/$DS_NAME -- sh -c "ip addr show && rdma link"
 ```
 
 ## Multi-Rail Topology Examples

--- a/tests/spectrum-x/readme_test.sh
+++ b/tests/spectrum-x/readme_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+README="profiles/spectrum-x/README.md"
+
+# Verify the README no longer references the obsolete standalone Pod manifest.
+if grep -qE '\b90-pod\.yaml\b' "$README"; then
+  echo "ERROR: $README references obsolete 90-pod.yaml"
+  exit 1
+fi
+
+# Verify the README references the generated DaemonSet manifest, with an
+# optional group-identifier suffix (e.g. 90-example-daemonset-<identifier>.yaml).
+if ! grep -qE '\b90-example-daemonset(-[^.]+)?\.yaml\b' "$README"; then
+  echo "ERROR: $README does not reference 90-example-daemonset.yaml"
+  exit 1
+fi
+
+# Verify the README documents deriving the bounded DaemonSet name from the
+# rendered manifest. Long identifiers are truncated/hashed in the Kubernetes
+# object name, so substituting the filename identifier directly would fail.
+if ! grep -qE 'DS_NAME=.*90-example-daemonset' "$README"; then
+  echo "ERROR: $README does not document deriving the DaemonSet name from the manifest"
+  exit 1
+fi
+
+echo "OK: README references the expected Spectrum-X example DaemonSet manifest and documents bounded-name lookup"


### PR DESCRIPTION
This PR corrects the documentation in `profiles/spectrum-x/README.md`: RA2.3 README test command references missing 90-pod.yaml.

## Changes
- `profiles/spectrum-x/README.md`: RA2.3 README test command references missing 90-pod.yaml, and documents deriving the actual bounded DaemonSet name from the rendered manifest so long identifiers do not fail.
- `tests/spectrum-x/readme_test.sh`: add a regression test that verifies the README no longer references the obsolete Pod manifest, references the generated DaemonSet manifest (with optional identifier suffix), and documents bounded-name lookup.

## Details
```diff
--- a/profiles/spectrum-x/README.md
+++ b/profiles/spectrum-x/README.md
@@ -1,13 +1,18 @@
 ## Testing
 
-Deploy the test pod to verify the configuration:
+Deploy the example DaemonSet to verify the configuration:
 
 ```bash
-kubectl apply -f 90-pod.yaml
+kubectl apply -f ./output/network-operator/90-example-daemonset-<identifier>.yaml
 ```
 
-Check the pod has access to all rails:
+Wait for the DaemonSet to be ready, then run a command in one of its pods.
+Because Kubernetes object names are bounded to 63 characters, the DaemonSet
+name inside the manifest may differ from the filename identifier when the
+group identifier is long. Extract the actual name from the rendered manifest
+(replace `<identifier>` with the group identifier from your generated filename):
 
 ```bash
-kubectl exec -it spectrum-x-multirail-test-pod -- sh -c "ip addr show && rdma link"
+DS_NAME=$(sed -n 's/^  name: //p' ./output/network-operator/90-example-daemonset-<identifier>.yaml | head -n1)
+kubectl rollout status daemonset/$DS_NAME
+kubectl exec -it daemonset/$DS_NAME -- sh -c "ip addr show && rdma link"
 ```
```

## Tests
- `tests/spectrum-x/readme_test.sh`

```bash
$ ./tests/spectrum-x/readme_test.sh
OK: README references the expected Spectrum-X example DaemonSet manifest and documents bounded-name lookup
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).