### PR TITLE
fix: qualify ICMP validation by source route

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,12 +418,14 @@ desiredNumberScheduled > 0` — a single ContainerCreating-stuck pod fails),
 and run the configured checks (`icmp`, `rping`, and/or `ib_write_bw`) with
 source-bound rail identity. Every profile renders the DaemonSet with a DOCA
 container for RDMA checks and a declared `netshoot` container for ICMP; validate
-applies that manifest without injecting containers at runtime. ICMP always uses
-`ping -I <src-iface>` for both same-rail and cross-rail probes in every
-validation mode; it never relies on binding only the source IP. `rping` uses
-`-I <src-ip>`, and `ib_write_bw` uses `--bind_source_ip <src-ip>`; every test
-also records a source-qualified `ip route get <dst> from <src>` lookup from the
-netshoot container. When `validation.gpuDirect.enabled` is true, a separate
+applies that manifest without injecting containers at runtime. Before every ICMP
+probe, validate checks that `ip route get <dst> from <src>` selects the named
+source interface. A route selecting another interface makes that rail pair not
+connected without forcing traffic onto it; otherwise ICMP uses
+`ping -I <src-ip>`. `rping` uses
+`-I <src-ip>`, and `ib_write_bw` uses `--bind_source_ip <src-ip>`; required RDMA
+tests also record a source-qualified route lookup from the netshoot container.
+When `validation.gpuDirect.enabled` is true, a separate
 DMA-BUF bandwidth stage repeats the selected `ib_write_bw` matrix with
 `--use_cuda=<endpoint-index> --use_cuda_dmabuf`. Source and destination CUDA
 indices are resolved independently from each node's per-PF `connectedGPU`

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -38,10 +38,11 @@ Each generated example DaemonSet declares two validation containers: the DOCA
 container runs `rping`, `ib_write_bw`, and DMA-BUF bandwidth, while the `netshoot` container runs
 ICMP and route checks from the same pod network namespace. Validation applies
 the generated DaemonSet as written; it does not inject a helper container at
-runtime. Every ICMP probe is pinned with `ping -I <src-iface>`, including
-same-rail and cross-rail probes in `quick`, `full`, and `strict` modes. Binding
-only the source IP is intentionally not used because it does not guarantee the
-probe stays on the selected Multus interface.
+runtime. Before every same-rail and cross-rail ICMP probe in `quick`, `full`,
+and `strict` modes, validation runs `ip route get <dst> from <src>` and compares
+the selected device with the source rail interface. A mismatch is reported as
+not connected without forcing the packet onto another route; a match is probed
+with `ping -I <src-ip>` so source-based policy rules are applied.
 
 Manifest-state checks for `NicConfigurationTemplate` and `NicFirmwareTemplate` use the operator-populated `status.nicDevices` list as the matched device set. An empty list, a list that does not yet reflect the current node, NIC type, PCI-address, serial-number, and part-number selectors, a missing named `NicDevice`, a device spec that does not yet reflect the current template payload, or a relevant device condition with a stale `observedGeneration` remains `IN-PROGRESS`. `NicConfigurationTemplate` considers `FirmwareUpdateInProgress` relevant only when the matched device has `spec.firmware`; a stale firmware condition cannot block a configuration-only deployment. Unrelated discovered devices are used only to verify selector freshness; their configuration and firmware state is ignored.
 

--- a/pkg/networkoperatorplugin/connectivity/connectivity.go
+++ b/pkg/networkoperatorplugin/connectivity/connectivity.go
@@ -572,7 +572,10 @@ func checkSourceRoutes(ctx context.Context, restConfig *rest.Config, namespaceBy
 	checks, hits, failures := 0, 0, 0
 	out := append([]PingTest(nil), tests...)
 	for i := range out {
-		if out[i].Expectation != ExpectRequired {
+		// Required RDMA checks retain their existing source-route guard. ICMP
+		// always needs the guard because its source IP activates SBR, while the
+		// selected route establishes whether the named source rail is used.
+		if out[i].Expectation != ExpectRequired && !out[i].Kind.IsICMP() {
 			continue
 		}
 		namespace := namespaceByPod[out[i].SrcPod]
@@ -603,9 +606,8 @@ func checkSourceRoutes(ctx context.Context, restConfig *rest.Config, namespaceBy
 				cache[key] = out[i].sourceRoute
 			}
 		}
-		if routeMismatch(out[i].sourceRoute, out[i]) {
-			out[i].sourceRouteErr = fmt.Errorf("source route selected dev %q, expected %q (route: %s)",
-				out[i].sourceRoute.Dev, out[i].SrcIface, out[i].sourceRoute.Output)
+		if routeErr := sourceRouteValidationError(out[i].sourceRoute, out[i]); routeErr != nil {
+			out[i].sourceRouteErr = routeErr
 			failures++
 		}
 	}

--- a/pkg/networkoperatorplugin/connectivity/icmp.go
+++ b/pkg/networkoperatorplugin/connectivity/icmp.go
@@ -27,7 +27,7 @@ import (
 func RunICMP(ctx context.Context, restConfig *rest.Config, namespace, pod, container string, test PingTest) PingResult {
 	r := initResult(test)
 	if r.Err != nil {
-		finalizeExpectedResult(&r, false, r.Err)
+		finalizeICMPRouteError(&r)
 		return r
 	}
 	if test.SrcIface == "" {
@@ -35,18 +35,14 @@ func RunICMP(ctx context.Context, restConfig *rest.Config, namespace, pod, conta
 		finalizeExpectedResult(&r, false, r.Err)
 		return r
 	}
-	if r.Expectation == ExpectRequired {
-		// RunMatrix pre-computes and caches required source routes across
-		// stages. Keep the standalone runner behavior for direct callers.
-		if r.Route.Command == "" {
-			r.Route = checkRoute(ctx, restConfig, namespace, pod, container, test)
-		}
-		if routeMismatch(r.Route, test) {
-			r.Err = fmt.Errorf("source route selected dev %q, expected %q (route: %s)",
-				r.Route.Dev, test.SrcIface, r.Route.Output)
-			finalizeExpectedResult(&r, false, r.Err)
-			return r
-		}
+	// RunMatrix pre-computes and caches ICMP source routes across stages.
+	// Keep the standalone runner behavior for direct callers.
+	if r.Route.Command == "" {
+		r.Route = checkRoute(ctx, restConfig, namespace, pod, container, test)
+	}
+	if r.Err = sourceRouteValidationError(r.Route, test); r.Err != nil {
+		finalizeICMPRouteError(&r)
+		return r
 	}
 	cmd := shellWithTimeout(icmpCommand(test),
 		commandTimeoutFor(test, icmpCommandTimeout))
@@ -57,6 +53,15 @@ func RunICMP(ctx context.Context, restConfig *rest.Config, namespace, pod, conta
 	return r
 }
 
+func finalizeICMPRouteError(result *PingResult) {
+	if isSourceRouteMismatchError(result.Err) {
+		finalizeExpectedResult(result, false, result.Err)
+		return
+	}
+	result.OK = false
+	result.ObservedOK = false
+}
+
 func icmpCommand(test PingTest) string {
-	return fmt.Sprintf("ping -c 1 -W 1 -I %s %s", shellArg(test.SrcIface), shellArg(test.DstIP))
+	return fmt.Sprintf("ping -c 1 -W 1 -I %s %s", shellArg(test.SrcIP), shellArg(test.DstIP))
 }

--- a/pkg/networkoperatorplugin/connectivity/icmp_test.go
+++ b/pkg/networkoperatorplugin/connectivity/icmp_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPlannedICMPCommandsPinSourceInterfaceInEveryMode(t *testing.T) {
+func TestPlannedICMPCommandsBindSourceIPInEveryMode(t *testing.T) {
 	pods := []TestPod{
 		mkPod("pod-a", "rail-0", "rail-1"),
 		mkPod("pod-b", "rail-0", "rail-1"),
@@ -50,15 +50,15 @@ func TestPlannedICMPCommandsPinSourceInterfaceInEveryMode(t *testing.T) {
 			icmpTests := testsForCheck(plan, CheckICMP)
 
 			for _, test := range icmpTests {
-				expected := fmt.Sprintf("ping -c 1 -W 1 -I %q %q", test.SrcIface, test.DstIP)
+				expected := fmt.Sprintf("ping -c 1 -W 1 -I %q %q", test.SrcIP, test.DstIP)
 				assert.Equal(t, expected, icmpCommand(test), "%+v", test)
-				assert.NotContains(t, icmpCommand(test), test.SrcIP, "%+v", test)
+				assert.NotContains(t, icmpCommand(test), test.SrcIface, "%+v", test)
 			}
 		})
 	}
 }
 
-func TestWrappedICMPCommandPinsInterfaceInTimeoutAndFallbackPaths(t *testing.T) {
+func TestWrappedICMPCommandBindsSourceIPInTimeoutAndFallbackPaths(t *testing.T) {
 	plan := PlanWithOptions([]TestPod{
 		mkPod("pod-a", "rail-0", "rail-1"),
 		mkPod("pod-b", "rail-0", "rail-1"),
@@ -70,5 +70,5 @@ func TestWrappedICMPCommandPinsInterfaceInTimeoutAndFallbackPaths(t *testing.T) 
 
 	assert.Contains(t, cmd, "timeout -s TERM -k 2 5 sh -c "+shellArg(icmpCommand(test)))
 	assert.Contains(t, cmd, "else "+icmpCommand(test)+" & pid=$!")
-	assert.NotContains(t, cmd, test.SrcIP)
+	assert.NotContains(t, cmd, test.SrcIface)
 }

--- a/pkg/networkoperatorplugin/connectivity/source.go
+++ b/pkg/networkoperatorplugin/connectivity/source.go
@@ -18,6 +18,7 @@ package connectivity
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -32,6 +33,17 @@ var routeDevRe = regexp.MustCompile(`(?:^|\s)dev\s+(\S+)`)
 
 const routeSkipMarker = "__L8K_ROUTE_SKIP__"
 const routeSkipErr = "ip command not found in validation container"
+
+type sourceRouteMismatchError struct {
+	selected string
+	expected string
+	output   string
+}
+
+func (e *sourceRouteMismatchError) Error() string {
+	return fmt.Sprintf("source route selected dev %q, expected %q (route: %s)",
+		e.selected, e.expected, e.output)
+}
 
 func initResult(test PingTest) PingResult {
 	exp := test.Expectation
@@ -140,6 +152,34 @@ func routeMismatch(route RouteCheck, test PingTest) bool {
 		return false
 	}
 	return !routeMatchesSourceInterface(route, test)
+}
+
+func sourceRouteValidationError(route RouteCheck, test PingTest) error {
+	if route.Err == routeSkipErr {
+		return nil
+	}
+	if route.Err != "" {
+		if route.Output == "" {
+			return fmt.Errorf("source route check failed: %s", route.Err)
+		}
+		return fmt.Errorf("source route check failed: %s (route: %s)", route.Err, route.Output)
+	}
+	if !route.OK {
+		return fmt.Errorf("source route check returned no device (route: %s)", route.Output)
+	}
+	if route.Dev != test.SrcIface {
+		return &sourceRouteMismatchError{
+			selected: route.Dev,
+			expected: test.SrcIface,
+			output:   route.Output,
+		}
+	}
+	return nil
+}
+
+func isSourceRouteMismatchError(err error) bool {
+	var mismatch *sourceRouteMismatchError
+	return errors.As(err, &mismatch)
 }
 
 func finalizeExpectedResult(r *PingResult, observedOK bool, observedErr error) {

--- a/pkg/networkoperatorplugin/connectivity/source_test.go
+++ b/pkg/networkoperatorplugin/connectivity/source_test.go
@@ -64,6 +64,48 @@ func TestCheckSourceRoutesReusesCachedRoute(t *testing.T) {
 	assert.NoError(t, got[0].sourceRouteErr)
 }
 
+func TestCheckSourceRoutesQualifiesNonRequiredICMP(t *testing.T) {
+	for _, expectation := range []Expectation{ExpectObserve, ExpectForbidden} {
+		t.Run(string(expectation), func(t *testing.T) {
+			test := PingTest{
+				Kind: ICMPCrossRail, SrcPod: "pod-a", DstPod: "pod-b",
+				SrcIP: "192.0.2.10", DstIP: "198.51.100.20", SrcIface: "net1",
+				Expectation: expectation,
+			}
+			key := routeCacheKey{
+				namespace: "default", pod: "pod-a", container: "netshoot",
+				srcIP: test.SrcIP, dstIP: test.DstIP,
+			}
+			cache := routeCache{key: {
+				Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
+			}}
+
+			got := checkSourceRoutes(context.Background(), nil,
+				map[string]string{"pod-a": "default"}, map[string]string{"pod-a": "netshoot"}, []PingTest{test}, cache)
+
+			assert.Len(t, got, 1)
+			assert.Equal(t, "net2", got[0].sourceRoute.Dev)
+			assert.EqualError(t, got[0].sourceRouteErr,
+				`source route selected dev "net2", expected "net1" (route: 198.51.100.20 dev net2 src 192.0.2.10)`)
+		})
+	}
+}
+
+func TestCheckSourceRoutesKeepsObservedRDMABehavior(t *testing.T) {
+	test := PingTest{
+		Kind: RDMAPingCrossRail, SrcPod: "pod-a", DstPod: "pod-b",
+		SrcIP: "192.0.2.10", DstIP: "198.51.100.20", SrcIface: "net1",
+		Expectation: ExpectObserve,
+	}
+
+	got := checkSourceRoutes(context.Background(), nil,
+		map[string]string{"pod-a": "default"}, map[string]string{"pod-a": "netshoot"}, []PingTest{test}, routeCache{})
+
+	assert.Len(t, got, 1)
+	assert.Empty(t, got[0].sourceRoute.Command)
+	assert.NoError(t, got[0].sourceRouteErr)
+}
+
 func TestBoundedTraceOutput(t *testing.T) {
 	input := strings.Repeat("x", traceOutputLimit+100)
 	got := boundedTraceOutput(input)
@@ -72,14 +114,98 @@ func TestBoundedTraceOutput(t *testing.T) {
 	assert.Contains(t, got, "truncated 100 bytes")
 }
 
-func TestRunICMPPreservesPrecomputedRouteError(t *testing.T) {
+func TestRunICMPPreservesPrecomputedRouteErrorForEveryExpectation(t *testing.T) {
+	for _, expectation := range []Expectation{ExpectRequired, ExpectObserve, ExpectForbidden} {
+		t.Run(string(expectation), func(t *testing.T) {
+			test := PingTest{
+				Kind: ICMPSameRail, SrcIface: "net1", Expectation: expectation,
+				sourceRouteErr: errors.New("route lookup failed"),
+			}
+
+			result := RunICMP(context.Background(), nil, "default", "pod-a", "netshoot", test)
+
+			assert.False(t, result.OK)
+			assert.False(t, result.ObservedOK)
+			assert.EqualError(t, result.Err, "route lookup failed")
+		})
+	}
+}
+
+func TestSourceRouteValidationErrorRejectsLookupAndParseFailures(t *testing.T) {
+	test := PingTest{SrcIface: "net1"}
+	tests := []struct {
+		name  string
+		route RouteCheck
+		want  string
+	}{
+		{
+			name:  "lookup failed",
+			route: RouteCheck{Command: "ip route get", Err: "command terminated with exit code 1"},
+			want:  "source route check failed: command terminated with exit code 1",
+		},
+		{
+			name:  "device missing",
+			route: RouteCheck{Command: "ip route get", Output: "unparseable route"},
+			want:  "source route check returned no device (route: unparseable route)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := sourceRouteValidationError(tc.route, test)
+
+			assert.EqualError(t, err, tc.want)
+			assert.False(t, isSourceRouteMismatchError(err))
+		})
+	}
+}
+
+func TestRunICMPTreatsForbiddenRouteLookupFailureAsValidationFailure(t *testing.T) {
 	test := PingTest{
-		Kind: ICMPSameRail, SrcIface: "net1", Expectation: ExpectRequired,
-		sourceRouteErr: errors.New("route lookup failed"),
+		Kind:        ICMPCrossRail,
+		SrcIface:    "net1",
+		Expectation: ExpectForbidden,
+		sourceRoute: RouteCheck{
+			Command: "ip route get",
+			Err:     "command terminated with exit code 1",
+		},
 	}
 
 	result := RunICMP(context.Background(), nil, "default", "pod-a", "netshoot", test)
 
 	assert.False(t, result.OK)
-	assert.EqualError(t, result.Err, "route lookup failed")
+	assert.False(t, result.ObservedOK)
+	assert.EqualError(t, result.Err,
+		"source route check failed: command terminated with exit code 1")
+}
+
+func TestRunICMPTreatsObservedRouteMismatchAsDisconnected(t *testing.T) {
+	test := PingTest{
+		Kind: ICMPCrossRail, SrcIface: "net1", Expectation: ExpectObserve,
+		sourceRoute: RouteCheck{
+			Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
+		},
+	}
+
+	result := RunICMP(context.Background(), nil, "default", "pod-a", "netshoot", test)
+
+	assert.True(t, result.OK)
+	assert.False(t, result.ObservedOK)
+	assert.EqualError(t, result.Err,
+		`source route selected dev "net2", expected "net1" (route: 198.51.100.20 dev net2 src 192.0.2.10)`)
+}
+
+func TestRunICMPTreatsForbiddenRouteMismatchAsDisconnected(t *testing.T) {
+	test := PingTest{
+		Kind: ICMPCrossRail, SrcIface: "net1", Expectation: ExpectForbidden,
+		sourceRoute: RouteCheck{
+			Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
+		},
+	}
+
+	result := RunICMP(context.Background(), nil, "default", "pod-a", "netshoot", test)
+
+	assert.True(t, result.OK)
+	assert.False(t, result.ObservedOK)
+	assert.NoError(t, result.Err)
 }

--- a/pkg/networkoperatorplugin/connectivity/timeout.go
+++ b/pkg/networkoperatorplugin/connectivity/timeout.go
@@ -68,7 +68,7 @@ func automaticTimeoutBudget(plan MatrixPlan, checks []Check) timeoutBudget {
 
 		switch check {
 		case CheckICMP:
-			budget.Tests += requiredRouteBudget(tests)
+			budget.Tests += allRouteBudget(tests)
 			for _, test := range tests {
 				budget.Tests += commandTimeoutFor(test, icmpCommandTimeout)
 			}
@@ -118,4 +118,11 @@ func requiredRouteBudget(tests []PingTest) time.Duration {
 		}
 	}
 	return budget
+}
+
+func allRouteBudget(tests []PingTest) time.Duration {
+	// Successful lookups are cached at runtime, but failures are deliberately
+	// retried and each retry can consume the full route deadline. Budget every
+	// ICMP lookup so cache hits become safety headroom instead of a shortfall.
+	return time.Duration(len(tests)) * routeCheckTimeout
 }

--- a/pkg/networkoperatorplugin/connectivity/timeout_test.go
+++ b/pkg/networkoperatorplugin/connectivity/timeout_test.go
@@ -45,11 +45,11 @@ func TestAutomaticTimeoutBudgetMirrorsSelectedExecutionPlan(t *testing.T) {
 
 	assert.Equal(t, 12, budget.PlannedTests)
 	assert.Equal(t, automaticSetupTimeout, budget.Setup)
-	assert.Equal(t, 6*time.Minute+21*time.Second, budget.Tests)
-	assert.Equal(t, 38*time.Second+100*time.Millisecond, budget.SafetyMargin)
-	assert.Equal(t, 6*time.Minute+59*time.Second+100*time.Millisecond, budget.executionTimeout())
+	assert.Equal(t, 6*time.Minute+41*time.Second, budget.Tests)
+	assert.Equal(t, 40*time.Second+100*time.Millisecond, budget.SafetyMargin)
+	assert.Equal(t, 7*time.Minute+21*time.Second+100*time.Millisecond, budget.executionTimeout())
 	assert.Equal(t, matrixCleanupTimeout, budget.Cleanup)
-	assert.Equal(t, 17*time.Minute+29*time.Second+100*time.Millisecond, budget.Total)
+	assert.Equal(t, 17*time.Minute+51*time.Second+100*time.Millisecond, budget.Total)
 }
 
 func TestAutomaticTimeoutBudgetIncludesOnlySelectedChecks(t *testing.T) {
@@ -66,9 +66,9 @@ func TestAutomaticTimeoutBudgetIncludesOnlySelectedChecks(t *testing.T) {
 	budget := automaticTimeoutBudget(plan, []Check{CheckICMP})
 
 	assert.Equal(t, 2, budget.PlannedTests)
-	assert.Equal(t, 20*time.Second, budget.Tests)
+	assert.Equal(t, 30*time.Second, budget.Tests)
 	assert.Equal(t, automaticSafetyMinimum, budget.SafetyMargin)
-	assert.Equal(t, automaticSetupTimeout+50*time.Second+matrixCleanupTimeout, budget.Total)
+	assert.Equal(t, automaticSetupTimeout+time.Minute+matrixCleanupTimeout, budget.Total)
 }
 
 func TestAutomaticTimeoutBudgetForThreeNodeFourRailQuickMatrix(t *testing.T) {
@@ -130,4 +130,15 @@ func TestRequiredRouteBudgetTreatsEmptyExpectationAsRequired(t *testing.T) {
 	}
 
 	assert.Equal(t, 2*routeCheckTimeout, requiredRouteBudget(tests))
+}
+
+func TestAllRouteBudgetIncludesEveryExpectation(t *testing.T) {
+	tests := []PingTest{
+		{Expectation: ""},
+		{Expectation: ExpectRequired},
+		{Expectation: ExpectObserve},
+		{Expectation: ExpectForbidden},
+	}
+
+	assert.Equal(t, 4*routeCheckTimeout, allRouteBudget(tests))
 }

--- a/skills/k8s-launch-kit-validate/SKILL.md
+++ b/skills/k8s-launch-kit-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-validate
-version: 1.0.6
+version: 1.0.7
 description: "Use this skill when the user wants to verify that an NVIDIA networking deployment matches the configuration that produced it. Activate for: 'is my deployment correct', 'are all the manifests applied', 'does the network operator version match', 'verify deployment', 'check cluster state against config', or any question about whether the cluster reflects what l8k generated. Wraps the `l8k validate` subcommand."
 metadata:
   requires:
@@ -96,9 +96,11 @@ l8k validate [--user-config <PATH>] [--deployment-files <DIR>] [--kubeconfig <PA
 - `strict`: full matrix. Cross-rail gates by `profile.routing`: `source-based`
   must succeed, `destination-based` must stay isolated.
 
-All checks are source-bound. ICMP always uses `ping -I <src-iface>` for
-same-rail and cross-rail probes in every validation mode; it never binds only
-the source IP. `rping` uses `-I <src-ip>`, and `ib_write_bw` uses
+All checks are source-bound. Before every ICMP probe, validate confirms that
+`ip route get <dst> from <src>` selects the named source interface. A mismatch
+is reported as not connected without forcing another route; a match is probed
+with `ping -I <src-ip>` so source-based policy rules apply. `rping` uses
+`-I <src-ip>`, and `ib_write_bw` uses
 `--bind_source_ip <src-ip>`. GPUDirect
 adds `--use_cuda=<endpoint-index> --use_cuda_dmabuf` independently on the
 client and server. Treat missing or ambiguous `connectedGPU` topology as a


### PR DESCRIPTION
## Summary

- qualify every ICMP probe with `ip route get <dst> from <src>` and require the selected device to match the named source rail
- restore `ping -I <src-ip>` so source-based policy rules participate in route selection
- cover quick/full/strict command generation plus observed and forbidden route mismatches
- update validation documentation and the validation skill contract

## Why

The interface-only binding introduced by #173 bypasses the source address lookup needed by the SBR CNI rules. It can also report a destination-based cross-rail probe as connected when Linux weak-host ARP behavior answers for the destination IP through a different rail.

Route qualification establishes the source rail without forcing a route. ICMP then binds the source IP only after the route selects the expected interface.

## Testing

- `go test ./pkg/networkoperatorplugin/connectivity -count=1`
- `go test ./pkg/networkoperatorplugin/... -count=1`
- `make test`
- `make build`
- `go vet ./...`

## Notes

`golangci-lint` is not installed in the local environment; hosted lint remains the corresponding verification gate.