### PR TITLE
generate: reject netplan-managed NIC naming conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Because `NicDevice` does not expose MAC addresses, Launch Kit reads them
 transiently from sysfs on every worker and checks whether host netplan uses a
 matching `match.macaddress` plus `set-name` rule. The group-level
 `netplanManaged` result identifies potential naming conflicts with udev rules
-deployed by NIC Configuration Operator; host-specific MACs are not saved.
+deployed by NIC Configuration Operator; host-specific MACs are not saved. If
+generation would emit a `NicInterfaceNameTemplate` for an affected group,
+`l8k generate` stops with a validation error. Remove the affected `set-name`
+stanzas from the host netplan configuration and re-run discovery before
+retrying generation.
 
 ### Select the Deployment Profile
 Discovery fills missing profile values from hardware and built-in defaults.
@@ -1453,6 +1457,16 @@ The `nicConfigurationOperator.deployNicInterfaceNameTemplate` setting controls w
 2. **rdma_shared deployment with empty network interface names** — When the deployment type is `rdma_shared` (macvlan-rdma-shared or ipoib-rdma-shared profiles) and PFs have empty `networkInterface` fields. The `rdmaSharedDevicePlugin` uses `ifNames` selectors that require interface names, so NicInterfaceNameTemplate must be enabled to provide them. This typically happens when discovery finds multiple nodes per group and omits device names for safety.
 
 When neither condition holds, name templates are disabled and the device plugin uses PCI addresses directly, avoiding the overhead of deploying the NIC configuration operator.
+
+Before emitting a `NicInterfaceNameTemplate`, `l8k generate` checks the
+selected source groups' discovered `netplanManaged` state. If the CR would
+configure a group marked `netplanManaged: true`, generation fails because the
+netplan `set-name` rule can conflict with NCO's udev rule for the same NIC.
+Clean up the affected `set-name` stanzas in the host netplan configuration,
+re-run `l8k discover` to refresh the group state, and then retry
+`l8k generate`. A group excluded with `--groups` or `--gpu-type` does not block
+generation, and neither does a group for which the name-template CR is not
+rendered.
 
 Spectrum-X interface prefixes default according to the selected multiplane mode:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -23,6 +23,14 @@ When ``generate`` uses a file-backed config, it writes resolved defaults and
 explicit CLI overrides back to that same file before rendering manifests.
 Comments in the original YAML are preserved.
 
+When a selected hardware group has ``netplanManaged: true``, generation stops
+if the chosen profile would emit a ``NicInterfaceNameTemplate`` for that group.
+The existing netplan ``set-name`` rule can conflict with the udev naming rule
+deployed by NIC Configuration Operator. Remove the affected ``set-name``
+stanzas from the host netplan configuration, re-run ``l8k discover``, and then
+retry ``l8k generate``. Groups excluded with ``--groups`` or ``--gpu-type`` do
+not participate in this check.
+
 Discovery defaults ``deployment`` to ``sriov`` and ``multirail`` to ``true``.
 It derives ``fabric`` only when every discovered group reports the same
 confirmed link type. If the fabric cannot be confirmed, discovery still saves

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -338,7 +338,7 @@ Fresh discovery may merge compatible source groups during generation, but it kee
 | `identifier` | Lowercase resource-name form of machine/GPU identity with complete `NVIDIA` segments removed and common machine segments shortened (`ThinkSystem` → `ts`, `PowerEdge` → `pe`), bounded to 30 bytes with balanced machine/GPU prefixes and a 6-character deterministic hash when needed, or `group-N` fallback. The Launch Kit machine node label uses the same value. |
 | `machineType` / `gpuType` | Discovered hardware identity. |
 | `linkType` | Per-group `Ethernet` or `InfiniBand` result when fabric probes agree. |
-| `netplanManaged` | `true` when any worker has an NVIDIA PF selected by a netplan `match.macaddress` stanza with a non-empty `set-name`; indicates a potential conflict with NCO udev naming. |
+| `netplanManaged` | `true` when any worker has an NVIDIA PF selected by a netplan `match.macaddress` stanza with a non-empty `set-name`. Generation fails if a `NicInterfaceNameTemplate` would configure this group; remove the affected `set-name` stanzas and re-run discovery before retrying generation. |
 | `presetApplied` | An exact topology preset was applied. |
 | `presetDeviation` | PF count, PCI address, or device ID drift from a matched preset. |
 | `capabilities.nodes` | Group-level SR-IOV, RDMA, and InfiniBand capability flags. |

--- a/docs/user/discovery.md
+++ b/docs/user/discovery.md
@@ -61,7 +61,11 @@ non-empty `set-name`. If any NVIDIA PF matches on any worker in a hardware
 group, the saved group has `netplanManaged: true`; otherwise it is `false`.
 This flags a potential conflict between netplan naming and udev rules deployed
 by NIC Configuration Operator without storing host-unique MAC addresses in the
-shared group configuration.
+shared group configuration. If `l8k generate` would emit a
+`NicInterfaceNameTemplate` for an affected group, it returns a validation error
+instead of generating conflicting NCO naming rules. Remove the affected
+`set-name` stanzas from the host netplan configuration and re-run discovery to
+clear the saved group state before retrying generation.
 
 GPU topology probing adds connected GPU, GPU PCI address, and proximity data
 per PF. A PIX-proximate NIC-to-GPU path can override heuristic traffic

--- a/pkg/app/generate.go
+++ b/pkg/app/generate.go
@@ -17,6 +17,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -184,6 +185,10 @@ func (l *Launcher) executeGeneration(configPath string) error {
 		l.logger.Info("Generating deployment files for profile", "profile", profile.Name)
 
 		if err := l.generateDeploymentFiles(&profile, fullConfig); err != nil {
+			var structured *apperrors.StructuredError
+			if errors.As(err, &structured) {
+				return structured
+			}
 			l.ui.Error("File generation failed: %v", err)
 			return apperrors.NewGeneralError("deployment files generation failed", err)
 		}

--- a/pkg/app/generate_profile_test.go
+++ b/pkg/app/generate_profile_test.go
@@ -5,6 +5,7 @@
 package app
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin"
 	"github.com/nvidia/k8s-launch-kit/pkg/options"
 	"github.com/nvidia/k8s-launch-kit/pkg/presets"
@@ -19,7 +21,42 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+func TestExecuteGenerationPreservesStructuredTemplateValidationError(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	t.Chdir(filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..")))
+
+	cfg, err := config.LoadFullConfig(
+		filepath.Join("pkg", "networkoperatorplugin", "testdata", "grouping", "mixed-same-type.yaml"),
+		ctrllog.Log,
+	)
+	require.NoError(t, err)
+	cfg.Profile = &config.Profile{
+		Fabric:     "ethernet",
+		Deployment: "sriov",
+		Multirail:  true,
+	}
+	cfg.ClusterConfig[0].NetplanManaged = true
+
+	raw, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	configPath := filepath.Join(t.TempDir(), "cluster-config.yaml")
+	require.NoError(t, os.WriteFile(configPath, raw, 0o600))
+
+	launcher := New(options.Options{})
+	launcher.ui = ui.NewSilent()
+	launcher.plugins[networkoperatorplugin.PluginName] = &networkoperatorplugin.NetworkOperatorPlugin{}
+
+	err = launcher.executeGeneration(configPath)
+	require.Error(t, err)
+	var structured *apperrors.StructuredError
+	require.True(t, errors.As(err, &structured))
+	assert.Equal(t, apperrors.ExitValidation, structured.ExitCode)
+	assert.Contains(t, structured.Message, "conflicting netplan configuration")
+}
 
 func TestGeneratePersistsResolvedProfileToOriginalConfig(t *testing.T) {
 	_, thisFile, _, ok := runtime.Caller(0)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -732,7 +732,9 @@ type ClusterConfig struct {
 	// NetplanManaged is true when discovery finds, on any worker in the
 	// group, an NVIDIA PF whose current MAC is selected by a host netplan
 	// match.macaddress stanza with a non-empty set-name. Such naming may
-	// conflict with udev rules deployed by NIC Configuration Operator.
+	// conflict with udev rules deployed by NIC Configuration Operator, so
+	// generation is rejected when a NicInterfaceNameTemplate would configure
+	// this group.
 	NetplanManaged bool `yaml:"netplanManaged"`
 	PresetApplied  bool `yaml:"presetApplied,omitempty"`
 	// PresetDeviation lists discrepancies between the matched preset and

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -194,7 +194,7 @@ profile:
 
 clusterConfig:
   - identifier: ""
-    netplanManaged: false # True when any worker has an NVIDIA PF selected by a netplan match.macaddress + set-name rule
+    netplanManaged: false # True when netplan set-name conflicts with NCO naming; blocks generation of NicInterfaceNameTemplate for this group
     capabilities:
       nodes:
         sriov: true # has nodes with feature.node.kubernetes.io/pci-15b3.present=true

--- a/pkg/networkoperatorplugin/netplan_managed_generate_test.go
+++ b/pkg/networkoperatorplugin/netplan_managed_generate_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networkoperatorplugin
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
+	"github.com/nvidia/k8s-launch-kit/pkg/profiles"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func loadNetplanManagedRenderConfig(t *testing.T) *config.LaunchKitConfig {
+	t.Helper()
+
+	cfg, err := config.LoadFullConfig(
+		filepath.Join("testdata", "grouping", "mixed-same-type.yaml"),
+		ctrllog.Log,
+	)
+	require.NoError(t, err)
+	cfg.Profile = &config.Profile{
+		Fabric:     "ethernet",
+		Deployment: "sriov",
+		Multirail:  true,
+	}
+	return cfg
+}
+
+func TestGenerateRejectsNetplanManagedInterfaceNameTemplates(t *testing.T) {
+	cfg := loadNetplanManagedRenderConfig(t)
+	cfg.ClusterConfig[0].NetplanManaged = true
+	cfg.ClusterConfig[2].NetplanManaged = true
+
+	_, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(
+		loadProfileFromDir(t, "sriov-ethernet-rdma"),
+		cfg,
+	)
+	require.Error(t, err)
+
+	var structured *apperrors.StructuredError
+	require.True(t, errors.As(err, &structured))
+	assert.Equal(t, apperrors.ExitValidation, structured.ExitCode)
+	assert.Equal(t, "validation", structured.Category)
+	assert.Contains(t, structured.Message, "NICs being configured")
+	assert.Contains(t, structured.Message, "conflicting netplan configuration")
+	assert.Contains(t, structured.Message, `clusterConfig group "group-0"`)
+	assert.Contains(t, structured.Message, `clusterConfig group "group-2"`)
+	assert.Equal(t,
+		"Clean up the set-name stanzas for the affected NICs in the host netplan configuration, re-run 'l8k discover', then retry 'l8k generate'.",
+		structured.Suggestion,
+	)
+	assert.Equal(t, apperrors.ExitValidation, apperrors.ExitCodeFromError(err))
+}
+
+func TestGenerateAllowsInterfaceNameTemplatesWhenAffectedGroupIsFilteredOut(t *testing.T) {
+	cfg := loadNetplanManagedRenderConfig(t)
+	cfg.ClusterConfig[0].NetplanManaged = true
+
+	rendered, err := (&NetworkOperatorPlugin{Groups: []string{"group-1", "group-2"}}).
+		GenerateProfileDeploymentFiles(loadProfileFromDir(t, "sriov-ethernet-rdma"), cfg)
+	require.NoError(t, err)
+	assert.Len(t, fileNamesMatching(rendered, "30-nicinterfacenametemplate"), 2)
+}
+
+func TestGenerateAllowsNetplanManagedGroupWhenInterfaceNameTemplateIsNotRendered(t *testing.T) {
+	t.Run("single source group uses PCI fallback", func(t *testing.T) {
+		cfg := loadNetplanManagedRenderConfig(t)
+		cfg.ClusterConfig = cfg.ClusterConfig[:1]
+		cfg.ClusterConfig[0].NetplanManaged = true
+
+		rendered, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(
+			loadProfileFromDir(t, "sriov-ethernet-rdma"),
+			cfg,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, fileNamesMatching(rendered, "30-nicinterfacenametemplate"))
+	})
+
+	t.Run("interface naming is disabled", func(t *testing.T) {
+		cfg := loadNetplanManagedRenderConfig(t)
+		cfg.ClusterConfig[0].NetplanManaged = true
+		cfg.NicConfigurationOperator.DeployNicInterfaceNameTemplate = false
+
+		rendered, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(
+			loadProfileFromDir(t, "sriov-ethernet-rdma"),
+			cfg,
+		)
+		require.NoError(t, err)
+		assert.Empty(t, fileNamesMatching(rendered, "30-nicinterfacenametemplate"))
+	})
+}
+
+func TestGenerateRejectsUnconditionallyRenderedSpectrumXInterfaceNameTemplate(t *testing.T) {
+	cfg := loadNetplanManagedRenderConfig(t)
+	cfg.ClusterConfig = cfg.ClusterConfig[:1]
+	cfg.ClusterConfig[0].NetplanManaged = true
+	cfg.Profile = &config.Profile{
+		Fabric:     "ethernet",
+		Deployment: "sriov",
+		Multirail:  true,
+		SpectrumX: &config.ProfileSpectrumX{
+			Enable:         true,
+			MultiplaneMode: "none",
+			NumberOfPlanes: 1,
+		},
+	}
+	cfg.NicConfigurationOperator.DeployNicInterfaceNameTemplate = false
+
+	templatePath, err := filepath.Abs(filepath.Join(
+		"..", "..", "profiles", "spectrum-x-ra2.2", "25-nicinterfacenametemplate.yaml",
+	))
+	require.NoError(t, err)
+	profile := &profiles.Profile{Templates: []string{templatePath}}
+
+	_, err = (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(profile, cfg)
+	require.Error(t, err)
+	assert.Equal(t, apperrors.ExitValidation, apperrors.ExitCodeFromError(err))
+}

--- a/pkg/networkoperatorplugin/render_plan.go
+++ b/pkg/networkoperatorplugin/render_plan.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/nvidia/k8s-launch-kit/pkg/config"
+	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
 	"github.com/nvidia/k8s-launch-kit/pkg/networkoperatorplugin/internal/pfutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -459,6 +460,7 @@ func renderForScope(
 		}
 
 	case ScopePerSource:
+		var netplanManagedGroups []config.ClusterConfig
 		for i, plan := range plans {
 			for _, src := range plan.Sources {
 				renderCfg := withClusterConfig(cfg, []config.ClusterConfig{src}, subnetsAt(planSubnets, i))
@@ -466,12 +468,40 @@ func renderForScope(
 				if err != nil {
 					return nil, err
 				}
+				// Check the rendered result rather than only the config switch:
+				// non-Spectrum-X templates can render empty after the single-group
+				// fallback disables interface naming, while Spectrum-X templates
+				// emit this CR independently of that switch. This is therefore the
+				// exact boundary where NicInterfaceNameTemplate is actually used.
+				if kind == "NicInterfaceNameTemplate" && len(rendered) > 0 && src.NetplanManaged {
+					netplanManagedGroups = append(netplanManagedGroups, src)
+				}
 				merge(rendered)
 			}
+		}
+		if len(netplanManagedGroups) > 0 {
+			return nil, newNetplanInterfaceNameConflictError(netplanManagedGroups)
 		}
 	}
 
 	return results, nil
+}
+
+func newNetplanInterfaceNameConflictError(groups []config.ClusterConfig) error {
+	labels := make([]string, 0, len(groups))
+	for _, group := range groups {
+		labels = append(labels, templateGroupLabel(group))
+	}
+	slices.Sort(labels)
+
+	return apperrors.NewValidationError(
+		fmt.Sprintf(
+			"cannot generate NicInterfaceNameTemplate: NICs being configured for %s are affected by conflicting netplan configuration",
+			strings.Join(labels, ", "),
+		),
+		nil,
+		"Clean up the set-name stanzas for the affected NICs in the host netplan configuration, re-run 'l8k discover', then retry 'l8k generate'.",
+	)
 }
 
 // networkNSReplicatedKinds is the set of Kinds rendered once per

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-config
-version: 1.2.5
+version: 1.2.6
 description: "Use this skill when the user needs help understanding, creating, or editing a k8s-launch-kit (l8k) configuration file (l8k-config.yaml or cluster-config.yaml). Activate for: config file questions, parameter tuning, subnet configuration, NV-IPAM setup, DOCA driver settings, maintenance concurrency, NIC configuration operator settings, changing MTU, VFs, resource names, or understanding what any config field does."
 metadata:
   requires:
@@ -72,7 +72,9 @@ Each `clusterConfig[]` entry has these key fields:
 - `netplanManaged` — true when any worker has an NVIDIA PF whose current MAC
   is selected by a host netplan `match.macaddress` stanza with a non-empty
   `set-name`. The flag identifies a potential conflict with NCO udev naming;
-  host-specific MACs are not persisted.
+  host-specific MACs are not persisted. If generation would emit a
+  `NicInterfaceNameTemplate` for this group, clean up the affected `set-name`
+  stanzas and re-run discovery instead of editing this flag by hand.
 - `capabilities.nodes.{sriov,rdma,ib}` — what the underlying hardware supports.
 - `pfs[]` — physical function list with PCI address, device ID, RDMA device,
   network interface, traffic class, rail, NUMA, GPU affinity, and `model` (the

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -386,7 +386,7 @@ clusterConfig:
   - # string — Group identifier/machine label (vendor-free; common machine aliases; max 30 bytes)
     identifier: ""
 
-    # bool — Any worker has an NVIDIA PF selected by netplan match.macaddress + set-name
+    # bool — Netplan set-name selects an NVIDIA PF; blocks an NCO interface-name template for this group
     netplanManaged: false
 
     capabilities:

--- a/skills/k8s-launch-kit-discover/SKILL.md
+++ b/skills/k8s-launch-kit-discover/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-discover
-version: 1.2.4
+version: 1.2.5
 description: "Use this skill when the user wants to discover their Kubernetes cluster's network hardware capabilities using k8s-launch-kit (l8k). Activate for: cluster discovery, hardware detection, NIC detection, finding what GPUs or NICs are in a cluster, creating a cluster config file, or when the user says 'discover' in the context of l8k or NVIDIA networking."
 metadata:
   requires:
@@ -183,7 +183,10 @@ is false. Do not add GPU counts or resource maps under `clusterConfig`.
 - `clusterConfig[].netplanManaged` is true when any worker has an NVIDIA PF
   selected by a host netplan `match.macaddress` plus `set-name` rule. Discovery
   checks every worker and uses PF MACs only transiently; they are not saved in
-  the shared group config.
+  the shared group config. If generation would emit a
+  `NicInterfaceNameTemplate` for an affected group, clean up the host's
+  `set-name` stanzas and re-run discovery before retrying generation; do not
+  clear the field manually.
 
 - The bootstrap namespace is **always** `nvidia-k8s-launch-kit` — not configurable. The
   daemon's SA / ClusterRole / ClusterRoleBinding are renamed to

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-generate
-version: 1.2.8
+version: 1.2.9
 description: "Use this skill when the user wants to generate Kubernetes YAML manifests for NVIDIA networking deployment using k8s-launch-kit (l8k). Activate for: manifest generation, profile selection, choosing between SR-IOV/host-device/RDMA-shared/IPoIB/MacVLAN/Spectrum-X, creating deployment files, or when the user asks 'which profile should I use' or needs help choosing a network configuration."
 metadata:
   requires:
@@ -98,6 +98,20 @@ l8k generate --user-config cluster-config.yaml \
 - **`l8k generate --for <preset>`** — skip discovery entirely when the SKU is already known and there is a preset for it. Useful for ahead-of-time generation (CI scaffolding, lab runbooks, demos), or when you don't have `kubectl` access yet. Requires `--node-selector` to identify the target nodes at apply time.
 
 A preset used with `--for` must declare `capabilities.nodes.{sriov,rdma,ib}` in its `topology.yaml`. All bundled presets do.
+
+## Netplan Interface-Name Conflict
+
+Before emitting a `NicInterfaceNameTemplate`, generation checks
+`clusterConfig[].netplanManaged` for the selected source groups. If an affected
+group would receive the CR, `l8k generate` returns a validation error because
+the host netplan `set-name` rule can conflict with NCO's udev naming rule for
+the same NIC. Clean up the affected `set-name` stanzas in the host netplan
+configuration, re-run `l8k discover`, and then retry `l8k generate`.
+
+The check follows the actual render plan: a group excluded with `--groups` or
+`--gpu-type` does not block generation, and neither does a group for which no
+`NicInterfaceNameTemplate` is rendered. Do not clear `netplanManaged` by hand;
+re-run discovery so the config reflects the host state.
 
 ## Profile Quick Reference
 


### PR DESCRIPTION
## Summary

- reject generation when an actually rendered `NicInterfaceNameTemplate` targets a source group marked `netplanManaged`
- evaluate the conflict after group filtering and interface-template fallback decisions, so excluded groups and non-rendered templates do not block generation
- preserve the conflict as a structured validation error with remediation to remove netplan `set-name` stanzas, re-run discovery, and retry generation
- document the behavior across the README, user/reference docs, default config, and bundled discover/config/generate skills

Follow-up to #238.

## Testing

- `make test`
- `make build`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 run ./...` (0 issues)
- `uv run --with-requirements requirements-docs.txt mkdocs build --strict`
- `git diff --check`