### PR TITLE
fix: drop NIC wait selector from SR-IOV operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,11 @@ Operator limits. For older releases, `maxParallelUpgrades` controls OFED and
 `SriovNetworkPoolConfig.spec.maxUnavailable` controls the SR-IOV internal
 drainer.
 
+l8k does not add the NIC Configuration Operator wait label to the SR-IOV
+config daemon's node selector. The daemon keeps the Network Operator chart's
+default scheduling selectors; drain sequencing remains controlled by the
+release-appropriate SR-IOV drain path described above.
+
 Changing to requestor mode modifies Helm values and operator Deployment
 environment variables. Upgrade an existing release with
 `--overwrite-existing`; applying only the generated custom resources cannot

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -111,6 +111,11 @@ The generated ``MaintenanceOperatorConfig`` receives
 therefore be used across release upgrades while l8k selects the applicable
 controller.
 
+l8k does not add ``network.nvidia.com/operator.nic-configuration.wait`` to
+the SR-IOV config daemon's node selector. The daemon retains the Network
+Operator chart's default scheduling selectors; drain sequencing remains
+controlled by the release-appropriate SR-IOV drain path described above.
+
 Upgrading an existing installation
 -----------------------------------
 

--- a/pkg/networkoperatorplugin/maintenance_render_test.go
+++ b/pkg/networkoperatorplugin/maintenance_render_test.go
@@ -68,6 +68,13 @@ var maintenanceProfileCases = []maintenanceProfileCase{
 		wantExternalDrain:  true,
 	},
 	{
+		dir:                "spectrum-x-ra2.2",
+		fabric:             "ethernet",
+		deployment:         "sriov",
+		wantDrainRequestor: true,
+		wantExternalDrain:  true,
+	},
+	{
 		dir:                "spectrum-x",
 		fabric:             "ethernet",
 		deployment:         "sriov",
@@ -187,6 +194,25 @@ func TestMaintenanceOperatorRemainsEnabledForNCOBeforeRequestorMode(t *testing.T
 	values := renderProfileValuesForMaintenance(t, "host-device-rdma", "25.10", true, "")
 	require.Equal(t, true, nestedMaintenanceMap(t, values, "maintenanceOperator")["enabled"])
 	require.NotContains(t, nestedMaintenanceMap(t, values, "operator"), "maintenanceOperator")
+}
+
+func TestSriovConfigDaemonDoesNotWaitForNICConfiguration(t *testing.T) {
+	for _, profile := range maintenanceProfileCases {
+		if !profile.wantExternalDrain {
+			continue
+		}
+		t.Run(profile.dir, func(t *testing.T) {
+			values := renderProfileValuesForMaintenance(t, profile.dir, "26.7", true, "")
+			operatorConfig := nestedMaintenanceMap(t, values, "sriov-network-operator", "sriovOperatorConfig")
+			selectorValue, hasSelector := operatorConfig["configDaemonNodeSelector"]
+			if !hasSelector {
+				return
+			}
+			selector, isMap := selectorValue.(map[string]any)
+			require.True(t, isMap, "configDaemonNodeSelector must be a map")
+			require.NotContains(t, selector, "network.nvidia.com/operator.nic-configuration.wait")
+		})
+	}
 }
 
 func TestMaintenanceOperatorValuesPreserveExplicitZero(t *testing.T) {

--- a/profiles/spectrum-x-ra2.1/00-values.yaml
+++ b/profiles/spectrum-x-ra2.1/00-values.yaml
@@ -68,11 +68,6 @@ sriovNetworkOperator:
 #     NV config / SR-IOV enablement for Spectrum-X. Letting the operator's
 #     own mellanox plugin run too would mutate the same state twice and
 #     produce flapping configurations.
-#
-# When NicConfigurationOperator is also deployed, gate the daemon's
-# nodeSelector on `network.nvidia.com/operator.nic-configuration.wait=false`
-# so the sriov daemon waits for NCO to finish per-node firmware/NIC config
-# before mutating VFs.
 sriov-network-operator:
 {{- if .NetworkOperator.ImagePullSecrets }}
   imagePullSecrets:
@@ -93,10 +88,6 @@ sriov-network-operator:
     # which doesn't always re-run on cross-profile upgrades.
     enableInjector: false
     enableOperatorWebhook: false
-{{- if .NicConfigurationOperator }}
-    configDaemonNodeSelector:
-      network.nvidia.com/operator.nic-configuration.wait: "false"
-{{- end }}
     featureGates:
       manageSoftwareBridges: true
     disablePlugins:

--- a/profiles/spectrum-x-ra2.1/README.md
+++ b/profiles/spectrum-x-ra2.1/README.md
@@ -92,8 +92,6 @@ maintenanceOperator:
 
 sriov-network-operator:
   sriovOperatorConfig:
-    configDaemonNodeSelector:
-      network.nvidia.com/operator.nic-configuration.wait: "false"
     featureGates:
       manageSoftwareBridges: true
     disablePlugins:

--- a/profiles/spectrum-x-ra2.2/00-values.yaml
+++ b/profiles/spectrum-x-ra2.2/00-values.yaml
@@ -69,11 +69,6 @@ sriovNetworkOperator:
 #     NV config / SR-IOV enablement for Spectrum-X. Letting the operator's
 #     own mellanox plugin run too would mutate the same state twice and
 #     produce flapping configurations.
-#
-# When NicConfigurationOperator is also deployed, gate the daemon's
-# nodeSelector on `network.nvidia.com/operator.nic-configuration.wait=false`
-# so the sriov daemon waits for NCO to finish per-node firmware/NIC config
-# before mutating VFs.
 sriov-network-operator:
 {{- if .NetworkOperator.ImagePullSecrets }}
   imagePullSecrets:
@@ -94,10 +89,6 @@ sriov-network-operator:
     # which doesn't always re-run on cross-profile upgrades.
     enableInjector: false
     enableOperatorWebhook: false
-{{- if .NicConfigurationOperator }}
-    configDaemonNodeSelector:
-      network.nvidia.com/operator.nic-configuration.wait: "false"
-{{- end }}
     featureGates:
       manageSoftwareBridges: true
 {{- if spectrumXUseDRA .Profile }}

--- a/profiles/spectrum-x-ra2.2/README.md
+++ b/profiles/spectrum-x-ra2.2/README.md
@@ -209,8 +209,6 @@ maintenanceOperator:
 
 sriov-network-operator:
   sriovOperatorConfig:
-    configDaemonNodeSelector:
-      network.nvidia.com/operator.nic-configuration.wait: "false"
     featureGates:
       manageSoftwareBridges: true
     disablePlugins:

--- a/profiles/spectrum-x/00-values.yaml
+++ b/profiles/spectrum-x/00-values.yaml
@@ -69,11 +69,6 @@ sriovNetworkOperator:
 #     NV config / SR-IOV enablement for Spectrum-X. Letting the operator's
 #     own mellanox plugin run too would mutate the same state twice and
 #     produce flapping configurations.
-#
-# When NicConfigurationOperator is also deployed, gate the daemon's
-# nodeSelector on `network.nvidia.com/operator.nic-configuration.wait=false`
-# so the sriov daemon waits for NCO to finish per-node firmware/NIC config
-# before mutating VFs.
 sriov-network-operator:
 {{- if .NetworkOperator.ImagePullSecrets }}
   imagePullSecrets:
@@ -94,10 +89,6 @@ sriov-network-operator:
     # which doesn't always re-run on cross-profile upgrades.
     enableInjector: false
     enableOperatorWebhook: false
-{{- if .NicConfigurationOperator }}
-    configDaemonNodeSelector:
-      network.nvidia.com/operator.nic-configuration.wait: "false"
-{{- end }}
     featureGates:
       manageSoftwareBridges: true
 {{- if spectrumXUseDRA .Profile }}

--- a/profiles/spectrum-x/README.md
+++ b/profiles/spectrum-x/README.md
@@ -226,8 +226,6 @@ maintenanceOperator:
 
 sriov-network-operator:
   sriovOperatorConfig:
-    configDaemonNodeSelector:
-      network.nvidia.com/operator.nic-configuration.wait: "false"
     featureGates:
       manageSoftwareBridges: true
     disablePlugins:

--- a/profiles/sriov-ethernet-rdma/00-values.yaml
+++ b/profiles/sriov-ethernet-rdma/00-values.yaml
@@ -61,11 +61,6 @@ sriovNetworkOperator:
 # defaults to FALSE in the upstream subchart — without this, the operator
 # logs `default SriovOperatorConfig object not found, cannot reconcile
 # SriovNetworkNodePolicies` and never reconciles any policies.
-#
-# When NicConfigurationOperator is also deployed, gate the daemon's
-# nodeSelector on `network.nvidia.com/operator.nic-configuration.wait=false`
-# so the sriov daemon waits for NCO to finish per-node firmware/NIC config
-# before mutating VFs.
 sriov-network-operator:
 {{- if .NetworkOperator.ImagePullSecrets }}
   imagePullSecrets:
@@ -93,7 +88,3 @@ sriov-network-operator:
     #     redundant and brings the same TLS-secret fragility.
     enableInjector: false
     enableOperatorWebhook: false
-{{- if .NicConfigurationOperator }}
-    configDaemonNodeSelector:
-      network.nvidia.com/operator.nic-configuration.wait: "false"
-{{- end }}

--- a/profiles/sriov-ib-rdma/00-values.yaml
+++ b/profiles/sriov-ib-rdma/00-values.yaml
@@ -61,11 +61,6 @@ sriovNetworkOperator:
 # defaults to FALSE in the upstream subchart — without this, the operator
 # logs `default SriovOperatorConfig object not found, cannot reconcile
 # SriovNetworkNodePolicies` and never reconciles any policies.
-#
-# When NicConfigurationOperator is also deployed, gate the daemon's
-# nodeSelector on `network.nvidia.com/operator.nic-configuration.wait=false`
-# so the sriov daemon waits for NCO to finish per-node firmware/NIC config
-# before mutating VFs.
 sriov-network-operator:
 {{- if .NetworkOperator.ImagePullSecrets }}
   imagePullSecrets:
@@ -89,7 +84,3 @@ sriov-network-operator:
     # NodePolicies via the crstate registry, so both helpers are unused.
     enableInjector: false
     enableOperatorWebhook: false
-{{- if .NicConfigurationOperator }}
-    configDaemonNodeSelector:
-      network.nvidia.com/operator.nic-configuration.wait: "false"
-{{- end }}

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-generate
-version: 1.2.9
+version: 1.2.10
 description: "Use this skill when the user wants to generate Kubernetes YAML manifests for NVIDIA networking deployment using k8s-launch-kit (l8k). Activate for: manifest generation, profile selection, choosing between SR-IOV/host-device/RDMA-shared/IPoIB/MacVLAN/Spectrum-X, creating deployment files, or when the user asks 'which profile should I use' or needs help choosing a network configuration."
 metadata:
   requires:
@@ -164,6 +164,12 @@ Operator enable both the Network Operator drain requestor and
 a coordinated handoff and must not be separated. The generated
 `MaintenanceOperatorConfig` gets the global limits from the config's
 `maintenance` section.
+
+Generated values do not add
+`network.nvidia.com/operator.nic-configuration.wait` to the SR-IOV config
+daemon node selector. The daemon keeps the Network Operator chart's default
+scheduling selectors; drain sequencing remains controlled by the
+release-appropriate SR-IOV drain path described below.
 
 Before release 26.1, OFED uses `maintenance.maxParallelUpgrades` and the SR-IOV
 internal drainer uses `maintenance.maxUnavailable` through


### PR DESCRIPTION
## Summary

- stop adding the NIC Configuration Operator wait label to the SR-IOV config daemon node selector
- apply the change to the Ethernet, InfiniBand, and all Spectrum-X SR-IOV profiles
- keep the chart defaults and release-appropriate SR-IOV drain path unchanged
- add profile-matrix regression coverage and update generated-values documentation

## Testing

- `make build`
- `make test`
- `go test ./pkg/networkoperatorplugin/... -count=1`
- `go vet ./...`
- smoke-rendered `mixed-same-type`, `same-ew-different-ns`, and `true-heterogeneous`; verified generated `values.yaml` files omit the selector
- `git diff --check`

## Not run

- `make lint`: `golangci-lint` is not installed in the local environment
- `mkdocs build --strict`: `mkdocs` is not installed in the local environment