### PR TITLE
fix: exclude restricted BlueFields from discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ skipped if you provide your own configuration file. Fresh discovery also
 resolves profile settings and stores the final values in `cluster-config.yaml`.
 With `--user-config`, discovery refreshes only `clusterConfig` and explicit CLI
 overrides, leaving every other section as supplied.
+Before waiting for `NicDevice` resources, Launch Kit probes each node for
+NVIDIA NICs. BlueField devices in zero-trust (`restricted`) mode are excluded
+because NIC Configuration Operator intentionally does not publish them; a node
+with another discoverable NIC remains in the wait set.
 Because `NicDevice` does not expose MAC addresses, Launch Kit reads them
 transiently from sysfs on every worker and checks whether host netplan uses a
 matching `match.macaddress` plus `set-name` rule. The group-level
@@ -271,7 +275,7 @@ Host Target Common Flags:
       --kubeconfig string                   Path to kubeconfig file for cluster deployment (required when using --deploy; falls back to $KUBECONFIG, then ~/.kube/config)
       --network-operator-namespace string   Override the network operator namespace from the config file
       --network-operator-release string     Network Operator release line to deploy (MAJOR.MINOR). Selects component image tags + repository from a built-in catalog and drives version-gated template sections. Supported: 26.1, 26.4, 26.7
-      --node-selector string                Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe (default "feature.node.kubernetes.io/pci-15b3.present=true")
+      --node-selector string                Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and discoverable NICs are detected via sysfs; restricted BlueFields are excluded (default "feature.node.kubernetes.io/pci-15b3.present=true")
       --skip-network-operator-helm          Skip Network Operator Helm values generation, chart installation, and Helm-specific validation
       --user-config string                  Use provided cluster configuration file (as base config for discovery or as full config without discovery)
 

--- a/docs/user/discovery.md
+++ b/docs/user/discovery.md
@@ -21,7 +21,7 @@ Discovery is self-contained. It does not require Node Feature Discovery (NFD) or
 2. Prepares the private `nvidia-k8s-launch-kit` namespace.
 3. Creates the NIC Configuration Operator CRDs only when they are missing.
 4. Runs a temporary NIC Configuration Daemon on the eligible nodes.
-5. Detects nodes with NVIDIA NICs through a PCI vendor `0x15b3` sysfs probe.
+5. Detects nodes with NVIDIA NICs through a PCI vendor `0x15b3` sysfs probe and excludes BlueFields whose host trust level is `restricted`.
 6. Reads the published `NicDevice` resources and probes GPU, NIC, fabric, module, NUMA, and rail data.
 7. Groups nodes, writes Launch Kit node labels, and saves the result. Fresh discovery resolves profile settings; with `--user-config`, only `clusterConfig` is replaced.
 8. Deletes the temporary namespace and cluster-scoped bootstrap RBAC. The CRDs remain installed.
@@ -31,7 +31,7 @@ The bootstrap namespace is fixed. `--network-operator-namespace` is accepted for
 ## Requirements
 
 - Kubernetes access through `--kubeconfig`, `$KUBECONFIG`, or `~/.kube/config`.
-- At least one Ready, schedulable node with an NVIDIA or Mellanox NIC.
+- At least one Ready, schedulable node with a discoverable NVIDIA or Mellanox NIC. BlueFields in zero-trust (`restricted`) mode do not count because NIC Configuration Operator does not publish `NicDevice` resources for them.
 - Image pull access on eligible nodes to the configured NIC Configuration Daemon image.
 
 For a private registry, forward one or more pull secrets:
@@ -43,6 +43,13 @@ l8k discover \
 ```
 
 The default `--node-selector` value is written to the saved configuration for deployment-time resource selection. It does not limit which nodes run the discovery daemon.
+
+Before waiting for `NicDevice` resources, Launch Kit checks BlueField trust
+mode with `mlxprivhost`. A restricted BlueField is excluded from the wait set.
+If the same node has another non-restricted NVIDIA NIC, that node remains in
+the wait set and its published devices are discovered normally. A failed or
+unrecognized trust query is treated as non-restricted, matching NIC
+Configuration Operator behavior.
 
 ## Hardware And GPU Topology
 
@@ -213,7 +220,7 @@ l8k discover \
   --save-cluster-config ./cluster-config.yaml
 ```
 
-Debug logs include node eligibility, sysfs NIC probing, machine/GPU source selection, GPU topology, fabric reads, PF traffic classification, preset matching, rail collapsing, hardware fingerprints, and label writes. Summary counts remain visible at info level.
+Debug logs include node eligibility, sysfs NIC and BlueField trust probing, machine/GPU source selection, GPU topology, fabric reads, PF traffic classification, preset matching, rail collapsing, hardware fingerprints, and label writes. Summary counts remain visible at info level.
 
 ## Saved Configuration
 

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -67,7 +67,12 @@ kubectl describe pod -n nvidia-k8s-launch-kit <pod-name>
 kubectl logs -n nvidia-k8s-launch-kit <pod-name>
 ```
 
-Common causes include an unavailable daemon image, a missing image pull secret, no Ready schedulable nodes, or no node exposing PCI vendor `0x15b3` through sysfs. NFD labels are not required for discovery scheduling.
+Common causes include an unavailable daemon image, a missing image pull secret,
+no Ready schedulable nodes, no node exposing PCI vendor `0x15b3` through
+sysfs, or a cluster where every detected BlueField is in zero-trust
+(`restricted`) mode. Restricted BlueFields are deliberately excluded because
+NIC Configuration Operator does not publish `NicDevice` resources for them.
+NFD labels are not required for discovery scheduling.
 
 ## Namespace Mismatch
 

--- a/pkg/cmd/discover.go
+++ b/pkg/cmd/discover.go
@@ -122,7 +122,7 @@ func init() {
 	discoverCmd.Flags().StringVar(&networkOperatorRelease, "network-operator-release", "",
 		fmt.Sprintf("Network Operator release line to deploy (MAJOR.MINOR). Supported: %s",
 			strings.Join(releases.SupportedReleases(), ", ")))
-	discoverCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe")
+	discoverCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and discoverable NICs are detected via sysfs; restricted BlueFields are excluded")
 	discoverCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for Network Operator components and authenticated Helm downloads (comma-separated)")
 	discoverCmd.Flags().StringVar(&enabledPlugins, "enabled-plugins", "network-operator", "Comma-separated list of plugins to enable")
 	discoverCmd.Flags().BoolVar(&keepNamespace, "keep-namespace", false, "Skip teardown of the nvidia-k8s-launch-kit namespace (for debugging)")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -266,7 +266,7 @@ func init() {
 	rootCmd.Flags().StringSliceVar(&groups, "groups", nil, "Generate manifests only for the named source groups (comma-separated identifiers from cluster-config.yaml). Mutually exclusive with --gpu-type.")
 	rootCmd.Flags().StringVar(&gpuType, "gpu-type", "", "Generate manifests only for source groups whose gpuType matches (case-insensitive). Mutually exclusive with --groups.")
 	rootCmd.MarkFlagsMutuallyExclusive("groups", "gpu-type")
-	rootCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe")
+	rootCmd.Flags().StringVar(&nodeSelector, "node-selector", "feature.node.kubernetes.io/pci-15b3.present=true", "Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and discoverable NICs are detected via sysfs; restricted BlueFields are excluded")
 	rootCmd.Flags().BoolVar(&collapseNicRails, "collapse-nic-rails", true, collapseNicRailsFlagHelp)
 	rootCmd.Flags().StringVar(&forPreset, "for", "", forFlagHelp())
 	rootCmd.Flags().StringSliceVar(&imagePullSecrets, "image-pull-secrets", nil, "Image pull secret names for Network Operator components and authenticated Helm downloads (comma-separated)")

--- a/pkg/cmd/schema.go
+++ b/pkg/cmd/schema.go
@@ -250,7 +250,7 @@ var schemaCmd = &cobra.Command{
 				"--node-selector": {
 					Type:        "string",
 					Default:     "feature.node.kubernetes.io/pci-15b3.present=true",
-					Description: "Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and NIC nodes are detected via a sysfs PCI-vendor probe",
+					Description: "Node selector written into the saved cluster-config (used at deploy time). Does NOT gate discovery scheduling — the daemon runs on all nodes and discoverable NICs are detected via sysfs; restricted BlueFields are excluded",
 				},
 				"--image-pull-secrets": {
 					Type:        "[]string",

--- a/pkg/networkoperatorplugin/discovery/discover.go
+++ b/pkg/networkoperatorplugin/discovery/discover.go
@@ -183,16 +183,29 @@ func DiscoverClusterConfig(ctx context.Context, c client.Client, restConfig *res
 		nodeLabels = map[string]map[string]string{}
 	}
 
-	// Filter the wait set to nodes that actually have an NVIDIA NIC. The daemon
-	// runs on every node (no nodeSelector), but only NIC-bearing nodes will
-	// ever report NicDevice CRs — waiting for the rest would time out. We
-	// detect NICs by probing each pod's sysfs for PCI vendor 0x15b3 rather than
-	// the NFD label, which may not exist yet at discover time. The
-	// `--node-selector` value is deliberately NOT used here; it only flows into
-	// the saved cluster-config nodeSelector (for deploy time, when NFD exists).
+	// Filter the wait set to nodes that actually have an NVIDIA NIC which can
+	// publish a NicDevice. The daemon runs on every node (no nodeSelector), but
+	// only nodes with a discoverable NIC will ever report NicDevice CRs —
+	// waiting for the rest would time out. We detect NICs by probing each pod's
+	// sysfs for PCI vendor 0x15b3 rather than the NFD label, which may not exist
+	// yet at discover time. BlueField devices in zero-trust (restricted) mode
+	// are excluded because NIC Configuration Operator intentionally skips them.
+	// The `--node-selector` value is deliberately NOT used here; it only flows
+	// into the saved cluster-config nodeSelector (for deploy time, when NFD
+	// exists).
 	if restConfig != nil {
-		expectedNodes = filterNodesWithNICs(ctx, restConfig, nicconfigdaemon.Namespace, expectedNodes, dsPods)
+		var restrictedOnlyNodes []string
+		expectedNodes, restrictedOnlyNodes = filterNodesWithNICs(ctx, restConfig,
+			nicconfigdaemon.Namespace, expectedNodes, dsPods)
+		if len(restrictedOnlyNodes) > 0 {
+			uiOutput.Warning("Excluding %d node(s) whose detected BlueField devices are all in zero-trust (restricted) mode; those devices do not publish NicDevice resources",
+				len(restrictedOnlyNodes))
+		}
 		if len(expectedNodes) == 0 {
+			if len(restrictedOnlyNodes) > 0 {
+				return fmt.Errorf("no discoverable NVIDIA NICs were found; detected BlueField devices on %d node(s) are all in zero-trust (restricted) mode",
+					len(restrictedOnlyNodes))
+			}
 			return fmt.Errorf("no nodes with an NVIDIA NIC (PCI vendor 15b3) were found")
 		}
 	} else if len(opts.NodeSelector) > 0 {
@@ -1794,33 +1807,80 @@ const sysfsNvidiaGPUIDCmd = `for d in /sys/bus/pci/devices/*; do
   break
 done`
 
-// sysfsMellanoxNICPresentCmd echoes "present" if any PCI device under
-// /sys/bus/pci/devices has vendor 0x15b3 (Mellanox / NVIDIA networking). Unlike
-// the NVIDIA GPU vendor (0x10de, shared by audio/NVSwitch controllers), every
-// 0x15b3 device is a NIC or DPU, so no PCI-class filter is needed. Breaks on
-// the first match; output is empty when no NVIDIA NIC is present; exit is
-// always 0. This replaces the NFD-label filter for deciding which nodes to
-// wait on — NFD may not be installed yet at discover time.
-const sysfsMellanoxNICPresentCmd = `for d in /sys/bus/pci/devices/*; do
+// sysfsMellanoxNICPresentCmd reports whether a node has an NVIDIA NIC that NIC
+// Configuration Operator can publish as a NicDevice. It scans PCI vendor
+// 0x15b3 and mirrors the operator's zero-trust handling for BlueField-2,
+// BlueField-3, BlueField-3 Lx, and BlueField-4: a device for which
+// `mlxprivhost -d <pci> q` successfully reports `level: restricted` is skipped.
+// If mlxprivhost fails or returns unrecognised output, the device remains
+// discoverable, matching the operator's fail-open behaviour. Output is
+// "present" when any discoverable device exists, "restricted" when the node
+// has only restricted BlueFields, and empty when no NVIDIA NIC is present.
+// The command always exits 0.
+const sysfsMellanoxNICPresentCmd = `pci_devices_path=${1:-/sys/bus/pci/devices}
+mlxprivhost_bin=${2:-mlxprivhost}
+restricted_found=false
+for d in "$pci_devices_path"/*; do
   v=$(cat "$d/vendor" 2>/dev/null)
-  if [ "$v" = "0x15b3" ]; then echo present; break; fi
-done`
+  [ "$v" = "0x15b3" ] || continue
 
-// mellanoxNICPresent reports whether the sysfs probe found an NVIDIA NIC.
-// Kept as a tiny pure helper so the decision is unit-testable without a cluster.
-func mellanoxNICPresent(output string) bool {
-	return strings.TrimSpace(output) != ""
+  device_id=$(cat "$d/device" 2>/dev/null)
+  case "$device_id" in
+    0xa2d6|0xa2d9|0xa2dc|0xa2df)
+      pci=${d##*/}
+      trust_output=$("$mlxprivhost_bin" -d "$pci" q 2>/dev/null)
+      trust_rc=$?
+      if [ "$trust_rc" -eq 0 ] && printf '%s\n' "$trust_output" | grep -iq '^[[:space:]]*level[[:space:]]*:[[:space:]]*restricted'; then
+        restricted_found=true
+        continue
+      fi
+      ;;
+  esac
+
+  echo present
+  exit 0
+done
+
+if [ "$restricted_found" = true ]; then
+  echo restricted
+fi`
+
+type mellanoxNICProbeResult string
+
+const (
+	mellanoxNICProbeNone       mellanoxNICProbeResult = ""
+	mellanoxNICProbePresent    mellanoxNICProbeResult = "present"
+	mellanoxNICProbeRestricted mellanoxNICProbeResult = "restricted"
+)
+
+// parseMellanoxNICProbeResult interprets the controlled marker emitted by the
+// sysfs/zero-trust probe. A present marker wins defensively if multiple lines
+// are ever returned, because one discoverable NIC is enough to expect a
+// NicDevice from the node.
+func parseMellanoxNICProbeResult(output string) mellanoxNICProbeResult {
+	result := mellanoxNICProbeNone
+	for line := range strings.SplitSeq(output, "\n") {
+		switch strings.TrimSpace(line) {
+		case string(mellanoxNICProbePresent):
+			return mellanoxNICProbePresent
+		case string(mellanoxNICProbeRestricted):
+			result = mellanoxNICProbeRestricted
+		}
+	}
+	return result
 }
 
 // filterNodesWithNICs returns the subset of candidateNodes that have an NVIDIA
-// NIC (PCI vendor 0x15b3), determined by execing the sysfs probe in each node's
-// daemon pod. Nodes without a daemon pod, or whose probe errors or reports no
-// NIC, are dropped. Replaces the NFD-label filter (filterNodesByLabels) so
-// discovery works on clusters where NFD is not yet installed.
+// NIC expected to publish a NicDevice, plus nodes whose only detected NVIDIA
+// devices are restricted BlueFields. Nodes without a daemon pod, or whose
+// probe errors or reports no NIC, are dropped. This replaces the NFD-label
+// filter (filterNodesByLabels) so discovery works before NFD is installed and
+// avoids waiting for NicDevices that zero-trust devices will never publish.
 func filterNodesWithNICs(ctx context.Context, restConfig *rest.Config,
-	namespace string, candidateNodes []string, dsPods []corev1.Pod) []string {
+	namespace string, candidateNodes []string, dsPods []corev1.Pod) ([]string, []string) {
 
 	var withNICs []string
+	var restrictedOnly []string
 	for _, node := range candidateNodes {
 		pod := findDaemonPod([]string{node}, dsPods)
 		if pod == nil {
@@ -1838,16 +1898,20 @@ func filterNodesWithNICs(ctx context.Context, restConfig *rest.Config,
 				"node", node, "pod", pod.Name)
 			continue
 		}
-		present := mellanoxNICPresent(output)
-		log.Log.V(1).Info("Probed node for NVIDIA NIC via sysfs vendor 0x15b3",
-			"node", node, "pod", pod.Name, "present", present)
-		if present {
+		probeResult := parseMellanoxNICProbeResult(output)
+		log.Log.V(1).Info("Probed node for discoverable NVIDIA NIC via sysfs and BlueField trust mode",
+			"node", node, "pod", pod.Name, "result", string(probeResult))
+		switch probeResult {
+		case mellanoxNICProbePresent:
 			withNICs = append(withNICs, node)
+		case mellanoxNICProbeRestricted:
+			restrictedOnly = append(restrictedOnly, node)
 		}
 	}
-	log.Log.Info("Filtered nodes by NVIDIA NIC presence",
-		"candidates", len(candidateNodes), "withNICs", len(withNICs))
-	return withNICs
+	log.Log.Info("Filtered nodes by discoverable NVIDIA NIC presence",
+		"candidates", len(candidateNodes), "withNICs", len(withNICs),
+		"restrictedOnly", len(restrictedOnly))
+	return withNICs, restrictedOnly
 }
 
 // parseGPUProductFromSysfs resolves a single-line sysfs device-ID output

--- a/pkg/networkoperatorplugin/discovery/discover_test.go
+++ b/pkg/networkoperatorplugin/discovery/discover_test.go
@@ -18,6 +18,10 @@ package discovery
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -378,21 +382,124 @@ func TestParseGPUProductFromSysfs(t *testing.T) {
 	}
 }
 
-func TestMellanoxNICPresent(t *testing.T) {
+func TestParseMellanoxNICProbeResult(t *testing.T) {
 	tests := []struct {
 		name   string
 		output string
-		want   bool
+		want   mellanoxNICProbeResult
 	}{
-		{"present marker", "present\n", true},
-		{"present with whitespace", "  present  \n", true},
-		{"empty", "", false},
-		{"whitespace only", "  \n\t", false},
+		{"present marker", "present\n", mellanoxNICProbePresent},
+		{"present with whitespace", "  present  \n", mellanoxNICProbePresent},
+		{"restricted marker", "restricted\n", mellanoxNICProbeRestricted},
+		{"restricted with whitespace", "  restricted  \n", mellanoxNICProbeRestricted},
+		{"present wins over restricted", "restricted\npresent\n", mellanoxNICProbePresent},
+		{"empty", "", mellanoxNICProbeNone},
+		{"whitespace only", "  \n\t", mellanoxNICProbeNone},
+		{"unexpected output", "mlxprivhost warning\n", mellanoxNICProbeNone},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, mellanoxNICPresent(tt.output))
+			assert.Equal(t, tt.want, parseMellanoxNICProbeResult(tt.output))
+		})
+	}
+}
+
+func TestSysfsMellanoxNICPresentCmd(t *testing.T) {
+	type fakePCIDevice struct {
+		name     string
+		vendorID string
+		deviceID string
+	}
+
+	tests := []struct {
+		name           string
+		devices        []fakePCIDevice
+		mlxprivhostRun string
+		want           string
+	}{
+		{
+			name: "no NVIDIA NIC",
+			devices: []fakePCIDevice{
+				{name: "0000:01:00.0", vendorID: "0x10de", deviceID: "0x2335"},
+			},
+			mlxprivhostRun: "exit 1",
+			want:           "",
+		},
+		{
+			name: "regular NVIDIA NIC",
+			devices: []fakePCIDevice{
+				{name: "0000:01:00.0", vendorID: "0x15b3", deviceID: "0x1023"},
+			},
+			mlxprivhostRun: "exit 1",
+			want:           "present",
+		},
+		{
+			name: "restricted BF3",
+			devices: []fakePCIDevice{
+				{name: "0000:01:00.0", vendorID: "0x15b3", deviceID: "0xa2dc"},
+			},
+			mlxprivhostRun: "printf 'level: restricted\\n'",
+			want:           "restricted",
+		},
+		{
+			name: "privileged BF3",
+			devices: []fakePCIDevice{
+				{name: "0000:01:00.0", vendorID: "0x15b3", deviceID: "0xa2dc"},
+			},
+			mlxprivhostRun: "printf 'level: privileged\\n'",
+			want:           "present",
+		},
+		{
+			name: "trust query failure is fail open",
+			devices: []fakePCIDevice{
+				{name: "0000:01:00.0", vendorID: "0x15b3", deviceID: "0xa2dc"},
+			},
+			mlxprivhostRun: "exit 1",
+			want:           "present",
+		},
+		{
+			name: "all known BlueField device IDs restricted",
+			devices: []fakePCIDevice{
+				{name: "0000:01:00.0", vendorID: "0x15b3", deviceID: "0xa2d6"},
+				{name: "0000:02:00.0", vendorID: "0x15b3", deviceID: "0xa2d9"},
+				{name: "0000:03:00.0", vendorID: "0x15b3", deviceID: "0xa2dc"},
+				{name: "0000:04:00.0", vendorID: "0x15b3", deviceID: "0xa2df"},
+			},
+			mlxprivhostRun: "printf 'level: restricted\\n'",
+			want:           "restricted",
+		},
+		{
+			name: "restricted BF3 plus regular NIC",
+			devices: []fakePCIDevice{
+				{name: "0000:01:00.0", vendorID: "0x15b3", deviceID: "0xa2dc"},
+				{name: "0000:02:00.0", vendorID: "0x15b3", deviceID: "0x1023"},
+			},
+			mlxprivhostRun: "printf 'level: restricted\\n'",
+			want:           "present",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pciRoot := t.TempDir()
+			for _, device := range tt.devices {
+				deviceDir := filepath.Join(pciRoot, device.name)
+				require.NoError(t, os.MkdirAll(deviceDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(deviceDir, "vendor"), []byte(device.vendorID+"\n"), 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(deviceDir, "device"), []byte(device.deviceID+"\n"), 0o644))
+			}
+
+			mlxprivhost := filepath.Join(t.TempDir(), "mlxprivhost")
+			require.NoError(t, os.WriteFile(mlxprivhost,
+				[]byte("#!/bin/sh\n"+tt.mlxprivhostRun+"\n"), 0o755))
+
+			//nolint:gosec // fixed test command and script; temp paths are positional parameters
+			cmd := exec.Command("/bin/sh", "-c", sysfsMellanoxNICPresentCmd,
+				"nic-probe", pciRoot, mlxprivhost)
+			output, err := cmd.CombinedOutput()
+			require.NoError(t, err, "probe output: %s", output)
+			assert.Equal(t, tt.want, strings.TrimSpace(string(output)))
 		})
 	}
 }

--- a/pkg/nicconfigdaemon/assets/daemon.yaml.tmpl
+++ b/pkg/nicconfigdaemon/assets/daemon.yaml.tmpl
@@ -145,7 +145,8 @@ spec:
       # not exist yet at discover time (NFD not installed), so the daemon must
       # not be pinned to it. Discovery can still provide node-name affinity for
       # the current Ready schedulable nodes, then probes each pod's sysfs for an
-      # NVIDIA NIC (PCI vendor 0x15b3) to decide which nodes to wait on.
+      # NVIDIA NIC (PCI vendor 0x15b3) and excludes restricted BlueFields to
+      # decide which nodes to wait on.
       # Tolerate every taint so the daemon also lands on control-plane (and
       # other tainted) nodes — on small/single-node clusters the control-plane
       # node may carry the data-plane NICs. This is a short-lived, privileged

--- a/pkg/nicconfigdaemon/bootstrap_test.go
+++ b/pkg/nicconfigdaemon/bootstrap_test.go
@@ -203,8 +203,9 @@ func TestEnsure_AppliesDaemonSetWithExpectedImage(t *testing.T) {
 	}, ds.Spec.Template.Spec.ImagePullSecrets)
 
 	// No nodeSelector: discovery runs on every node (the NFD
-	// pci-15b3.present label may not exist yet at discover time). NIC-bearing
-	// nodes are selected later via a sysfs probe, not a label.
+	// pci-15b3.present label may not exist yet at discover time). Nodes with
+	// discoverable NICs are selected later via a trust-aware sysfs probe, not a
+	// label.
 	assert.Empty(t, ds.Spec.Template.Spec.NodeSelector)
 
 	// Tolerate every taint so the daemon also lands on control-plane / tainted

--- a/skills/k8s-launch-kit-discover/SKILL.md
+++ b/skills/k8s-launch-kit-discover/SKILL.md
@@ -60,7 +60,7 @@ l8k discover --save-cluster-config <OUTPUT> [--kubeconfig <PATH>]
 | `--collapse-nic-rails` | — | `true` | Advertise one rail per NIC: collapse a NIC's multi-plane east-west PFs to its master PF, keeping a rail per port only for NICs whose VPD model is genuinely dual-port ("2-port"/"Dual-port"). Set `=false` to keep one rail per PF (dev setups). See "Rail collapsing" below. |
 | `--network-operator-namespace` | — | — | **Deprecated for `discover`**: accepted but ignored. The daemon always runs in `nvidia-k8s-launch-kit`. Still used by `l8k generate` / `l8k deploy`. |
 | `--user-config` | — | — | Config whose `clusterConfig` is refreshed; all other sections are preserved unless explicitly overridden by a CLI flag |
-| `--node-selector` | — | `feature.node.kubernetes.io/pci-15b3.present=true` | Value written into the **saved** `cluster-config.yaml` `nodeSelector` (for deploy time). It does **not** gate discovery scheduling or the NicDevice wait set — the daemon is restricted to Ready schedulable nodes and NIC-bearing nodes are detected via a sysfs `0x15b3` probe. |
+| `--node-selector` | — | `feature.node.kubernetes.io/pci-15b3.present=true` | Value written into the **saved** `cluster-config.yaml` `nodeSelector` (for deploy time). It does **not** gate discovery scheduling or the NicDevice wait set — the daemon is restricted to Ready schedulable nodes and discoverable NICs are detected via sysfs; restricted BlueFields are excluded. |
 | `--image-pull-secrets` | — | — | Image pull secret names (comma-separated). Forwarded to the discovery DaemonSet and persisted for generated policies, Network Operator Helm values, and authenticated chart downloads during deploy. |
 | `--fabric` | — | discovered unanimous link type | Fabric override: `ethernet` or `infiniband`. |
 | `--deployment-type` | — | `sriov` | Deployment override: `sriov`, `rdma_shared`, or `host_device`. |
@@ -160,7 +160,10 @@ the GPU label is still written when `gpuType` alone is resolved.
   NFD `nodeSelector` and tolerates taints, so eligible control-plane/tainted
   nodes are included. NIC-bearing nodes are detected by a sysfs probe for PCI
   vendor `0x15b3` rather than the NFD
-  `feature.node.kubernetes.io/pci-15b3.present` label.
+  `feature.node.kubernetes.io/pci-15b3.present` label. BlueFields for which
+  `mlxprivhost` reports `level: restricted` are excluded because the daemon
+  will not publish `NicDevice` resources for them. Mixed nodes remain eligible
+  when they have at least one non-restricted NVIDIA NIC.
 - Image-pull access from every worker node to
   `<networkOperator.repository>/nic-configuration-operator-daemon:<networkOperator.componentVersion>`.
   Use `--image-pull-secrets <name>` (or `networkOperator.imagePullSecrets`
@@ -215,6 +218,9 @@ Do not add GPU counts or resource maps under `clusterConfig`.
 - If discovery reports "no nodes with an NVIDIA NIC (PCI vendor 15b3) were found",
   the daemon ran but no node's sysfs exposed a `0x15b3` device (no Mellanox/NVIDIA
   NICs, or `/sys` not mounted/readable in the pod).
+- If discovery reports "no discoverable NVIDIA NICs were found", every detected
+  BlueField is in zero-trust (`restricted`) mode. Those devices cannot be
+  configured from the host and intentionally do not publish `NicDevice` resources.
 - After determining each group's `(machineType, gpuType)`, discovery looks up a topology preset under `presets/` using **exact-match** lookup on that pair. A matching preset overrides heuristic-derived topology fields (traffic class, rail, NUMA, GPU affinity). There is no any-GPU fallback — a preset with empty `gpuType:` is rejected at load time. If no preset matches, discovery proceeds with heuristic classification.
 - If you already know the SKU and want to skip cluster discovery entirely, use `l8k generate --for <preset>` (see `k8s-launch-kit-generate`).
 

--- a/skills/k8s-launch-kit-discover/references/discovery-internals.md
+++ b/skills/k8s-launch-kit-discover/references/discovery-internals.md
@@ -64,11 +64,18 @@ only hard-fails when no pod ever became Ready.
 
 To pick which nodes to wait on for `NicDevice` CRs, `filterNodesWithNICs` execs a
 sysfs probe (`sysfsMellanoxNICPresentCmd`) into each daemon pod that scans
-`/sys/bus/pci/devices/*/vendor` for `0x15b3`; only NIC-bearing nodes enter the
-wait set. The `--node-selector` flag is **not** used for scheduling or the wait —
-it only populates the **saved** `cluster-config.yaml` `nodeSelector` for deploy
-time. (Fallback: when no REST config is available for pod exec, the legacy
-`--node-selector` label filter is used instead.)
+`/sys/bus/pci/devices/*/vendor` for `0x15b3`. For BlueField-2, BlueField-3,
+BlueField-3 Lx, and BlueField-4 devices, the same probe runs
+`mlxprivhost -d <pci> q`. Devices that successfully report
+`level: restricted` are excluded, mirroring NIC Configuration Operator's
+zero-trust handling; failed or unrecognized trust queries remain discoverable,
+also matching the operator. A node enters the wait set when at least one
+discoverable NIC remains. A restricted-only node is reported separately and
+excluded so discovery does not wait for a `NicDevice` that can never be
+published. The `--node-selector` flag is **not** used for scheduling or the
+wait — it only populates the **saved** `cluster-config.yaml` `nodeSelector` for
+deploy time. (Fallback: when no REST config is available for pod exec, the
+legacy `--node-selector` label filter is used instead.)
 
 ### Leftover pre-clean
 

--- a/skills/k8s-launch-kit-troubleshoot/SKILL.md
+++ b/skills/k8s-launch-kit-troubleshoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-troubleshoot
-version: 1.1.2
+version: 1.1.3
 description: "Use this skill when the user has problems with NVIDIA Network Operator on Kubernetes, or wants to analyze a sosreport diagnostic dump. Activate for: OFED driver crashes, SR-IOV pods failing, NicClusterPolicy errors, network operator pod issues, RDMA not working, NIC configuration failures, pods stuck in CrashLoopBackOff or ContainerCreating with network annotations, VF allocation issues, or when the user mentions 'troubleshoot', 'debug', 'sosreport', 'diagnose', or describes any NVIDIA networking failure -- even if they don't explicitly ask for troubleshooting."
 metadata:
   requires:
@@ -66,7 +66,8 @@ kubectl get pods -A -o wide | grep -E 'ContainerCreating|Init'
 | No VFs on node | SriovNetworkNodePolicy not matching | Verify `nodeSelector` labels match worker nodes |
 | RDMA not working | Missing RDMA device plugin or wrong resource name | Check `rdma-shared-dp` pods, verify resource annotations |
 | Phase 0 Helm chart download returns HTTP 401 or an image-pull-Secret error | The configured Secret is missing from the operator namespace, unreadable by the kubeconfig, or has no compatible Docker auth entry | Verify the Secret in `networkOperator.namespace`; for NGC, its `.dockerconfigjson` must contain `nvcr.io` credentials |
-| `l8k discover` daemon pods stuck (ImagePullBackOff / Pending) | Bad image tag, missing pull secret, or no `feature.node.kubernetes.io/pci-15b3.present=true` nodes | Re-run with `--keep-namespace` then `kubectl describe pod -n nvidia-k8s-launch-kit`. Fix `networkOperator.componentVersion` / pass `--image-pull-secrets` / verify NFD is running. |
+| `l8k discover` daemon pods stuck (ImagePullBackOff / Pending) | Bad image tag, missing pull secret, or no Ready schedulable nodes | Re-run with `--keep-namespace` then `kubectl describe pod -n nvidia-k8s-launch-kit`. Fix `networkOperator.componentVersion`, pass `--image-pull-secrets`, or restore node readiness. NFD is not required. |
+| `l8k discover` waits for a node that has only a BlueField | The BlueField is in zero-trust (`restricted`) mode and NIC Configuration Operator will not publish a `NicDevice` | Use a Launch Kit version that excludes restricted BlueFields from the wait set; confirm the mode with `mlxprivhost -d <pci> q` in the daemon pod. |
 | `l8k validate` / `deploy` can't find Network Operator pods | Operator namespace mismatch | Verify `--network-operator-namespace` matches actual namespace (does NOT apply to `l8k discover` — it ignores the flag and uses its own `nvidia-k8s-launch-kit` namespace) |
 | IPPool not allocating | NV-IPAM subnet exhausted or misconfigured | Check `ippools` CR status, verify CIDR ranges |
 | `--for requires --node-selector` | `--for` was passed without `--node-selector` | Add `--node-selector key=val,…`. The synthesized clusterConfig has no live worker-node list; the selector identifies target nodes at apply time. |

--- a/skills/k8s-launch-kit-troubleshoot/references/common-failures.md
+++ b/skills/k8s-launch-kit-troubleshoot/references/common-failures.md
@@ -189,17 +189,20 @@ NetworkAttachmentDefinition is missing/misconfigured.
 **Symptom**: Running `--discover-cluster-config` completes but produces an empty
 `clusterConfig` array or reports "no groups found".
 
-**Root cause**: The label selector does not match any nodes, or nodes do not have
-NVIDIA/Mellanox NICs detected by NFD.
+**Root cause**: No Ready, schedulable node has a discoverable NVIDIA/Mellanox
+NIC, or all detected BlueFields are in zero-trust (`restricted`) mode and are
+therefore excluded from `NicDevice` discovery.
 
 **Remediation**:
-1. Verify nodes have the expected label:
-   `kubectl get nodes -l feature.node.kubernetes.io/pci-15b3.present=true`
-2. If using `--node-selector`, verify your selector matches existing node labels:
-   `kubectl get nodes --show-labels`
-3. Verify Node Feature Discovery (NFD) is running:
-   `kubectl get pods -n node-feature-discovery` (or the namespace where NFD is deployed)
-4. Check that NodeFeature CRs are populated:
-   `kubectl get nodefeatures -A`
-5. If NFD is running but NIC labels are missing, the NICs may not be properly detected
-   by the host OS. Check `lspci | grep Mellanox` on the node.
+1. Verify the candidate nodes are Ready and not cordoned:
+   `kubectl get nodes`
+2. Re-run discovery with `--keep-namespace`, then inspect the daemon pod and
+   logs in `nvidia-k8s-launch-kit`.
+3. Check that the host exposes NVIDIA NICs:
+   `lspci -Dn | grep 15b3`
+4. For each BlueField PCI address, query the host trust mode from the daemon
+   pod: `mlxprivhost -d <pci> q`. A `level: restricted` result is intentionally
+   excluded because NIC Configuration Operator cannot configure or publish it.
+5. NFD and `feature.node.kubernetes.io/pci-15b3.present` are not prerequisites
+   for discovery. `--node-selector` is saved for deployment-time selection and
+   does not constrain the discovery daemon or its `NicDevice` wait set.


### PR DESCRIPTION
## Summary

- exclude zero-trust restricted BlueField devices from the NicDevice wait set
- keep mixed nodes eligible when another discoverable NVIDIA NIC exists
- preserve NCO fail-open handling for failed or unrecognized trust queries
- update discovery docs, CLI help, and bundled skills

## Why

NCO intentionally skips restricted BlueFields, so a restricted-only node never publishes a NicDevice. Launch Kit previously counted any NVIDIA PCI device and waited until the device-discovery timeout.

## Testing

- go test ./... -count=1
- go test -race ./pkg/networkoperatorplugin/discovery/... -count=1
- go vet ./...
- make build
- make build-linux
- git diff --check

Not run locally:

- make lint: golangci-lint is not installed
- mkdocs build --strict: MkDocs is not installed