### PR TITLE
fix: RA2.3 l8k invocation omits required generate subcommand

### DIFF
--- a/profiles/spectrum-x/README.md
+++ b/profiles/spectrum-x/README.md
@@ -234,7 +234,7 @@ sriov-network-operator:
 
 ```bash
 # Generate deployment files
-l8k --user-config config.yaml --save-deployment-files ./output
+l8k generate --user-config config.yaml --save-deployment-files ./output
 
 # Apply manifests
 kubectl apply -f ./output/network-operator/


### PR DESCRIPTION
This PR corrects the documentation in `profiles/spectrum-x/README.md`: RA2.3 l8k invocation omits required generate subcommand.

## Changes
- `profiles/spectrum-x/README.md`: RA2.3 l8k invocation omits required generate subcommand.

## Details
```diff
--- a/profiles/spectrum-x/README.md
+++ b/profiles/spectrum-x/README.md
@@ -1,1 +1,1 @@
-l8k --user-config config.yaml --save-deployment-files ./output
+l8k generate --user-config config.yaml --save-deployment-files ./output
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).