### PR TITLE
spectrum-x: set pciPerformanceOptimized in the RA2.3 NIC template

### DIFF
--- a/profiles/spectrum-x/30-nicconfigurationtemplate.yaml
+++ b/profiles/spectrum-x/30-nicconfigurationtemplate.yaml
@@ -22,3 +22,6 @@ spec:
       multiplaneMode: "{{.Profile.SpectrumX.MultiplaneMode}}"  # none, swplb, hwplb
       numberOfPlanes: {{.Profile.SpectrumX.NumberOfPlanes}}
       overlay: "{{.SpectrumX.Overlay}}"
+    pciPerformanceOptimized:
+      enabled: true
+      maxReadRequest: 4096


### PR DESCRIPTION
The RA 2.3 deployment guide prescribes `pciPerformanceOptimized` on the `NicConfigurationTemplate`:

```yaml
    pciPerformanceOptimized:
      enabled: true
      maxReadRequest: 4096
```

Source: *NVIDIA Spectrum-X Deployment Guide v2.3 - GB300 NVL72*, "NIC Configuration Template" (p.122).

`profiles/spectrum-x/30-nicconfigurationtemplate.yaml` doesn't emit it, so a generated RA2.3 deployment leaves PCI max read request at the device default. Everything else in that template already matches the guide — `numVfs: 1`, `linkType: Ethernet`, `nicSelector.pciAddresses`, and the profile ConfigMap reference.

Three lines, no template logic, no flags.

## Scope

RA2.3 only. RA2.1 configures NIC tuning on the host rather than through `NicConfigurationTemplate` — its K8s appendix has no such resource — and RA2.2 is cancelled. Neither of those profiles emits the block today and this PR leaves them alone.

## Testing

`go build ./...` and `go test ./...` both clean.