### PR TITLE
Detect netplan-managed NIC names during discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ the daemon and its CRDs are created in a dedicated namespace, used to publish
 `NicDevice` CRs, and torn down when discovery finishes. This phase can be
 skipped if you provide your own configuration file. Discovery also resolves
 missing profile settings and stores the final values in `cluster-config.yaml`.
+Because `NicDevice` does not expose MAC addresses, Launch Kit reads them
+transiently from sysfs on every worker and checks whether host netplan uses a
+matching `match.macaddress` plus `set-name` rule. The group-level
+`netplanManaged` result identifies potential naming conflicts with udev rules
+deployed by NIC Configuration Operator; host-specific MACs are not saved.
 
 ### Select the Deployment Profile
 Discovery fills missing profile values from hardware and built-in defaults.
@@ -1536,6 +1541,16 @@ state checks) live in the parent `pkg/networkoperatorplugin` package and
 are reachable from there for callers that need them. The release catalog
 that powers `WithRelease` is exposed separately at
 `pkg/networkoperatorplugin/releases` (`LookupRelease`, `SupportedReleases`).
+
+Per-PF host attributes that `NicDevice` does not expose use the integration
+point in `pkg/networkoperatorplugin/discovery/gputopology.go`:
+`pfDiscoveryProbeCmd` walks NVIDIA/Mellanox physical PCI functions once and emits
+PCI-keyed `key=value` records, `parsePFDiscoveryBlock` retains those records,
+and consumers either map stable attributes into `config.PFConfig` through
+`applyPFDiscoveryAttributes` or use node-specific attributes transiently for a
+group-level decision. Add new per-PF probes through that path so each worker
+keeps a single batched sysfs walk. NUMA is persisted per PF; MAC addresses are
+used only to derive `ClusterConfig.NetplanManaged` and are never serialized.
 
 ### Docker
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -301,6 +301,7 @@ clusterConfig:
   - identifier: pe-xe9680-h200
     machineType: PowerEdge-XE9680
     gpuType: NVIDIA-H200
+    netplanManaged: true
     capabilities:
       nodes:
         sriov: true
@@ -324,6 +325,7 @@ Fresh discovery may merge compatible source groups during generation, but it kee
 | `identifier` | Lowercase resource-name form of machine/GPU identity with complete `NVIDIA` segments removed and common machine segments shortened (`ThinkSystem` → `ts`, `PowerEdge` → `pe`), bounded to 30 bytes with balanced machine/GPU prefixes and a 6-character deterministic hash when needed, or `group-N` fallback. The Launch Kit machine node label uses the same value. |
 | `machineType` / `gpuType` | Discovered hardware identity. |
 | `linkType` | Per-group `Ethernet` or `InfiniBand` result when fabric probes agree. |
+| `netplanManaged` | `true` when any worker has an NVIDIA PF selected by a netplan `match.macaddress` stanza with a non-empty `set-name`; indicates a potential conflict with NCO udev naming. |
 | `presetApplied` | An exact topology preset was applied. |
 | `presetDeviation` | PF count, PCI address, or device ID drift from a matched preset. |
 | `capabilities.nodes` | Group-level SR-IOV, RDMA, and InfiniBand capability flags. |
@@ -332,4 +334,7 @@ Fresh discovery may merge compatible source groups during generation, but it kee
 | `storageModules` / `thirdPartyRDMAModules` | Optional site-supplied dependent module lists. |
 | `pfs` | Physical-function inventory. |
 
-Each PF can include `deviceID`, `pciAddress`, `rdmaDevice`, `networkInterface`, `traffic`, `rail`, `psid`, `partNumber`, `model`, `numaNode`, `connectedGPU`, `connectedGPUPCIAddress`, and `gpuProximity`.
+Each PF can include `deviceID`, `pciAddress`, `rdmaDevice`, `networkInterface`,
+`traffic`, `rail`, `psid`, `partNumber`, `model`, `numaNode`, `connectedGPU`,
+`connectedGPUPCIAddress`, and `gpuProximity`. PF MAC addresses are
+host-specific and are not part of the saved configuration.

--- a/docs/user/discovery.md
+++ b/docs/user/discovery.md
@@ -46,13 +46,27 @@ The default `--node-selector` value is written to the saved configuration for de
 
 ## Hardware And GPU Topology
 
-For each NIC, discovery records the device ID, PCI address, RDMA device, network interface, VPD identifiers, model, traffic direction, and rail. GPU and host details use layered sources:
+For each NIC, discovery records the device ID, PCI address, RDMA device,
+network interface, VPD identifiers, model, traffic direction, and rail. GPU and
+host details use layered sources:
 
 1. Existing `nvidia.com/gpu.machine` and `nvidia.com/gpu.product` node labels.
 2. DMI data and `nvidia-smi` from the temporary daemon pod.
 3. Sysfs PCI data and the embedded NVIDIA subset of `pci.ids` when `nvidia-smi` is unavailable.
 
-GPU topology probing adds NUMA, connected GPU, GPU PCI address, and proximity data per PF. A PIX-proximate NIC-to-GPU path can override heuristic traffic classification and trigger rail reassignment. Probe failures are non-fatal; discovery keeps the hardware data it can confirm.
+The same batched sysfs probe adds the NUMA node and reads current PF MAC
+addresses transiently. On every worker, discovery compares those addresses
+with host netplan device stanzas that contain both `match.macaddress` and a
+non-empty `set-name`. If any NVIDIA PF matches on any worker in a hardware
+group, the saved group has `netplanManaged: true`; otherwise it is `false`.
+This flags a potential conflict between netplan naming and udev rules deployed
+by NIC Configuration Operator without storing host-unique MAC addresses in the
+shared group configuration.
+
+GPU topology probing adds connected GPU, GPU PCI address, and proximity data
+per PF. A PIX-proximate NIC-to-GPU path can override heuristic traffic
+classification and trigger rail reassignment. Probe failures are non-fatal;
+discovery keeps the hardware data it can confirm.
 
 ## Profile Resolution
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -722,8 +722,13 @@ type ClusterConfig struct {
 	// IB, a non-zero sm_lid) and the verdicts agree. Otherwise omitted —
 	// the discovery couldn't prove the cluster is using a specific fabric,
 	// and downstream code should treat the field's absence as "unknown".
-	LinkType      string `yaml:"linkType,omitempty"`
-	PresetApplied bool   `yaml:"presetApplied,omitempty"`
+	LinkType string `yaml:"linkType,omitempty"`
+	// NetplanManaged is true when discovery finds, on any worker in the
+	// group, an NVIDIA PF whose current MAC is selected by a host netplan
+	// match.macaddress stanza with a non-empty set-name. Such naming may
+	// conflict with udev rules deployed by NIC Configuration Operator.
+	NetplanManaged bool `yaml:"netplanManaged"`
+	PresetApplied  bool `yaml:"presetApplied,omitempty"`
 	// PresetDeviation lists discrepancies between the matched preset and
 	// the cluster's actually-discovered hardware. When non-empty, the
 	// preset was applied (so rail/NUMA topology fields are populated) but

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -343,6 +343,22 @@ func TestDefaultConfigYAMLReturnsFreshCopy(t *testing.T) {
 	assert.NotEqual(t, byte('X'), b[0])
 }
 
+func TestClusterConfigNetplanManagedYAMLRoundTrip(t *testing.T) {
+	input := ClusterConfig{NetplanManaged: true}
+
+	marshaled, err := yaml.Marshal(input)
+	require.NoError(t, err)
+	assert.Contains(t, string(marshaled), "netplanManaged: true")
+
+	var reloaded ClusterConfig
+	require.NoError(t, yaml.Unmarshal(marshaled, &reloaded))
+	assert.True(t, reloaded.NetplanManaged)
+
+	marshaled, err = yaml.Marshal(ClusterConfig{NetplanManaged: false})
+	require.NoError(t, err)
+	assert.Contains(t, string(marshaled), "netplanManaged: false")
+}
+
 func TestNormalizeSpectrumXProfileConfigFromFullConfigMap(t *testing.T) {
 	spcx := &ProfileSpectrumX{
 		Profile: `apiVersion: v1

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -189,6 +189,7 @@ profile:
 
 clusterConfig:
   - identifier: ""
+    netplanManaged: false # True when any worker has an NVIDIA PF selected by a netplan match.macaddress + set-name rule
     capabilities:
       nodes:
         sriov: true # has nodes with feature.node.kubernetes.io/pci-15b3.present=true

--- a/pkg/networkoperatorplugin/discovery/discover.go
+++ b/pkg/networkoperatorplugin/discovery/discover.go
@@ -254,11 +254,13 @@ func DiscoverClusterConfig(ctx context.Context, c client.Client, restConfig *res
 				}
 			}
 
-			// Probe GPU topology from nvidia-smi: populates NumaNode,
-			// ConnectedGPU, GPUProximity per PF; if any PF has PIX to a GPU,
-			// the PIX-gate override rewrites Traffic and re-runs rails.
-			// Failures are non-fatal; when nvidia-smi is absent, today's
-			// part-number classification continues to govern.
+			// Probe GPU topology plus node-local per-PF attributes. This
+			// populates NumaNode, ConnectedGPU, and GPUProximity per PF and
+			// derives the group-level NetplanManaged flag without persisting
+			// host-specific MACs. If any PF has PIX to a GPU, the PIX-gate
+			// override rewrites Traffic and re-runs rails. Failures are
+			// non-fatal; when nvidia-smi is absent, today's part-number
+			// classification continues to govern.
 			discoverGPUTopology(ctx, restConfig,
 				nicconfigdaemon.Namespace, group, dsPods)
 

--- a/pkg/networkoperatorplugin/discovery/gputopology.go
+++ b/pkg/networkoperatorplugin/discovery/gputopology.go
@@ -19,10 +19,13 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"io"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
 
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -30,29 +33,98 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 )
 
-// topologyProbeCmd runs in the nic-configuration-daemon pod. It emits three
-// blocks (some may be empty):
-//  1. nvidia-smi --query-gpu CSV: "<index>, <pci.bus_id>"
-//     --- TOPO --- marker
-//  2. nvidia-smi topo -mp output (matrix + NIC legend)
-//     --- NUMA --- marker
-//  3. Per-Mellanox-PF lines: "<pci>|<numa_node>"
-//
-// The shell is wrapped so that missing/crashing nvidia-smi keeps the overall
-// exit code at 0 (stdout simply lacks the nvidia-smi blocks). The sysfs NUMA
-// walk always runs independently of nvidia-smi.
-const topologyProbeCmd = `if [ -x /host/usr/bin/nvidia-smi ]; then
+// gpuTopologyProbeCmd emits the nvidia-smi-owned part of the batched topology
+// probe. Missing or crashing nvidia-smi keeps the overall exit code at 0 so
+// the independent per-PF sysfs discovery still runs.
+const gpuTopologyProbeCmd = `if [ -x /host/usr/bin/nvidia-smi ]; then
   export LD_LIBRARY_PATH=/host/usr/lib/x86_64-linux-gnu:/host/usr/lib/aarch64-linux-gnu:$LD_LIBRARY_PATH
   /host/usr/bin/nvidia-smi --query-gpu=index,pci.bus_id --format=csv,noheader 2>/dev/null || true
   echo '---TOPO---'
   /host/usr/bin/nvidia-smi topo -mp 2>/dev/null || true
-fi
-echo '---NUMA---'
+fi`
+
+// pfDiscoveryProbeCmd is the integration point for host attributes that are
+// unavailable from NicDevice. It walks every NVIDIA/Mellanox physical PCI
+// function once and emits an extensible record keyed by normalized PCI address:
+//
+//	<pci>|<attribute>=<value>|<attribute>=<value>...
+//
+// To add a per-PF discovery feature, collect another key=value attribute in
+// this walk and preserve it in parsePFDiscoveryBlock. From there, either map
+// it onto PFConfig in applyPFDiscoveryAttributes or consume it transiently for
+// a node-local/group-level discovery decision. Empty attributes are omitted,
+// and a failure to read one attribute must not prevent the other attributes or
+// PFs from being reported.
+const pfDiscoveryProbeCmd = `echo '---PF---'
 for d in /sys/bus/pci/devices/*; do
   v=$(cat "$d/vendor" 2>/dev/null) || continue
   [ "$v" = "0x15b3" ] || continue
-  echo "$(basename "$d")|$(cat "$d/numa_node" 2>/dev/null || echo -1)"
+  [ -e "$d/physfn" ] && continue
+
+  pci=$(basename "$d")
+  numa=$(cat "$d/numa_node" 2>/dev/null || echo -1)
+  printf '%s|numaNode=%s' "$pci" "$numa"
+
+  mac=''
+  for address_file in "$d"/net/*/address; do
+    [ -r "$address_file" ] || continue
+    mac=$(cat "$address_file" 2>/dev/null || true)
+    [ -n "$mac" ] && break
+  done
+  [ -n "$mac" ] && printf '|macAddress=%s' "$mac"
+  printf '\n'
 done`
+
+const (
+	netplanMarker     = "---NETPLAN---"
+	netplanFileMarker = "---NETPLAN-FILE---"
+)
+
+// netplanDiscoveryProbeCmd emits a sanitized structural projection of the
+// host's netplan files. Only empty mapping keys, YAML document separators,
+// match.macaddress, and set-name values leave the node; unrelated settings
+// (including credentials) are never copied into the exec response.
+//
+// The Go parser uses the retained YAML indentation to determine whether a MAC
+// match and set-name belong to the same netplan device stanza.
+const netplanDiscoveryProbeCmd = `echo '---NETPLAN---'
+for netplan_file in /host/etc/netplan/*.yaml /host/etc/netplan/*.yml; do
+  [ -r "$netplan_file" ] || continue
+  echo '---NETPLAN-FILE---'
+  awk '
+    {
+      line = $0
+      sub(/[[:space:]]+#.*$/, "", line)
+      if (line ~ /^[[:space:]]*---[[:space:]]*$/ ||
+          line ~ /^[[:space:]]*[^:#][^:]*:[[:space:]]*$/ ||
+          line ~ /^[[:space:]]*(macaddress|set-name):[[:space:]]*[^[:space:]].*$/) {
+        print line
+      }
+    }
+  ' "$netplan_file" 2>/dev/null || true
+done`
+
+// nodePFDiscoveryProbeCmd is the reusable node-local probe for per-PF
+// attributes and their host-network configuration consumers. It runs once on
+// every worker in a hardware group because MAC addresses and netplan files are
+// node-specific.
+const nodePFDiscoveryProbeCmd = pfDiscoveryProbeCmd + "\n" + netplanDiscoveryProbeCmd
+
+// topologyProbeCmd runs the representative node's GPU and node-local discovery
+// families in one pod exec. It emits four blocks (some may be empty):
+//  1. nvidia-smi --query-gpu CSV: "<index>, <pci.bus_id>"
+//     --- TOPO --- marker
+//  2. nvidia-smi topo -mp output (matrix + NIC legend)
+//     --- PF --- marker
+//  3. Per-PF key=value records emitted by pfDiscoveryProbeCmd.
+//     --- NETPLAN --- marker
+//  4. Sanitized per-file netplan projections.
+const topologyProbeCmd = gpuTopologyProbeCmd + "\n" + nodePFDiscoveryProbeCmd
+
+const (
+	pfAttributeNUMANode   = "numaNode"
+	pfAttributeMACAddress = "macAddress"
+)
 
 // proximity represents one cell of the nvidia-smi topology matrix.
 // Ordering: lower value = closer. self is a sentinel for the diagonal.
@@ -109,9 +181,15 @@ type topoData struct {
 	gpuPCI map[int]string
 	// matrix maps RDMA device name -> (GPU index -> proximity label).
 	matrix map[string]map[int]proximity
-	// numa maps normalized PCI address -> numa_node value as read from sysfs
-	// (-1 meaning "no NUMA locality").
-	numa map[string]int
+	// pfAttributes maps normalized PCI address to the extensible key=value
+	// records emitted by pfDiscoveryProbeCmd.
+	pfAttributes map[string]map[string]string
+	// netplanSetNameMACs contains canonical MAC addresses from netplan device
+	// stanzas that have both match.macaddress and a non-empty set-name.
+	netplanSetNameMACs map[string]struct{}
+	// netplanParseErrors counts malformed sanitized YAML documents. Parsing is
+	// best-effort, so valid files and documents still contribute matches.
+	netplanParseErrors int
 }
 
 // normalizePCI converts PCI addresses to a canonical lowercase 4-digit-domain
@@ -148,27 +226,38 @@ func busOf(pciAddr string) int {
 	return int(bus)
 }
 
-// parseTopologyProbe parses the three-block output emitted by topologyProbeCmd.
+// parseTopologyProbe parses the four-block output emitted by topologyProbeCmd.
 // All blocks are optional; a missing block produces an empty map on the
-// corresponding field rather than an error. The only hard error is a totally
-// unparseable input (which we treat as empty).
+// corresponding field. Unparseable per-PF lines are ignored, while malformed
+// netplan documents are counted so callers can log the partial result.
 func parseTopologyProbe(output string) topoData {
 	data := topoData{
-		gpuPCI: map[int]string{},
-		matrix: map[string]map[int]proximity{},
-		numa:   map[string]int{},
+		gpuPCI:             map[int]string{},
+		matrix:             map[string]map[int]proximity{},
+		pfAttributes:       map[string]map[string]string{},
+		netplanSetNameMACs: map[string]struct{}{},
 	}
 
 	const (
-		topoMarker = "---TOPO---"
-		numaMarker = "---NUMA---"
+		topoMarker       = "---TOPO---"
+		pfMarker         = "---PF---"
+		legacyNUMAMarker = "---NUMA---"
 	)
 
 	// Segment the output by markers.
-	var queryBlock, topoBlock, numaBlock string
+	var queryBlock, topoBlock, pfBlock, netplanBlock string
 	s := output
-	if i := strings.Index(s, numaMarker); i >= 0 {
-		numaBlock = s[i+len(numaMarker):]
+	if i := strings.Index(s, netplanMarker); i >= 0 {
+		netplanBlock = s[i+len(netplanMarker):]
+		s = s[:i]
+	}
+	if i := strings.Index(s, pfMarker); i >= 0 {
+		pfBlock = s[i+len(pfMarker):]
+		s = s[:i]
+	} else if i := strings.Index(s, legacyNUMAMarker); i >= 0 {
+		// Keep parsing captured output from the former positional NUMA-only
+		// format. New probes always emit the generic ---PF--- block.
+		pfBlock = s[i+len(legacyNUMAMarker):]
 		s = s[:i]
 	}
 	if i := strings.Index(s, topoMarker); i >= 0 {
@@ -182,7 +271,8 @@ func parseTopologyProbe(output string) topoData {
 
 	parseGPUQuery(queryBlock, data.gpuPCI)
 	parseTopoMatrix(topoBlock, data.matrix)
-	parseNUMABlock(numaBlock, data.numa)
+	parsePFDiscoveryBlock(pfBlock, data.pfAttributes)
+	data.netplanParseErrors = parseNetplanSetNameMACs(netplanBlock, data.netplanSetNameMACs)
 	return data
 }
 
@@ -341,26 +431,148 @@ func stripANSI(s string) string {
 	return b.String()
 }
 
-// parseNUMABlock parses lines like "0000:19:00.0|0" emitted by the sysfs walk.
-func parseNUMABlock(block string, out map[string]int) {
+// parsePFDiscoveryBlock parses the extensible records emitted by
+// pfDiscoveryProbeCmd. Unknown attributes are retained so adding a new probe
+// does not require changing this parser. The former positional
+// "<pci>|<numa_node>" record remains accepted for captured fixtures and
+// rolling upgrades.
+func parsePFDiscoveryBlock(block string, out map[string]map[string]string) {
 	for _, line := range strings.Split(block, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
-		parts := strings.SplitN(line, "|", 2)
-		if len(parts) != 2 {
+		parts := strings.Split(line, "|")
+		if len(parts) < 2 {
 			continue
 		}
 		pci := normalizePCI(parts[0])
 		if pci == "" {
 			continue
 		}
-		n, err := strconv.Atoi(strings.TrimSpace(parts[1]))
-		if err != nil {
+		attributes := out[pci]
+		if attributes == nil {
+			attributes = map[string]string{}
+		}
+		for i, field := range parts[1:] {
+			field = strings.TrimSpace(field)
+			if field == "" {
+				continue
+			}
+			key, value, ok := strings.Cut(field, "=")
+			if !ok {
+				if i == 0 {
+					// Legacy positional NUMA value.
+					attributes[pfAttributeNUMANode] = field
+				}
+				continue
+			}
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+			if key != "" && value != "" {
+				attributes[key] = value
+			}
+		}
+		if len(attributes) > 0 {
+			out[pci] = attributes
+		}
+	}
+}
+
+// parseNetplanSetNameMACs parses the sanitized YAML projections emitted by
+// netplanDiscoveryProbeCmd. It returns the number of malformed documents while
+// retaining matches from every valid document and file.
+func parseNetplanSetNameMACs(block string, out map[string]struct{}) int {
+	parseErrors := 0
+	for _, fileBlock := range strings.Split(block, netplanFileMarker) {
+		fileBlock = strings.TrimSpace(fileBlock)
+		if fileBlock == "" {
 			continue
 		}
-		out[pci] = n
+
+		decoder := yaml.NewDecoder(strings.NewReader(fileBlock))
+		for {
+			var document interface{}
+			err := decoder.Decode(&document)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				parseErrors++
+				break
+			}
+			collectNetplanSetNameMACs(document, out)
+		}
+	}
+	return parseErrors
+}
+
+// collectNetplanSetNameMACs recursively finds device mappings with a non-empty
+// set-name and a sibling match.macaddress. Recursion keeps the detector
+// independent of whether the stanza is under ethernets, wifis, or another
+// netplan physical-device collection.
+func collectNetplanSetNameMACs(value interface{}, out map[string]struct{}) {
+	switch typed := value.(type) {
+	case map[interface{}]interface{}:
+		setName, _ := typed["set-name"].(string)
+		match, _ := typed["match"].(map[interface{}]interface{})
+		macAddress, _ := match["macaddress"].(string)
+		if strings.TrimSpace(setName) != "" {
+			if mac := normalizeMAC(macAddress); mac != "" {
+				out[mac] = struct{}{}
+			}
+		}
+		for _, child := range typed {
+			collectNetplanSetNameMACs(child, out)
+		}
+	case []interface{}:
+		for _, child := range typed {
+			collectNetplanSetNameMACs(child, out)
+		}
+	}
+}
+
+func normalizeMAC(value string) string {
+	mac, err := net.ParseMAC(strings.TrimSpace(value))
+	if err != nil {
+		return ""
+	}
+	return mac.String()
+}
+
+// hasNetplanManagedPF reports whether a current per-PF MAC is also referenced
+// by a netplan set-name rule. PF MACs remain transient and are never copied
+// into the group-shared configuration.
+func hasNetplanManagedPF(data topoData) bool {
+	for _, attributes := range data.pfAttributes {
+		mac := normalizeMAC(attributes[pfAttributeMACAddress])
+		if mac == "" {
+			continue
+		}
+		if _, ok := data.netplanSetNameMACs[mac]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// applyPFDiscoveryAttributes is the schema boundary for per-PF probe data.
+// The parser above is intentionally generic; this function validates and maps
+// only attributes supported by PFConfig. Add future per-PF fields here rather
+// than coupling their parsing to the shell record order.
+func applyPFDiscoveryAttributes(pfs []config.PFConfig, discovered map[string]map[string]string) {
+	for i := range pfs {
+		attributes := discovered[normalizePCI(pfs[i].PciAddress)]
+		if attributes == nil {
+			continue
+		}
+
+		if value := attributes[pfAttributeNUMANode]; value != "" {
+			if numaNode, err := strconv.Atoi(value); err == nil && numaNode >= 0 {
+				n := numaNode
+				pfs[i].NumaNode = &n
+			}
+		}
 	}
 }
 
@@ -471,10 +683,85 @@ func reclassifyAndReassignRails(pfs []config.PFConfig) {
 	}
 }
 
-// discoverGPUTopology execs a single probe into the nic-configuration-daemon
-// pod for one representative node of the group, parses the output, and
-// enriches the group's PFs with NumaNode, ConnectedGPU, GPUProximity. If the
-// PIX-gate fires it additionally rewrites Traffic and re-runs rail numbering.
+func podContainerName(pod *corev1.Pod) string {
+	if pod == nil || len(pod.Spec.Containers) == 0 {
+		return ""
+	}
+	return pod.Spec.Containers[0].Name
+}
+
+// discoverGroupNetplanManagement checks every worker because both PF MAC
+// addresses and netplan files are node-local. The group-level flag is an OR:
+// one matching set-name rule is sufficient to indicate a potential naming
+// conflict with NCO-managed udev rules.
+//
+// representativeData is reused from topologyProbeCmd to avoid probing that
+// node twice. When the representative probe failed, pass nil and every worker
+// is checked with the smaller nodePFDiscoveryProbeCmd.
+func discoverGroupNetplanManagement(ctx context.Context, restConfig *rest.Config,
+	namespace string, group *config.ClusterConfig, dsPods []corev1.Pod,
+	representativePod *corev1.Pod, representativeData *topoData) {
+
+	checkedRepresentative := representativePod != nil && representativeData != nil
+	if checkedRepresentative {
+		if representativeData.netplanParseErrors > 0 {
+			log.Log.Info("Some netplan files could not be parsed during discovery",
+				"group", group.Identifier,
+				"node", representativePod.Spec.NodeName,
+				"parseErrors", representativeData.netplanParseErrors)
+		}
+		if hasNetplanManagedPF(*representativeData) {
+			group.NetplanManaged = true
+			log.Log.Info("Detected netplan-managed NVIDIA PF naming",
+				"group", group.Identifier,
+				"node", representativePod.Spec.NodeName)
+			return
+		}
+	}
+
+	for _, node := range group.WorkerNodes {
+		if checkedRepresentative && node == representativePod.Spec.NodeName {
+			continue
+		}
+		pod := findDaemonPod([]string{node}, dsPods)
+		if pod == nil {
+			log.Log.Info("No nic-configuration-daemon pod found; netplan management could not be checked",
+				"group", group.Identifier, "node", node)
+			continue
+		}
+
+		output, err := execInPod(ctx, restConfig, namespace, pod.Name, podContainerName(pod),
+			[]string{"/bin/sh", "-c", nodePFDiscoveryProbeCmd})
+		if err != nil {
+			log.Log.Error(err, "failed to exec per-PF netplan discovery probe",
+				"group", group.Identifier, "node", node, "pod", pod.Name)
+			continue
+		}
+
+		data := parseTopologyProbe(output)
+		if data.netplanParseErrors > 0 {
+			log.Log.Info("Some netplan files could not be parsed during discovery",
+				"group", group.Identifier,
+				"node", node,
+				"parseErrors", data.netplanParseErrors)
+		}
+		if hasNetplanManagedPF(data) {
+			group.NetplanManaged = true
+			log.Log.Info("Detected netplan-managed NVIDIA PF naming",
+				"group", group.Identifier,
+				"node", node)
+			return
+		}
+	}
+}
+
+// discoverGPUTopology execs a combined GPU/per-PF probe in one representative
+// nic-configuration-daemon pod, parses the output, and enriches the group's PFs
+// with the generic per-PF sysfs attributes plus ConnectedGPU and GPUProximity.
+// It also checks every other worker with the smaller node-local probe to derive
+// the group-level NetplanManaged flag without persisting host-specific MACs. If
+// the PIX-gate fires it additionally rewrites Traffic and re-runs rail
+// numbering.
 //
 // All failures are non-fatal: logged, the corresponding fields stay empty,
 // and Traffic/Rail continue to reflect whatever the part-number heuristic
@@ -485,34 +772,39 @@ func discoverGPUTopology(ctx context.Context, restConfig *rest.Config,
 	if group == nil || len(group.PFs) == 0 {
 		return
 	}
+	group.NetplanManaged = false
 
 	targetPod := findDaemonPod(group.WorkerNodes, dsPods)
 	if targetPod == nil {
-		log.Log.Info("No nic-configuration-daemon pod found on group nodes; skipping GPU topology probing",
+		log.Log.Info("No nic-configuration-daemon pod found on group nodes; skipping host topology probing",
 			"group", group.Identifier)
 		return
 	}
-	containerName := ""
-	if len(targetPod.Spec.Containers) > 0 {
-		containerName = targetPod.Spec.Containers[0].Name
-	}
 
-	output, err := execInPod(ctx, restConfig, namespace, targetPod.Name, containerName,
+	output, err := execInPod(ctx, restConfig, namespace, targetPod.Name, podContainerName(targetPod),
 		[]string{"/bin/sh", "-c", topologyProbeCmd})
 	if err != nil {
-		log.Log.Error(err, "failed to exec GPU topology probe", "pod", targetPod.Name)
+		log.Log.Error(err, "failed to exec representative host topology probe", "pod", targetPod.Name)
+		discoverGroupNetplanManagement(ctx, restConfig, namespace, group, dsPods, targetPod, nil)
 		return
 	}
 
 	data := parseTopologyProbe(output)
+	discoverGroupNetplanManagement(ctx, restConfig, namespace, group, dsPods, targetPod, &data)
 
-	// Step 1: NumaNode enrichment. Works with or without nvidia-smi.
+	// Step 1: generic per-PF sysfs enrichment. Works with or without
+	// nvidia-smi and is the integration point for attributes NicDevice does
+	// not expose.
+	applyPFDiscoveryAttributes(group.PFs, data.pfAttributes)
 	for i := range group.PFs {
-		pci := normalizePCI(group.PFs[i].PciAddress)
-		if n, ok := data.numa[pci]; ok && n >= 0 {
-			nn := n
-			group.PFs[i].NumaNode = &nn
+		pf := &group.PFs[i]
+		if pf.NumaNode == nil {
+			continue
 		}
+		log.Log.V(1).Info("PF sysfs attributes discovered",
+			"group", group.Identifier,
+			"pci", pf.PciAddress,
+			"numaNode", strconv.Itoa(*pf.NumaNode))
 	}
 
 	// Step 2: if no matrix or no GPUs, topology enrichment stops here.

--- a/pkg/networkoperatorplugin/discovery/gputopology_test.go
+++ b/pkg/networkoperatorplugin/discovery/gputopology_test.go
@@ -17,6 +17,10 @@
 package discovery
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -69,21 +73,141 @@ func TestParseGPUQuery(t *testing.T) {
 	assert.Len(t, out, 4)
 }
 
-func TestParseNUMABlock(t *testing.T) {
+func TestParsePFDiscoveryBlock(t *testing.T) {
 	in := `
-0000:19:00.0|0
-0000:5a:00.0|0
-0000:9b:00.0|1
+0000:19:00.0|numaNode=0|macAddress=02:00:00:00:00:19|futureAttribute=value
+0000:5a:00.0|numaNode=0
+0000:9b:00.0|numaNode=1|macAddress=
 0000:d8:00.0|-1
 bogus_line
 |no-pci
 `
-	out := map[string]int{}
-	parseNUMABlock(in, out)
-	assert.Equal(t, 0, out["0000:19:00.0"])
-	assert.Equal(t, 1, out["0000:9b:00.0"])
-	assert.Equal(t, -1, out["0000:d8:00.0"])
+	out := map[string]map[string]string{}
+	parsePFDiscoveryBlock(in, out)
+	assert.Equal(t, "0", out["0000:19:00.0"][pfAttributeNUMANode])
+	assert.Equal(t, "02:00:00:00:00:19", out["0000:19:00.0"][pfAttributeMACAddress])
+	assert.Equal(t, "value", out["0000:19:00.0"]["futureAttribute"])
+	assert.Equal(t, "1", out["0000:9b:00.0"][pfAttributeNUMANode])
+	assert.NotContains(t, out["0000:9b:00.0"], pfAttributeMACAddress)
+	assert.Equal(t, "-1", out["0000:d8:00.0"][pfAttributeNUMANode])
 	assert.Len(t, out, 4)
+}
+
+func TestParseNetplanSetNameMACs(t *testing.T) {
+	block := `
+---NETPLAN-FILE---
+network:
+  ethernets:
+    fabric0:
+      match:
+        macaddress: "02-00-00-00-00-19"
+      set-name: ens19
+    noRename:
+      match:
+        macaddress: "02:00:00:00:00:5a"
+---
+network:
+  wifis:
+    wireless0:
+      set-name: wlan0
+      match:
+        macaddress: "02:00:00:00:00:9b"
+---NETPLAN-FILE---
+network:
+  ethernets:
+    malformed: [
+---NETPLAN-FILE---
+network:
+  ethernets:
+    fabric1:
+      match:
+        macaddress: 02:00:00:00:00:d8
+      set-name: ens216
+`
+
+	out := map[string]struct{}{}
+	parseErrors := parseNetplanSetNameMACs(block, out)
+
+	assert.Equal(t, 1, parseErrors)
+	assert.Contains(t, out, "02:00:00:00:00:19")
+	assert.Contains(t, out, "02:00:00:00:00:9b")
+	assert.Contains(t, out, "02:00:00:00:00:d8")
+	assert.NotContains(t, out, "02:00:00:00:00:5a")
+}
+
+func TestNetplanDiscoveryProbeCmdSanitizesHostConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("probe contract requires POSIX sh and awk")
+	}
+
+	netplanDir := t.TempDir()
+	contents := `network:
+  version: 2
+  ethernets:
+    fabric0:
+      match:
+        macaddress: "02:00:00:00:00:19"
+      set-name: ens19
+      auth:
+        password: top-secret
+`
+	require.NoError(t, os.WriteFile(filepath.Join(netplanDir, "50-fabric.yaml"), []byte(contents), 0o600))
+
+	probe := strings.ReplaceAll(netplanDiscoveryProbeCmd, "/host/etc/netplan", netplanDir)
+	command := exec.Command("/bin/sh", "-c", probe) //nolint:gosec // fixed test command with a temp path
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "probe output: %s", output)
+	assert.Contains(t, string(output), `macaddress: "02:00:00:00:00:19"`)
+	assert.Contains(t, string(output), "set-name: ens19")
+	assert.NotContains(t, string(output), "top-secret")
+
+	data := parseTopologyProbe("---PF---\n0000:19:00.0|macAddress=02:00:00:00:00:19\n" + string(output))
+	assert.True(t, hasNetplanManagedPF(data))
+}
+
+func TestHasNetplanManagedPF(t *testing.T) {
+	data := topoData{
+		pfAttributes: map[string]map[string]string{
+			"0000:19:00.0": {pfAttributeMACAddress: "02-00-00-00-00-19"},
+			"0000:5a:00.0": {pfAttributeMACAddress: "not-a-mac"},
+		},
+		netplanSetNameMACs: map[string]struct{}{
+			"02:00:00:00:00:19": {},
+		},
+	}
+
+	assert.True(t, hasNetplanManagedPF(data))
+
+	data.netplanSetNameMACs = map[string]struct{}{
+		"02:00:00:00:00:5a": {},
+	}
+	assert.False(t, hasNetplanManagedPF(data))
+}
+
+func TestApplyPFDiscoveryAttributes(t *testing.T) {
+	pfs := []config.PFConfig{
+		{PciAddress: "0000:19:00.0"},
+		{PciAddress: "0000:5A:00.0"},
+		{PciAddress: "0000:9b:00.0"},
+	}
+	discovered := map[string]map[string]string{
+		"0000:19:00.0": {
+			pfAttributeNUMANode:   "0",
+			pfAttributeMACAddress: "02-00-00-00-00-19",
+			"futureAttribute":     "ignored by PFConfig mapper",
+		},
+		"0000:5a:00.0": {
+			pfAttributeNUMANode:   "not-an-int",
+			pfAttributeMACAddress: "not-a-mac",
+		},
+	}
+
+	applyPFDiscoveryAttributes(pfs, discovered)
+
+	require.NotNil(t, pfs[0].NumaNode)
+	assert.Equal(t, 0, *pfs[0].NumaNode)
+	assert.Nil(t, pfs[1].NumaNode)
+	assert.Nil(t, pfs[2].NumaNode)
 }
 
 func TestStripANSI(t *testing.T) {
@@ -241,12 +365,20 @@ NIC Legend:
   NIC2: rocep13s0f0
   NIC3: rocep55s0f0
   NIC4: rocep181s0f0
----NUMA---
-0000:22:00.0|0
+---PF---
+0000:22:00.0|numaNode=0|macAddress=02:00:00:00:00:22
 0000:22:00.1|0
 0000:0d:00.0|0
 0000:37:00.0|0
 0000:b5:00.0|1
+---NETPLAN---
+---NETPLAN-FILE---
+network:
+  ethernets:
+    fabric0:
+      match:
+        macaddress: "02:00:00:00:00:22"
+      set-name: fabric0
 `
 	data := parseTopologyProbe(output)
 	require.Len(t, data.gpuPCI, 4)
@@ -265,9 +397,12 @@ NIC Legend:
 		}
 	}
 
-	// Verify NUMA map.
-	assert.Equal(t, 0, data.numa["0000:22:00.0"])
-	assert.Equal(t, 1, data.numa["0000:b5:00.0"])
+	// Verify generic per-PF attributes, including legacy positional NUMA rows.
+	assert.Equal(t, "0", data.pfAttributes["0000:22:00.0"][pfAttributeNUMANode])
+	assert.Equal(t, "02:00:00:00:00:22", data.pfAttributes["0000:22:00.0"][pfAttributeMACAddress])
+	assert.Equal(t, "1", data.pfAttributes["0000:b5:00.0"][pfAttributeNUMANode])
+	assert.Contains(t, data.netplanSetNameMACs, "02:00:00:00:00:22")
+	assert.True(t, hasNetplanManagedPF(data))
 }
 
 // TestParseTopologyProbe_SR680a covers the DGX-class machine from the
@@ -323,16 +458,16 @@ func TestDiscoverGPUTopology_Algorithm_SR680a(t *testing.T) {
 
 	// Construct the group's PFs in PCI-ascending order, as buildClusterConfig would.
 	pfs := []config.PFConfig{
-		{PciAddress: "0000:19:00.0", RdmaDevice: "rocep25s0f0", Traffic: "east-west"},   // BF-3 slot 1
-		{PciAddress: "0000:2a:00.0", RdmaDevice: "rocep42s0f0", Traffic: "east-west"},   // BF-3 slot 2
-		{PciAddress: "0000:3b:00.0", RdmaDevice: "rocep59s0f0", Traffic: "east-west"},   // BF-3 slot 3
-		{PciAddress: "0000:4c:00.0", RdmaDevice: "rocep76s0f0", Traffic: "east-west"},   // BF-3 slot 4
-		{PciAddress: "0000:5a:00.0", RdmaDevice: "rocep90s0f0", Traffic: "north-south"}, // CX-6 Lx port 0
-		{PciAddress: "0000:5a:00.1", RdmaDevice: "rocep90s0f1", Traffic: "north-south"}, // CX-6 Lx port 1
-		{PciAddress: "0000:9b:00.0", RdmaDevice: "rocep155s0f0", Traffic: "east-west"},  // BF-3 slot 5
-		{PciAddress: "0000:ab:00.0", RdmaDevice: "rocep171s0f0", Traffic: "east-west"},  // BF-3 slot 6
-		{PciAddress: "0000:c1:00.0", RdmaDevice: "rocep193s0f0", Traffic: "east-west"},  // BF-3 slot 7
-		{PciAddress: "0000:cb:00.0", RdmaDevice: "rocep203s0f0", Traffic: "east-west"},  // BF-3 slot 8
+		{PciAddress: "0000:19:00.0", RdmaDevice: "rocep25s0f0", Traffic: "east-west"},    // BF-3 slot 1
+		{PciAddress: "0000:2a:00.0", RdmaDevice: "rocep42s0f0", Traffic: "east-west"},    // BF-3 slot 2
+		{PciAddress: "0000:3b:00.0", RdmaDevice: "rocep59s0f0", Traffic: "east-west"},    // BF-3 slot 3
+		{PciAddress: "0000:4c:00.0", RdmaDevice: "rocep76s0f0", Traffic: "east-west"},    // BF-3 slot 4
+		{PciAddress: "0000:5a:00.0", RdmaDevice: "rocep90s0f0", Traffic: "north-south"},  // CX-6 Lx port 0
+		{PciAddress: "0000:5a:00.1", RdmaDevice: "rocep90s0f1", Traffic: "north-south"},  // CX-6 Lx port 1
+		{PciAddress: "0000:9b:00.0", RdmaDevice: "rocep155s0f0", Traffic: "east-west"},   // BF-3 slot 5
+		{PciAddress: "0000:ab:00.0", RdmaDevice: "rocep171s0f0", Traffic: "east-west"},   // BF-3 slot 6
+		{PciAddress: "0000:c1:00.0", RdmaDevice: "rocep193s0f0", Traffic: "east-west"},   // BF-3 slot 7
+		{PciAddress: "0000:cb:00.0", RdmaDevice: "rocep203s0f0", Traffic: "east-west"},   // BF-3 slot 8
 		{PciAddress: "0000:d8:00.0", RdmaDevice: "rocep216s0f0", Traffic: "north-south"}, // Orphan BF-3
 	}
 

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -69,8 +69,14 @@ Each `clusterConfig[]` entry has these key fields:
 - `identifier` — group name (used for `NicNodePolicy` naming). For groups with both `machineType` and `gpuType` resolved, this is the lowercased machine/GPU identity with complete `NVIDIA` segments removed and common machine segments shortened (`ThinkSystem` → `ts`, `PowerEdge` → `pe`), bounded to 30 bytes with balanced component prefixes and a 6-character deterministic hash when needed; otherwise a fallback `group-N`. The Launch Kit machine node label uses the same value.
 - `machineType` — server model (e.g. `PowerEdge-XE9680`); populated from `nvidia.com/gpu.machine` label or DMI fallback.
 - `gpuType` — GPU SKU (e.g. `NVIDIA-H200`); populated from `nvidia.com/gpu.product` label or `nvidia-smi` fallback. **Note:** this field used to be called `productType` — the rename happened to disambiguate it from the server model. Old `productType:` keys in hand-authored configs must be renamed to `gpuType:`.
+- `netplanManaged` — true when any worker has an NVIDIA PF whose current MAC
+  is selected by a host netplan `match.macaddress` stanza with a non-empty
+  `set-name`. The flag identifies a potential conflict with NCO udev naming;
+  host-specific MACs are not persisted.
 - `capabilities.nodes.{sriov,rdma,ib}` — what the underlying hardware supports.
-- `pfs[]` — physical function list with PCI address, device ID, RDMA device, network interface, traffic class, rail, NUMA, GPU affinity, and `model` (the VPD model/description string read from `NicDevice.Status.modelName`).
+- `pfs[]` — physical function list with PCI address, device ID, RDMA device,
+  network interface, traffic class, rail, NUMA, GPU affinity, and `model` (the
+  VPD model/description string read from `NicDevice.Status.modelName`).
   - **One rail per NIC (default).** Discovery advertises one rail per physical NIC: a NIC's multi-plane east-west PFs (planes of one port, e.g. Spectrum-X ConnectX-8/9) collapse to the master PF, so an 8-PF node lists 4 east-west PFs / 4 rails. A NIC whose `model` is genuinely dual-port (`2-port`/`Dual-port`) keeps a rail per port. Run `l8k discover --collapse-nic-rails=false` to emit one rail per PF (legacy/dev behaviour).
 - `nodeSelector` — Kubernetes node selector for this group. Source groups key on the machine label written by `l8k discover`: `nvidia.kubernetes-launch-kit.machine: <identifier>`. Auto-merged groups (different machineTypes sharing a GPU type) key on `nvidia.kubernetes-launch-kit.gpu: <gpuType>` instead — the GPU label retains its discovered value, including `NVIDIA`, so the merged selector binds correctly across source machineTypes.
 - `workerNodes` — explicit hostnames (populated by discovery).

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -379,6 +379,9 @@ clusterConfig:
   - # string — Group identifier/machine label (vendor-free; common machine aliases; max 30 bytes)
     identifier: ""
 
+    # bool — Any worker has an NVIDIA PF selected by netplan match.macaddress + set-name
+    netplanManaged: false
+
     capabilities:
       nodes:
         # bool — Nodes have SR-IOV capable NICs

--- a/skills/k8s-launch-kit-discover/SKILL.md
+++ b/skills/k8s-launch-kit-discover/SKILL.md
@@ -118,6 +118,7 @@ clusterConfig:
   - identifier: "dgx-b200-h100-nvl"
     machineType: DGX-B200
     gpuType: NVIDIA-H100-NVL
+    netplanManaged: true
     capabilities:
       nodes:
         sriov: true
@@ -179,6 +180,10 @@ is false. Do not add GPU counts or resource maps under `clusterConfig`.
   profile values user input and therefore preserves them.
 - If fabric probes are mixed or unconfirmed, discovery still writes the file
   with an empty `profile.fabric`; set `--fabric` on discovery or generation.
+- `clusterConfig[].netplanManaged` is true when any worker has an NVIDIA PF
+  selected by a host netplan `match.macaddress` plus `set-name` rule. Discovery
+  checks every worker and uses PF MACs only transiently; they are not saved in
+  the shared group config.
 
 - The bootstrap namespace is **always** `nvidia-k8s-launch-kit` — not configurable. The
   daemon's SA / ClusterRole / ClusterRoleBinding are renamed to

--- a/skills/k8s-launch-kit-discover/references/discovery-internals.md
+++ b/skills/k8s-launch-kit-discover/references/discovery-internals.md
@@ -79,6 +79,38 @@ ConfigMap/stale `NicDevice` CRs; CRDs preserved), then `Ensure` deploys fresh.
 
 ---
 
+## Per-PF Discovery Integration Point
+
+`pkg/networkoperatorplugin/discovery/gputopology.go` owns the extension rails
+for host attributes that `NicDevice` does not publish:
+
+1. `pfDiscoveryProbeCmd` walks `/sys/bus/pci/devices/*` once, filters vendor
+   `0x15b3` and virtual functions, and emits one PCI-keyed record per PF:
+   `<pci>|<attribute>=<value>|...`.
+2. `parsePFDiscoveryBlock` normalizes the PCI address and retains every
+   non-empty key/value pair, including unknown keys. This makes the transport
+   format forward-compatible.
+3. Consumers choose the correct lifetime for each attribute:
+   `applyPFDiscoveryAttributes` validates stable values such as NUMA and maps
+   them onto `config.PFConfig`; node-specific values such as MAC addresses stay
+   transient and feed group-level decisions.
+
+NUMA and current netdevice MAC address use this path today. MACs are compared
+with a sanitized projection of host netplan device stanzas; a
+`match.macaddress` plus non-empty `set-name` match sets the group's
+`netplanManaged` flag. Every worker is probed because MACs and netplan files are
+node-local, and the group flag is true if any worker matches. The representative
+worker combines this with the GPU probe; other workers run only the smaller
+per-PF/netplan probe.
+
+To integrate a new per-PF field, add its best-effort read to
+`pfDiscoveryProbeCmd`, decide whether its lifetime permits persistence in
+`PFConfig` or requires transient aggregation, and extend parser/consumer tests.
+Do not add a second PCI walk on the same worker. One missing attribute must not
+suppress the other attributes or PF records.
+
+---
+
 ## Node Grouping Algorithm
 
 Nodes are grouped by their **physical-function layout**. Two nodes belong to the same


### PR DESCRIPTION
## Summary

- refactor the NVIDIA PF sysfs walk into an extensible PCI-keyed discovery path for future per-PF features
- probe every worker and compare transient PF MAC addresses with sanitized host netplan device stanzas containing `match.macaddress` and a non-empty `set-name`
- persist only the group-level `netplanManaged` boolean, using OR semantics across workers; host-specific MAC addresses are never serialized
- retain legacy NUMA probe compatibility and document the integration point across user, reference, developer, and bundled skill docs

The netplan projection exports only structural mapping keys, MAC matches, and set-name values from the node. Other netplan settings, including credentials, are not copied into the exec response.

## Testing

- `go test ./...`
- `make build`
- `golangci-lint v2.13.2 run ./...`
- `uv run --with-requirements requirements-docs.txt mkdocs build --strict`