### PR TITLE
fix: measure dual-bound cross-rail ICMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,11 +418,12 @@ desiredNumberScheduled > 0` — a single ContainerCreating-stuck pod fails),
 and run the configured checks (`icmp`, `rping`, and/or `ib_write_bw`) with
 source-bound rail identity. Every profile renders the DaemonSet with a DOCA
 container for RDMA checks and a declared `netshoot` container for ICMP; validate
-applies that manifest without injecting containers at runtime. Before every ICMP
-probe, validate checks that `ip route get <dst> from <src>` selects the named
-source interface. A route selecting another interface makes that rail pair not
-connected without forcing traffic onto it; otherwise ICMP uses
-`ping -I <src-ip>`. `rping` uses
+applies that manifest without injecting containers at runtime. ICMP uses
+`ping -I <src-iface> -I <src-ip>` so the probe both stays on the selected rail
+and activates source-based policy rules. The preceding
+`ip route get <dst> from <src>` result is retained as diagnostic evidence; it
+does not replace the actual ping result. Route differences are shown as
+non-gating diagnostics in the terminal and HTML reports. `rping` uses
 `-I <src-ip>`, and `ib_write_bw` uses `--bind_source_ip <src-ip>`; required RDMA
 tests also record a source-qualified route lookup from the netshoot container.
 When `validation.gpuDirect.enabled` is true, a separate

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -39,10 +39,12 @@ container runs `rping`, `ib_write_bw`, and DMA-BUF bandwidth, while the `netshoo
 ICMP and route checks from the same pod network namespace. Validation applies
 the generated DaemonSet as written; it does not inject a helper container at
 runtime. Before every same-rail and cross-rail ICMP probe in `quick`, `full`,
-and `strict` modes, validation runs `ip route get <dst> from <src>` and compares
-the selected device with the source rail interface. A mismatch is reported as
-not connected without forcing the packet onto another route; a match is probed
-with `ping -I <src-ip>` so source-based policy rules are applied.
+and `strict` modes, validation records `ip route get <dst> from <src>` as
+diagnostic evidence. The route lookup never substitutes for the probe. ICMP
+uses `ping -I <src-iface> -I <src-ip>` so the packet is constrained to the
+selected rail while its source address activates source-based policy rules.
+Route differences are shown as non-gating diagnostics in both terminal and
+HTML reports.
 
 Manifest-state checks for `NicConfigurationTemplate` and `NicFirmwareTemplate` use the operator-populated `status.nicDevices` list as the matched device set. An empty list, a list that does not yet reflect the current node, NIC type, PCI-address, serial-number, and part-number selectors, a missing named `NicDevice`, a device spec that does not yet reflect the current template payload, or a relevant device condition with a stale `observedGeneration` remains `IN-PROGRESS`. `NicConfigurationTemplate` considers `FirmwareUpdateInProgress` relevant only when the matched device has `spec.firmware`; a stale firmware condition cannot block a configuration-only deployment. Unrelated discovered devices are used only to verify selector freshness; their configuration and firmware state is ignored.
 

--- a/pkg/networkoperatorplugin/connectivity/connectivity.go
+++ b/pkg/networkoperatorplugin/connectivity/connectivity.go
@@ -569,20 +569,26 @@ type routeCache map[routeCacheKey]RouteCheck
 
 func checkSourceRoutes(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, cache routeCache) []PingTest {
 	started := time.Now()
-	checks, hits, failures := 0, 0, 0
+	checks, hits, failures, diagnosticIssues := 0, 0, 0, 0
 	out := append([]PingTest(nil), tests...)
 	for i := range out {
 		// Required RDMA checks retain their existing source-route guard. ICMP
-		// always needs the guard because its source IP activates SBR, while the
-		// selected route establishes whether the named source rail is used.
+		// records the same route data for diagnostics, but the dual-bound ping
+		// itself is authoritative for connectivity.
 		if out[i].Expectation != ExpectRequired && !out[i].Kind.IsICMP() {
 			continue
 		}
 		namespace := namespaceByPod[out[i].SrcPod]
 		container := containerByPod[out[i].SrcPod]
 		if namespace == "" || container == "" {
-			out[i].sourceRouteErr = fmt.Errorf("no netshoot namespace/container lookup for source pod %s", out[i].SrcPod)
-			failures++
+			routeErr := fmt.Errorf("no netshoot namespace/container lookup for source pod %s", out[i].SrcPod)
+			if out[i].Kind.IsICMP() {
+				out[i].sourceRoute = RouteCheck{Err: routeErr.Error()}
+				diagnosticIssues++
+			} else {
+				out[i].sourceRouteErr = routeErr
+				failures++
+			}
 			continue
 		}
 		key := routeCacheKey{
@@ -607,12 +613,18 @@ func checkSourceRoutes(ctx context.Context, restConfig *rest.Config, namespaceBy
 			}
 		}
 		if routeErr := sourceRouteValidationError(out[i].sourceRoute, out[i]); routeErr != nil {
-			out[i].sourceRouteErr = routeErr
-			failures++
+			if out[i].Kind.IsICMP() {
+				diagnosticIssues++
+				testLogger(out[i]).V(1).Info("ICMP source route diagnostic differs from requested rail", "error", routeErr.Error())
+			} else {
+				out[i].sourceRouteErr = routeErr
+				failures++
+			}
 		}
 	}
 	connectivityLogger().V(1).Info("source route checks completed",
-		"tests", len(tests), "executed", checks, "cacheHits", hits, "failures", failures,
+		"tests", len(tests), "executed", checks, "cacheHits", hits,
+		"failures", failures, "diagnosticIssues", diagnosticIssues,
 		"duration", time.Since(started).Round(time.Millisecond).String())
 	return out
 }

--- a/pkg/networkoperatorplugin/connectivity/icmp.go
+++ b/pkg/networkoperatorplugin/connectivity/icmp.go
@@ -25,43 +25,51 @@ import (
 )
 
 func RunICMP(ctx context.Context, restConfig *rest.Config, namespace, pod, container string, test PingTest) PingResult {
+	return runICMP(ctx, restConfig, namespace, pod, container, test, kubeclient.ExecInPod)
+}
+
+type execInPodFunc func(context.Context, *rest.Config, string, string, string, []string) (kubeclient.ExecResult, error)
+
+func runICMP(ctx context.Context, restConfig *rest.Config, namespace, pod, container string, test PingTest, execInPod execInPodFunc) PingResult {
 	r := initResult(test)
 	if r.Err != nil {
-		finalizeICMPRouteError(&r)
-		return r
+		// Source-route checks are diagnostic for ICMP. The ping command binds
+		// both the interface and source address, so its observed result is the
+		// authoritative connectivity signal.
+		testLogger(test).V(1).Info("ICMP source route diagnostic unavailable", "error", r.Err.Error())
+		r.Err = nil
 	}
 	if test.SrcIface == "" {
 		r.Err = fmt.Errorf("icmp needs source interface for rail %q", test.SrcRail)
-		finalizeExpectedResult(&r, false, r.Err)
+		r.OK = false
+		r.ObservedOK = false
+		return r
+	}
+	if test.SrcIP == "" {
+		r.Err = fmt.Errorf("icmp needs source IP for rail %q", test.SrcRail)
+		r.OK = false
+		r.ObservedOK = false
 		return r
 	}
 	// RunMatrix pre-computes and caches ICMP source routes across stages.
-	// Keep the standalone runner behavior for direct callers.
+	// Keep the standalone runner behavior for direct callers, but never let
+	// this diagnostic replace the actual ping probe.
 	if r.Route.Command == "" {
 		r.Route = checkRoute(ctx, restConfig, namespace, pod, container, test)
 	}
-	if r.Err = sourceRouteValidationError(r.Route, test); r.Err != nil {
-		finalizeICMPRouteError(&r)
-		return r
+	if routeErr := sourceRouteValidationError(r.Route, test); routeErr != nil {
+		testLogger(test).V(1).Info("ICMP source route diagnostic differs from requested rail", "error", routeErr.Error())
 	}
 	cmd := shellWithTimeout(icmpCommand(test),
 		commandTimeoutFor(test, icmpCommandTimeout))
 	testLogger(test).V(2).Info("ICMP command", "command", boundedTraceOutput(cmd))
-	res, err := kubeclient.ExecInPod(ctx, restConfig, namespace, pod, container, []string{"/bin/sh", "-c", cmd})
+	res, err := execInPod(ctx, restConfig, namespace, pod, container, []string{"/bin/sh", "-c", cmd})
 	r.Stdout, r.Stderr = res.Stdout, res.Stderr
 	finalizeExpectedResult(&r, err == nil, err)
 	return r
 }
 
-func finalizeICMPRouteError(result *PingResult) {
-	if isSourceRouteMismatchError(result.Err) {
-		finalizeExpectedResult(result, false, result.Err)
-		return
-	}
-	result.OK = false
-	result.ObservedOK = false
-}
-
 func icmpCommand(test PingTest) string {
-	return fmt.Sprintf("ping -c 1 -W 1 -I %s %s", shellArg(test.SrcIP), shellArg(test.DstIP))
+	return fmt.Sprintf("ping -c 1 -W 1 -I %s -I %s %s",
+		shellArg(test.SrcIface), shellArg(test.SrcIP), shellArg(test.DstIP))
 }

--- a/pkg/networkoperatorplugin/connectivity/icmp_test.go
+++ b/pkg/networkoperatorplugin/connectivity/icmp_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPlannedICMPCommandsBindSourceIPInEveryMode(t *testing.T) {
+func TestPlannedICMPCommandsBindSourceInterfaceAndIPInEveryMode(t *testing.T) {
 	pods := []TestPod{
 		mkPod("pod-a", "rail-0", "rail-1"),
 		mkPod("pod-b", "rail-0", "rail-1"),
@@ -50,15 +50,14 @@ func TestPlannedICMPCommandsBindSourceIPInEveryMode(t *testing.T) {
 			icmpTests := testsForCheck(plan, CheckICMP)
 
 			for _, test := range icmpTests {
-				expected := fmt.Sprintf("ping -c 1 -W 1 -I %q %q", test.SrcIP, test.DstIP)
+				expected := fmt.Sprintf("ping -c 1 -W 1 -I %q -I %q %q", test.SrcIface, test.SrcIP, test.DstIP)
 				assert.Equal(t, expected, icmpCommand(test), "%+v", test)
-				assert.NotContains(t, icmpCommand(test), test.SrcIface, "%+v", test)
 			}
 		})
 	}
 }
 
-func TestWrappedICMPCommandBindsSourceIPInTimeoutAndFallbackPaths(t *testing.T) {
+func TestWrappedICMPCommandBindsSourceInterfaceAndIPInTimeoutAndFallbackPaths(t *testing.T) {
 	plan := PlanWithOptions([]TestPod{
 		mkPod("pod-a", "rail-0", "rail-1"),
 		mkPod("pod-b", "rail-0", "rail-1"),
@@ -70,5 +69,4 @@ func TestWrappedICMPCommandBindsSourceIPInTimeoutAndFallbackPaths(t *testing.T) 
 
 	assert.Contains(t, cmd, "timeout -s TERM -k 2 5 sh -c "+shellArg(icmpCommand(test)))
 	assert.Contains(t, cmd, "else "+icmpCommand(test)+" & pid=$!")
-	assert.NotContains(t, cmd, test.SrcIface)
 }

--- a/pkg/networkoperatorplugin/connectivity/report.go
+++ b/pkg/networkoperatorplugin/connectivity/report.go
@@ -396,6 +396,7 @@ func reportFuncMap() template.FuncMap {
 			}
 			return out
 		},
+		"icmpRouteDiagnostics": collectICMPRouteDiagnostics,
 		// familyTitle is the human-friendly section header for a
 		// given kind family.
 		"familyTitle": func(fam string) string {

--- a/pkg/networkoperatorplugin/connectivity/report.html.tmpl
+++ b/pkg/networkoperatorplugin/connectivity/report.html.tmpl
@@ -943,6 +943,29 @@ footer strong { color: var(--text-muted); }
         </table>
       {{- end}}
 
+      {{- $routeDiagnostics := icmpRouteDiagnostics .Matrix.PingResults}}
+      {{- if $routeDiagnostics}}
+      <div class="matrix-rail">ICMP source-route diagnostics (non-gating)</div>
+      <table class="matrix-table">
+        <thead>
+          <tr><th>Source</th><th>Src rail</th><th>Src iface</th><th>Destination</th><th>Dst rail</th><th>Dst iface</th><th>Diagnostic</th></tr>
+        </thead>
+        <tbody>
+          {{- range $routeDiagnostics}}
+          <tr>
+            <td>{{srcLabel .Result.Test}}</td>
+            <td><code>{{.Result.Test.SrcRail}}</code></td>
+            <td><code>{{.Result.Test.SrcIface}}</code></td>
+            <td>{{dstLabel .Result.Test}}</td>
+            <td><code>{{.Result.Test.DstRail}}</code></td>
+            <td><code>{{.Result.Test.DstIface}}</code></td>
+            <td>{{.Message}}</td>
+          </tr>
+          {{- end}}
+        </tbody>
+      </table>
+      {{- end}}
+
       {{- $gpuResults := gpudirectResults .Matrix.PingResults}}
       {{- if $gpuResults}}
       <div class="matrix-rail">GPUDirect DMA-BUF endpoint details</div>

--- a/pkg/networkoperatorplugin/connectivity/report_test.go
+++ b/pkg/networkoperatorplugin/connectivity/report_test.go
@@ -302,6 +302,33 @@ func TestRenderHTML_HandlesNilOptionalFields(t *testing.T) {
 	assert.Contains(t, buf.String(), "Connectivity testing was not run")
 }
 
+func TestRenderHTML_SurfacesNonGatingICMPRouteDiagnostic(t *testing.T) {
+	data := ReportData{
+		Cluster: ClusterInfo{L8kVersion: "v0", GeneratedAt: time.Now()},
+		Matrix: &MatrixResult{PingResults: []PingResult{{
+			Test: PingTest{
+				Kind: ICMPCrossRail, SrcPod: "pod-a", DstPod: "pod-b",
+				SrcNode: "worker-a", DstNode: "worker-b",
+				SrcRail: "rail-0", DstRail: "rail-1", SrcIface: "net1", DstIface: "net2",
+				Expectation: ExpectObserve,
+			},
+			OK: true, ObservedOK: true, Expectation: ExpectObserve,
+			Route: RouteCheck{
+				Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
+			},
+		}}},
+	}
+	var buf bytes.Buffer
+
+	require.NoError(t, RenderHTML(&buf, data))
+
+	html := buf.String()
+	assert.Contains(t, html, "ICMP source-route diagnostics (non-gating)")
+	assert.Contains(t, html, "worker-a")
+	assert.Contains(t, html, "worker-b")
+	assert.Contains(t, html, `source route selected dev &#34;net2&#34;, expected &#34;net1&#34;`)
+}
+
 func TestRenderHTML_GPUDirectFamilyIncludesEndpointEvidence(t *testing.T) {
 	data := ReportData{
 		Cluster: ClusterInfo{L8kVersion: "v0", GeneratedAt: time.Now()},

--- a/pkg/networkoperatorplugin/connectivity/source.go
+++ b/pkg/networkoperatorplugin/connectivity/source.go
@@ -18,7 +18,6 @@ package connectivity
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -177,9 +176,24 @@ func sourceRouteValidationError(route RouteCheck, test PingTest) error {
 	return nil
 }
 
-func isSourceRouteMismatchError(err error) bool {
-	var mismatch *sourceRouteMismatchError
-	return errors.As(err, &mismatch)
+type icmpRouteDiagnostic struct {
+	Result  PingResult
+	Message string
+}
+
+func collectICMPRouteDiagnostics(results []PingResult) []icmpRouteDiagnostic {
+	out := make([]icmpRouteDiagnostic, 0)
+	for _, result := range results {
+		if !result.Test.Kind.IsICMP() || result.Route.Command == "" {
+			continue
+		}
+		routeErr := sourceRouteValidationError(result.Route, result.Test)
+		if routeErr == nil {
+			continue
+		}
+		out = append(out, icmpRouteDiagnostic{Result: result, Message: routeErr.Error()})
+	}
+	return out
 }
 
 func finalizeExpectedResult(r *PingResult, observedOK bool, observedErr error) {

--- a/pkg/networkoperatorplugin/connectivity/source_test.go
+++ b/pkg/networkoperatorplugin/connectivity/source_test.go
@@ -23,7 +23,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nvidia/k8s-launch-kit/pkg/kubeclient"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
 
 func TestShellWithTimeoutPrefersNativeTimeout(t *testing.T) {
@@ -64,8 +67,8 @@ func TestCheckSourceRoutesReusesCachedRoute(t *testing.T) {
 	assert.NoError(t, got[0].sourceRouteErr)
 }
 
-func TestCheckSourceRoutesQualifiesNonRequiredICMP(t *testing.T) {
-	for _, expectation := range []Expectation{ExpectObserve, ExpectForbidden} {
+func TestCheckSourceRoutesKeepsICMPRouteMismatchDiagnostic(t *testing.T) {
+	for _, expectation := range []Expectation{ExpectRequired, ExpectObserve, ExpectForbidden} {
 		t.Run(string(expectation), func(t *testing.T) {
 			test := PingTest{
 				Kind: ICMPCrossRail, SrcPod: "pod-a", DstPod: "pod-b",
@@ -85,8 +88,7 @@ func TestCheckSourceRoutesQualifiesNonRequiredICMP(t *testing.T) {
 
 			assert.Len(t, got, 1)
 			assert.Equal(t, "net2", got[0].sourceRoute.Dev)
-			assert.EqualError(t, got[0].sourceRouteErr,
-				`source route selected dev "net2", expected "net1" (route: 198.51.100.20 dev net2 src 192.0.2.10)`)
+			assert.NoError(t, got[0].sourceRouteErr)
 		})
 	}
 }
@@ -106,6 +108,28 @@ func TestCheckSourceRoutesKeepsObservedRDMABehavior(t *testing.T) {
 	assert.NoError(t, got[0].sourceRouteErr)
 }
 
+func TestCheckSourceRoutesKeepsRequiredRDMAGuard(t *testing.T) {
+	test := PingTest{
+		Kind: RDMAPingCrossRail, SrcPod: "pod-a", DstPod: "pod-b",
+		SrcIP: "192.0.2.10", DstIP: "198.51.100.20", SrcIface: "net1",
+		Expectation: ExpectRequired,
+	}
+	key := routeCacheKey{
+		namespace: "default", pod: "pod-a", container: "netshoot",
+		srcIP: test.SrcIP, dstIP: test.DstIP,
+	}
+	cache := routeCache{key: {
+		Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
+	}}
+
+	got := checkSourceRoutes(context.Background(), nil,
+		map[string]string{"pod-a": "default"}, map[string]string{"pod-a": "netshoot"}, []PingTest{test}, cache)
+
+	assert.Len(t, got, 1)
+	assert.EqualError(t, got[0].sourceRouteErr,
+		`source route selected dev "net2", expected "net1" (route: 198.51.100.20 dev net2 src 192.0.2.10)`)
+}
+
 func TestBoundedTraceOutput(t *testing.T) {
 	input := strings.Repeat("x", traceOutputLimit+100)
 	got := boundedTraceOutput(input)
@@ -114,19 +138,26 @@ func TestBoundedTraceOutput(t *testing.T) {
 	assert.Contains(t, got, "truncated 100 bytes")
 }
 
-func TestRunICMPPreservesPrecomputedRouteErrorForEveryExpectation(t *testing.T) {
+func TestRunICMPExecutesProbeDespitePrecomputedRouteError(t *testing.T) {
 	for _, expectation := range []Expectation{ExpectRequired, ExpectObserve, ExpectForbidden} {
 		t.Run(string(expectation), func(t *testing.T) {
 			test := PingTest{
-				Kind: ICMPSameRail, SrcIface: "net1", Expectation: expectation,
+				Kind: ICMPSameRail, SrcIface: "net1", SrcIP: "192.0.2.10", DstIP: "198.51.100.20", Expectation: expectation,
+				sourceRoute:    RouteCheck{Command: "ip route get", Err: "command terminated with exit code 1"},
 				sourceRouteErr: errors.New("route lookup failed"),
 			}
+			called := false
+			execInPod := func(_ context.Context, _ *rest.Config, _, _, _ string, command []string) (kubeclient.ExecResult, error) {
+				called = true
+				require.Equal(t, []string{"/bin/sh", "-c", shellWithTimeout(icmpCommand(test), commandTimeoutFor(test, icmpCommandTimeout))}, command)
+				return kubeclient.ExecResult{Stdout: "1 packets transmitted, 1 received"}, nil
+			}
 
-			result := RunICMP(context.Background(), nil, "default", "pod-a", "netshoot", test)
+			result := runICMP(context.Background(), nil, "default", "pod-a", "netshoot", test, execInPod)
 
-			assert.False(t, result.OK)
-			assert.False(t, result.ObservedOK)
-			assert.EqualError(t, result.Err, "route lookup failed")
+			assert.True(t, called)
+			assert.True(t, result.ObservedOK)
+			assert.Equal(t, expectation != ExpectForbidden, result.OK)
 		})
 	}
 }
@@ -155,57 +186,69 @@ func TestSourceRouteValidationErrorRejectsLookupAndParseFailures(t *testing.T) {
 			err := sourceRouteValidationError(tc.route, test)
 
 			assert.EqualError(t, err, tc.want)
-			assert.False(t, isSourceRouteMismatchError(err))
 		})
 	}
 }
 
-func TestRunICMPTreatsForbiddenRouteLookupFailureAsValidationFailure(t *testing.T) {
+func TestRunICMPUsesObservedFailureDespiteRouteLookupFailure(t *testing.T) {
 	test := PingTest{
 		Kind:        ICMPCrossRail,
 		SrcIface:    "net1",
+		SrcIP:       "192.0.2.10",
+		DstIP:       "198.51.100.20",
 		Expectation: ExpectForbidden,
 		sourceRoute: RouteCheck{
 			Command: "ip route get",
 			Err:     "command terminated with exit code 1",
 		},
 	}
-
-	result := RunICMP(context.Background(), nil, "default", "pod-a", "netshoot", test)
-
-	assert.False(t, result.OK)
-	assert.False(t, result.ObservedOK)
-	assert.EqualError(t, result.Err,
-		"source route check failed: command terminated with exit code 1")
-}
-
-func TestRunICMPTreatsObservedRouteMismatchAsDisconnected(t *testing.T) {
-	test := PingTest{
-		Kind: ICMPCrossRail, SrcIface: "net1", Expectation: ExpectObserve,
-		sourceRoute: RouteCheck{
-			Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
-		},
+	pingErr := errors.New("ping exited with code 1")
+	execInPod := func(_ context.Context, _ *rest.Config, _, _, _ string, _ []string) (kubeclient.ExecResult, error) {
+		return kubeclient.ExecResult{}, pingErr
 	}
 
-	result := RunICMP(context.Background(), nil, "default", "pod-a", "netshoot", test)
-
-	assert.True(t, result.OK)
-	assert.False(t, result.ObservedOK)
-	assert.EqualError(t, result.Err,
-		`source route selected dev "net2", expected "net1" (route: 198.51.100.20 dev net2 src 192.0.2.10)`)
-}
-
-func TestRunICMPTreatsForbiddenRouteMismatchAsDisconnected(t *testing.T) {
-	test := PingTest{
-		Kind: ICMPCrossRail, SrcIface: "net1", Expectation: ExpectForbidden,
-		sourceRoute: RouteCheck{
-			Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
-		},
-	}
-
-	result := RunICMP(context.Background(), nil, "default", "pod-a", "netshoot", test)
+	result := runICMP(context.Background(), nil, "default", "pod-a", "netshoot", test, execInPod)
 
 	assert.True(t, result.OK)
 	assert.False(t, result.ObservedOK)
 	assert.NoError(t, result.Err)
+}
+
+func TestRunICMPUsesObservedSuccessDespiteRouteMismatch(t *testing.T) {
+	test := PingTest{
+		Kind: ICMPCrossRail, SrcIface: "net1", SrcIP: "192.0.2.10", DstIP: "198.51.100.20", Expectation: ExpectObserve,
+		sourceRoute: RouteCheck{
+			Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
+		},
+	}
+	called := false
+	execInPod := func(_ context.Context, _ *rest.Config, _, _, _ string, _ []string) (kubeclient.ExecResult, error) {
+		called = true
+		return kubeclient.ExecResult{}, nil
+	}
+
+	result := runICMP(context.Background(), nil, "default", "pod-a", "netshoot", test, execInPod)
+
+	assert.True(t, called)
+	assert.True(t, result.OK)
+	assert.True(t, result.ObservedOK)
+	assert.NoError(t, result.Err)
+}
+
+func TestRunICMPUsesObservedSuccessForForbiddenRouteMismatch(t *testing.T) {
+	test := PingTest{
+		Kind: ICMPCrossRail, SrcIface: "net1", SrcIP: "192.0.2.10", DstIP: "198.51.100.20", Expectation: ExpectForbidden,
+		sourceRoute: RouteCheck{
+			Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
+		},
+	}
+	execInPod := func(_ context.Context, _ *rest.Config, _, _, _ string, _ []string) (kubeclient.ExecResult, error) {
+		return kubeclient.ExecResult{}, nil
+	}
+
+	result := runICMP(context.Background(), nil, "default", "pod-a", "netshoot", test, execInPod)
+
+	assert.False(t, result.OK)
+	assert.True(t, result.ObservedOK)
+	assert.EqualError(t, result.Err, "cross-rail traffic succeeded but profile routing expects isolation")
 }

--- a/pkg/networkoperatorplugin/connectivity/text_report.go
+++ b/pkg/networkoperatorplugin/connectivity/text_report.go
@@ -83,6 +83,19 @@ func RenderMatrixText(uiOutput ui.Output, result *MatrixResult) {
 		}
 	}
 
+	routeDiagnostics := collectICMPRouteDiagnostics(result.PingResults)
+	if len(routeDiagnostics) > 0 {
+		uiOutput.Info("")
+		uiOutput.Info("ICMP source-route diagnostics (non-gating):")
+		for _, diagnostic := range routeDiagnostics {
+			r := diagnostic.Result
+			uiOutput.Info("  %s [%s/%s] → %s [%s/%s]: %s",
+				axisLabel(r.Test.SrcNode, r.Test.SrcPod), r.Test.SrcRail, r.Test.SrcIface,
+				axisLabel(r.Test.DstNode, r.Test.DstPod), r.Test.DstRail, r.Test.DstIface,
+				diagnostic.Message)
+		}
+	}
+
 	var gpuResults []PingResult
 	for _, r := range result.PingResults {
 		if r.Test.Kind.IsGPUDirectDMABuf() {

--- a/pkg/networkoperatorplugin/connectivity/text_report_test.go
+++ b/pkg/networkoperatorplugin/connectivity/text_report_test.go
@@ -201,6 +201,30 @@ func TestRenderMatrixText_EmptyResultsIsNoOp(t *testing.T) {
 	assert.Empty(t, out.lines)
 }
 
+func TestRenderMatrixText_SurfacesNonGatingICMPRouteDiagnostic(t *testing.T) {
+	result := &MatrixResult{PingResults: []PingResult{{
+		Test: PingTest{
+			Kind: ICMPCrossRail, SrcPod: "pod-a", DstPod: "pod-b",
+			SrcNode: "worker-a", DstNode: "worker-b",
+			SrcRail: "rail-0", DstRail: "rail-1", SrcIface: "net1", DstIface: "net2",
+			Expectation: ExpectObserve,
+		},
+		OK: true, ObservedOK: true, Expectation: ExpectObserve,
+		Route: RouteCheck{
+			Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
+		},
+	}}}
+	out := &captureOutput{}
+
+	RenderMatrixText(out, result)
+
+	joined := strings.Join(out.lines, "\n")
+	assert.Contains(t, joined, "connected")
+	assert.Contains(t, joined, "ICMP source-route diagnostics (non-gating):")
+	assert.Contains(t, joined, "worker-a [rail-0/net1] → worker-b [rail-1/net2]")
+	assert.Contains(t, joined, `source route selected dev "net2", expected "net1"`)
+}
+
 func TestRenderMatrixText_GPUDirectFamilyIncludesEndpointDetails(t *testing.T) {
 	result := &MatrixResult{PingResults: []PingResult{{
 		Test: PingTest{

--- a/skills/k8s-launch-kit-validate/SKILL.md
+++ b/skills/k8s-launch-kit-validate/SKILL.md
@@ -96,10 +96,12 @@ l8k validate [--user-config <PATH>] [--deployment-files <DIR>] [--kubeconfig <PA
 - `strict`: full matrix. Cross-rail gates by `profile.routing`: `source-based`
   must succeed, `destination-based` must stay isolated.
 
-All checks are source-bound. Before every ICMP probe, validate confirms that
-`ip route get <dst> from <src>` selects the named source interface. A mismatch
-is reported as not connected without forcing another route; a match is probed
-with `ping -I <src-ip>` so source-based policy rules apply. `rping` uses
+All checks are source-bound. ICMP uses
+`ping -I <src-iface> -I <src-ip>` so the probe stays on the selected rail while
+its source address activates source-based policy rules. The preceding
+`ip route get <dst> from <src>` output is diagnostic only and never replaces
+the observed ping result. Route differences are visible in the terminal and
+HTML reports as non-gating diagnostics. `rping` uses
 `-I <src-ip>`, and `ib_write_bw` uses
 `--bind_source_ip <src-ip>`. GPUDirect
 adds `--use_cuda=<endpoint-index> --use_cuda_dmabuf` independently on the


### PR DESCRIPTION
## What changed

- bind ICMP to both the selected source interface and source IP
- always execute ICMP; keep source-route lookup as diagnostic evidence only
- preserve the required-RDMA source-route guard
- update validation docs and add regression tests for route mismatch/lookup failure

## Why

The fix in #251 restored source-IP binding, but its route precheck short-circuited cross-rail ICMP whenever `ip route get` selected a different device. The validator therefore reported a predicted result without sending a packet.

Binding only the interface does not reliably activate SBR, while binding only the source IP can still follow a destination-selected rail. The ICMP command now supplies both identities:

    ping -I <src-iface> -I <src-ip> <dst-ip>

The exact `nicolaka/netshoot:latest` helper image accepts both bindings. A local control probe succeeded with the correct interface and returned 100% loss with an intentionally wrong interface.

## Validation

- `go test ./...`
- `go vet ./...`
- `make build`
- `golangci-lint v2.11 run ./...`
