### PR TITLE
fix: align UNLOAD_THIRD_PARTY_RDMA_MODULES description with glossary

### DIFF
--- a/skills/k8s-network-engineer/references/config-schema.md
+++ b/skills/k8s-network-engineer/references/config-schema.md
@@ -33,8 +33,8 @@ Controls DOCA/OFED driver deployment in the NicClusterPolicy.
 | `unloadThirdPartyRDMAModules`   | bool   | `true`                           | Unload kernel modules that depend on MLX/OFED drivers    |
 
 When `unloadThirdPartyRDMAModules` is true and dependent modules are discovered,
-the generated NicClusterPolicy includes `UNLOAD_THIRD_PARTY_RDMA_MODULES` env var
-(space-separated module names) in the ofedDriver section.
+the generated NicClusterPolicy sets the `UNLOAD_THIRD_PARTY_RDMA_MODULES` env var
+to `"true"` (a boolean flag) in the ofedDriver section.
 
 ## maintenance
 


### PR DESCRIPTION
This PR fixes a script issue in `skills/k8s-network-engineer/references/config-schema.md`: align UNLOAD_THIRD_PARTY_RDMA_MODULES description with glossary.

## Changes
- `skills/k8s-network-engineer/references/config-schema.md`: align UNLOAD_THIRD_PARTY_RDMA_MODULES description with glossary.

## Details
```diff
--- a/skills/k8s-network-engineer/references/config-schema.md
+++ b/skills/k8s-network-engineer/references/config-schema.md
@@ -1,3 +1,3 @@
-When `unloadThirdPartyRDMAModules` is true and dependent modules are discovered,
-the generated NicClusterPolicy includes `UNLOAD_THIRD_PARTY_RDMA_MODULES` env var
-(space-separated module names) in the ofedDriver section.
+When `unloadThirdPartyRDMAModules` is true and dependent modules are discovered,
+the generated NicClusterPolicy sets the `UNLOAD_THIRD_PARTY_RDMA_MODULES` env var
+to `"true"` (a boolean flag) in the ofedDriver section.
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).