### PR TITLE
fix: preserve GA Network Operator releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -891,10 +891,13 @@ Every catalog entry is synchronized nightly from
 `Mellanox/network-operator`'s `v<MAJOR.MINOR>.x` branch. When the release
 branch for the highest catalog key has not been created yet, the synchronizer
 uses `master` and verifies that its Network Operator version still belongs to
-that release line. When values change, the workflow verifies the synchronized
-catalog, opens or refreshes its PR, and squash-merges it automatically. The
-release stage checks out that merge commit and verifies the catalog is still
-current before publishing anything. Run the same update locally with
+that release line. A line that already points to a GA release keeps its entire
+public artifact set while upstream advertises a beta or release candidate for
+the next patch; synchronization resumes when that patch becomes GA. When
+values change, the workflow verifies the synchronized catalog, opens or
+refreshes its PR, and squash-merges it automatically. The release stage checks
+out that merge commit and verifies the catalog is still current before
+publishing anything. Run the same update locally with
 `GITHUB_TOKEN=<token> make sync-network-operator-releases` (authentication
 avoids GitHub's low anonymous API rate limit).
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -57,6 +57,11 @@ Supported release lines are currently:
 
 The release line fills Network Operator versions, component image tags, DOCA driver version, full-runtime validation image, repositories, Helm repository URL, and version-gated template behavior. Spectrum-X releases also carry a manually maintained xPlane repository and version used in `spectrumXOperator.xPlane` instead of reusing the generic component tag.
 
+Nightly synchronization follows each upstream release branch. Once a catalog
+line points to a GA Network Operator release, beta and release-candidate builds
+of a later patch do not replace its public artifact set. The line advances
+again when that patch is published as GA.
+
 ## Network Operator
 
 | Field | Meaning |

--- a/hack/sync-network-operator-releases/main.go
+++ b/hack/sync-network-operator-releases/main.go
@@ -91,8 +91,18 @@ func main() {
 		exitWithError(fmt.Errorf("sync Network Operator releases: %w", err))
 	}
 
+	for _, preserved := range result.Preserved {
+		fmt.Printf(
+			"kept %s at GA %s; ignored prerelease %s from %s\n",
+			preserved.Release,
+			preserved.CurrentOperatorVersion,
+			preserved.CandidateOperatorVersion,
+			preserved.Ref,
+		)
+	}
+
 	if !result.Changed {
-		fmt.Println("Network Operator release catalog is already current")
+		fmt.Println("Network Operator release catalog requires no updates")
 		return
 	}
 

--- a/hack/sync-network-operator-releases/sync.go
+++ b/hack/sync-network-operator-releases/sync.go
@@ -56,8 +56,9 @@ type syncOptions struct {
 }
 
 type syncResult struct {
-	Changed bool
-	Updates []releaseUpdate
+	Changed   bool
+	Updates   []releaseUpdate
+	Preserved []preservedRelease
 }
 
 type releaseUpdate struct {
@@ -65,6 +66,13 @@ type releaseUpdate struct {
 	Ref                    string
 	NetworkOperatorVersion string
 	DOCADriverVersion      string
+}
+
+type preservedRelease struct {
+	Release                  string
+	Ref                      string
+	CurrentOperatorVersion   string
+	CandidateOperatorVersion string
 }
 
 type upstreamReleaseFile struct {
@@ -126,6 +134,11 @@ func syncCatalog(ctx context.Context, opts syncOptions) (syncResult, error) {
 		return syncResult{}, err
 	}
 
+	var document yaml.Node
+	if err := yaml.Unmarshal(original, &document); err != nil {
+		return syncResult{}, fmt.Errorf("parse catalog document: %w", err)
+	}
+
 	client, err := newGitHubClient(
 		opts.APIBaseURL,
 		upstreamRepository,
@@ -137,6 +150,7 @@ func syncCatalog(ctx context.Context, opts syncOptions) (syncResult, error) {
 	}
 
 	desired := make([]desiredReleaseWithSource, 0, len(managed))
+	preserved := make([]preservedRelease, 0)
 	latestRelease := managed[len(managed)-1].Key
 	for _, catalogEntry := range managed {
 		release := catalogEntry.Key
@@ -155,16 +169,32 @@ func syncCatalog(ctx context.Context, opts syncOptions) (syncResult, error) {
 			return syncResult{}, fmt.Errorf("validate release %s from %s: %w", release, ref, err)
 		}
 
+		currentVersion, err := catalogNetworkOperatorVersion(&document, release)
+		if err != nil {
+			return syncResult{}, err
+		}
+		keepCurrent, err := shouldKeepCurrentGA(
+			currentVersion,
+			releaseValues.NetworkOperatorVersion,
+		)
+		if err != nil {
+			return syncResult{}, fmt.Errorf("compare release %s versions: %w", release, err)
+		}
+		if keepCurrent {
+			preserved = append(preserved, preservedRelease{
+				Release:                  release,
+				Ref:                      ref,
+				CurrentOperatorVersion:   currentVersion,
+				CandidateOperatorVersion: releaseValues.NetworkOperatorVersion,
+			})
+			continue
+		}
+
 		desired = append(desired, desiredReleaseWithSource{
 			Release: release,
 			Ref:     ref,
 			Desired: releaseValues,
 		})
-	}
-
-	var document yaml.Node
-	if err := yaml.Unmarshal(original, &document); err != nil {
-		return syncResult{}, fmt.Errorf("parse catalog document: %w", err)
 	}
 
 	changedItems := make([]desiredReleaseWithSource, 0, len(desired))
@@ -178,7 +208,10 @@ func syncCatalog(ctx context.Context, opts syncOptions) (syncResult, error) {
 		}
 	}
 	if len(changedItems) == 0 {
-		return syncResult{Changed: false}, nil
+		return syncResult{
+			Changed:   false,
+			Preserved: preserved,
+		}, nil
 	}
 
 	var updated bytes.Buffer
@@ -196,8 +229,9 @@ func syncCatalog(ctx context.Context, opts syncOptions) (syncResult, error) {
 	}
 
 	result := syncResult{
-		Changed: true,
-		Updates: make([]releaseUpdate, 0, len(changedItems)),
+		Changed:   true,
+		Updates:   make([]releaseUpdate, 0, len(changedItems)),
+		Preserved: preserved,
 	}
 	for _, item := range changedItems {
 		result.Updates = append(result.Updates, releaseUpdate{
@@ -208,6 +242,45 @@ func syncCatalog(ctx context.Context, opts syncOptions) (syncResult, error) {
 		})
 	}
 	return result, nil
+}
+
+func catalogNetworkOperatorVersion(document *yaml.Node, release string) (string, error) {
+	if document == nil || document.Kind != yaml.DocumentNode || len(document.Content) == 0 {
+		return "", errors.New("catalog YAML has no document")
+	}
+
+	releasesNode, err := mappingValue(document.Content[0], "releases")
+	if err != nil {
+		return "", err
+	}
+	releaseNode, err := mappingValue(releasesNode, release)
+	if err != nil {
+		return "", fmt.Errorf("catalog release %s: %w", release, err)
+	}
+	networkOperatorNode, err := mappingValue(releaseNode, "networkOperator")
+	if err != nil {
+		return "", fmt.Errorf("catalog release %s: %w", release, err)
+	}
+	versionNode, err := mappingValue(networkOperatorNode, "version")
+	if err != nil {
+		return "", fmt.Errorf("catalog release %s: %w", release, err)
+	}
+	if versionNode.Kind != yaml.ScalarNode || versionNode.Value == "" {
+		return "", fmt.Errorf("catalog release %s field version must be a non-empty scalar", release)
+	}
+	return versionNode.Value, nil
+}
+
+func shouldKeepCurrentGA(currentTag string, candidateTag string) (bool, error) {
+	current, err := semver.NewVersion(currentTag)
+	if err != nil {
+		return false, fmt.Errorf("current Network Operator version %q is invalid: %w", currentTag, err)
+	}
+	candidate, err := semver.NewVersion(candidateTag)
+	if err != nil {
+		return false, fmt.Errorf("candidate Network Operator version %q is invalid: %w", candidateTag, err)
+	}
+	return current.Prerelease() == "" && candidate.Prerelease() != "", nil
 }
 
 func catalogReleases(catalogYAML []byte) ([]catalogRelease, error) {

--- a/hack/sync-network-operator-releases/sync_test.go
+++ b/hack/sync-network-operator-releases/sync_test.go
@@ -193,6 +193,133 @@ func TestSyncCatalogDoesNotFallbackForOlderRelease(t *testing.T) {
 	assert.NotContains(t, strings.Join(fake.requests, "\n"), "/branches/master")
 }
 
+func TestSyncCatalogKeepsCurrentGAUntilCandidateIsGA(t *testing.T) {
+	original := stable264CatalogYAML()
+	catalogPath := writeTestCatalog(t, original)
+	fake := &fakeGitHub{
+		branches: map[string]bool{
+			"v26.4.x": true,
+		},
+		files: map[string]string{
+			"v26.4.x": upstreamReleaseYAML(
+				"v26.4.2-rc.1",
+				stagingOperatorRepository,
+				stagingComponentRepository,
+				"doca3.4.1-26.04-1.2.0.0-0",
+			),
+		},
+		requests: nil,
+	}
+	server := httptest.NewServer(fake)
+	t.Cleanup(server.Close)
+
+	result, err := syncCatalog(context.Background(), syncOptions{
+		CatalogPath: catalogPath,
+		APIBaseURL:  server.URL,
+		Token:       "",
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+	assert.False(t, result.Changed)
+	assert.Empty(t, result.Updates)
+	require.Len(t, result.Preserved, 1)
+	assert.Equal(t, "26.4", result.Preserved[0].Release)
+	assert.Equal(t, "v26.4.x", result.Preserved[0].Ref)
+	assert.Equal(t, "v26.4.1", result.Preserved[0].CurrentOperatorVersion)
+	assert.Equal(t, "v26.4.2-rc.1", result.Preserved[0].CandidateOperatorVersion)
+	assert.Equal(t, []byte(original), readTestCatalog(t, catalogPath))
+
+	fake.files["v26.4.x"] = upstreamReleaseYAML(
+		"v26.4.2",
+		stableOperatorRepository,
+		stableComponentRepository,
+		"doca3.4.1-26.04-1.2.0.0-0",
+	)
+
+	result, err = syncCatalog(context.Background(), syncOptions{
+		CatalogPath: catalogPath,
+		APIBaseURL:  server.URL,
+		Token:       "",
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Changed)
+	require.Len(t, result.Updates, 1)
+	assert.Empty(t, result.Preserved)
+
+	var catalog struct {
+		Releases map[string]catalogReleaseValues `yaml:"releases"`
+	}
+	require.NoError(t, yaml.Unmarshal(readTestCatalog(t, catalogPath), &catalog))
+	updated := catalog.Releases["26.4"]
+	assert.Equal(t, "v26.4.2", updated.NetworkOperator.Version)
+	assert.Equal(t, "network-operator-v26.4.2", updated.NetworkOperator.ComponentVersion)
+	assert.Equal(t, stableComponentRepository, updated.NetworkOperator.Repository)
+	assert.Equal(t, stableOperatorRepository, updated.NetworkOperator.OperatorRepository)
+	assert.Equal(t, stableHelmRepoURL, updated.NetworkOperator.HelmRepoURL)
+	assert.Equal(t, "doca3.4.1-26.04-1.2.0.0-0", updated.DOCADriver.Version)
+}
+
+func TestSyncCatalogPreservesGAWhileUpdatingAnotherRelease(t *testing.T) {
+	catalogPath := writeTestCatalog(t, testCatalogYAML())
+	fake := &fakeGitHub{
+		branches: map[string]bool{
+			"v26.1.x": true,
+			"v26.7.x": true,
+		},
+		files: map[string]string{
+			"v26.1.x": upstreamReleaseYAML(
+				"v26.1.2-rc.1",
+				stagingOperatorRepository,
+				stagingComponentRepository,
+				"doca3.3.0-26.01-1.1.0.0-0",
+			),
+			"v26.7.x": upstreamReleaseYAML(
+				"v26.7.0-rc.1",
+				stagingOperatorRepository,
+				stagingComponentRepository,
+				"doca3.5.0-26.07-0.5.1.0-0",
+			),
+		},
+		requests: nil,
+	}
+	server := httptest.NewServer(fake)
+	t.Cleanup(server.Close)
+
+	result, err := syncCatalog(context.Background(), syncOptions{
+		CatalogPath: catalogPath,
+		APIBaseURL:  server.URL,
+		Token:       "",
+		HTTPClient:  server.Client(),
+	})
+	require.NoError(t, err)
+	assert.True(t, result.Changed)
+	require.Len(t, result.Updates, 1)
+	assert.Equal(t, "26.7", result.Updates[0].Release)
+	require.Len(t, result.Preserved, 1)
+	assert.Equal(t, "26.1", result.Preserved[0].Release)
+	assert.Equal(t, "v26.1.1", result.Preserved[0].CurrentOperatorVersion)
+	assert.Equal(t, "v26.1.2-rc.1", result.Preserved[0].CandidateOperatorVersion)
+
+	var catalog struct {
+		Releases map[string]catalogReleaseValues `yaml:"releases"`
+	}
+	require.NoError(t, yaml.Unmarshal(readTestCatalog(t, catalogPath), &catalog))
+
+	preserved := catalog.Releases["26.1"]
+	assert.Equal(t, "v26.1.1", preserved.NetworkOperator.Version)
+	assert.Equal(t, "network-operator-v26.1.1", preserved.NetworkOperator.ComponentVersion)
+	assert.Equal(t, stableComponentRepository, preserved.NetworkOperator.Repository)
+	assert.Equal(t, stableOperatorRepository, preserved.NetworkOperator.OperatorRepository)
+	assert.Equal(t, stableHelmRepoURL, preserved.NetworkOperator.HelmRepoURL)
+	assert.Equal(t, "doca3.3.0-26.01-1.0.0.0-0", preserved.DOCADriver.Version)
+	assert.Equal(t, "registry.example/validation:26.1", preserved.Validation.Image)
+
+	updated := catalog.Releases["26.7"]
+	assert.Equal(t, "v26.7.0-rc.1", updated.NetworkOperator.Version)
+	assert.Equal(t, "doca3.5.0-26.07-0.5.1.0-0", updated.DOCADriver.Version)
+}
+
 func TestSyncCatalogRejectsMismatchedMasterWithoutWriting(t *testing.T) {
 	original := testCatalogYAML()
 	catalogPath := writeTestCatalog(t, original)
@@ -307,6 +434,54 @@ func TestRequireNewerTag(t *testing.T) {
 	assert.Contains(t, err.Error(), "is not newer")
 }
 
+func TestShouldKeepCurrentGA(t *testing.T) {
+	tests := []struct {
+		name      string
+		current   string
+		candidate string
+		expected  bool
+	}{
+		{
+			name:      "keep GA over release candidate",
+			current:   "v26.4.1",
+			candidate: "v26.4.2-rc.1",
+			expected:  true,
+		},
+		{
+			name:      "keep GA over beta",
+			current:   "v26.4.1",
+			candidate: "v26.4.2-beta.1",
+			expected:  true,
+		},
+		{
+			name:      "promote prerelease to GA",
+			current:   "v26.4.2-rc.1",
+			candidate: "v26.4.2",
+			expected:  false,
+		},
+		{
+			name:      "advance prerelease",
+			current:   "v26.4.2-beta.1",
+			candidate: "v26.4.2-rc.1",
+			expected:  false,
+		},
+		{
+			name:      "advance GA",
+			current:   "v26.4.1",
+			candidate: "v26.4.2",
+			expected:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := shouldKeepCurrentGA(test.current, test.candidate)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 func writeTestCatalog(t *testing.T, contents string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "releases.yaml")
@@ -346,6 +521,23 @@ releases:
       version: doca3.5.0-26.07-0.4.2.0-0
     validation:
       image: registry.example/validation:26.7
+`
+}
+
+func stable264CatalogYAML() string {
+	return `# Test stable release catalog
+releases:
+  "26.4":
+    networkOperator:
+      version: v26.4.1
+      componentVersion: network-operator-v26.4.1
+      repository: nvcr.io/nvidia/mellanox
+      operatorRepository: nvcr.io/nvidia/cloud-native
+      helmRepoURL: https://helm.ngc.nvidia.com/nvidia
+    docaDriver:
+      version: doca3.4.1-26.04-1.1.0.0-1
+    validation:
+      image: registry.example/validation:26.4
 `
 }
 

--- a/pkg/networkoperatorplugin/releases/releases.yaml
+++ b/pkg/networkoperatorplugin/releases/releases.yaml
@@ -29,11 +29,11 @@ releases:
       image: nvcr.io/nvidia/doca/doca:full-rt-cuda13.0.0-3.2.3-runtime-host
   "26.4":
     networkOperator:
-      version: v26.4.2-rc.1
-      componentVersion: network-operator-v26.4.2-rc.1
-      repository: nvcr.io/nvstaging/mellanox
-      operatorRepository: nvcr.io/nvstaging/mellanox
-      helmRepoURL: https://helm.ngc.nvidia.com/nvstaging/mellanox
+      version: v26.4.1
+      componentVersion: network-operator-v26.4.1
+      repository: nvcr.io/nvidia/mellanox
+      operatorRepository: nvcr.io/nvidia/cloud-native
+      helmRepoURL: https://helm.ngc.nvidia.com/nvidia
     docaDriver:
       version: doca3.4.1-26.04-1.1.0.0-1
     xPlane:

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-config
-version: 1.2.7
+version: 1.2.8
 description: "Use this skill when the user needs help understanding, creating, or editing a k8s-launch-kit (l8k) configuration file (l8k-config.yaml or cluster-config.yaml). Activate for: config file questions, parameter tuning, subnet configuration, NV-IPAM setup, DOCA driver settings, maintenance concurrency, NIC configuration operator settings, changing MTU, VFs, resource names, or understanding what any config field does."
 metadata:
   requires:
@@ -175,6 +175,10 @@ networkNamespaces: ["my-namespace"]
   repeating profile flags; use flags only for overrides.
 - Use `l8k schema` to discover the Network Operator release keys supported by
   the installed l8k version.
+- Treat a GA catalog entry as sticky during nightly synchronization: an
+  upstream beta or release candidate for the next patch must not replace its
+  public Network Operator artifact set. Update the entry again when the patch
+  is GA.
 - `nvIpam` subnets are auto-generated if not specified — one per rail using non-routable ranges.
 - `docaDriver.unloadThirdPartyRDMAModules: true` auto-populates `UNLOAD_THIRD_PARTY_RDMA_MODULES` from discovered OFED-dependent modules.
 - For release 26.1+, SR-IOV requestor mode requires both the Network Operator drain requestor and the SR-IOV external drainer. l8k renders both; applying only CRs cannot enable their Deployment environment variables.


### PR DESCRIPTION
## Summary

- keep a stable Network Operator catalog entry when upstream advertises a beta or release candidate for a later patch
- resume synchronization when that patch reaches GA
- restore the 26.4 catalog line from v26.4.2-rc.1 to the public v26.4.1 artifact cohort
- document the promotion rule and cover RC, beta, prerelease advancement, and GA promotion

## Validation

- go test -count=1 ./hack/sync-network-operator-releases
- go test -count=1 ./pkg/networkoperatorplugin/releases
- make build
- go test -race -count=1 ./...
- go vet ./...
- golangci-lint v2.11 run ./...
- live scratch-catalog sync against v26.4.x: retained v26.4.1 and produced no diff