### PR TITLE
fix: quote numeric deviceID example to match declared string type

### DIFF
--- a/skills/k8s-network-engineer/references/config-schema.md
+++ b/skills/k8s-network-engineer/references/config-schema.md
@@ -279,19 +279,19 @@ clusterConfig:
       - worker-0
       - worker-1
     pfs:
-      - deviceID: 1023
+      - deviceID: "1023"
         pciAddress: "0000:05:00.0"
         rdmaDevice: ""
         networkInterface: ""
         traffic: east-west
         rail: 0
-      - deviceID: 1023
+      - deviceID: "1023"
         pciAddress: "0000:75:00.0"
         rdmaDevice: ""
         networkInterface: ""
         traffic: east-west
         rail: 1
-      - deviceID: 1023
+      - deviceID: "1023"
         pciAddress: "0000:6a:00.0"
         rdmaDevice: ""
         networkInterface: ""


### PR DESCRIPTION
This PR addresses the following issue in `skills/k8s-network-engineer/references/config-schema.md`: quote numeric deviceID example to match declared string type.

## Changes
- `skills/k8s-network-engineer/references/config-schema.md`: quote numeric deviceID example to match declared string type.

## Details
```diff
--- a/skills/k8s-network-engineer/references/config-schema.md
+++ b/skills/k8s-network-engineer/references/config-schema.md
@@ -1,17 +1,17 @@
-      - deviceID: 1023
-        pciAddress: "0000:05:00.0"
-        rdmaDevice: ""
-        networkInterface: ""
-        traffic: east-west
-        rail: 0
-      - deviceID: 1023
-        pciAddress: "0000:75:00.0"
-        rdmaDevice: ""
-        networkInterface: ""
-        traffic: east-west
-        rail: 1
-      - deviceID: 1023
-        pciAddress: "0000:6a:00.0"
-        rdmaDevice: ""
-        networkInterface: ""
-        traffic: north-south
+      - deviceID: "1023"
+        pciAddress: "0000:05:00.0"
+        rdmaDevice: ""
+        networkInterface: ""
+        traffic: east-west
+        rail: 0
+      - deviceID: "1023"
+        pciAddress: "0000:75:00.0"
+        rdmaDevice: ""
+        networkInterface: ""
+        traffic: east-west
+        rail: 1
+      - deviceID: "1023"
+        pciAddress: "0000:6a:00.0"
+        rdmaDevice: ""
+        networkInterface: ""
+        traffic: north-south
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).