### PR TITLE
fix: RA2.3 README points to non-existent 90-pod.yaml manifest

### DIFF
--- a/profiles/spectrum-x/README.md
+++ b/profiles/spectrum-x/README.md
@@ -245,7 +245,7 @@ kubectl apply -f ./output/network-operator/
 Deploy the test pod to verify the configuration:
 
 ```bash
-kubectl apply -f 90-pod.yaml
+kubectl apply -f 90-example-daemonset.yaml
 ```
 
 Check the pod has access to all rails:


### PR DESCRIPTION
This PR corrects the documentation in `profiles/spectrum-x/README.md`: RA2.3 README points to non-existent 90-pod.yaml manifest.

## Changes
- `profiles/spectrum-x/README.md`: RA2.3 README points to non-existent 90-pod.yaml manifest.

## Details
```diff
--- a/profiles/spectrum-x/README.md
+++ b/profiles/spectrum-x/README.md
@@ -1,1 +1,1 @@
-kubectl apply -f 90-pod.yaml
+kubectl apply -f 90-example-daemonset.yaml
```

## Tests
- `profiles/spectrum-x/test_readme.py`

```diff
--- /dev/null
+++ b/profiles/spectrum-x/test_readme.py
@@ -0,0 +1,11 @@
+import re
+from pathlib import Path
+
+
+def test_readme_apply_targets_exist_in_generated_list():
+    readme = Path(__file__).with_name('README.md')
+    content = readme.read_text()
+    generated = set(re.findall(r'`(\d{2}-[\w-]+\.yaml)`', content))
+    apply_targets = re.findall(r'kubectl apply -f\s+(\S+\.yaml)', content)
+    missing = [t for t in apply_targets if Path(t).name not in generated]
+    assert not missing, f'ReADME kubectl apply targets not listed as generated: {missing}'
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).