### PR TITLE
Add Network Operator Helm skip control

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ Based on the discovered/provided configuration, generate a complete set of YAML 
 When generation uses a file-backed config, resolved defaults and CLI overrides
 are written back to that same file while its comments are preserved.
 
+Set `networkOperator.skipHelmChart: true` or pass
+`--skip-network-operator-helm` when another system manages the Network
+Operator Helm release. Generation then omits `values.yaml`; deploy skips chart
+installation and Helm preflight checks; validate skips Helm release and values
+checks; and clean retains the externally owned release. Network Operator custom
+resource generation, deployment, validation, and cleanup, component-version
+checks, stray-resource checks, and connectivity validation are unchanged.
+
 ## Installation
 
 ### Quick install (from GitHub Releases)
@@ -253,6 +261,7 @@ Host Target Common Flags:
       --network-operator-namespace string   Override the network operator namespace from the config file
       --network-operator-release string     Network Operator release line to deploy (MAJOR.MINOR). Selects component image tags + repository from a built-in catalog and drives version-gated template sections. Supported: 26.1, 26.4, 26.7
       --node-selector string                Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe (default "feature.node.kubernetes.io/pci-15b3.present=true")
+      --skip-network-operator-helm          Skip Network Operator Helm values generation, chart installation, and Helm-specific validation
       --user-config string                  Use provided cluster configuration file (as base config for discovery or as full config without discovery)
 
 Host Target Discovery Flags:
@@ -333,6 +342,12 @@ Every Kubernetes object in the generated bundle carries
 the object without replacing annotations already supplied by a profile or a
 custom workload manifest.
 
+For clusters where the Network Operator chart is managed separately, add
+`--skip-network-operator-helm` to `generate`, `deploy`, and `validate`, or set
+`networkOperator.skipHelmChart: true` once in `cluster-config.yaml`. Launch Kit
+still generates, deploys, validates, and cleans up the Network Operator custom
+resources, while `clean` leaves the externally owned Helm release installed.
+
 Apply the generated manifests to the cluster:
 
 ```bash
@@ -398,7 +413,9 @@ DMA-BUF bandwidth stage repeats the selected `ib_write_bw` matrix with
 `--use_cuda=<endpoint-index> --use_cuda_dmabuf`. Source and destination CUDA
 indices are resolved independently from each node's per-PF `connectedGPU`
 topology; missing or ambiguous mappings fail explicitly instead of falling
-back to GPU 0. The
+back to GPU 0. Helm release/version and values checks are reported as skipped
+when `networkOperator.skipHelmChart` or `--skip-network-operator-helm` is
+enabled; component and manifest checks continue. The
 matrix is on by default (`--connectivity=false` to skip) and cleans up the
 test DaemonSet unless `--keep` is set. Fresh `l8k discover` output includes
 the default validation block:
@@ -635,7 +652,7 @@ The preset YAML must declare a `capabilities.nodes.{sriov,rdma,ib}` block to be 
 l8k clean --kubeconfig ~/.kube/config
 ```
 
-The command resolves the operator namespace from an explicit
+The command resolves the operator namespace and Helm ownership from an explicit
 `--network-operator-namespace`, `networkOperator.namespace` in
 `--user-config`, `./cluster-config.yaml`, or an explicit `--config-dir`, then
 the `nvidia-network-operator` default. Custom installation namespaces must be
@@ -644,14 +661,17 @@ target. The command discovers every namespaced custom resource in that
 namespace and the known cluster-scoped Network Operator CRs, sends deletion
 requests to the complete set before monitoring any CR for finalizer completion,
 and re-sweeps both scopes before uninstalling the `network-operator` Helm
-release last. The namespace, CRDs, unrelated Secrets, files on disk, and custom
-resources outside the namespace are preserved; Helm metadata and chart-managed
-resources are removed with the release.
+release last. When the resolved config sets `networkOperator.skipHelmChart:
+true`, the release is treated as externally owned and is retained. The
+namespace, CRDs, unrelated Secrets, files on disk, and custom resources outside
+the namespace are preserved; when Helm is uninstalled, Helm metadata and
+chart-managed resources are removed with the release.
 
-Pass `--keep-helm-chart` to delete the custom resources while leaving the Helm
-release installed. Cleanup is destructive and confirms the resolved target in
-text mode. See [the cleanup guide](docs/user/cleanup.md) for the full deletion
-boundary and automation output.
+Pass `--keep-helm-chart` to retain the Helm release explicitly regardless of
+config. Both retention mechanisms leave the custom-resource cleanup boundary
+unchanged. Cleanup is destructive and confirms the resolved target and Helm
+action in text mode. See [the cleanup guide](docs/user/cleanup.md) for the full
+deletion boundary and automation output.
 
 ### Troubleshooting Network Operator Issues
 
@@ -757,6 +777,7 @@ l8k generate --user-config cluster-config.yaml \
 # Equivalent via config file
 # networkOperator:
 #   selectedRelease: "26.4"
+#   skipHelmChart: true  # manage the Helm release out of band
 
 # Discover supported releases
 l8k schema | jq '.supportedNetworkOperatorReleases'
@@ -1026,6 +1047,7 @@ Example of the configuration file discovered from the cluster:
 networkOperator:
   version: v26.1.0
   componentVersion: network-operator-v26.1.0
+  skipHelmChart: false
   repository: nvcr.io/nvidia/mellanox
   namespace: nvidia-network-operator
   imagePullSecrets: []

--- a/docs/advanced/deployment.md
+++ b/docs/advanced/deployment.md
@@ -30,6 +30,12 @@ The chart is downloaded to a temporary directory. Launch Kit does not add or mod
 
 If Helm metadata is absent, phase 0 is skipped so environments that manage the chart out of band can still apply the generated CRs.
 
+Set `networkOperator.skipHelmChart: true` or pass
+`--skip-network-operator-helm` to disable Helm management explicitly even if a
+bundle still contains `values.yaml`. Launch Kit skips phase 0 and the Helm
+chart-version/values preflight checks, but retains component-version and stray
+resource preflight checks plus every manifest apply/reconciliation phase.
+
 ## Preflight
 
 Before applying custom resources, Launch Kit compares the bundle with the cluster:
@@ -40,6 +46,9 @@ Before applying custom resources, Launch Kit compares the bundle with the cluste
 | Helm values | Installed user values differ from generated `values.yaml`. |
 | Component versions | Live `NicClusterPolicy` component versions differ from the release catalog. |
 | Stray resources | l8k-managed Network Operator CRs exist but are not in the generated bundle. Spectrum-X operator-generated `SriovNetworkPoolConfig`, `SriovNetworkNodePolicy`, and `OVSNetwork` objects are excluded. |
+
+The two Helm rows are reported as skipped when Network Operator Helm
+management is disabled. The remaining rows still gate deployment.
 
 Without `--overwrite-existing`, any mismatch stops deployment and all detected drift is reported together.
 

--- a/docs/advanced/generation.md
+++ b/docs/advanced/generation.md
@@ -57,11 +57,11 @@ deployment/
     `-- 60-example-daemonset-<group>.yaml
 ```
 
-The exact files depend on the profile:
+The exact files depend on the profile and Helm-management setting:
 
 | Order | Content |
 | --- | --- |
-| `values.yaml` | Network Operator Helm values consumed by deployment phase 0. |
+| `values.yaml` | Network Operator Helm values consumed by deployment phase 0. Omitted when `networkOperator.skipHelmChart` or `--skip-network-operator-helm` is enabled. |
 | `10` | Cluster-wide `NicClusterPolicy`. |
 | `11` | Per-group `NicNodePolicy` resources where the release/profile uses them. |
 | `20` | NV-IPAM `IPPool` resources. |
@@ -70,6 +70,23 @@ The exact files depend on the profile:
 | `40`, `60`, or `90` example | Temporary workload consumed by validation, depending on profile. |
 
 Group and namespace suffixes are added when one render produces multiple copies.
+
+## Skip Network Operator Helm Artifacts
+
+When another system owns the Network Operator Helm release, omit Launch Kit's
+Helm input while retaining the generated custom resources:
+
+```bash
+l8k generate \
+  --user-config ./cluster-config.yaml \
+  --skip-network-operator-helm \
+  --save-deployment-files ./deployment
+```
+
+The equivalent persistent setting is
+`networkOperator.skipHelmChart: true`. The plugin output directory is cleaned
+before rendering, so a `values.yaml` from an earlier run cannot remain in the
+new bundle.
 
 ## Generate Without Discovery
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -56,6 +56,7 @@ flowchart TB
 
         subgraph netop["Network Operator domain — pkg/networkoperatorplugin"]
             plugin["plugin.Plugin implementation"]
+            cfgoverrides["CLI-to-config override registry\nflag · config paths · explicit setter"]
             discovery["Discovery\nbootstrap daemon · inventory · grouping · node labels"]
             rendering["Generation\nprofile selection · templates · render plan"]
             releases["Embedded release catalog"]
@@ -78,7 +79,7 @@ flowchart TB
 
     subgraph artifacts["Host artifacts and embedded inputs"]
         clusterconfig["cluster-config.yaml"]
-        deploymentfiles["deployment/network-operator/\nvalues.yaml + ordered manifests"]
+        deploymentfiles["deployment/network-operator/\noptional values.yaml + ordered manifests"]
         report["k8s-launch-kit-validation-report.html"]
         profiledata["profiles/ · presets/ · release catalog · default config"]
     end
@@ -121,6 +122,10 @@ flowchart TB
     launcher --> presets
     launcher --> plugin
 
+    flags --> cfgoverrides
+    hostpaths --> cfgoverrides
+    plugin --> cfgoverrides
+    cfgoverrides --> config
     plugin --> discovery
     plugin --> rendering
     plugin --> deploy
@@ -195,8 +200,8 @@ flowchart LR
     discover["discover\nHost inventory and profile intent"]
     config["cluster-config.yaml\nhardware + resolved Host intent"]
     generate["generate\nselect profile and render"]
-    manifests["deployment/network-operator/\nHelm values + Kubernetes YAML"]
-    deploy["deploy\npreflight + Helm + phased SSA"]
+    manifests["deployment/network-operator/\noptional Helm values + Kubernetes YAML"]
+    deploy["deploy\npreflight + optional Helm + phased SSA"]
     live["Live Network Operator deployment"]
     validate["validate\nrelease + state + topology + data plane"]
     report["Text / JSON verdict\n+ HTML report"]
@@ -216,6 +221,21 @@ flowchart LR
 
 The legacy root command composes `discover → generate → optional deploy` in one
 Host operation. Validation deliberately remains a separate phase.
+
+`networkOperator.skipHelmChart` is a Host-specific lifecycle switch routed by
+`--skip-network-operator-helm`. It removes the `values.yaml` artifact and
+bypasses the Helm install/version/values/uninstall edges, while preserving the
+Network Operator manifest, component-version, stray-resource, data-plane, and
+custom-resource cleanup paths. Cleanup reads the persistent config setting to
+avoid removing a release owned by another system.
+
+Config-backed Host flags are registered once in the Network Operator plugin's
+CLI-to-config override registry. Each entry owns the CLI flag name, the YAML
+path or paths it controls, explicit-value detection, and the setter. Discover,
+generate, standalone deploy, and standalone validate all call the same
+`ApplyCLIConfigOverrides` boundary after loading configuration. `l8k schema`
+publishes the same registry metadata as `flags[].configPaths`, so routing and
+automation do not maintain a second flag-to-config table.
 
 ## Target binding and execution
 
@@ -258,7 +278,7 @@ It does not construct a Kubernetes client or enter any Host lifecycle service.
 flowchart TB
     subgraph deployflow["Host deploy"]
         d0["Resolve config, manifests, kubeconfig"]
-        d1["Phase 0: Helm install / upgrade"]
+        d1["Phase 0: optional Helm install / upgrade"]
         d05["Phase 0.5: drift and stray-resource preflight"]
         d2["Phase 1: NicClusterPolicy + readiness"]
         d3["Phase 2: NicNodePolicies + per-policy readiness"]
@@ -269,7 +289,7 @@ flowchart TB
 
     subgraph validateflow["Host validate"]
         v0["Resolve config, manifests, kubeconfig, preset catalog"]
-        v1["Helm release, component versions, values drift, stray CRs"]
+        v1["Optional Helm release/values, component versions, stray CRs"]
         v2["crstate manifest classification"]
         v3{"Static state terminal?"}
         v4["Connectivity matrix and optional GPUDirect DMA-BUF"]
@@ -290,7 +310,7 @@ flowchart TB
 | `pkg/target` | Names, phases, capabilities, common invocation policy, registry, operation contract | Cobra, Host options, DPF options, Kubernetes clients |
 | `pkg/target/host` | Typed Host requests, explicit-value semantics, Host path/config resolution, phase services | DPF implementation or cross-target composition |
 | `pkg/app` | Discover/generate/root workflow state and Network Operator plugin coordination | CLI parsing or process exit |
-| `pkg/networkoperatorplugin` | Host discovery, rendering, deployment state machine, validation primitives | Target selection |
+| `pkg/networkoperatorplugin` | Host CLI-to-config override registry, discovery, rendering, deployment state machine, validation primitives | Target selection |
 | `pkg/config`, `pkg/options` | Existing Host configuration and option models | A universal union of Host and DPF configuration |
 | `pkg/ui`, `pkg/errors`, `pkg/log` | Presentation, structured failures, and logging | Domain decisions |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ Each stage is independently invocable:
 - `l8k generate` renders a profile-specific manifest bundle under `deployment/network-operator/`.
 - `l8k deploy` installs or upgrades the Network Operator Helm chart, applies CRs in dependency order, and waits for reconciliation.
 - `l8k validate` runs the deployment acceptance checks and produces the report used to green-light the deployment.
-- `l8k clean` removes Network Operator custom resources and then uninstalls its Helm release.
+- `l8k clean` removes Network Operator custom resources and uninstalls its Helm release unless config marks the chart externally owned.
 
 ## Links
 

--- a/docs/integrator/ai-skills.md
+++ b/docs/integrator/ai-skills.md
@@ -20,7 +20,7 @@ AI skills are documentation for an agent. They are not Launch Kit runtime plugin
 | `k8s-launch-kit-generate` | Select a profile and render manifests. |
 | `k8s-launch-kit-dryrun` | Preview generated or server-side deployment changes. |
 | `k8s-launch-kit-deploy` | Apply generated resources in dependency order. |
-| `k8s-launch-kit-clean` | Remove Network Operator custom resources and its Helm release. |
+| `k8s-launch-kit-clean` | Remove Network Operator custom resources and uninstall or retain its Helm release according to ownership config. |
 | `k8s-launch-kit-validate` | Run deployment acceptance and interpret the validation report. |
 | `k8s-launch-kit-pipeline` | Coordinate discovery, generation, and deployment as an end-to-end flow. |
 | `k8s-launch-kit-troubleshoot` | Diagnose discovery, operator, SR-IOV, RDMA, and IPAM failures. |

--- a/docs/integrator/automation.md
+++ b/docs/integrator/automation.md
@@ -84,6 +84,10 @@ Cleanup returns a command-specific summary:
 }
 ```
 
+`cleanup.keepHelmChart` reports the effective retention policy. It is `true`
+when either `networkOperator.skipHelmChart` in the resolved config or the
+explicit `--keep-helm-chart` flag retains the release.
+
 `l8k clean --output json` auto-confirms an irreversible cluster mutation and
 has no dry-run mode. Automation must pin the intended kubeconfig and should
 pass `--network-operator-namespace` explicitly after independently checking

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 # CLI Reference
 
 Run `l8k <command> --help` for the authoritative flag list. Run `l8k schema` for machine-readable capabilities.
+Config-backed flags include a `configPaths` list in schema output, sourced
+from the same registry that applies explicit CLI values to loaded config.
 
 ## Commands
 
@@ -38,10 +40,11 @@ flag groups and `l8k schema` for each flag's `targets` list.
 | --- | --- | --- | --- |
 | `--target` | discover, generate, deploy, validate, root pipeline | target-agnostic | Target name. Defaults to `host`. |
 | `--kubeconfig` | discover, deploy, clean, validate | host | Path to kubeconfig. Falls back to `$KUBECONFIG` and then `~/.kube/config`. It represents the host workload cluster, not a universal multi-context input. |
-| `--user-config` | discover, generate, deploy, clean, validate | host | Config file to merge, render, validate against, or use for cleanup namespace resolution. |
+| `--user-config` | discover, generate, deploy, clean, validate | host | Config file to merge, render, validate against, or use for cleanup namespace and Helm-ownership resolution. |
 | `--config-dir` | all | host | Directory containing optional `l8k-config.yaml` and `presets/` overrides. |
 | `--network-operator-release` | discover, generate | host | Release line such as `26.1`, `26.4`, or `26.7`. |
 | `--network-operator-namespace` | generate, deploy, clean, validate | host | Override the Network Operator namespace. It is a no-op for discovery. |
+| `--skip-network-operator-helm` | generate, deploy, validate, root pipeline | host | Skip `values.yaml` generation, Network Operator chart installation, and Helm-specific validation. Custom-resource handling remains enabled. |
 | `--output json` | all | target-agnostic | Emit a single JSON result to stdout for automation. |
 | `--quiet` | root pipeline | target-agnostic | Suppress informational output. |
 | `--log-level` | all | target-agnostic | Enable `trace`, `debug`, `info`, `warn`, or `error` logging. `debug` shows structured progress; `trace` also shows bounded command output. |
@@ -105,6 +108,7 @@ Discovery also accepts the profile and Spectrum-X flags below. Explicit flags ov
 | `--kubeconfig` | Kubeconfig used with `--deploy`. |
 | `--dry-run` | Preview the deploy stage used with `--deploy`. |
 | `--overwrite-existing` | Allow convergence when deploy preflight finds Helm or managed-resource drift. |
+| `--skip-network-operator-helm` | Omit `values.yaml`; with `--deploy`, also skip chart installation and Helm preflight checks. |
 
 ## Deploy Flags
 
@@ -114,6 +118,7 @@ Discovery also accepts the profile and Spectrum-X flags below. Explicit flags ov
 | `--dry-run` | Use server-side dry run. |
 | `--deploy-timeout` | End-to-end deploy timeout. `0` means unbounded. |
 | `--overwrite-existing` | Allow Helm upgrade when an existing Network Operator release has different values. |
+| `--skip-network-operator-helm` | Skip chart installation and Helm chart-version/values preflight checks; still apply manifests and check component versions and strays. |
 
 ## Clean Flags
 
@@ -121,9 +126,12 @@ Discovery also accepts the profile and Spectrum-X flags below. Explicit flags ov
 Network Operator namespace and the known cluster-scoped Network Operator CRs.
 It sends deletion requests to the complete set before monitoring any CR for
 finalizer completion, then re-sweeps both scopes before uninstalling the
-`network-operator` Helm release. It preserves the namespace, CRDs, unrelated
-Secrets, generated files, and resources outside the namespace. Helm release
-metadata and chart-managed resources are removed with the release.
+`network-operator` Helm release. If the resolved config sets
+`networkOperator.skipHelmChart: true`, the release is externally owned and is
+retained instead. It preserves the namespace, CRDs, unrelated Secrets,
+generated files, and resources outside the namespace. When Helm is
+uninstalled, Helm release metadata and chart-managed resources are removed
+with the release.
 
 Namespace resolution uses the first available source: an explicit
 `--network-operator-namespace`, `networkOperator.namespace` from
@@ -134,9 +142,9 @@ in-cluster objects do not select a destructive cleanup target.
 
 | Flag | Description |
 | --- | --- |
-| `--keep-helm-chart` | Delete custom resources but leave the Network Operator Helm release and chart-managed resources installed. |
+| `--keep-helm-chart` | Delete custom resources but leave the Network Operator Helm release and chart-managed resources installed regardless of config. |
 | `--kubeconfig` | Cluster to clean. Falls back to `$KUBECONFIG` and then `~/.kube/config`. |
-| `--user-config` | Optional config used only to read `networkOperator.namespace`. |
+| `--user-config` | Optional config used only to read `networkOperator.namespace` and `networkOperator.skipHelmChart`; unrelated stale settings do not block cleanup. |
 | `--network-operator-namespace` | Explicit cleanup namespace; takes precedence over config and the standard default. |
 
 Cleanup is destructive and asks for confirmation in text mode. JSON mode is
@@ -158,6 +166,7 @@ full deletion boundary.
 | `--report-path` | HTML report path. Use `-` to disable. |
 | `--keep` | Keep the test DaemonSet after validation. |
 | `--wait` | Wait for in-progress manifests to reach a terminal state. |
+| `--skip-network-operator-helm` | Skip Helm release version and values checks; retain component, manifest, stray-resource, and connectivity checks. |
 
 Use `--log-level debug` with `validate` for structured check, endpoint, route,
 stage, batch, test, cleanup, and report timings. `--log-level trace` also emits

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -56,6 +56,7 @@ The release line fills Network Operator versions, component image tags, DOCA dri
 | `selectedRelease` | Catalog release line. Equivalent to `--network-operator-release`. |
 | `version` | Network Operator chart/operator version. Filled by the selected release. |
 | `componentVersion` | Tag used by managed component images. |
+| `skipHelmChart` | When `true`, generation omits `values.yaml`, deploy skips Network Operator chart installation and Helm preflight checks, validate skips Helm release-version and values checks, and clean retains the externally owned Helm release. Network Operator CR generation, deployment, validation, and cleanup remain enabled. Equivalent to `--skip-network-operator-helm` for generate, deploy, and validate. |
 | `repository` | Registry path for component images such as drivers, CNI, IPAM, and device plugins. |
 | `operatorRepository` | Registry path for the Network Operator controller image. |
 | `helmRepoURL` | Chart repository used by `l8k deploy`. Empty means Helm phase 0 is skipped. |
@@ -63,6 +64,18 @@ The release line fills Network Operator versions, component image tags, DOCA dri
 | `imagePullSecrets` | Secret names propagated into the discovery daemon, generated policies, and Helm values for the Network Operator and enabled subcharts. During deploy, matching credentials also authenticate the Helm chart download. |
 
 When `selectedRelease` is set, catalog values replace explicit version and repository fields so the cohort remains consistent.
+
+Use `skipHelmChart: true` when another system owns the Network Operator Helm
+release:
+
+```yaml
+networkOperator:
+  selectedRelease: "26.7"
+  skipHelmChart: true
+```
+
+The selected release still drives rendered component versions and their
+validation; only the Helm artifact/install/check/uninstall boundary is disabled.
 
 For an authenticated Helm repository, each referenced Secret must already
 exist in `networkOperator.namespace` before `l8k deploy` starts, and the

--- a/docs/user/cleanup.md
+++ b/docs/user/cleanup.md
@@ -7,7 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 
 Use `l8k clean` to tear down the Network Operator deployment on one Kubernetes
 cluster. The command removes custom resources first so the installed
-controllers can process their finalizers, then uninstalls the Helm release.
+controllers can process their finalizers, then uninstalls the Helm release
+unless the resolved config marks it externally owned.
 
 ```bash
 l8k clean --kubeconfig ~/.kube/config
@@ -35,8 +36,9 @@ The first available namespace source wins:
 Custom installation namespaces must be supplied by flag or trusted local
 config. Cleanup deliberately does not infer a destructive target from
 user-creatable in-cluster objects such as Helm release Secrets. The config is
-read only for the namespace; stale release settings elsewhere in the file do
-not block cleanup.
+read only for `networkOperator.namespace` and
+`networkOperator.skipHelmChart`; stale release settings elsewhere in the file
+do not block cleanup.
 
 ```bash
 l8k clean --kubeconfig ~/.kube/config \
@@ -59,7 +61,8 @@ Cleanup performs these operations in order:
    CR's finalizer from blocking on another CR that has not entered deletion.
 4. Re-scan both scopes and repeat the delete-all-then-wait sequence for any
    custom resources created or exposed during policy teardown.
-5. Uninstall the `network-operator` Helm release and wait for Helm-managed
+5. Unless `networkOperator.skipHelmChart: true` or `--keep-helm-chart` retains
+   it, uninstall the `network-operator` Helm release and wait for Helm-managed
    resources to be removed.
 
 Because step 1 intentionally covers every custom-resource kind, do not keep
@@ -85,8 +88,17 @@ no-ops, making the command safe to re-run after a partial cleanup.
 
 ## Keep the Helm Release
 
-Use `--keep-helm-chart` to remove the custom resources while leaving the
-Network Operator release and its chart-managed resources installed:
+When the resolved config sets `networkOperator.skipHelmChart: true`, cleanup
+treats the Network Operator Helm release as externally owned and retains it
+while still deleting the same custom resources:
+
+```yaml
+networkOperator:
+  skipHelmChart: true
+```
+
+Use `--keep-helm-chart` to request the same retention explicitly regardless of
+config:
 
 ```bash
 l8k clean --kubeconfig ~/.kube/config --keep-helm-chart
@@ -104,8 +116,8 @@ l8k clean --kubeconfig ~/.kube/config --output json 2>/dev/null | jq .
 ```
 
 A successful result includes the resolved namespace, the number of deleted
-custom resources, whether Helm removed a release, and whether
-`--keep-helm-chart` was requested:
+custom resources, whether Helm removed a release, and the effective Helm
+retention policy derived from config and `--keep-helm-chart`:
 
 ```json
 {

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -26,6 +26,12 @@ When `--user-config` is omitted, Launch Kit checks `./cluster-config.yaml`, the 
 | Preflight | Stray CRs and Helm value drift that can make the apply path ambiguous. |
 | Connectivity | ICMP, `rping`, host-memory `ib_write_bw`, and optional GPUDirect DMA-BUF bandwidth checks between generated test DaemonSet pods. |
 
+When another system owns the Network Operator Helm release, set
+`networkOperator.skipHelmChart: true` or pass
+`--skip-network-operator-helm`. The Helm release/version and values checks are
+then reported as skipped. Component versions, manifest state, stray-resource
+preflight, connectivity, and the HTML report still run.
+
 Connectivity is skipped when manifests are missing, errored, or still in progress.
 
 Each generated example DaemonSet declares two validation containers: the DOCA
@@ -40,6 +46,9 @@ probe stays on the selected Multus interface.
 Manifest-state checks for `NicConfigurationTemplate` and `NicFirmwareTemplate` use the operator-populated `status.nicDevices` list as the matched device set. An empty list, a list that does not yet reflect the current node, NIC type, PCI-address, serial-number, and part-number selectors, a missing named `NicDevice`, a device spec that does not yet reflect the current template payload, or a relevant device condition with a stale `observedGeneration` remains `IN-PROGRESS`. `NicConfigurationTemplate` considers `FirmwareUpdateInProgress` relevant only when the matched device has `spec.firmware`; a stale firmware condition cannot block a configuration-only deployment. Unrelated discovered devices are used only to verify selector freshness; their configuration and firmware state is ignored.
 
 Preflight uses the same checks as deployment: Helm chart version, generated Helm values, component versions, and stray l8k-managed CRs. SR-IOV pool configs, node policies, and OVS networks labeled with `spectrumx.nvidia.com/owner-name` are controller-owned outputs of `SpectrumXRailPoolConfig`, so they are not reported as strays. Validation never remediates drift.
+
+The Helm chart/version checks are omitted when Helm management is disabled;
+component and stray-resource checks remain active.
 
 ## Validation Modes
 

--- a/pkg/app/discover.go
+++ b/pkg/app/discover.go
@@ -106,22 +106,9 @@ func (l *Launcher) discoverClusterConfig() error {
 		l.ui.Info("Using default configuration: %s", source)
 	}
 
-	// Override namespace from CLI flag if provided
-	if l.options.NetworkOperatorNamespace != "" {
-		defaults.NetworkOperator.Namespace = l.options.NetworkOperatorNamespace
-		l.logger.Info("Using CLI override for network operator namespace", "namespace", l.options.NetworkOperatorNamespace)
-	}
-
-	// Override image pull secrets from CLI flag if provided
-	if len(l.options.ImagePullSecrets) > 0 {
-		defaults.NetworkOperator.ImagePullSecrets = l.options.ImagePullSecrets
-		l.logger.Info("Using CLI override for image pull secrets", "secrets", l.options.ImagePullSecrets)
-	}
-
-	// Apply --network-operator-release so the saved cluster-config.yaml
-	// reflects the user's chosen release line, not whatever the default
-	// l8k-config.yaml shipped with.
-	if err := networkoperatorplugin.ApplyNetworkOperatorRelease(l.options, defaults); err != nil {
+	// Apply every config-backed CLI flag through the shared mapping registry so
+	// discovery, generation, deploy, and validate use identical precedence.
+	if err := networkoperatorplugin.ApplyCLIConfigOverrides(l.options, defaults); err != nil {
 		return apperrors.NewValidationError(err.Error(), err, "Run 'l8k --help' for supported releases")
 	}
 

--- a/pkg/cmd/clean.go
+++ b/pkg/cmd/clean.go
@@ -21,11 +21,20 @@ import (
 
 var keepHelmChart bool
 
+type cleanSettings struct {
+	Namespace           string
+	NamespaceSource     string
+	KeepHelmChart       bool
+	HelmRetentionSource string
+}
+
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
 	Short: "Remove a Network Operator deployment from a Kubernetes cluster",
 	Long: `Delete custom resources associated with the Network Operator deployment and,
-by default, uninstall the network-operator Helm release.
+by default, uninstall the network-operator Helm release. When the resolved
+config sets networkOperator.skipHelmChart: true, cleanup treats the release as
+externally owned and keeps it installed.
 
 The operator namespace is resolved from --network-operator-namespace, then a
 user or explicit default config, and finally defaults to
@@ -35,8 +44,7 @@ resources are also removed. Custom installation namespaces must be supplied by
 flag or config; untrusted in-cluster objects never select the cleanup target.
 
 The namespace and CustomResourceDefinitions are preserved. Pass
---keep-helm-chart to remove the custom resources while leaving the Helm release
-and its chart-managed resources installed.`,
+--keep-helm-chart to retain the Helm release regardless of config.`,
 	Example: `  # Remove Network Operator CRs and uninstall the Helm release
   l8k clean --kubeconfig ~/.kube/config
 
@@ -44,8 +52,12 @@ and its chart-managed resources installed.`,
   l8k clean --kubeconfig ~/.kube/config \
     --network-operator-namespace custom-network-operator
 
-  # Remove all CRs but keep the operator chart installed
+  # Remove all CRs but keep the operator chart installed explicitly
   l8k clean --kubeconfig ~/.kube/config --keep-helm-chart
+
+  # Config with networkOperator.skipHelmChart: true also keeps the chart
+  l8k clean --kubeconfig ~/.kube/config \
+    --user-config ./cluster-config.yaml
 
   # Non-interactive agent mode (JSON output auto-confirms)
   l8k clean --kubeconfig ~/.kube/config --output json`,
@@ -72,46 +84,52 @@ and its chart-managed resources installed.`,
 		uiOutput, jsonOutput := ui.NewOutputForFormat(outputFormat, yesFlag)
 		ctx := ui.WithOutput(cmd.Context(), uiOutput)
 
-		namespace, source, err := resolveCleanNamespace()
+		settings, err := resolveCleanSettings(keepHelmChart)
 		if err != nil {
 			exitWithError(apperrors.NewValidationError(
-				"failed to resolve namespace from user config",
+				"failed to resolve cleanup settings from user config",
 				err,
-				"Fix the config or pass --network-operator-namespace <namespace>",
+				"Fix or remove the selected config before cleanup",
 			), outputFormat)
 		}
-		if problems := validation.IsDNS1123Label(namespace); len(problems) > 0 {
+		if problems := validation.IsDNS1123Label(settings.Namespace); len(problems) > 0 {
 			exitWithError(apperrors.NewValidationError(
-				fmt.Sprintf("invalid Network Operator namespace %q", namespace),
+				fmt.Sprintf("invalid Network Operator namespace %q", settings.Namespace),
 				fmt.Errorf("%s", problems[0]),
 				"Pass a valid DNS-1123 namespace with --network-operator-namespace",
 			), outputFormat)
 		}
 
 		uiOutput.Section("Network Operator cleanup")
-		uiOutput.Info("Target namespace: %s (%s)", namespace, source)
-		if keepHelmChart {
-			uiOutput.Info("Helm release: keep %s installed", "network-operator")
+		uiOutput.Info("Target namespace: %s (%s)", settings.Namespace, settings.NamespaceSource)
+		if settings.KeepHelmChart {
+			uiOutput.Info("Helm release: keep %s installed (%s)",
+				"network-operator", settings.HelmRetentionSource)
 		} else {
 			uiOutput.Info("Helm release: uninstall %s", "network-operator")
 		}
 
-		confirmed, err := uiOutput.Confirm(fmt.Sprintf(
-			"Delete all custom resources in namespace %s and the known cluster-scoped Network Operator resources?",
-			namespace,
-		))
+		confirmation := fmt.Sprintf(
+			"Delete all custom resources in namespace %s and the known cluster-scoped Network Operator resources, then uninstall the network-operator Helm release?",
+			settings.Namespace)
+		if settings.KeepHelmChart {
+			confirmation = fmt.Sprintf(
+				"Delete all custom resources in namespace %s and the known cluster-scoped Network Operator resources while keeping the network-operator Helm release installed?",
+				settings.Namespace)
+		}
+		confirmed, err := uiOutput.Confirm(confirmation)
 		if err != nil {
 			exitWithError(apperrors.NewGeneralError("failed to read cleanup confirmation", err), outputFormat)
 		}
 		if !confirmed {
 			uiOutput.Info("Cleanup cancelled; no changes were made")
-			finalizeCleanJSON(jsonOutput, namespace, 0, false, keepHelmChart)
+			finalizeCleanJSON(jsonOutput, settings.Namespace, 0, false, settings.KeepHelmChart)
 			return
 		}
 
 		result, err := networkoperatorplugin.Clean(ctx, k8sClient, networkoperatorplugin.CleanOptions{
-			Namespace:     namespace,
-			KeepHelmChart: keepHelmChart,
+			Namespace:     settings.Namespace,
+			KeepHelmChart: settings.KeepHelmChart,
 			RestConfig:    restConfig,
 		})
 		if err != nil {
@@ -132,45 +150,66 @@ and its chart-managed resources installed.`,
 			result.Namespace,
 			result.CustomResourcesDeleted,
 			result.HelmReleaseRemoved,
-			keepHelmChart,
+			settings.KeepHelmChart,
 		)
 	},
 }
 
-func resolveCleanNamespace() (string, string, error) {
-	if networkOperatorNamespace != "" {
-		return networkOperatorNamespace, "--network-operator-namespace", nil
+func resolveCleanSettings(explicitKeepHelmChart bool) (cleanSettings, error) {
+	settings := cleanSettings{
+		Namespace:       defaultOperatorNamespace,
+		NamespaceSource: "default",
+		KeepHelmChart:   explicitKeepHelmChart,
 	}
-	// Cleanup only needs one field from the user config. Do not apply release
-	// catalog defaults or validate unrelated deployment settings here: an old
-	// generated config must not prevent the operator from being removed.
+	if explicitKeepHelmChart {
+		settings.HelmRetentionSource = "--keep-helm-chart"
+	}
+
+	// Cleanup only needs namespace and Helm-ownership fields from the user
+	// config. Do not apply release catalog defaults or validate unrelated
+	// deployment settings here: an old generated config must not prevent CRs
+	// from being removed.
 	path := userConfigPathBeforeDefaults()
 	if path == "" && configDir != "" {
 		var err error
 		path, err = defaultConfigPathFor(configDir)
 		if err != nil {
-			return "", "--config-dir", err
+			return settings, err
 		}
 	}
-	if path == "" {
-		return defaultOperatorNamespace, "default", nil
+	if path != "" {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return settings, fmt.Errorf("read %s: %w", path, err)
+		}
+		var cfg struct {
+			NetworkOperator *struct {
+				Namespace     string `yaml:"namespace"`
+				SkipHelmChart bool   `yaml:"skipHelmChart"`
+			} `yaml:"networkOperator"`
+		}
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			return settings, fmt.Errorf("parse %s: %w", path, err)
+		}
+		if cfg.NetworkOperator != nil {
+			if cfg.NetworkOperator.Namespace != "" {
+				settings.Namespace = cfg.NetworkOperator.Namespace
+				settings.NamespaceSource = path
+			}
+			if cfg.NetworkOperator.SkipHelmChart {
+				settings.KeepHelmChart = true
+				if settings.HelmRetentionSource == "" {
+					settings.HelmRetentionSource = "networkOperator.skipHelmChart in " + path
+				}
+			}
+		}
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", path, fmt.Errorf("read %s: %w", path, err)
+
+	if networkOperatorNamespace != "" {
+		settings.Namespace = networkOperatorNamespace
+		settings.NamespaceSource = "--network-operator-namespace"
 	}
-	var cfg struct {
-		NetworkOperator *struct {
-			Namespace string `yaml:"namespace"`
-		} `yaml:"networkOperator"`
-	}
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return "", path, fmt.Errorf("parse %s: %w", path, err)
-	}
-	if cfg.NetworkOperator == nil || cfg.NetworkOperator.Namespace == "" {
-		return defaultOperatorNamespace, "default", nil
-	}
-	return cfg.NetworkOperator.Namespace, path, nil
+	return settings, nil
 }
 
 func finalizeCleanJSON(
@@ -200,9 +239,9 @@ func init() {
 	rootCmd.AddCommand(cleanCmd)
 
 	cleanCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (falls back to $KUBECONFIG, then ~/.kube/config)")
-	cleanCmd.Flags().StringVar(&userConfig, "user-config", "", "Cluster config file used to resolve networkOperator.namespace")
+	cleanCmd.Flags().StringVar(&userConfig, "user-config", "", "Cluster config file used to resolve networkOperator.namespace and networkOperator.skipHelmChart")
 	cleanCmd.Flags().StringVar(&networkOperatorNamespace, "network-operator-namespace", "", "Override the Network Operator namespace from cluster-config.yaml")
-	cleanCmd.Flags().BoolVar(&keepHelmChart, "keep-helm-chart", false, "Delete Network Operator custom resources but keep the network-operator Helm release installed")
+	cleanCmd.Flags().BoolVar(&keepHelmChart, "keep-helm-chart", false, "Delete Network Operator custom resources but keep the network-operator Helm release installed regardless of config")
 
 	setFlagGroup(cleanCmd, "kubeconfig", GroupCommon)
 	setFlagGroup(cleanCmd, "user-config", GroupCommon)

--- a/pkg/cmd/clean_test.go
+++ b/pkg/cmd/clean_test.go
@@ -23,11 +23,13 @@ func preserveCleanFlagState(t *testing.T) {
 	oldUserConfig := userConfig
 	oldDeploymentFiles := deploymentFiles
 	oldConfigDir := configDir
+	oldKeepHelmChart := keepHelmChart
 	t.Cleanup(func() {
 		networkOperatorNamespace = oldNamespace
 		userConfig = oldUserConfig
 		deploymentFiles = oldDeploymentFiles
 		configDir = oldConfigDir
+		keepHelmChart = oldKeepHelmChart
 	})
 }
 
@@ -43,33 +45,73 @@ func TestCleanCommandFlags(t *testing.T) {
 	assert.Equal(t, "false", cleanCmd.Flags().Lookup("keep-helm-chart").DefValue)
 }
 
-func TestResolveCleanNamespace(t *testing.T) {
-	t.Run("explicit flag wins", func(t *testing.T) {
+func TestResolveCleanSettings(t *testing.T) {
+	t.Run("explicit namespace wins while config retention still applies", func(t *testing.T) {
 		preserveCleanFlagState(t)
+		path := filepath.Join(t.TempDir(), "cluster-config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`networkOperator:
+  namespace: config-namespace
+  skipHelmChart: true
+`), 0o600))
 		networkOperatorNamespace = "explicit-namespace"
-		userConfig = filepath.Join(t.TempDir(), "does-not-exist.yaml")
+		userConfig = path
 
-		namespace, source, err := resolveCleanNamespace()
+		settings, err := resolveCleanSettings(false)
 		require.NoError(t, err)
-		assert.Equal(t, "explicit-namespace", namespace)
-		assert.Equal(t, "--network-operator-namespace", source)
+		assert.Equal(t, "explicit-namespace", settings.Namespace)
+		assert.Equal(t, "--network-operator-namespace", settings.NamespaceSource)
+		assert.True(t, settings.KeepHelmChart)
+		assert.Contains(t, settings.HelmRetentionSource, "networkOperator.skipHelmChart")
+		assert.Contains(t, settings.HelmRetentionSource, path)
 	})
 
-	t.Run("reads only namespace from user config", func(t *testing.T) {
+	t.Run("reads namespace and retention from user config", func(t *testing.T) {
 		preserveCleanFlagState(t)
 		path := filepath.Join(t.TempDir(), "cluster-config.yaml")
 		require.NoError(t, os.WriteFile(path, []byte(`networkOperator:
   namespace: operator-system
+  skipHelmChart: true
 unrelatedSetting:
   oldField: still-ignored
 `), 0o600))
 		networkOperatorNamespace = ""
 		userConfig = path
 
-		namespace, source, err := resolveCleanNamespace()
+		settings, err := resolveCleanSettings(false)
 		require.NoError(t, err)
-		assert.Equal(t, "operator-system", namespace)
-		assert.Equal(t, path, source)
+		assert.Equal(t, "operator-system", settings.Namespace)
+		assert.Equal(t, path, settings.NamespaceSource)
+		assert.True(t, settings.KeepHelmChart)
+		assert.Contains(t, settings.HelmRetentionSource, path)
+	})
+
+	t.Run("explicit keep flag retains without config", func(t *testing.T) {
+		preserveCleanFlagState(t)
+		t.Chdir(t.TempDir())
+		networkOperatorNamespace = ""
+		userConfig = ""
+		deploymentFiles = ""
+		configDir = ""
+
+		settings, err := resolveCleanSettings(true)
+		require.NoError(t, err)
+		assert.True(t, settings.KeepHelmChart)
+		assert.Equal(t, "--keep-helm-chart", settings.HelmRetentionSource)
+	})
+
+	t.Run("false config setting leaves Helm uninstall enabled", func(t *testing.T) {
+		preserveCleanFlagState(t)
+		path := filepath.Join(t.TempDir(), "cluster-config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(`networkOperator:
+  skipHelmChart: false
+`), 0o600))
+		networkOperatorNamespace = ""
+		userConfig = path
+
+		settings, err := resolveCleanSettings(false)
+		require.NoError(t, err)
+		assert.False(t, settings.KeepHelmChart)
+		assert.Empty(t, settings.HelmRetentionSource)
 	})
 
 	t.Run("reports malformed user config", func(t *testing.T) {
@@ -79,10 +121,10 @@ unrelatedSetting:
 		networkOperatorNamespace = ""
 		userConfig = path
 
-		_, source, err := resolveCleanNamespace()
+		_, err := resolveCleanSettings(false)
 		require.Error(t, err)
-		assert.Equal(t, path, source)
 		assert.Contains(t, err.Error(), "parse")
+		assert.Contains(t, err.Error(), path)
 	})
 
 	t.Run("reads an explicit config directory override", func(t *testing.T) {
@@ -91,16 +133,18 @@ unrelatedSetting:
 		path := filepath.Join(dir, "l8k-config.yaml")
 		require.NoError(t, os.WriteFile(path, []byte(`networkOperator:
   namespace: config-dir-operator
+  skipHelmChart: true
 `), 0o600))
 		networkOperatorNamespace = ""
 		userConfig = ""
 		deploymentFiles = ""
 		configDir = dir
 
-		namespace, source, err := resolveCleanNamespace()
+		settings, err := resolveCleanSettings(false)
 		require.NoError(t, err)
-		assert.Equal(t, "config-dir-operator", namespace)
-		assert.Equal(t, path, source)
+		assert.Equal(t, "config-dir-operator", settings.Namespace)
+		assert.Equal(t, path, settings.NamespaceSource)
+		assert.True(t, settings.KeepHelmChart)
 	})
 
 	t.Run("uses the standard default without trusted config", func(t *testing.T) {
@@ -111,10 +155,12 @@ unrelatedSetting:
 		deploymentFiles = ""
 		configDir = ""
 
-		namespace, source, err := resolveCleanNamespace()
+		settings, err := resolveCleanSettings(false)
 		require.NoError(t, err)
-		assert.Equal(t, defaultOperatorNamespace, namespace)
-		assert.Equal(t, "default", source)
+		assert.Equal(t, defaultOperatorNamespace, settings.Namespace)
+		assert.Equal(t, "default", settings.NamespaceSource)
+		assert.False(t, settings.KeepHelmChart)
+		assert.Empty(t, settings.HelmRetentionSource)
 	})
 }
 

--- a/pkg/cmd/deploy.go
+++ b/pkg/cmd/deploy.go
@@ -89,6 +89,10 @@ is used as the manifest directory.`,
 				ConfigDir:         configDir,
 				OperatorNamespace: networkOperatorNamespace,
 				OverwriteExisting: overwriteExistingFlag,
+				SkipNetworkOperatorHelm: hosttarget.Explicit[bool]{
+					Value: skipNetworkOperatorHelm,
+					Set:   cmd.Flags().Changed("skip-network-operator-helm"),
+				},
 			},
 			hosttarget.NewDeployRunner(),
 		))
@@ -109,6 +113,7 @@ func init() {
 	deployCmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "Preview the deployment via server-side dry-run without persisting changes")
 	deployCmd.Flags().DurationVar(&deployTimeout, "deploy-timeout", 0, "Maximum end-to-end wall-clock budget for the deploy phase (e.g. 45m, 2h). 0 (the default) means no deadline; the deploy polls until every manifest reaches a terminal state. Useful for matching a maintenance window when SR-IOV reconciliation on a large cluster can take an hour or more.")
 	deployCmd.Flags().BoolVar(&overwriteExistingFlag, "overwrite-existing", false, "Converge the cluster to the rendered manifests when preflight detects drift: helm upgrade the chart on chart-version/values mismatch, delete stray Network Operator CRs in the operator namespace, and rewrite NicClusterPolicy component versions via SSA. Off by default — preflight fails fast and lists what would change.")
+	deployCmd.Flags().BoolVar(&skipNetworkOperatorHelm, "skip-network-operator-helm", false, "Skip Network Operator Helm chart installation and Helm-specific preflight checks")
 
 	setFlagGroup(deployCmd, "kubeconfig", GroupCommon)
 	setFlagGroup(deployCmd, "user-config", GroupCommon)
@@ -117,5 +122,6 @@ func init() {
 	setFlagGroup(deployCmd, "deploy-timeout", GroupExecution)
 	setFlagGroup(deployCmd, "dry-run", GroupExecution)
 	setFlagGroup(deployCmd, "overwrite-existing", GroupDeploy)
+	setFlagGroup(deployCmd, "skip-network-operator-helm", GroupCommon)
 	markDeployTargetScopes()
 }

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -115,12 +115,16 @@ Optionally deploy the generated manifests with --deploy.`,
 			Kubeconfig:               kubeconfig,
 			NetworkOperatorNamespace: networkOperatorNamespace,
 			NetworkOperatorRelease:   networkOperatorRelease,
-			EnabledPlugins:           parseEnabledPlugins(enabledPlugins),
-			WorkloadManifest:         workloadManifest,
-			OutputFormat:             outputFormat,
-			Yes:                      yesFlag,
-			Quiet:                    quietFlag,
-			DryRun:                   dryRunFlag,
+
+			SkipNetworkOperatorHelm:    skipNetworkOperatorHelm,
+			SkipNetworkOperatorHelmSet: cmd.Flag("skip-network-operator-helm").Changed,
+
+			EnabledPlugins:   parseEnabledPlugins(enabledPlugins),
+			WorkloadManifest: workloadManifest,
+			OutputFormat:     outputFormat,
+			Yes:              yesFlag,
+			Quiet:            quietFlag,
+			DryRun:           dryRunFlag,
 		}
 
 		// Set EnableDocaDriver only if the flag was explicitly provided
@@ -173,6 +177,7 @@ func init() {
 	generateCmd.Flags().StringVar(&networkOperatorRelease, "network-operator-release", "",
 		fmt.Sprintf("Network Operator release line to deploy (MAJOR.MINOR). Supported: %s",
 			strings.Join(releases.SupportedReleases(), ", ")))
+	generateCmd.Flags().BoolVar(&skipNetworkOperatorHelm, "skip-network-operator-helm", false, "Skip Network Operator Helm values generation and, with --deploy, chart installation and Helm preflight checks")
 	generateCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for Network Operator components and authenticated Helm downloads (comma-separated)")
 	generateCmd.Flags().StringVar(&enabledPlugins, "enabled-plugins", "network-operator", "Comma-separated list of plugins to enable")
 
@@ -186,6 +191,7 @@ func init() {
 	setFlagGroup(generateCmd, "kubeconfig", GroupCommon)
 	setFlagGroup(generateCmd, "network-operator-namespace", GroupCommon)
 	setFlagGroup(generateCmd, "network-operator-release", GroupCommon)
+	setFlagGroup(generateCmd, "skip-network-operator-helm", GroupCommon)
 	setFlagGroup(generateCmd, "image-pull-secrets", GroupCommon)
 	setFlagGroup(generateCmd, "enabled-plugins", GroupCommon)
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -84,6 +84,7 @@ var (
 	deployTimeoutRoot        time.Duration
 	keepNamespace            bool
 	collapseNicRails         bool
+	skipNetworkOperatorHelm  bool
 )
 
 // collapseNicRailsFlagHelp is the shared help text for --collapse-nic-rails on
@@ -195,12 +196,16 @@ Use 'l8k schema' to discover tool capabilities programmatically.`,
 			SaveClusterConfig:        saveClusterConfig,
 			NetworkOperatorNamespace: networkOperatorNamespace,
 			NetworkOperatorRelease:   networkOperatorRelease,
-			EnabledPlugins:           enabledPlugins,
-			WorkloadManifest:         workloadManifest,
-			OutputFormat:             outputFormat,
-			Yes:                      yesFlag,
-			Quiet:                    quietFlag,
-			DryRun:                   dryRunFlag,
+
+			SkipNetworkOperatorHelm:    skipNetworkOperatorHelm,
+			SkipNetworkOperatorHelmSet: cmd.Flag("skip-network-operator-helm").Changed,
+
+			EnabledPlugins:   enabledPlugins,
+			WorkloadManifest: workloadManifest,
+			OutputFormat:     outputFormat,
+			Yes:              yesFlag,
+			Quiet:            quietFlag,
+			DryRun:           dryRunFlag,
 		}
 
 		// Set EnableDocaDriver only if the flag was explicitly provided
@@ -240,6 +245,7 @@ func init() {
 	rootCmd.Flags().StringVar(&networkOperatorRelease, "network-operator-release", "",
 		fmt.Sprintf("Network Operator release line to deploy (MAJOR.MINOR). Selects component image tags + repository from a built-in catalog and drives version-gated template sections. Supported: %s",
 			strings.Join(releases.SupportedReleases(), ", ")))
+	rootCmd.Flags().BoolVar(&skipNetworkOperatorHelm, "skip-network-operator-helm", false, "Skip Network Operator Helm values generation, chart installation, and Helm-specific validation")
 
 	// Phase 2: Deployment generation flags
 	rootCmd.Flags().StringVar(&fabric, "fabric", "", "Select the fabric type to deploy (infiniband, ethernet)")
@@ -295,6 +301,7 @@ func init() {
 	setFlagGroup(rootCmd, "kubeconfig", GroupCommon)
 	setFlagGroup(rootCmd, "network-operator-namespace", GroupCommon)
 	setFlagGroup(rootCmd, "network-operator-release", GroupCommon)
+	setFlagGroup(rootCmd, "skip-network-operator-helm", GroupCommon)
 	setFlagGroup(rootCmd, "node-selector", GroupCommon)
 	setFlagGroup(rootCmd, "image-pull-secrets", GroupCommon)
 

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/releases"
 	"github.com/nvidia/k8s-launch-kit/pkg/target"
 )
@@ -56,6 +57,7 @@ type flagSchema struct {
 	Description string   `json:"description"`
 	Required    bool     `json:"required,omitempty"`
 	Targets     []string `json:"targets"`
+	ConfigPaths []string `json:"configPaths,omitempty"`
 }
 
 type targetSchema struct {
@@ -87,7 +89,7 @@ var schemaCmd = &cobra.Command{
 					Example:     "l8k deploy --deployment-files ./deployment --kubeconfig ~/.kube/config",
 				},
 				"clean": {
-					Description: "Delete Network Operator custom resources and uninstall its Helm release",
+					Description: "Delete Network Operator custom resources and uninstall its Helm release unless config or --keep-helm-chart retains it",
 					Example:     "l8k clean --kubeconfig ~/.kube/config [--keep-helm-chart]",
 				},
 				"validate": {
@@ -210,7 +212,12 @@ var schemaCmd = &cobra.Command{
 				"--keep-helm-chart": {
 					Type:        "bool",
 					Default:     "false",
-					Description: "With l8k clean, delete custom resources but keep the network-operator Helm release installed",
+					Description: "With l8k clean, delete custom resources but keep the network-operator Helm release installed regardless of config",
+				},
+				"--skip-network-operator-helm": {
+					Type:        "bool",
+					Default:     "false",
+					Description: "Skip Network Operator Helm values generation, chart installation, and Helm-specific validation while retaining Network Operator manifest handling.",
 				},
 				"--dry-run": {
 					Type:        "bool",
@@ -310,6 +317,7 @@ func annotateSchemaFlagTargets(s *schema) {
 	}
 	for name, spec := range s.Flags {
 		spec.Targets = schemaFlagTargets(name)
+		spec.ConfigPaths = networkoperatorplugin.ConfigPathsForFlag(name)
 		s.Flags[name] = spec
 	}
 }

--- a/pkg/cmd/schema_test.go
+++ b/pkg/cmd/schema_test.go
@@ -46,11 +46,12 @@ func TestSchemaDescribesTargetsAdditively(t *testing.T) {
 
 func TestSchemaFlagsDeclareTargetOwnership(t *testing.T) {
 	s := schema{Flags: map[string]flagSchema{
-		"--target":     {},
-		"--output":     {},
-		"--dry-run":    {},
-		"--fabric":     {},
-		"--kubeconfig": {},
+		"--target":                     {},
+		"--output":                     {},
+		"--dry-run":                    {},
+		"--fabric":                     {},
+		"--kubeconfig":                 {},
+		"--skip-network-operator-helm": {},
 	}}
 	annotateSchemaFlagTargets(&s)
 	for name, spec := range s.Flags {
@@ -62,6 +63,9 @@ func TestSchemaFlagsDeclareTargetOwnership(t *testing.T) {
 	assert.Equal(t, []string{"host", "dpf"}, s.Flags["--dry-run"].Targets)
 	assert.Equal(t, []string{"host"}, s.Flags["--fabric"].Targets)
 	assert.Equal(t, []string{"host"}, s.Flags["--kubeconfig"].Targets)
+	assert.Equal(t, []string{"networkOperator.skipHelmChart"},
+		s.Flags["--skip-network-operator-helm"].ConfigPaths)
+	assert.Empty(t, s.Flags["--kubeconfig"].ConfigPaths)
 }
 
 func TestAnnotateSchemaFlagTargetsNilSafe(t *testing.T) {

--- a/pkg/cmd/target_cli.go
+++ b/pkg/cmd/target_cli.go
@@ -273,7 +273,7 @@ func markRootTargetScopes() {
 		"target", "output", "log-level", "log-file", "yes", "quiet", "dry-run", "deploy", "deploy-timeout")
 	setFlagTargetScope(rootCmd, []target.Name{target.Host},
 		"enabled-plugins", "discover-cluster-config", "save-cluster-config", "user-config",
-		"network-operator-namespace", "network-operator-release", "fabric", "deployment-type",
+		"network-operator-namespace", "network-operator-release", "skip-network-operator-helm", "fabric", "deployment-type",
 		"multirail", "routing", "ignore-arp", "spectrum-x", "multiplane-mode", "number-of-planes",
 		"topology-scheme", "ip-version", "topology-file", "spectrum-x-config",
 		"spectrum-x-configmap-name", "groups", "gpu-type", "node-selector", "collapse-nic-rails",
@@ -298,19 +298,19 @@ func markGenerateTargetScopes() {
 		"spectrum-x", "multiplane-mode", "number-of-planes", "topology-scheme", "ip-version",
 		"topology-file", "spectrum-x-config", "spectrum-x-configmap-name", "groups", "gpu-type",
 		"for", "node-selector", "save-deployment-files", "network-namespaces", "enable-doca-driver",
-		"workload-manifest", "network-operator-namespace", "network-operator-release",
+		"workload-manifest", "network-operator-namespace", "network-operator-release", "skip-network-operator-helm",
 		"image-pull-secrets", "enabled-plugins", "kubeconfig", "overwrite-existing")
 }
 
 func markDeployTargetScopes() {
 	setFlagTargetScope(deployCmd, []target.Name{target.Host, target.DPF}, "dry-run", "deploy-timeout")
 	setFlagTargetScope(deployCmd, []target.Name{target.Host},
-		"kubeconfig", "deployment-files", "network-operator-namespace", "user-config", "overwrite-existing")
+		"kubeconfig", "deployment-files", "network-operator-namespace", "user-config", "overwrite-existing", "skip-network-operator-helm")
 }
 
 func markValidateTargetScopes() {
 	setFlagTargetScope(validateCmd, []target.Name{target.Host},
-		"kubeconfig", "deployment-files", "user-config", "network-operator-namespace", "connectivity",
+		"kubeconfig", "deployment-files", "user-config", "network-operator-namespace", "skip-network-operator-helm", "connectivity",
 		"keep", "connectivity-timeout", "validation-mode", "validation-checks",
 		"rdma-rping-iterations", "rdma-ib-write-size", "rdma-ib-write-min-bandwidth-gbps",
 		"wait", "report-path")

--- a/pkg/cmd/target_cli_test.go
+++ b/pkg/cmd/target_cli_test.go
@@ -146,6 +146,9 @@ func TestImportantFlagScopes(t *testing.T) {
 		{command: generateCmd, flag: "deploy", expected: []target.Name{target.Host, target.DPF}},
 		{command: deployCmd, flag: "dry-run", expected: []target.Name{target.Host, target.DPF}},
 		{command: validateCmd, flag: "connectivity", expected: []target.Name{target.Host}},
+		{command: generateCmd, flag: "skip-network-operator-helm", expected: []target.Name{target.Host}},
+		{command: deployCmd, flag: "skip-network-operator-helm", expected: []target.Name{target.Host}},
+		{command: validateCmd, flag: "skip-network-operator-helm", expected: []target.Name{target.Host}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.command.Name()+"/"+tt.flag, func(t *testing.T) {

--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -103,6 +103,10 @@ func newHostValidateRequest(cmd *cobra.Command) hosttarget.ValidateRequest {
 		UserConfig:        userConfig,
 		ConfigDir:         configDir,
 		OperatorNamespace: networkOperatorNamespace,
+		SkipNetworkOperatorHelm: hosttarget.Explicit[bool]{
+			Value: skipNetworkOperatorHelm,
+			Set:   cmd.Flags().Changed("skip-network-operator-helm"),
+		},
 		Connectivity: hosttarget.Explicit[bool]{
 			Value: validateConnectivity,
 			Set:   cmd.Flags().Changed("connectivity"),
@@ -143,6 +147,7 @@ func init() {
 	validateCmd.Flags().StringVar(&deploymentFiles, "deployment-files", DefaultDeploymentDir, "Directory containing the manifests to verify")
 	validateCmd.Flags().StringVar(&userConfig, "user-config", "", "Cluster config file (auto-detected from ./cluster-config.yaml). Used to read networkOperator.selectedRelease and operator namespace.")
 	validateCmd.Flags().StringVar(&networkOperatorNamespace, "network-operator-namespace", "", "Override the network operator namespace from cluster-config.yaml")
+	validateCmd.Flags().BoolVar(&skipNetworkOperatorHelm, "skip-network-operator-helm", false, "Skip Network Operator Helm release version and values validation")
 	validateCmd.Flags().BoolVar(&validateConnectivity, "connectivity", true, "Run a source-bound connectivity matrix (icmp + rping + ib_write_bw) between pods of the example DaemonSet. Default true. Pass --connectivity=false to skip when only the static manifest checks are wanted.")
 	validateCmd.Flags().BoolVar(&validateKeep, "keep", false, "Leave the example DaemonSet running after --connectivity completes (useful for debugging).")
 	validateCmd.Flags().DurationVar(&validateConnectivityTimeout, "connectivity-timeout", 0, "Maximum wall-clock budget for connectivity workload setup and test execution. 0 (default) calculates the budget from the generated matrix plan.")
@@ -158,6 +163,7 @@ func init() {
 	setFlagGroup(validateCmd, "user-config", GroupCommon)
 	setFlagGroup(validateCmd, "deployment-files", GroupGeneration)
 	setFlagGroup(validateCmd, "network-operator-namespace", GroupCommon)
+	setFlagGroup(validateCmd, "skip-network-operator-helm", GroupCommon)
 	setFlagGroup(validateCmd, "connectivity", GroupValidation)
 	setFlagGroup(validateCmd, "connectivity-timeout", GroupValidation)
 	setFlagGroup(validateCmd, "keep", GroupValidation)

--- a/pkg/cmd/validate_config_test.go
+++ b/pkg/cmd/validate_config_test.go
@@ -34,6 +34,7 @@ func newValidateRequestTestCommand() *cobra.Command {
 	cmd.Flags().IntVar(&validateRDMAIBWriteSize, "rdma-ib-write-size", 0, "")
 	cmd.Flags().Float64Var(&validateRDMAIBWriteMinGbps, "rdma-ib-write-min-bandwidth-gbps", 0, "")
 	cmd.Flags().DurationVar(&validateConnectivityTimeout, "connectivity-timeout", 0, "")
+	cmd.Flags().BoolVar(&skipNetworkOperatorHelm, "skip-network-operator-helm", false, "")
 	return cmd
 }
 
@@ -46,6 +47,7 @@ func resetValidateRequestGlobals(t *testing.T) {
 	validateRDMAIBWriteSize = 0
 	validateRDMAIBWriteMinGbps = 0
 	validateConnectivityTimeout = 0
+	skipNetworkOperatorHelm = false
 }
 
 func TestNewHostValidateRequestCapturesExplicitValues(t *testing.T) {
@@ -60,6 +62,7 @@ func TestNewHostValidateRequestCapturesExplicitValues(t *testing.T) {
 	require.NoError(t, cmd.Flags().Set("rdma-ib-write-size", "8192"))
 	require.NoError(t, cmd.Flags().Set("rdma-ib-write-min-bandwidth-gbps", "0"))
 	require.NoError(t, cmd.Flags().Set("connectivity-timeout", "42m"))
+	require.NoError(t, cmd.Flags().Set("skip-network-operator-helm", "false"))
 
 	request := newHostValidateRequest(cmd)
 	assert.True(t, request.Connectivity.Set)
@@ -75,6 +78,8 @@ func TestNewHostValidateRequestCapturesExplicitValues(t *testing.T) {
 	assert.Zero(t, request.RDMAMinBandwidth.Value)
 	assert.True(t, request.RDMAMinBandwidth.Set)
 	assert.Equal(t, 42*time.Minute, request.ConnectivityTime)
+	assert.True(t, request.SkipNetworkOperatorHelm.Set)
+	assert.False(t, request.SkipNetworkOperatorHelm.Value)
 }
 
 func TestNewHostValidateRequestPreservesOmission(t *testing.T) {
@@ -89,6 +94,7 @@ func TestNewHostValidateRequestPreservesOmission(t *testing.T) {
 	assert.False(t, request.RDMAIBWriteSize.Set)
 	assert.False(t, request.RDMAMinBandwidth.Set)
 	assert.Zero(t, request.ConnectivityTime)
+	assert.False(t, request.SkipNetworkOperatorHelm.Set)
 }
 
 func TestValidateConnectivityTimeoutDefaultsToAutomatic(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -269,6 +269,12 @@ type LaunchKitConfig struct {
 type NetworkOperatorConfig struct {
 	Version          string `yaml:"version"`
 	ComponentVersion string `yaml:"componentVersion"`
+	// SkipHelmChart disables l8k's Network Operator Helm boundary. Generate
+	// omits values.yaml, deploy skips chart installation and Helm preflight
+	// checks, validate skips Helm release version and values checks, and clean
+	// retains the externally-owned Helm release. Network Operator manifests,
+	// component-version checks, and clean's CR deletion are unaffected.
+	SkipHelmChart bool `yaml:"skipHelmChart"`
 	// SelectedRelease is the catalog key (MAJOR.MINOR, e.g. "26.4") chosen via
 	// --network-operator-release. Empty means "no release pinned"; templates
 	// treat that as "latest" so existing configs render the newest gates by

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -10,6 +10,10 @@ networkOperator:
   version: v26.4.0
   componentVersion: network-operator-v26.4.0
   selectedRelease: "26.4"
+  # Skip Network Operator Helm values generation, chart installation,
+  # Helm-specific validation, and Helm release removal during cleanup. Network
+  # Operator CR generation, deployment, validation, and cleanup still run.
+  skipHelmChart: false
   # repository — registry path for COMPONENT images managed by the operator
   # (ofedDriver, nvIpam, multus, device plugins, …). Rendered into
   # NicClusterPolicy / NicNodePolicy.
@@ -45,7 +49,8 @@ validation:
     enabled: false
     gpuResourceType: nvidia.com/gpu
   # connectivity gates the data-plane validation stage. Static manifest,
-  # Helm release, component-version, and preflight checks always run.
+  # component-version, and preflight checks always run. Helm checks run unless
+  # networkOperator.skipHelmChart is true.
   connectivity: true
   # mode controls matrix coverage and gating.
   # quick: same-rail all nodes plus one non-gating cross-rail canary per rail pair.

--- a/pkg/networkoperatorplugin/config_overrides.go
+++ b/pkg/networkoperatorplugin/config_overrides.go
@@ -1,0 +1,373 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkoperatorplugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/nvidia/k8s-launch-kit/pkg/options"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// ConfigFlagMapping describes the configuration fields controlled by one CLI
+// flag. A flag may update more than one field when it selects a coordinated
+// configuration cohort, as --network-operator-release does.
+type ConfigFlagMapping struct {
+	FlagName    string
+	ConfigPaths []string
+}
+
+type configFlagOverride struct {
+	ConfigFlagMapping
+	shouldApply func(options.Options, *config.LaunchKitConfig) bool
+	apply       func(options.Options, *config.LaunchKitConfig) error
+}
+
+// ConfigFlagMappings returns the canonical CLI-to-config mapping without the
+// internal setter functions. Callers use this for schema/help introspection;
+// ApplyCLIConfigOverrides is the only mutation entry point.
+func ConfigFlagMappings() []ConfigFlagMapping {
+	registry := configFlagOverrideRegistry()
+	out := make([]ConfigFlagMapping, 0, len(registry))
+	for _, entry := range registry {
+		out = append(out, ConfigFlagMapping{
+			FlagName:    entry.FlagName,
+			ConfigPaths: append([]string(nil), entry.ConfigPaths...),
+		})
+	}
+	return out
+}
+
+// ConfigPathsForFlag returns the config paths controlled by flagName. Both
+// "flag-name" and "--flag-name" forms are accepted.
+func ConfigPathsForFlag(flagName string) []string {
+	flagName = strings.TrimPrefix(flagName, "--")
+	for _, mapping := range configFlagOverrideRegistry() {
+		if mapping.FlagName == flagName {
+			return append([]string(nil), mapping.ConfigPaths...)
+		}
+	}
+	return nil
+}
+
+// ApplyCLIConfigOverrides is the single mutation boundary for config-backed
+// CLI flags. It is shared by discover, generate, standalone deploy, and
+// standalone validate so a new mapping is implemented once.
+func ApplyCLIConfigOverrides(opts options.Options, cfg *config.LaunchKitConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("config must not be nil")
+	}
+
+	for _, entry := range configFlagOverrideRegistry() {
+		if !entry.shouldApply(opts, cfg) {
+			continue
+		}
+		if err := entry.apply(opts, cfg); err != nil {
+			return fmt.Errorf("apply --%s to %s: %w",
+				entry.FlagName, strings.Join(entry.ConfigPaths, ", "), err)
+		}
+		log.Log.V(1).Info("Applied config flag mapping",
+			"flag", entry.FlagName, "configPaths", entry.ConfigPaths)
+	}
+
+	if opts.SpectrumX && cfg.Profile != nil && cfg.Profile.SpectrumX != nil {
+		if err := config.NormalizeSpectrumXProfileConfig(cfg.Profile.SpectrumX); err != nil {
+			return fmt.Errorf("invalid Spectrum-X profile config: %w", err)
+		}
+	}
+	return nil
+}
+
+func configFlagOverrideRegistry() []configFlagOverride {
+	profileAvailable := func(_ options.Options, cfg *config.LaunchKitConfig) bool {
+		return cfg.Profile != nil
+	}
+	spectrumXAvailable := func(opts options.Options, cfg *config.LaunchKitConfig) bool {
+		return opts.SpectrumX && cfg.Profile != nil
+	}
+
+	return []configFlagOverride{
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName: "network-operator-release",
+				ConfigPaths: []string{
+					"networkOperator.selectedRelease",
+					"networkOperator.version",
+					"networkOperator.componentVersion",
+					"networkOperator.repository",
+					"networkOperator.operatorRepository",
+					"networkOperator.helmRepoURL",
+					"docaDriver.version",
+				},
+			},
+			shouldApply: func(opts options.Options, cfg *config.LaunchKitConfig) bool {
+				return opts.NetworkOperatorRelease != "" ||
+					(cfg.NetworkOperator != nil && cfg.NetworkOperator.SelectedRelease != "")
+			},
+			apply: ApplyNetworkOperatorRelease,
+		},
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName:    "network-operator-namespace",
+				ConfigPaths: []string{"networkOperator.namespace"},
+			},
+			shouldApply: func(opts options.Options, _ *config.LaunchKitConfig) bool {
+				return opts.NetworkOperatorNamespace != ""
+			},
+			apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+				ensureNetworkOperatorConfig(cfg).Namespace = opts.NetworkOperatorNamespace
+				return nil
+			},
+		},
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName:    "skip-network-operator-helm",
+				ConfigPaths: []string{"networkOperator.skipHelmChart"},
+			},
+			shouldApply: func(opts options.Options, _ *config.LaunchKitConfig) bool {
+				return opts.SkipNetworkOperatorHelmSet
+			},
+			apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+				ensureNetworkOperatorConfig(cfg).SkipHelmChart = opts.SkipNetworkOperatorHelm
+				return nil
+			},
+		},
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName:    "image-pull-secrets",
+				ConfigPaths: []string{"networkOperator.imagePullSecrets"},
+			},
+			shouldApply: func(opts options.Options, _ *config.LaunchKitConfig) bool {
+				return len(opts.ImagePullSecrets) > 0
+			},
+			apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+				ensureNetworkOperatorConfig(cfg).ImagePullSecrets = append([]string(nil), opts.ImagePullSecrets...)
+				return nil
+			},
+		},
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName:    "network-namespaces",
+				ConfigPaths: []string{"networkNamespaces"},
+			},
+			shouldApply: func(opts options.Options, _ *config.LaunchKitConfig) bool {
+				return len(opts.NetworkNamespaces) > 0
+			},
+			apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+				cfg.NetworkNamespaces = append([]string(nil), opts.NetworkNamespaces...)
+				return nil
+			},
+		},
+		stringProfileOverride("fabric", "profile.fabric", profileAvailable,
+			func(opts options.Options) string { return opts.Fabric },
+			func(profile *config.Profile, value string) { profile.Fabric = value }),
+		stringProfileOverride("deployment-type", "profile.deployment", profileAvailable,
+			func(opts options.Options) string { return opts.DeploymentType },
+			func(profile *config.Profile, value string) { profile.Deployment = value }),
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName:    "multirail",
+				ConfigPaths: []string{"profile.multirail"},
+			},
+			shouldApply: func(opts options.Options, cfg *config.LaunchKitConfig) bool {
+				return opts.MultirailSet && profileAvailable(opts, cfg)
+			},
+			apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+				cfg.Profile.Multirail = opts.Multirail
+				cfg.Profile.MultirailSet = true
+				return nil
+			},
+		},
+		stringProfileOverride("routing", "profile.routing", profileAvailable,
+			func(opts options.Options) string { return opts.Routing },
+			func(profile *config.Profile, value string) { profile.Routing = value }),
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName:    "ignore-arp",
+				ConfigPaths: []string{"profile.ignoreARP"},
+			},
+			shouldApply: func(opts options.Options, cfg *config.LaunchKitConfig) bool {
+				return opts.IgnoreARPSet && profileAvailable(opts, cfg)
+			},
+			apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+				cfg.Profile.IgnoreARP = opts.IgnoreARP
+				cfg.Profile.IgnoreARPSet = true
+				return nil
+			},
+		},
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName:    "workload-manifest",
+				ConfigPaths: []string{"workload.manifest"},
+			},
+			shouldApply: func(opts options.Options, cfg *config.LaunchKitConfig) bool {
+				return opts.WorkloadManifest != "" && profileAvailable(opts, cfg)
+			},
+			apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+				if cfg.Workload == nil {
+					cfg.Workload = &config.WorkloadConfig{}
+				}
+				cfg.Workload.Manifest = opts.WorkloadManifest
+				return nil
+			},
+		},
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName:    "enable-doca-driver",
+				ConfigPaths: []string{"docaDriver.enable"},
+			},
+			shouldApply: func(opts options.Options, cfg *config.LaunchKitConfig) bool {
+				return opts.EnableDocaDriver != nil && profileAvailable(opts, cfg)
+			},
+			apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+				ensureDOCADriverConfig(cfg).Enable = *opts.EnableDocaDriver
+				return nil
+			},
+		},
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName:    "spectrum-x",
+				ConfigPaths: []string{"profile.spectrumX.enable", "profile.spectrumX.spcxVersion"},
+			},
+			shouldApply: spectrumXAvailable,
+			apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+				sx := ensureSpectrumXProfile(cfg)
+				sx.Enable = true
+				if opts.SPCXVersion != "" {
+					sx.SPCXVersion = opts.SPCXVersion
+				}
+				return nil
+			},
+		},
+		spectrumXStringOverride("multiplane-mode", "profile.spectrumX.multiplaneMode", spectrumXAvailable,
+			func(opts options.Options) string { return opts.MultiplaneMode },
+			func(sx *config.ProfileSpectrumX, value string) { sx.MultiplaneMode = value }),
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName:    "number-of-planes",
+				ConfigPaths: []string{"profile.spectrumX.numberOfPlanes"},
+			},
+			shouldApply: func(opts options.Options, cfg *config.LaunchKitConfig) bool {
+				return spectrumXAvailable(opts, cfg) && opts.NumberOfPlanes != 0
+			},
+			apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+				ensureSpectrumXProfile(cfg).NumberOfPlanes = opts.NumberOfPlanes
+				return nil
+			},
+		},
+		spectrumXStringOverride("topology-scheme", "profile.spectrumX.topologyType", spectrumXAvailable,
+			func(opts options.Options) string { return opts.TopologyScheme },
+			func(sx *config.ProfileSpectrumX, value string) { sx.TopologyType = value }),
+		spectrumXStringOverride("ip-version", "profile.spectrumX.ipVersion", spectrumXAvailable,
+			func(opts options.Options) string { return opts.IPVersion },
+			func(sx *config.ProfileSpectrumX, value string) { sx.IPVersion = value }),
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName:    "topology-file",
+				ConfigPaths: []string{"profile.spectrumX.topologyFile"},
+			},
+			shouldApply: func(opts options.Options, cfg *config.LaunchKitConfig) bool {
+				return spectrumXAvailable(opts, cfg) && opts.TopologyFile != ""
+			},
+			apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+				resolved, err := filepath.Abs(opts.TopologyFile)
+				if err != nil {
+					return fmt.Errorf("resolve path %s: %w", opts.TopologyFile, err)
+				}
+				sx := ensureSpectrumXProfile(cfg)
+				sx.TopologyFile = opts.TopologyFile
+				sx.ResolvedTopologyFile = resolved
+				return nil
+			},
+		},
+		spectrumXStringOverride("spectrum-x-configmap-name", "profile.spectrumX.configMapName", spectrumXAvailable,
+			func(opts options.Options) string { return opts.SpectrumXConfigMapName },
+			func(sx *config.ProfileSpectrumX, value string) { sx.ConfigMapName = value }),
+		{
+			ConfigFlagMapping: ConfigFlagMapping{
+				FlagName:    "spectrum-x-config",
+				ConfigPaths: []string{"profile.spectrumX.profile"},
+			},
+			shouldApply: func(opts options.Options, cfg *config.LaunchKitConfig) bool {
+				return spectrumXAvailable(opts, cfg) && opts.SpectrumXConfig != ""
+			},
+			apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+				profileConfig, err := os.ReadFile(opts.SpectrumXConfig)
+				if err != nil {
+					return fmt.Errorf("read %s: %w", opts.SpectrumXConfig, err)
+				}
+				ensureSpectrumXProfile(cfg).Profile = string(profileConfig)
+				return nil
+			},
+		},
+	}
+}
+
+func stringProfileOverride(
+	flagName string,
+	configPath string,
+	profileAvailable func(options.Options, *config.LaunchKitConfig) bool,
+	value func(options.Options) string,
+	set func(*config.Profile, string),
+) configFlagOverride {
+	return configFlagOverride{
+		ConfigFlagMapping: ConfigFlagMapping{FlagName: flagName, ConfigPaths: []string{configPath}},
+		shouldApply: func(opts options.Options, cfg *config.LaunchKitConfig) bool {
+			return profileAvailable(opts, cfg) && value(opts) != ""
+		},
+		apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+			set(cfg.Profile, value(opts))
+			return nil
+		},
+	}
+}
+
+func spectrumXStringOverride(
+	flagName string,
+	configPath string,
+	spectrumXAvailable func(options.Options, *config.LaunchKitConfig) bool,
+	value func(options.Options) string,
+	set func(*config.ProfileSpectrumX, string),
+) configFlagOverride {
+	return configFlagOverride{
+		ConfigFlagMapping: ConfigFlagMapping{FlagName: flagName, ConfigPaths: []string{configPath}},
+		shouldApply: func(opts options.Options, cfg *config.LaunchKitConfig) bool {
+			return spectrumXAvailable(opts, cfg) && value(opts) != ""
+		},
+		apply: func(opts options.Options, cfg *config.LaunchKitConfig) error {
+			set(ensureSpectrumXProfile(cfg), value(opts))
+			return nil
+		},
+	}
+}
+
+func ensureNetworkOperatorConfig(cfg *config.LaunchKitConfig) *config.NetworkOperatorConfig {
+	if cfg.NetworkOperator == nil {
+		cfg.NetworkOperator = &config.NetworkOperatorConfig{}
+	}
+	return cfg.NetworkOperator
+}
+
+func ensureDOCADriverConfig(cfg *config.LaunchKitConfig) *config.DOCADriverConfig {
+	if cfg.DOCADriver == nil {
+		cfg.DOCADriver = &config.DOCADriverConfig{
+			UnloadStorageModules:        true,
+			UnloadThirdPartyRDMAModules: true,
+			SkipPreflightChecks:         false,
+		}
+	}
+	return cfg.DOCADriver
+}
+
+func ensureSpectrumXProfile(cfg *config.LaunchKitConfig) *config.ProfileSpectrumX {
+	if cfg.Profile.SpectrumX == nil {
+		cfg.Profile.SpectrumX = &config.ProfileSpectrumX{}
+	}
+	return cfg.Profile.SpectrumX
+}

--- a/pkg/networkoperatorplugin/deploy.go
+++ b/pkg/networkoperatorplugin/deploy.go
@@ -69,6 +69,10 @@ type DeployOptions struct {
 	// namespace with different user-supplied values. When false (default),
 	// a value-conflict surfaces as an error pointing at this flag.
 	OverwriteExisting bool
+	// SkipHelmChart disables both Network Operator Helm installation and the
+	// Helm-specific deploy preflight checks. Manifest apply and component/
+	// stray-resource preflight checks remain enabled.
+	SkipHelmChart bool
 	// RestConfig is required for Phase 0. When nil, Phase 0 is skipped
 	// (backward-compatible: lets users keep managing the chart out-of-band).
 	RestConfig *rest.Config
@@ -123,6 +127,7 @@ func (p *NetworkOperatorPlugin) DeployProfile(ctx context.Context, profile *prof
 		LaunchKitVersion:  p.LaunchKitVersion,
 		DryRun:            p.DryRun,
 		OverwriteExisting: p.OverwriteExisting,
+		SkipHelmChart:     p.NetworkOperator != nil && p.NetworkOperator.SkipHelmChart,
 		RestConfig:        p.RESTConfig,
 		NetworkOperator:   p.NetworkOperator,
 		DOCAVersion:       p.DOCAVersion,
@@ -812,6 +817,11 @@ func splitYAMLDocuments(s string) []string {
 // A value-conflict against an existing release surfaces as a
 // DeploymentError pointing at --overwrite-existing.
 func runHelmInstallPhase(ctx context.Context, manifestsDir string, opts DeployOptions, uiOutput ui.Output) error {
+	if opts.SkipHelmChart {
+		log.Log.V(1).Info("Network Operator Helm management disabled; skipping operator install")
+		return nil
+	}
+
 	valuesPath := filepath.Join(manifestsDir, helmValuesFile)
 	valuesYAML, err := os.ReadFile(valuesPath)
 	if err != nil {
@@ -961,8 +971,9 @@ func runPreflightPhase(ctx context.Context, kubeClient client.Client, manifestsD
 // individual checks soft-skip when an input is missing.
 func buildPreflightInputs(kubeClient client.Client, manifestsDir string, opts DeployOptions) (preflight.Inputs, error) {
 	in := preflight.Inputs{
-		KubeClient: kubeClient,
-		RestConfig: opts.RestConfig,
+		KubeClient:     kubeClient,
+		RestConfig:     opts.RestConfig,
+		SkipHelmChecks: opts.SkipHelmChart,
 	}
 	if opts.NetworkOperator != nil {
 		in.OperatorNamespace = opts.NetworkOperator.Namespace
@@ -975,9 +986,12 @@ func buildPreflightInputs(kubeClient client.Client, manifestsDir string, opts De
 		in.ExpectedDOCAVersion = opts.DOCAVersion
 	}
 
-	// Best-effort: read values.yaml (helm checks soft-skip if absent).
-	if b, err := os.ReadFile(filepath.Join(manifestsDir, helmValuesFile)); err == nil {
-		in.GeneratedValuesYAML = b
+	// Best-effort: read values.yaml when Helm management is enabled (helm
+	// checks soft-skip if absent).
+	if !opts.SkipHelmChart {
+		if b, err := os.ReadFile(filepath.Join(manifestsDir, helmValuesFile)); err == nil {
+			in.GeneratedValuesYAML = b
+		}
 	}
 
 	// Best-effort: scan manifests dir for rendered object refs (stray

--- a/pkg/networkoperatorplugin/networkoperator.go
+++ b/pkg/networkoperatorplugin/networkoperator.go
@@ -19,8 +19,6 @@ package networkoperatorplugin
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/discovery"
@@ -190,29 +188,8 @@ func ApplyNetworkOperatorRelease(options options.Options, fullConfig *config.Lau
 // ApplyOptionsToConfig applies CLI options to the configuration, overriding file values.
 // CLI flags take precedence over config file values for any explicitly set option.
 func (p *NetworkOperatorPlugin) ApplyOptionsToConfig(options options.Options, fullConfig *config.LaunchKitConfig) error {
-	if err := ApplyNetworkOperatorRelease(options, fullConfig); err != nil {
+	if err := ApplyCLIConfigOverrides(options, fullConfig); err != nil {
 		return err
-	}
-
-	// Apply network operator namespace override from CLI
-	if options.NetworkOperatorNamespace != "" {
-		if fullConfig.NetworkOperator == nil {
-			fullConfig.NetworkOperator = &config.NetworkOperatorConfig{}
-		}
-		fullConfig.NetworkOperator.Namespace = options.NetworkOperatorNamespace
-	}
-
-	// Apply image pull secrets override from CLI
-	if len(options.ImagePullSecrets) > 0 {
-		if fullConfig.NetworkOperator == nil {
-			fullConfig.NetworkOperator = &config.NetworkOperatorConfig{}
-		}
-		fullConfig.NetworkOperator.ImagePullSecrets = options.ImagePullSecrets
-	}
-
-	// Apply network namespaces override from CLI.
-	if len(options.NetworkNamespaces) > 0 {
-		fullConfig.NetworkNamespaces = options.NetworkNamespaces
 	}
 	// Default to a single "default" namespace when neither config nor CLI set it.
 	if len(fullConfig.NetworkNamespaces) == 0 {
@@ -225,98 +202,6 @@ func (p *NetworkOperatorPlugin) ApplyOptionsToConfig(options options.Options, fu
 			DeployNicInterfaceNameTemplate: true,
 			RdmaPrefix:                     "rdma_r%rail_id%",
 			NetdevPrefix:                   "eth_r%rail_id%",
-		}
-	}
-
-	if fullConfig.Profile == nil {
-		return nil
-	}
-
-	// Apply base profile overrides from CLI (non-empty strings and true bools override config)
-	if options.Fabric != "" {
-		fullConfig.Profile.Fabric = options.Fabric
-	}
-	if options.DeploymentType != "" {
-		fullConfig.Profile.Deployment = options.DeploymentType
-	}
-	// `MultirailSet` is true only when the user explicitly passed
-	// `--multirail` (regardless of value). Without it, the bool zero
-	// value can't be distinguished from "not passed", so a user who
-	// did NOT pass the flag would clobber the hardware default of
-	// true with `false`. See `pkg/options.Options.MultirailSet`.
-	if options.MultirailSet {
-		fullConfig.Profile.Multirail = options.Multirail
-		fullConfig.Profile.MultirailSet = true
-	}
-	if options.Routing != "" {
-		fullConfig.Profile.Routing = options.Routing
-	}
-	if options.IgnoreARPSet {
-		fullConfig.Profile.IgnoreARP = options.IgnoreARP
-		fullConfig.Profile.IgnoreARPSet = true
-	}
-
-	// Apply workload manifest override from CLI
-	if options.WorkloadManifest != "" {
-		if fullConfig.Workload == nil {
-			fullConfig.Workload = &config.WorkloadConfig{}
-		}
-		fullConfig.Workload.Manifest = options.WorkloadManifest
-	}
-
-	// Apply DOCA driver enable override from CLI
-	if options.EnableDocaDriver != nil {
-		if fullConfig.DOCADriver == nil {
-			fullConfig.DOCADriver = &config.DOCADriverConfig{
-				UnloadStorageModules:        true,
-				UnloadThirdPartyRDMAModules: true,
-				SkipPreflightChecks:         false,
-			}
-		}
-		fullConfig.DOCADriver.Enable = *options.EnableDocaDriver
-	}
-
-	// Apply Spectrum-X CLI options
-	if options.SpectrumX {
-		if fullConfig.Profile.SpectrumX == nil {
-			fullConfig.Profile.SpectrumX = &config.ProfileSpectrumX{}
-		}
-		fullConfig.Profile.SpectrumX.Enable = true
-		if options.SPCXVersion != "" {
-			fullConfig.Profile.SpectrumX.SPCXVersion = options.SPCXVersion
-		}
-		if options.MultiplaneMode != "" {
-			fullConfig.Profile.SpectrumX.MultiplaneMode = options.MultiplaneMode
-		}
-		if options.NumberOfPlanes != 0 {
-			fullConfig.Profile.SpectrumX.NumberOfPlanes = options.NumberOfPlanes
-		}
-		if options.TopologyScheme != "" {
-			fullConfig.Profile.SpectrumX.TopologyType = options.TopologyScheme
-		}
-		if options.IPVersion != "" {
-			fullConfig.Profile.SpectrumX.IPVersion = options.IPVersion
-		}
-		if options.TopologyFile != "" {
-			fullConfig.Profile.SpectrumX.TopologyFile = options.TopologyFile
-			resolvedTopologyFile, err := filepath.Abs(options.TopologyFile)
-			if err != nil {
-				return fmt.Errorf("failed to resolve --topology-file %s: %w", options.TopologyFile, err)
-			}
-			fullConfig.Profile.SpectrumX.ResolvedTopologyFile = resolvedTopologyFile
-		}
-		if options.SpectrumXConfigMapName != "" {
-			fullConfig.Profile.SpectrumX.ConfigMapName = options.SpectrumXConfigMapName
-		}
-		if options.SpectrumXConfig != "" {
-			profileConfig, err := os.ReadFile(options.SpectrumXConfig)
-			if err != nil {
-				return fmt.Errorf("failed to read --spectrum-x-config %s: %w", options.SpectrumXConfig, err)
-			}
-			fullConfig.Profile.SpectrumX.Profile = string(profileConfig)
-		}
-		if err := config.NormalizeSpectrumXProfileConfig(fullConfig.Profile.SpectrumX); err != nil {
-			return fmt.Errorf("invalid Spectrum-X profile config: %w", err)
 		}
 	}
 

--- a/pkg/networkoperatorplugin/preflight/helm.go
+++ b/pkg/networkoperatorplugin/preflight/helm.go
@@ -29,6 +29,11 @@ func CheckHelmChartVersion(ctx context.Context, in Inputs) Result {
 		Name: "Helm chart version",
 		Code: CodeHelmChartVersion,
 	}
+	if in.SkipHelmChecks {
+		r.Skipped = true
+		r.Reason = "Network Operator Helm management disabled by configuration"
+		return r
+	}
 	if in.ExpectedChartVersion == "" {
 		r.Skipped = true
 		r.Reason = "no expected chart version (no --network-operator-release pinned)"
@@ -100,6 +105,11 @@ func CheckHelmValues(ctx context.Context, in Inputs) Result {
 	r := Result{
 		Name: "Helm values",
 		Code: CodeHelmValues,
+	}
+	if in.SkipHelmChecks {
+		r.Skipped = true
+		r.Reason = "Network Operator Helm management disabled by configuration"
+		return r
 	}
 	if len(in.GeneratedValuesYAML) == 0 {
 		r.Skipped = true

--- a/pkg/networkoperatorplugin/preflight/helm_test.go
+++ b/pkg/networkoperatorplugin/preflight/helm_test.go
@@ -26,6 +26,15 @@ func TestCheckHelmChartVersion_SkipsWithoutExpected(t *testing.T) {
 	assert.Contains(t, r.Reason, "no expected chart version")
 }
 
+func TestCheckHelmChartVersion_SkipsWhenHelmManagementDisabled(t *testing.T) {
+	r := CheckHelmChartVersion(context.Background(), Inputs{
+		SkipHelmChecks:       true,
+		ExpectedChartVersion: "26.7.0",
+	})
+	require.True(t, r.Skipped)
+	assert.Contains(t, r.Reason, "disabled by configuration")
+}
+
 func TestCheckHelmChartVersion_SkipsWithoutRestConfig(t *testing.T) {
 	r := CheckHelmChartVersion(context.Background(), Inputs{
 		ExpectedChartVersion: "26.4.0-beta.9",
@@ -39,6 +48,15 @@ func TestCheckHelmValues_SkipsWithoutValuesYAML(t *testing.T) {
 	require.True(t, r.Skipped)
 	assert.Equal(t, CodeHelmValues, r.Code)
 	assert.Contains(t, r.Reason, "no values.yaml")
+}
+
+func TestCheckHelmValues_SkipsWhenHelmManagementDisabled(t *testing.T) {
+	r := CheckHelmValues(context.Background(), Inputs{
+		SkipHelmChecks:      true,
+		GeneratedValuesYAML: []byte("nfd:\n  enabled: true\n"),
+	})
+	require.True(t, r.Skipped)
+	assert.Contains(t, r.Reason, "disabled by configuration")
 }
 
 func TestCheckHelmValues_SkipsWithoutRestConfig(t *testing.T) {

--- a/pkg/networkoperatorplugin/preflight/types.go
+++ b/pkg/networkoperatorplugin/preflight/types.go
@@ -120,6 +120,10 @@ type Inputs struct {
 	// constructs its own action.Configuration internally.
 	RestConfig *rest.Config
 
+	// SkipHelmChecks explicitly disables chart-version and values checks when
+	// l8k is configured not to manage the Network Operator Helm release.
+	SkipHelmChecks bool
+
 	// OperatorNamespace is where the network-operator chart is
 	// installed and where namespaced CRs are enumerated.
 	OperatorNamespace string

--- a/pkg/networkoperatorplugin/render_plan.go
+++ b/pkg/networkoperatorplugin/render_plan.go
@@ -371,6 +371,9 @@ func renderForScope(
 	// ScopeClusterWide CR manifests — and emit under the helm-convention
 	// filename `values.yaml`.
 	if isHelmValuesTemplate(filepath.Base(templatePath)) {
+		if cfg != nil && cfg.NetworkOperator != nil && cfg.NetworkOperator.SkipHelmChart {
+			return map[string]string{}, nil
+		}
 		merged := mergedClusterConfigs(plans)
 		renderCfg := withClusterConfig(cfg, merged, allSubnets(planSubnets))
 		rendered, err := ProcessTemplate(templatePath, renderCfg, "")

--- a/pkg/networkoperatorplugin/skip_helm_test.go
+++ b/pkg/networkoperatorplugin/skip_helm_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkoperatorplugin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	"github.com/nvidia/k8s-launch-kit/pkg/options"
+	"github.com/nvidia/k8s-launch-kit/pkg/ui"
+)
+
+func TestApplyOptionsToConfigSkipNetworkOperatorHelm(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  bool
+		opts     options.Options
+		expected bool
+	}{
+		{
+			name:     "omitted flag preserves config",
+			initial:  true,
+			expected: true,
+		},
+		{
+			name: "explicit true enables skip",
+			opts: options.Options{
+				SkipNetworkOperatorHelm:    true,
+				SkipNetworkOperatorHelmSet: true,
+			},
+			expected: true,
+		},
+		{
+			name:    "explicit false disables config skip",
+			initial: true,
+			opts: options.Options{
+				SkipNetworkOperatorHelm:    false,
+				SkipNetworkOperatorHelmSet: true,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.LaunchKitConfig{
+				NetworkOperator: &config.NetworkOperatorConfig{SkipHelmChart: tt.initial},
+			}
+			require.NoError(t, (&NetworkOperatorPlugin{}).ApplyOptionsToConfig(tt.opts, cfg))
+			assert.Equal(t, tt.expected, cfg.NetworkOperator.SkipHelmChart)
+		})
+	}
+}
+
+func TestConfigFlagMappings(t *testing.T) {
+	mappings := ConfigFlagMappings()
+	require.NotEmpty(t, mappings)
+
+	seen := map[string]struct{}{}
+	for _, mapping := range mappings {
+		assert.NotEmpty(t, mapping.FlagName)
+		assert.NotEmpty(t, mapping.ConfigPaths)
+		_, duplicate := seen[mapping.FlagName]
+		assert.Falsef(t, duplicate, "duplicate mapping for --%s", mapping.FlagName)
+		seen[mapping.FlagName] = struct{}{}
+		for _, configPath := range mapping.ConfigPaths {
+			assert.NotEmpty(t, configPath)
+		}
+	}
+
+	assert.Equal(t, []string{"networkOperator.skipHelmChart"},
+		ConfigPathsForFlag("--skip-network-operator-helm"))
+	assert.Equal(t, []string{"networkOperator.skipHelmChart"},
+		ConfigPathsForFlag("skip-network-operator-helm"))
+	assert.Nil(t, ConfigPathsForFlag("not-config-backed"))
+}
+
+func TestRenderForScopeSkipsHelmValues(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), helmValuesTemplateName)
+	require.NoError(t, os.WriteFile(templatePath, []byte("nfd:\n  enabled: true\n"), 0o600))
+
+	rendered, err := renderForScope(templatePath, &config.LaunchKitConfig{
+		NetworkOperator: &config.NetworkOperatorConfig{SkipHelmChart: true},
+	}, nil, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, rendered)
+}
+
+func TestGenerateProfileSkipsHelmValuesButKeepsManifests(t *testing.T) {
+	cfg, err := config.LoadFullConfig(
+		filepath.Join("testdata", "grouping", "mixed-same-type.yaml"),
+		logr.Discard(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.NetworkOperator)
+	cfg.NetworkOperator.SkipHelmChart = true
+	cfg.Profile = &config.Profile{
+		Fabric:     "ethernet",
+		Deployment: "sriov",
+		Multirail:  true,
+	}
+
+	rendered, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(
+		loadProfileFromDir(t, "sriov-ethernet-rdma"), cfg)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, rendered)
+	assert.NotContains(t, rendered, helmValuesOutputName)
+	assert.Contains(t, rendered, "10-nicclusterpolicy.yaml")
+}
+
+func TestRunHelmInstallPhaseSkipsBeforeReadingValues(t *testing.T) {
+	err := runHelmInstallPhase(context.Background(), filepath.Join(t.TempDir(), "missing"), DeployOptions{
+		SkipHelmChart: true,
+	}, ui.NewSilent())
+
+	require.NoError(t, err)
+}
+
+func TestBuildPreflightInputsSkipsOnlyHelmChecks(t *testing.T) {
+	in, err := buildPreflightInputs(nil, t.TempDir(), DeployOptions{
+		SkipHelmChart: true,
+		NetworkOperator: &config.NetworkOperatorConfig{
+			Version:          "v26.7.0",
+			ComponentVersion: "network-operator-v26.7.0",
+		},
+		DOCAVersion: "doca-26.7",
+	})
+
+	require.NoError(t, err)
+	assert.True(t, in.SkipHelmChecks)
+	assert.Empty(t, in.GeneratedValuesYAML)
+	assert.Equal(t, "network-operator-v26.7.0", in.ExpectedComponentVersion)
+	assert.Equal(t, "doca-26.7", in.ExpectedDOCAVersion)
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -54,6 +54,11 @@ type Options struct {
 	// embedded releases catalog and drives version-gated template sections.
 	NetworkOperatorRelease string
 	ImagePullSecrets       []string // Image pull secret names for Network Operator components and Helm repository authentication
+	// SkipNetworkOperatorHelm disables values.yaml generation, Network Operator
+	// Helm installation, and Helm-specific validation. The Set companion keeps
+	// an omitted flag distinct from --skip-network-operator-helm=false.
+	SkipNetworkOperatorHelm    bool
+	SkipNetworkOperatorHelmSet bool
 
 	// Phase 2: Deployment Generation
 	Fabric         string // Fabric type to deploy

--- a/pkg/target/host/deploy.go
+++ b/pkg/target/host/deploy.go
@@ -88,6 +88,7 @@ func (deployRunner) Run(ctx context.Context, request DeployRequest) error {
 		LaunchKitVersion:  request.LaunchKitVersion,
 		DryRun:            request.DryRun,
 		OverwriteExisting: request.OverwriteExisting,
+		SkipHelmChart:     request.SkipNetworkOperatorHelm.Set && request.SkipNetworkOperatorHelm.Value,
 		RestConfig:        restConfig,
 	}
 	cfg, cfgPath, cfgErr := LoadUserConfig(UserConfigInput{
@@ -98,6 +99,9 @@ func (deployRunner) Run(ctx context.Context, request DeployRequest) error {
 		ConfigDir:                request.ConfigDir,
 		UserConfig:               request.UserConfig,
 		NetworkOperatorNamespace: request.OperatorNamespace,
+
+		SkipNetworkOperatorHelm:    request.SkipNetworkOperatorHelm.Value,
+		SkipNetworkOperatorHelmSet: request.SkipNetworkOperatorHelm.Set,
 	})
 	if cfgErr != nil {
 		return apperrors.NewValidationError(
@@ -108,6 +112,9 @@ func (deployRunner) Run(ctx context.Context, request DeployRequest) error {
 	}
 	if cfg != nil {
 		deployOpts.NetworkOperator = cfg.NetworkOperator
+		if cfg.NetworkOperator != nil {
+			deployOpts.SkipHelmChart = cfg.NetworkOperator.SkipHelmChart
+		}
 		if cfg.DOCADriver != nil {
 			deployOpts.DOCAVersion = cfg.DOCADriver.Version
 		}

--- a/pkg/target/host/driver.go
+++ b/pkg/target/host/driver.go
@@ -52,11 +52,14 @@ type DeployRequest struct {
 	ConfigDir         string
 	OperatorNamespace string
 	OverwriteExisting bool
-	OutputFormat      string
-	Quiet             bool
-	AutoApprove       bool
-	DryRun            bool
-	Timeout           time.Duration
+
+	SkipNetworkOperatorHelm Explicit[bool]
+
+	OutputFormat string
+	Quiet        bool
+	AutoApprove  bool
+	DryRun       bool
+	Timeout      time.Duration
 }
 
 // ValidateRequest contains the Host-owned inputs for standalone validation.
@@ -66,20 +69,23 @@ type ValidateRequest struct {
 	UserConfig        string
 	ConfigDir         string
 	OperatorNamespace string
-	Connectivity      Explicit[bool]
-	Keep              bool
-	ConnectivityTime  time.Duration
-	Mode              Explicit[string]
-	Checks            Explicit[[]string]
-	RDMAPIterations   Explicit[int]
-	RDMAIBWriteSize   Explicit[int]
-	RDMAMinBandwidth  Explicit[float64]
-	Wait              time.Duration
-	ReportPath        string
-	Version           string
-	OutputFormat      string
-	Quiet             bool
-	AutoApprove       bool
+
+	SkipNetworkOperatorHelm Explicit[bool]
+
+	Connectivity     Explicit[bool]
+	Keep             bool
+	ConnectivityTime time.Duration
+	Mode             Explicit[string]
+	Checks           Explicit[[]string]
+	RDMAPIterations  Explicit[int]
+	RDMAIBWriteSize  Explicit[int]
+	RDMAMinBandwidth Explicit[float64]
+	Wait             time.Duration
+	ReportPath       string
+	Version          string
+	OutputFormat     string
+	Quiet            bool
+	AutoApprove      bool
 }
 
 // LauncherRunner executes one app.Launcher-backed Host phase.

--- a/pkg/target/host/paths.go
+++ b/pkg/target/host/paths.go
@@ -160,10 +160,10 @@ func UserConfigPathForGenerate(input UserConfigInput) string {
 	return path
 }
 
-// LoadUserConfig loads the resolved Host config and applies release and
-// namespace overlays used by standalone deploy and validate. When parsing
-// succeeds but a release overlay fails, it returns the parsed config together
-// with the error so validation can retain that evidence in a partial report.
+// LoadUserConfig loads the resolved Host config and applies every config-backed
+// CLI override through the shared mapping registry. When parsing succeeds but
+// an override fails, it returns the parsed config together with the error so
+// validation can retain that evidence in a partial report.
 func LoadUserConfig(input UserConfigInput, opts options.Options) (*config.LaunchKitConfig, string, error) {
 	path, err := UserConfigPathFor(input)
 	if err != nil {
@@ -179,14 +179,8 @@ func LoadUserConfig(input UserConfigInput, opts options.Options) (*config.Launch
 	if cfg == nil {
 		return nil, path, fmt.Errorf("user-config %s is empty", path)
 	}
-	if err := networkoperatorplugin.ApplyNetworkOperatorRelease(opts, cfg); err != nil {
-		return cfg, path, fmt.Errorf("apply release catalog: %w", err)
-	}
-	if opts.NetworkOperatorNamespace != "" {
-		if cfg.NetworkOperator == nil {
-			cfg.NetworkOperator = &config.NetworkOperatorConfig{}
-		}
-		cfg.NetworkOperator.Namespace = opts.NetworkOperatorNamespace
+	if err := networkoperatorplugin.ApplyCLIConfigOverrides(opts, cfg); err != nil {
+		return cfg, path, fmt.Errorf("apply CLI config overrides: %w", err)
 	}
 	return cfg, path, nil
 }

--- a/pkg/target/host/paths_test.go
+++ b/pkg/target/host/paths_test.go
@@ -100,3 +100,27 @@ clusterConfig:
 	require.Len(t, cfg.ClusterConfig, 1)
 	assert.Equal(t, "retained-report-group", cfg.ClusterConfig[0].Identifier)
 }
+
+func TestLoadUserConfigAppliesExplicitSkipNetworkOperatorHelmOverride(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cluster-config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`networkOperator:
+  skipHelmChart: true
+`), 0o600))
+
+	t.Run("omitted preserves config", func(t *testing.T) {
+		cfg, _, err := LoadUserConfig(UserConfigInput{Explicit: path}, options.Options{})
+		require.NoError(t, err)
+		require.NotNil(t, cfg.NetworkOperator)
+		assert.True(t, cfg.NetworkOperator.SkipHelmChart)
+	})
+
+	t.Run("explicit false overrides config", func(t *testing.T) {
+		cfg, _, err := LoadUserConfig(UserConfigInput{Explicit: path}, options.Options{
+			SkipNetworkOperatorHelm:    false,
+			SkipNetworkOperatorHelmSet: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cfg.NetworkOperator)
+		assert.False(t, cfg.NetworkOperator.SkipHelmChart)
+	})
+}

--- a/pkg/target/host/validate.go
+++ b/pkg/target/host/validate.go
@@ -41,6 +41,8 @@ import (
 
 const defaultOperatorNamespace = "nvidia-network-operator"
 
+const skipNetworkOperatorHelmReason = "Network Operator Helm management disabled by configuration"
+
 type validateRunner struct{}
 
 // NewValidateRunner returns the production standalone Host validation service.
@@ -49,6 +51,8 @@ func NewValidateRunner() ValidateRunner {
 }
 
 func (validateRunner) Run(operationContext context.Context, request ValidateRequest) error {
+	skipNetworkOperatorHelm := request.SkipNetworkOperatorHelm.Set && request.SkipNetworkOperatorHelm.Value
+
 	// State accumulated during the run. exitWithReport captures it by
 	// reference so every error path emits the HTML report with whatever was
 	// observed before returning to the outer process boundary.
@@ -141,6 +145,9 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 		ConfigDir:                request.ConfigDir,
 		UserConfig:               request.UserConfig,
 		NetworkOperatorNamespace: request.OperatorNamespace,
+
+		SkipNetworkOperatorHelm:    request.SkipNetworkOperatorHelm.Value,
+		SkipNetworkOperatorHelmSet: request.SkipNetworkOperatorHelm.Set,
 	})
 	cfgPath = loadedCfgPath
 	// Preserve successfully parsed user input in partial reports even when a
@@ -148,6 +155,9 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 	// existing soft-failure path below and skips config-derived version checks.
 	if cfg != nil {
 		reportConfig = cfg
+		if cfg.NetworkOperator != nil {
+			skipNetworkOperatorHelm = cfg.NetworkOperator.SkipHelmChart
+		}
 	}
 	if cfgErr != nil {
 		log.Log.V(1).Info("user-config not loaded; version check will be skipped",
@@ -211,18 +221,22 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 
 	ctx := operationContext
 
-	var vcErr error
 	checkStarted := time.Now()
-	versionCheck, vcErr = networkoperatorplugin.CheckHelmReleaseVersion(ctx, k8sClient, operatorNamespace, selectedRelease)
-	log.Log.V(1).Info("validation check completed", "check", "helm release version",
-		"success", vcErr == nil, "duration", time.Since(checkStarted).Round(time.Millisecond).String())
-	if vcErr != nil {
-		return exitWithReport(apperrors.NewClusterError(
-			"version check failed",
-			vcErr,
-			"Check that the kubeconfig has list-secrets permission in the operator namespace",
-		))
+	if skipNetworkOperatorHelm {
+		versionCheck = &networkoperatorplugin.VersionCheck{Skipped: true, Reason: skipNetworkOperatorHelmReason}
+	} else {
+		var vcErr error
+		versionCheck, vcErr = networkoperatorplugin.CheckHelmReleaseVersion(ctx, k8sClient, operatorNamespace, selectedRelease)
+		if vcErr != nil {
+			return exitWithReport(apperrors.NewClusterError(
+				"version check failed",
+				vcErr,
+				"Check that the kubeconfig has list-secrets permission in the operator namespace",
+			))
+		}
 	}
+	log.Log.V(1).Info("validation check completed", "check", "helm release version",
+		"skipped", versionCheck.Skipped, "duration", time.Since(checkStarted).Round(time.Millisecond).String())
 
 	// Cross-check the NicClusterPolicy + NicNodePolicy
 	// component versions against the catalog. Soft errors only
@@ -245,13 +259,19 @@ func (validateRunner) Run(operationContext context.Context, request ValidateRequ
 	// `l8k generate` produced. Mismatches mean re-running
 	// `l8k deploy` would change the chart configuration —
 	// exit code 4, same as a version mismatch.
-	valuesPath := filepath.Join(manifestDir, "values.yaml")
-	var generatedValuesYAML []byte
-	if b, err := os.ReadFile(valuesPath); err == nil {
-		generatedValuesYAML = b
-	}
 	checkStarted = time.Now()
-	hvCheck, hvErr := networkoperatorplugin.CheckHelmReleaseValues(ctx, restConfig, operatorNamespace, generatedValuesYAML)
+	var hvCheck *networkoperatorplugin.HelmValuesCheck
+	var hvErr error
+	if skipNetworkOperatorHelm {
+		hvCheck = &networkoperatorplugin.HelmValuesCheck{Skipped: true, Reason: skipNetworkOperatorHelmReason}
+	} else {
+		valuesPath := filepath.Join(manifestDir, "values.yaml")
+		var generatedValuesYAML []byte
+		if b, err := os.ReadFile(valuesPath); err == nil {
+			generatedValuesYAML = b
+		}
+		hvCheck, hvErr = networkoperatorplugin.CheckHelmReleaseValues(ctx, restConfig, operatorNamespace, generatedValuesYAML)
+	}
 	log.Log.V(1).Info("validation check completed", "check", "Helm values drift",
 		"success", hvErr == nil, "duration", time.Since(checkStarted).Round(time.Millisecond).String())
 	if hvErr != nil {

--- a/skills/k8s-launch-kit-clean/SKILL.md
+++ b/skills/k8s-launch-kit-clean/SKILL.md
@@ -46,7 +46,9 @@ l8k clean \
 Omit `--network-operator-namespace` only when the user expects l8k to resolve
 it from `--user-config`, `./cluster-config.yaml`, an explicit `--config-dir`,
 or the `nvidia-network-operator` default. l8k does not trust in-cluster objects
-to select a destructive cleanup target.
+to select a destructive cleanup target. The same trusted local config supplies
+`networkOperator.skipHelmChart`; when true, l8k treats the Helm release as
+externally owned and retains it.
 
 To retain the installed release and its chart-managed resources:
 
@@ -74,7 +76,7 @@ The command:
   delete-all-then-wait ordering for re-sweeps.
 - Keeps controllers installed until CR deletion and finalizers complete.
 - Uninstalls the `network-operator` Helm release last unless
-  `--keep-helm-chart` is set.
+  `networkOperator.skipHelmChart` or `--keep-helm-chart` retains it.
 - Preserves the namespace, CRDs, Secrets not owned by Helm, local files, and
   namespaced custom resources elsewhere. Helm metadata and chart-managed
   resources are removed with the release.
@@ -92,6 +94,9 @@ Require `.success == true`, then report:
 - `.cleanup.customResourcesDeleted`
 - `.cleanup.helmReleaseRemoved`
 - `.cleanup.keepHelmChart`
+
+`cleanup.keepHelmChart` is the effective policy from config plus the explicit
+flag, not merely whether `--keep-helm-chart` appeared on the command line.
 
 If the Helm release was meant to be removed, verify it is absent with the same
 read-only `helm list` command. If it was kept, verify it remains deployed.

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-config
-version: 1.2.4
+version: 1.2.5
 description: "Use this skill when the user needs help understanding, creating, or editing a k8s-launch-kit (l8k) configuration file (l8k-config.yaml or cluster-config.yaml). Activate for: config file questions, parameter tuning, subnet configuration, NV-IPAM setup, DOCA driver settings, maintenance concurrency, NIC configuration operator settings, changing MTU, VFs, resource names, or understanding what any config field does."
 metadata:
   requires:
@@ -50,7 +50,7 @@ false across rewrites.
 
 | Section | What It Controls |
 |---------|-----------------|
-| `networkOperator` | Operator namespace, version, image repository, helm chart repository (`helmRepoURL`) |
+| `networkOperator` | Operator namespace, version, image repository, Helm repository, and `skipHelmChart` ownership switch |
 | `docaDriver` | OFED/DOCA driver image, version, blacklist settings |
 | `maintenance` | Maintenance Operator, SR-IOV drain, and legacy OFED upgrade concurrency |
 | `nvIpam` | NV-IPAM IP pool ranges and subnet generation |
@@ -140,6 +140,11 @@ maintenance:
 # Useful only for mirrors or private chart hosts.
 networkOperator:
   helmRepoURL: "https://my-mirror.example.com/charts"
+  # Keep generating/applying Network Operator CRs but let another system own
+  # the Helm release. Generate/deploy/validate have the equivalent CLI flag
+  # --skip-network-operator-helm; clean reads this persistent ownership setting
+  # and retains the release while deleting Network Operator CRs.
+  skipHelmChart: true
 
 # Configure NV-IPAM subnets manually
 nvIpam:

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -9,6 +9,13 @@ Comments describe the type, default value, and effect on generated manifests.
 # Controls the NVIDIA Network Operator Helm chart installation.
 # ============================================================================
 networkOperator:
+  # bool | default: false
+  # Omit values.yaml, skip the Network Operator Helm install and Helm-specific
+  # deploy/validate checks, and retain the externally owned release during
+  # cleanup. CR generation, apply, validation, and cleanup still run. CLI for
+  # generate/deploy/validate: --skip-network-operator-helm.
+  skipHelmChart: false
+
   # string | default: "v26.1.0"
   # Helm chart version. Determines which operator image and CRDs are deployed.
   version: v26.1.0

--- a/skills/k8s-launch-kit-deploy/SKILL.md
+++ b/skills/k8s-launch-kit-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-deploy
-version: 1.3.4
+version: 1.3.5
 description: "Use this skill when the user wants to deploy generated NVIDIA networking manifests to a Kubernetes cluster using k8s-launch-kit (l8k). Activate for: applying manifests, deploying to cluster, the `l8k deploy` subcommand or the legacy --deploy flag on `l8k generate`, applying generated files, or any mention of pushing l8k output to a live cluster. Even if the user just says 'apply these' or 'push to cluster' after generating manifests, use this skill."
 metadata:
   requires:
@@ -29,6 +29,12 @@ l8k deploy [--deployment-files <DIR>] [--kubeconfig <PATH>] [--dry-run]
 `l8k deploy` reads YAML files from `--deployment-files` (default `./deployment`) and applies them in dependency order. It auto-prefers `<DIR>/network-operator/` (the layout `l8k generate` produces) and falls back to `<DIR>` itself.
 
 When the deployment directory contains a `values.yaml` (the `l8k generate` profile renderer emits one per profile), Phase 0 runs first: the Helm Go SDK installs (or upgrades, with `--overwrite-existing`) the `nvidia/network-operator` chart in the namespace from `networkOperator.namespace`. The chart version and Helm repo URL come from the embedded release catalog selected via `--network-operator-release`. Phase 0 is skipped silently when `values.yaml` is absent — backward compatible with users managing the chart out of band.
+
+`networkOperator.skipHelmChart: true` or
+`--skip-network-operator-helm` explicitly skips Phase 0 and its Helm
+chart-version/values preflight checks even when an external bundle has a
+`values.yaml`. Component-version and stray-resource preflight checks plus all
+manifest apply phases remain enabled.
 
 When `networkOperator.imagePullSecrets` is non-empty, l8k reads the named
 Docker Secrets from the operator namespace and uses compatible credentials to
@@ -59,6 +65,7 @@ l8k generate --user-config <CONFIG> --fabric <FABRIC> --deployment-type <TYPE> -
 | `--kubeconfig` | — | Path to kubeconfig with cluster-admin access (falls back to `$KUBECONFIG`) |
 | `--dry-run` | — | Server-side dry-run (`client.DryRunAll`) — cluster validates without persisting |
 | `--overwrite-existing` | — | Converge detected l8k-owned drift: upgrade a mismatched Helm release, delete conflicting generated-resource kinds, and rewrite owned policy fields. Spectrum-X operator-generated child resources are excluded from conflicts. |
+| `--skip-network-operator-helm` | — | Skip Network Operator chart install/upgrade and Helm preflight checks; still deploy the generated CRs. |
 
 ## Examples
 

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-generate
-version: 1.2.7
+version: 1.2.8
 description: "Use this skill when the user wants to generate Kubernetes YAML manifests for NVIDIA networking deployment using k8s-launch-kit (l8k). Activate for: manifest generation, profile selection, choosing between SR-IOV/host-device/RDMA-shared/IPoIB/MacVLAN/Spectrum-X, creating deployment files, or when the user asks 'which profile should I use' or needs help choosing a network configuration."
 metadata:
   requires:
@@ -48,6 +48,7 @@ to that source file; embedded `--for` generation does not write a config.
 | `--gpu-type` | — | `NVIDIA-H200` | Restrict output to source groups whose `gpuType` matches (case-insensitive). Mutually exclusive with `--groups`. |
 | `--for` | — | preset directory name | Skip discovery: synthesize `clusterConfig` from a topology preset. Requires `--node-selector`. List options with `l8k preset list`. |
 | `--node-selector` | Required with `--for` | `key=val,key2=val2` | Identifies which nodes the synthesized clusterConfig targets at apply time. |
+| `--skip-network-operator-helm` | — | boolean | Omit `values.yaml`; with `--deploy`, also skip Network Operator chart installation and Helm preflight checks. |
 
 *Not required when `--spectrum-x` is used.
 
@@ -114,7 +115,7 @@ read `references/profile-decision-tree.md`.
 
 ## Output
 
-Generated YAMLs are written to the output directory under `network-operator/`. Each profile also emits a `values.yaml` (Helm values for the `nvidia/network-operator` chart) alongside the CR manifests:
+Generated YAMLs are written to the output directory under `network-operator/`. Each profile normally emits a `values.yaml` (Helm values for the `nvidia/network-operator` chart) alongside the CR manifests:
 
 When `validation.gpuDirect.enabled` is true, every generated example
 DaemonSet requests `validation.gpuDirect.gpuResourceType` only on its primary
@@ -135,6 +136,11 @@ output/
 ```
 
 `values.yaml` is rendered from the profile's `00-values.yaml` template. `--network-operator-release <MAJOR.MINOR>` populates the chart repository URL and image tag from the embedded catalog. For Spectrum-X profiles, the same catalog entry supplies the independently versioned xPlane repository and tag rather than reusing the generic Network Operator component coordinates. To install or upgrade the chart alongside the CRs, pass `--deploy` (and `--overwrite-existing` when the release already exists with different values).
+
+Set `networkOperator.skipHelmChart: true` or pass
+`--skip-network-operator-helm` when another system owns the Helm release. The
+output directory is cleaned and `values.yaml` is omitted; all Network Operator
+custom-resource manifests are still rendered.
 
 For Network Operator 26.1 and newer, the rendered values enable Maintenance
 Operator requestor mode. Profiles with DOCA/OFED enable

--- a/skills/k8s-launch-kit-pipeline/SKILL.md
+++ b/skills/k8s-launch-kit-pipeline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-pipeline
-version: 1.1.1
+version: 1.1.2
 description: "Use this skill when the user wants to run the full k8s-launch-kit (l8k) pipeline end-to-end: discover cluster hardware, select a profile, generate manifests, and deploy them all in one command. Also activate for CI/CD integration, automation pipelines, 'one-liner', 'complete workflow', or end-to-end NVIDIA networking deployment."
 metadata:
   requires:
@@ -103,8 +103,13 @@ l8k generate --user-config ./cluster-config.yaml \
 | Full pipeline (root) | `l8k --discover-cluster-config ... --deploy` |
 | Full pipeline (subcommands) | `l8k discover ... && l8k generate ... --deploy` |
 | Full pipeline dry-run | `l8k --discover-cluster-config ... --deploy --dry-run` |
+| External Helm ownership | `l8k ... --skip-network-operator-helm --deploy` |
 
 Note: The root command's strength is chaining all phases — it runs discover, generate, and deploy in a single invocation. Use subcommands when you need intermediate inspection or different flags per phase.
+
+With `--skip-network-operator-helm`, generation omits `values.yaml` and deploy
+skips the Network Operator Helm install/preflight boundary while continuing to
+apply and reconcile the generated custom resources.
 
 ## Phase Order
 

--- a/skills/k8s-launch-kit-shared/SKILL.md
+++ b/skills/k8s-launch-kit-shared/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-shared
-version: 1.0.2
+version: 1.0.3
 description: "k8s-launch-kit (l8k) CLI: Shared patterns for binary location, global flags, output formatting, exit codes, and error handling. Read this before using any other k8s-launch-kit skill."
 ---
 
@@ -45,7 +45,7 @@ After installation, `l8k` is available system-wide.
 | `l8k discover` | Discover cluster hardware and produce cluster-config.yaml |
 | `l8k generate` | Generate Kubernetes YAML manifests from config + profile (use `--for <preset>` to skip cluster discovery for known SKUs) |
 | `l8k deploy` | Apply generated manifests and install or upgrade the Network Operator Helm release |
-| `l8k clean` | Delete Network Operator custom resources and optionally uninstall its Helm release |
+| `l8k clean` | Delete Network Operator custom resources and uninstall its Helm release unless config or a flag retains it |
 | `l8k validate` | Verify the Helm release, manifests, component versions, and connectivity |
 | `l8k preset list` | List bundled topology presets (directory + machineType + gpuType) |
 | `l8k preset update` | Download latest topology presets from GitHub |
@@ -90,11 +90,21 @@ package ownership, artifacts, or external integration boundaries.
 | `--network-namespaces <NS,...>` | Comma-separated namespaces for the secondary-network CRs + example test DaemonSets; one copy rendered per namespace (shared resources like IPPools/NodePolicies are NOT duplicated). Default: `default` |
 | `--node-selector <LABELS>` | Restrict to nodes matching labels (comma-separated, ANDed) |
 | `--image-pull-secrets <NAMES>` | Image pull secret names for Network Operator components and authenticated Helm chart downloads (comma-separated) |
+| `--skip-network-operator-helm` | On generate/deploy/validate and the root pipeline, skip Network Operator Helm values, installation, and Helm-specific validation while retaining custom-resource handling |
+
+The persistent `networkOperator.skipHelmChart` setting also makes `l8k clean`
+retain the externally owned Helm release while deleting Network Operator custom
+resources. Clean does not route the skip flag; use config for the ownership
+policy or `--keep-helm-chart` for an explicit retention-only override.
 
 `l8k discover` and `l8k generate` both accept the profile flags `--fabric`,
 `--deployment-type`, `--multirail`, `--spectrum-x`, `--multiplane-mode`, and
 `--number-of-planes`. Discovery persists the resolved values; later generation
 reuses them unless another explicit CLI override is supplied.
+
+For automation, `l8k schema` exposes `configPaths` on config-backed flags. The
+metadata comes from the same registry that applies explicit flag values, so use
+it instead of maintaining a separate CLI-to-YAML mapping.
 
 ## Agent / JSON Mode
 

--- a/skills/k8s-launch-kit-validate/SKILL.md
+++ b/skills/k8s-launch-kit-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-validate
-version: 1.0.5
+version: 1.0.6
 description: "Use this skill when the user wants to verify that an NVIDIA networking deployment matches the configuration that produced it. Activate for: 'is my deployment correct', 'are all the manifests applied', 'does the network operator version match', 'verify deployment', 'check cluster state against config', or any question about whether the cluster reflects what l8k generated. Wraps the `l8k validate` subcommand."
 metadata:
   requires:
@@ -60,6 +60,11 @@ Exit code is non-zero (4) on any missing manifest, version mismatch, or
 gating connectivity failure. Version checks soft-skip when prerequisites are
 absent — no `cluster-config.yaml`, no Helm release Secret, etc.
 
+If `networkOperator.skipHelmChart: true` is set, or the user passes
+`--skip-network-operator-helm`, both Helm release/version and values checks are
+reported as skipped. Component-version, manifest, stray-resource, connectivity,
+and report stages still run.
+
 ## Usage
 
 ```bash
@@ -73,6 +78,7 @@ l8k validate [--user-config <PATH>] [--deployment-files <DIR>] [--kubeconfig <PA
 | `--kubeconfig` | `$KUBECONFIG` | Path to kubeconfig with read access to the cluster |
 | `--user-config` | `./cluster-config.yaml` | Cluster config YAML; used for `networkOperator.selectedRelease` and the operator namespace |
 | `--deployment-files` | `./deployment` | Directory containing the manifests to verify |
+| `--skip-network-operator-helm` | `networkOperator.skipHelmChart` (`false`) | Skip Helm release/version and values validation only |
 | `--validation-mode` | `validation.mode` (`strict`) | Connectivity mode: `quick`, `full`, or `strict` |
 | `--validation-checks` | `validation.checks` (`icmp,rping,ib_write_bw`) | Comma-separated connectivity checks; `""` disables all |
 | `--connectivity-timeout` | automatic (`0`) | Total connectivity budget is calculated from the generated matrix plan; set a positive duration for an explicit hard setup and execution deadline |


### PR DESCRIPTION
## Summary

- add `networkOperator.skipHelmChart` and route `--skip-network-operator-helm` through the root pipeline, generate, deploy, and validate commands
- centralize config-backed CLI overrides in one flag-to-config registry, including explicit boolean precedence
- omit `values.yaml`, skip Helm installation/preflight, and report Helm validation checks as skipped while retaining Network Operator custom-resource handling
- expose mapped `configPaths` in `l8k schema` and update README, architecture/reference documentation, and bundled Launch Kit skills

## Behavior

When Helm management is disabled:

- generate cleans the output directory and omits only `values.yaml`
- deploy skips Network Operator chart installation and Helm chart-version/value checks
- validate reports Helm release/version and values checks as skipped
- manifest generation/apply, component-version checks, stray-resource checks, and connectivity validation continue unchanged

An explicit `--skip-network-operator-helm=false` overrides `networkOperator.skipHelmChart: true`.

## Testing

- `go test -race -count=1 ./...`
- `go build ./...`
- `make build`
- `golangci-lint v2.11.0 run ./...`
- `mkdocs build --strict`
- `make update-readme`
- verified root/generate/deploy/validate help and `l8k schema` output