### PR TITLE
fix: honor routed interface in ICMP validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,12 +418,13 @@ desiredNumberScheduled > 0` — a single ContainerCreating-stuck pod fails),
 and run the configured checks (`icmp`, `rping`, and/or `ib_write_bw`) with
 source-bound rail identity. Every profile renders the DaemonSet with a DOCA
 container for RDMA checks and a declared `netshoot` container for ICMP; validate
-applies that manifest without injecting containers at runtime. ICMP uses
-`ping -I <src-iface> -I <src-ip>` so the probe both stays on the selected rail
-and activates source-based policy rules. The preceding
-`ip route get <dst> from <src>` result is retained as diagnostic evidence; it
-does not replace the actual ping result. Route differences are shown as
-non-gating diagnostics in the terminal and HTML reports. `rping` uses
+applies that manifest without injecting containers at runtime. Before every ICMP
+probe, validate checks that `ip route get <dst> from <src>` selects the named
+source interface. A route selecting another interface makes that rail pair not
+connected without forcing traffic onto it; otherwise ICMP uses
+`ping -I <src-ip>`. Routing diagnostics compare that decision with the profile:
+source-based routing expects the source interface, while destination-based
+routing expects the destination interface. `rping` uses
 `-I <src-ip>`, and `ib_write_bw` uses `--bind_source_ip <src-ip>`; required RDMA
 tests also record a source-qualified route lookup from the netshoot container.
 When `validation.gpuDirect.enabled` is true, a separate

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -39,12 +39,13 @@ container runs `rping`, `ib_write_bw`, and DMA-BUF bandwidth, while the `netshoo
 ICMP and route checks from the same pod network namespace. Validation applies
 the generated DaemonSet as written; it does not inject a helper container at
 runtime. Before every same-rail and cross-rail ICMP probe in `quick`, `full`,
-and `strict` modes, validation records `ip route get <dst> from <src>` as
-diagnostic evidence. The route lookup never substitutes for the probe. ICMP
-uses `ping -I <src-iface> -I <src-ip>` so the packet is constrained to the
-selected rail while its source address activates source-based policy rules.
-Route differences are shown as non-gating diagnostics in both terminal and
-HTML reports.
+and `strict` modes, validation runs `ip route get <dst> from <src>`. A route
+that does not select the requested source interface means that rail pair is not
+connected; validation does not force the packet onto that interface. When the
+source rail is selected, ICMP uses `ping -I <src-ip>` so source-based policy
+rules participate naturally. Routing diagnostics compare the selected device
+with the profile expectation: the source interface for source-based routing,
+or the destination interface for destination-based routing.
 
 Manifest-state checks for `NicConfigurationTemplate` and `NicFirmwareTemplate` use the operator-populated `status.nicDevices` list as the matched device set. An empty list, a list that does not yet reflect the current node, NIC type, PCI-address, serial-number, and part-number selectors, a missing named `NicDevice`, a device spec that does not yet reflect the current template payload, or a relevant device condition with a stale `observedGeneration` remains `IN-PROGRESS`. `NicConfigurationTemplate` considers `FirmwareUpdateInProgress` relevant only when the matched device has `spec.firmware`; a stale firmware condition cannot block a configuration-only deployment. Unrelated discovered devices are used only to verify selector freshness; their configuration and firmware state is ignored.
 

--- a/pkg/networkoperatorplugin/connectivity/connectivity.go
+++ b/pkg/networkoperatorplugin/connectivity/connectivity.go
@@ -569,12 +569,12 @@ type routeCache map[routeCacheKey]RouteCheck
 
 func checkSourceRoutes(ctx context.Context, restConfig *rest.Config, namespaceByPod, containerByPod map[string]string, tests []PingTest, cache routeCache) []PingTest {
 	started := time.Now()
-	checks, hits, failures, diagnosticIssues := 0, 0, 0, 0
+	checks, hits, failures, sourceRailMisses, diagnosticIssues := 0, 0, 0, 0, 0
 	out := append([]PingTest(nil), tests...)
 	for i := range out {
-		// Required RDMA checks retain their existing source-route guard. ICMP
-		// records the same route data for diagnostics, but the dual-bound ping
-		// itself is authoritative for connectivity.
+		// Required RDMA checks retain their existing source-route guard. Every
+		// ICMP test also needs the route decision to establish whether the
+		// requested source rail would actually carry the packet.
 		if out[i].Expectation != ExpectRequired && !out[i].Kind.IsICMP() {
 			continue
 		}
@@ -582,13 +582,9 @@ func checkSourceRoutes(ctx context.Context, restConfig *rest.Config, namespaceBy
 		container := containerByPod[out[i].SrcPod]
 		if namespace == "" || container == "" {
 			routeErr := fmt.Errorf("no netshoot namespace/container lookup for source pod %s", out[i].SrcPod)
-			if out[i].Kind.IsICMP() {
-				out[i].sourceRoute = RouteCheck{Err: routeErr.Error()}
-				diagnosticIssues++
-			} else {
-				out[i].sourceRouteErr = routeErr
-				failures++
-			}
+			out[i].sourceRoute = RouteCheck{Err: routeErr.Error()}
+			out[i].sourceRouteErr = routeErr
+			failures++
 			continue
 		}
 		key := routeCacheKey{
@@ -613,18 +609,24 @@ func checkSourceRoutes(ctx context.Context, restConfig *rest.Config, namespaceBy
 			}
 		}
 		if routeErr := sourceRouteValidationError(out[i].sourceRoute, out[i]); routeErr != nil {
-			if out[i].Kind.IsICMP() {
-				diagnosticIssues++
-				testLogger(out[i]).V(1).Info("ICMP source route diagnostic differs from requested rail", "error", routeErr.Error())
+			out[i].sourceRouteErr = routeErr
+			if isSourceRouteMismatchError(routeErr) {
+				sourceRailMisses++
 			} else {
-				out[i].sourceRouteErr = routeErr
 				failures++
+			}
+		}
+		if out[i].Kind.IsICMP() {
+			if routeErr := profileRouteValidationError(out[i].sourceRoute, out[i]); routeErr != nil {
+				diagnosticIssues++
+				testLogger(out[i]).V(1).Info("ICMP route differs from profile routing mode", "error", routeErr.Error())
 			}
 		}
 	}
 	connectivityLogger().V(1).Info("source route checks completed",
 		"tests", len(tests), "executed", checks, "cacheHits", hits,
-		"failures", failures, "diagnosticIssues", diagnosticIssues,
+		"failures", failures, "sourceRailMisses", sourceRailMisses,
+		"diagnosticIssues", diagnosticIssues,
 		"duration", time.Since(started).Round(time.Millisecond).String())
 	return out
 }

--- a/pkg/networkoperatorplugin/connectivity/icmp.go
+++ b/pkg/networkoperatorplugin/connectivity/icmp.go
@@ -33,11 +33,8 @@ type execInPodFunc func(context.Context, *rest.Config, string, string, string, [
 func runICMP(ctx context.Context, restConfig *rest.Config, namespace, pod, container string, test PingTest, execInPod execInPodFunc) PingResult {
 	r := initResult(test)
 	if r.Err != nil {
-		// Source-route checks are diagnostic for ICMP. The ping command binds
-		// both the interface and source address, so its observed result is the
-		// authoritative connectivity signal.
-		testLogger(test).V(1).Info("ICMP source route diagnostic unavailable", "error", r.Err.Error())
-		r.Err = nil
+		finalizeICMPRouteError(&r)
+		return r
 	}
 	if test.SrcIface == "" {
 		r.Err = fmt.Errorf("icmp needs source interface for rail %q", test.SrcRail)
@@ -52,13 +49,14 @@ func runICMP(ctx context.Context, restConfig *rest.Config, namespace, pod, conta
 		return r
 	}
 	// RunMatrix pre-computes and caches ICMP source routes across stages.
-	// Keep the standalone runner behavior for direct callers, but never let
-	// this diagnostic replace the actual ping probe.
+	// Keep the standalone runner behavior for direct callers. The route must
+	// select the requested source rail before ping can measure that rail pair.
 	if r.Route.Command == "" {
 		r.Route = checkRoute(ctx, restConfig, namespace, pod, container, test)
 	}
-	if routeErr := sourceRouteValidationError(r.Route, test); routeErr != nil {
-		testLogger(test).V(1).Info("ICMP source route diagnostic differs from requested rail", "error", routeErr.Error())
+	if r.Err = sourceRouteValidationError(r.Route, test); r.Err != nil {
+		finalizeICMPRouteError(&r)
+		return r
 	}
 	cmd := shellWithTimeout(icmpCommand(test),
 		commandTimeoutFor(test, icmpCommandTimeout))
@@ -69,7 +67,15 @@ func runICMP(ctx context.Context, restConfig *rest.Config, namespace, pod, conta
 	return r
 }
 
+func finalizeICMPRouteError(result *PingResult) {
+	if isSourceRouteMismatchError(result.Err) {
+		finalizeExpectedResult(result, false, result.Err)
+		return
+	}
+	result.OK = false
+	result.ObservedOK = false
+}
+
 func icmpCommand(test PingTest) string {
-	return fmt.Sprintf("ping -c 1 -W 1 -I %s -I %s %s",
-		shellArg(test.SrcIface), shellArg(test.SrcIP), shellArg(test.DstIP))
+	return fmt.Sprintf("ping -c 1 -W 1 -I %s %s", shellArg(test.SrcIP), shellArg(test.DstIP))
 }

--- a/pkg/networkoperatorplugin/connectivity/icmp_test.go
+++ b/pkg/networkoperatorplugin/connectivity/icmp_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPlannedICMPCommandsBindSourceInterfaceAndIPInEveryMode(t *testing.T) {
+func TestPlannedICMPCommandsBindSourceIPInEveryMode(t *testing.T) {
 	pods := []TestPod{
 		mkPod("pod-a", "rail-0", "rail-1"),
 		mkPod("pod-b", "rail-0", "rail-1"),
@@ -50,14 +50,15 @@ func TestPlannedICMPCommandsBindSourceInterfaceAndIPInEveryMode(t *testing.T) {
 			icmpTests := testsForCheck(plan, CheckICMP)
 
 			for _, test := range icmpTests {
-				expected := fmt.Sprintf("ping -c 1 -W 1 -I %q -I %q %q", test.SrcIface, test.SrcIP, test.DstIP)
+				expected := fmt.Sprintf("ping -c 1 -W 1 -I %q %q", test.SrcIP, test.DstIP)
 				assert.Equal(t, expected, icmpCommand(test), "%+v", test)
+				assert.NotContains(t, icmpCommand(test), test.SrcIface, "%+v", test)
 			}
 		})
 	}
 }
 
-func TestWrappedICMPCommandBindsSourceInterfaceAndIPInTimeoutAndFallbackPaths(t *testing.T) {
+func TestWrappedICMPCommandBindsSourceIPInTimeoutAndFallbackPaths(t *testing.T) {
 	plan := PlanWithOptions([]TestPod{
 		mkPod("pod-a", "rail-0", "rail-1"),
 		mkPod("pod-b", "rail-0", "rail-1"),
@@ -69,4 +70,5 @@ func TestWrappedICMPCommandBindsSourceInterfaceAndIPInTimeoutAndFallbackPaths(t 
 
 	assert.Contains(t, cmd, "timeout -s TERM -k 2 5 sh -c "+shellArg(icmpCommand(test)))
 	assert.Contains(t, cmd, "else "+icmpCommand(test)+" & pid=$!")
+	assert.NotContains(t, cmd, test.SrcIface)
 }

--- a/pkg/networkoperatorplugin/connectivity/matrix.go
+++ b/pkg/networkoperatorplugin/connectivity/matrix.go
@@ -101,27 +101,28 @@ type TestPod struct {
 // SrcRDMADev / DstRDMADev carry the per-pod RDMA device names so the
 // test runner can pass `-d <dev>` for ib_write_bw.
 type PingTest struct {
-	Kind             PingTestKind
-	SrcPod           string
-	DstPod           string
-	SrcNode          string
-	DstNode          string
-	Rail             string // for same-rail tests; "<srcRail>→<dstRail>" for cross
-	SrcIP            string
-	DstIP            string
-	SrcRail          string
-	DstRail          string
-	SrcIface         string
-	DstIface         string
-	SrcRDMADev       string
-	DstRDMADev       string
-	SrcGPUIndex      int
-	DstGPUIndex      int
-	SrcGPUPCIAddress string
-	DstGPUPCIAddress string
-	Expectation      Expectation
-	sourceRoute      RouteCheck
-	sourceRouteErr   error
+	Kind               PingTestKind
+	SrcPod             string
+	DstPod             string
+	SrcNode            string
+	DstNode            string
+	Rail               string // for same-rail tests; "<srcRail>→<dstRail>" for cross
+	SrcIP              string
+	DstIP              string
+	SrcRail            string
+	DstRail            string
+	SrcIface           string
+	DstIface           string
+	SrcRDMADev         string
+	DstRDMADev         string
+	SrcGPUIndex        int
+	DstGPUIndex        int
+	SrcGPUPCIAddress   string
+	DstGPUPCIAddress   string
+	Expectation        Expectation
+	expectedRouteIface string
+	sourceRoute        RouteCheck
+	sourceRouteErr     error
 }
 
 // PingTestKind enumerates the buckets the matrix renders into. Order
@@ -256,6 +257,7 @@ func PlanWithOptions(pods []TestPod, mode Mode, routing string) MatrixPlan {
 				}
 				icmpT := base
 				icmpT.Kind = ICMPSameRail
+				icmpT.expectedRouteIface = srcIface
 				plan.ICMPSameRail = append(plan.ICMPSameRail, icmpT)
 				srcDev, hasSrcDev := src.RDMADevsByRail[rail]
 				dstDev, hasDstDev := dst.RDMADevsByRail[rail]
@@ -294,6 +296,11 @@ func PlanWithOptions(pods []TestPod, mode Mode, routing string) MatrixPlan {
 				}
 				icmpC := base
 				icmpC.Kind = ICMPCrossRail
+				if routing == config.RoutingSourceBased {
+					icmpC.expectedRouteIface = srcIface
+				} else {
+					icmpC.expectedRouteIface = dstIface
+				}
 				plan.ICMPCrossRail = append(plan.ICMPCrossRail, icmpC)
 				srcDev, hasSrcDev := src.RDMADevsByRail[srcRail]
 				dstDev, hasDstDev := dst.RDMADevsByRail[dstRail]

--- a/pkg/networkoperatorplugin/connectivity/matrix_test.go
+++ b/pkg/networkoperatorplugin/connectivity/matrix_test.go
@@ -283,6 +283,21 @@ func TestPlan_StrictCrossRailExpectationFollowsRouting(t *testing.T) {
 	assert.Equal(t, ExpectForbidden, destination.RDMACrossRail[0].Expectation)
 }
 
+func TestPlan_CrossRailRouteExpectationFollowsRouting(t *testing.T) {
+	pods := []TestPod{
+		mkPod("pod-a", "rail-0", "rail-1"),
+		mkPod("pod-b", "rail-0", "rail-1"),
+	}
+
+	source := PlanWithOptions(pods, ModeQuick, config.RoutingSourceBased)
+	require.NotEmpty(t, source.ICMPCrossRail)
+	assert.Equal(t, source.ICMPCrossRail[0].SrcIface, source.ICMPCrossRail[0].expectedRouteIface)
+
+	destination := PlanWithOptions(pods, ModeQuick, config.RoutingDestinationBased)
+	require.NotEmpty(t, destination.ICMPCrossRail)
+	assert.Equal(t, destination.ICMPCrossRail[0].DstIface, destination.ICMPCrossRail[0].expectedRouteIface)
+}
+
 func TestPlan_StableOrderingAcrossRuns(t *testing.T) {
 	pods := []TestPod{
 		mkPod("pod-b", "rail-0", "rail-1"),

--- a/pkg/networkoperatorplugin/connectivity/report.html.tmpl
+++ b/pkg/networkoperatorplugin/connectivity/report.html.tmpl
@@ -945,7 +945,7 @@ footer strong { color: var(--text-muted); }
 
       {{- $routeDiagnostics := icmpRouteDiagnostics .Matrix.PingResults}}
       {{- if $routeDiagnostics}}
-      <div class="matrix-rail">ICMP source-route diagnostics (non-gating)</div>
+		<div class="matrix-rail">ICMP routing diagnostics</div>
       <table class="matrix-table">
         <thead>
           <tr><th>Source</th><th>Src rail</th><th>Src iface</th><th>Destination</th><th>Dst rail</th><th>Dst iface</th><th>Diagnostic</th></tr>

--- a/pkg/networkoperatorplugin/connectivity/report_test.go
+++ b/pkg/networkoperatorplugin/connectivity/report_test.go
@@ -302,7 +302,7 @@ func TestRenderHTML_HandlesNilOptionalFields(t *testing.T) {
 	assert.Contains(t, buf.String(), "Connectivity testing was not run")
 }
 
-func TestRenderHTML_SurfacesNonGatingICMPRouteDiagnostic(t *testing.T) {
+func TestRenderHTML_SurfacesUnexpectedICMPRouteDiagnostic(t *testing.T) {
 	data := ReportData{
 		Cluster: ClusterInfo{L8kVersion: "v0", GeneratedAt: time.Now()},
 		Matrix: &MatrixResult{PingResults: []PingResult{{
@@ -310,9 +310,10 @@ func TestRenderHTML_SurfacesNonGatingICMPRouteDiagnostic(t *testing.T) {
 				Kind: ICMPCrossRail, SrcPod: "pod-a", DstPod: "pod-b",
 				SrcNode: "worker-a", DstNode: "worker-b",
 				SrcRail: "rail-0", DstRail: "rail-1", SrcIface: "net1", DstIface: "net2",
-				Expectation: ExpectObserve,
+				Expectation:        ExpectObserve,
+				expectedRouteIface: "net1",
 			},
-			OK: true, ObservedOK: true, Expectation: ExpectObserve,
+			OK: true, ObservedOK: false, Expectation: ExpectObserve,
 			Route: RouteCheck{
 				Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
 			},
@@ -323,7 +324,7 @@ func TestRenderHTML_SurfacesNonGatingICMPRouteDiagnostic(t *testing.T) {
 	require.NoError(t, RenderHTML(&buf, data))
 
 	html := buf.String()
-	assert.Contains(t, html, "ICMP source-route diagnostics (non-gating)")
+	assert.Contains(t, html, "ICMP routing diagnostics")
 	assert.Contains(t, html, "worker-a")
 	assert.Contains(t, html, "worker-b")
 	assert.Contains(t, html, `source route selected dev &#34;net2&#34;, expected &#34;net1&#34;`)

--- a/pkg/networkoperatorplugin/connectivity/source.go
+++ b/pkg/networkoperatorplugin/connectivity/source.go
@@ -18,6 +18,7 @@ package connectivity
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -154,6 +155,18 @@ func routeMismatch(route RouteCheck, test PingTest) bool {
 }
 
 func sourceRouteValidationError(route RouteCheck, test PingTest) error {
+	return routeValidationError(route, test.SrcIface)
+}
+
+func profileRouteValidationError(route RouteCheck, test PingTest) error {
+	expected := test.expectedRouteIface
+	if expected == "" {
+		expected = test.SrcIface
+	}
+	return routeValidationError(route, expected)
+}
+
+func routeValidationError(route RouteCheck, expectedIface string) error {
 	if route.Err == routeSkipErr {
 		return nil
 	}
@@ -166,14 +179,19 @@ func sourceRouteValidationError(route RouteCheck, test PingTest) error {
 	if !route.OK {
 		return fmt.Errorf("source route check returned no device (route: %s)", route.Output)
 	}
-	if route.Dev != test.SrcIface {
+	if route.Dev != expectedIface {
 		return &sourceRouteMismatchError{
 			selected: route.Dev,
-			expected: test.SrcIface,
+			expected: expectedIface,
 			output:   route.Output,
 		}
 	}
 	return nil
+}
+
+func isSourceRouteMismatchError(err error) bool {
+	var mismatch *sourceRouteMismatchError
+	return errors.As(err, &mismatch)
 }
 
 type icmpRouteDiagnostic struct {
@@ -187,7 +205,7 @@ func collectICMPRouteDiagnostics(results []PingResult) []icmpRouteDiagnostic {
 		if !result.Test.Kind.IsICMP() || result.Route.Command == "" {
 			continue
 		}
-		routeErr := sourceRouteValidationError(result.Route, result.Test)
+		routeErr := profileRouteValidationError(result.Route, result.Test)
 		if routeErr == nil {
 			continue
 		}

--- a/pkg/networkoperatorplugin/connectivity/source_test.go
+++ b/pkg/networkoperatorplugin/connectivity/source_test.go
@@ -19,6 +19,7 @@ package connectivity
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -67,13 +68,14 @@ func TestCheckSourceRoutesReusesCachedRoute(t *testing.T) {
 	assert.NoError(t, got[0].sourceRouteErr)
 }
 
-func TestCheckSourceRoutesKeepsICMPRouteMismatchDiagnostic(t *testing.T) {
+func TestCheckSourceRoutesUsesICMPRouteMismatchAsSourceRailOutcome(t *testing.T) {
 	for _, expectation := range []Expectation{ExpectRequired, ExpectObserve, ExpectForbidden} {
 		t.Run(string(expectation), func(t *testing.T) {
 			test := PingTest{
 				Kind: ICMPCrossRail, SrcPod: "pod-a", DstPod: "pod-b",
-				SrcIP: "192.0.2.10", DstIP: "198.51.100.20", SrcIface: "net1",
-				Expectation: expectation,
+				SrcIP: "192.0.2.10", DstIP: "198.51.100.20", SrcIface: "net1", DstIface: "net2",
+				Expectation:        expectation,
+				expectedRouteIface: "net2",
 			}
 			key := routeCacheKey{
 				namespace: "default", pod: "pod-a", container: "netshoot",
@@ -88,7 +90,9 @@ func TestCheckSourceRoutesKeepsICMPRouteMismatchDiagnostic(t *testing.T) {
 
 			assert.Len(t, got, 1)
 			assert.Equal(t, "net2", got[0].sourceRoute.Dev)
-			assert.NoError(t, got[0].sourceRouteErr)
+			assert.EqualError(t, got[0].sourceRouteErr,
+				`source route selected dev "net2", expected "net1" (route: 198.51.100.20 dev net2 src 192.0.2.10)`)
+			assert.NoError(t, profileRouteValidationError(got[0].sourceRoute, got[0]))
 		})
 	}
 }
@@ -138,7 +142,7 @@ func TestBoundedTraceOutput(t *testing.T) {
 	assert.Contains(t, got, "truncated 100 bytes")
 }
 
-func TestRunICMPExecutesProbeDespitePrecomputedRouteError(t *testing.T) {
+func TestRunICMPPreservesPrecomputedRouteErrorForEveryExpectation(t *testing.T) {
 	for _, expectation := range []Expectation{ExpectRequired, ExpectObserve, ExpectForbidden} {
 		t.Run(string(expectation), func(t *testing.T) {
 			test := PingTest{
@@ -149,15 +153,15 @@ func TestRunICMPExecutesProbeDespitePrecomputedRouteError(t *testing.T) {
 			called := false
 			execInPod := func(_ context.Context, _ *rest.Config, _, _, _ string, command []string) (kubeclient.ExecResult, error) {
 				called = true
-				require.Equal(t, []string{"/bin/sh", "-c", shellWithTimeout(icmpCommand(test), commandTimeoutFor(test, icmpCommandTimeout))}, command)
-				return kubeclient.ExecResult{Stdout: "1 packets transmitted, 1 received"}, nil
+				return kubeclient.ExecResult{}, fmt.Errorf("unexpected command: %v", command)
 			}
 
 			result := runICMP(context.Background(), nil, "default", "pod-a", "netshoot", test, execInPod)
 
-			assert.True(t, called)
-			assert.True(t, result.ObservedOK)
-			assert.Equal(t, expectation != ExpectForbidden, result.OK)
+			assert.False(t, called)
+			assert.False(t, result.ObservedOK)
+			assert.False(t, result.OK)
+			assert.EqualError(t, result.Err, "route lookup failed")
 		})
 	}
 }
@@ -186,11 +190,12 @@ func TestSourceRouteValidationErrorRejectsLookupAndParseFailures(t *testing.T) {
 			err := sourceRouteValidationError(tc.route, test)
 
 			assert.EqualError(t, err, tc.want)
+			assert.False(t, isSourceRouteMismatchError(err))
 		})
 	}
 }
 
-func TestRunICMPUsesObservedFailureDespiteRouteLookupFailure(t *testing.T) {
+func TestRunICMPTreatsForbiddenRouteLookupFailureAsValidationFailure(t *testing.T) {
 	test := PingTest{
 		Kind:        ICMPCrossRail,
 		SrcIface:    "net1",
@@ -202,19 +207,21 @@ func TestRunICMPUsesObservedFailureDespiteRouteLookupFailure(t *testing.T) {
 			Err:     "command terminated with exit code 1",
 		},
 	}
-	pingErr := errors.New("ping exited with code 1")
+	called := false
 	execInPod := func(_ context.Context, _ *rest.Config, _, _, _ string, _ []string) (kubeclient.ExecResult, error) {
-		return kubeclient.ExecResult{}, pingErr
+		called = true
+		return kubeclient.ExecResult{}, nil
 	}
 
 	result := runICMP(context.Background(), nil, "default", "pod-a", "netshoot", test, execInPod)
 
-	assert.True(t, result.OK)
+	assert.False(t, called)
+	assert.False(t, result.OK)
 	assert.False(t, result.ObservedOK)
-	assert.NoError(t, result.Err)
+	assert.EqualError(t, result.Err, "source route check failed: command terminated with exit code 1")
 }
 
-func TestRunICMPUsesObservedSuccessDespiteRouteMismatch(t *testing.T) {
+func TestRunICMPTreatsObservedRouteMismatchAsDisconnected(t *testing.T) {
 	test := PingTest{
 		Kind: ICMPCrossRail, SrcIface: "net1", SrcIP: "192.0.2.10", DstIP: "198.51.100.20", Expectation: ExpectObserve,
 		sourceRoute: RouteCheck{
@@ -229,26 +236,63 @@ func TestRunICMPUsesObservedSuccessDespiteRouteMismatch(t *testing.T) {
 
 	result := runICMP(context.Background(), nil, "default", "pod-a", "netshoot", test, execInPod)
 
-	assert.True(t, called)
+	assert.False(t, called)
 	assert.True(t, result.OK)
-	assert.True(t, result.ObservedOK)
-	assert.NoError(t, result.Err)
+	assert.False(t, result.ObservedOK)
+	assert.EqualError(t, result.Err,
+		`source route selected dev "net2", expected "net1" (route: 198.51.100.20 dev net2 src 192.0.2.10)`)
 }
 
-func TestRunICMPUsesObservedSuccessForForbiddenRouteMismatch(t *testing.T) {
+func TestRunICMPTreatsForbiddenRouteMismatchAsDisconnected(t *testing.T) {
 	test := PingTest{
 		Kind: ICMPCrossRail, SrcIface: "net1", SrcIP: "192.0.2.10", DstIP: "198.51.100.20", Expectation: ExpectForbidden,
 		sourceRoute: RouteCheck{
 			Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
 		},
 	}
+	called := false
 	execInPod := func(_ context.Context, _ *rest.Config, _, _, _ string, _ []string) (kubeclient.ExecResult, error) {
+		called = true
 		return kubeclient.ExecResult{}, nil
 	}
 
 	result := runICMP(context.Background(), nil, "default", "pod-a", "netshoot", test, execInPod)
 
-	assert.False(t, result.OK)
+	assert.False(t, called)
+	assert.True(t, result.OK)
+	assert.False(t, result.ObservedOK)
+	assert.NoError(t, result.Err)
+}
+
+func TestRunICMPExecutesSourceBoundPingWhenRouteUsesSourceRail(t *testing.T) {
+	test := PingTest{
+		Kind: ICMPCrossRail, SrcIface: "net1", SrcIP: "192.0.2.10", DstIP: "198.51.100.20", Expectation: ExpectObserve,
+		sourceRoute: RouteCheck{
+			Command: "ip route get", Output: "198.51.100.20 via 192.0.2.1 dev net1 src 192.0.2.10", Dev: "net1", OK: true,
+		},
+	}
+	called := false
+	execInPod := func(_ context.Context, _ *rest.Config, _, _, _ string, command []string) (kubeclient.ExecResult, error) {
+		called = true
+		require.Equal(t, []string{"/bin/sh", "-c", shellWithTimeout(icmpCommand(test), commandTimeoutFor(test, icmpCommandTimeout))}, command)
+		return kubeclient.ExecResult{Stdout: "1 packets transmitted, 1 received"}, nil
+	}
+
+	result := runICMP(context.Background(), nil, "default", "pod-a", "netshoot", test, execInPod)
+
+	assert.True(t, called)
+	assert.True(t, result.OK)
 	assert.True(t, result.ObservedOK)
-	assert.EqualError(t, result.Err, "cross-rail traffic succeeded but profile routing expects isolation")
+	assert.NoError(t, result.Err)
+}
+
+func TestProfileRouteValidationFollowsRoutingMode(t *testing.T) {
+	route := RouteCheck{Command: "ip route get", Output: "198.51.100.20 dev net2", Dev: "net2", OK: true}
+
+	sbr := PingTest{SrcIface: "net1", DstIface: "net2", expectedRouteIface: "net1"}
+	dbr := PingTest{SrcIface: "net1", DstIface: "net2", expectedRouteIface: "net2"}
+
+	assert.EqualError(t, profileRouteValidationError(route, sbr),
+		`source route selected dev "net2", expected "net1" (route: 198.51.100.20 dev net2)`)
+	assert.NoError(t, profileRouteValidationError(route, dbr))
 }

--- a/pkg/networkoperatorplugin/connectivity/text_report.go
+++ b/pkg/networkoperatorplugin/connectivity/text_report.go
@@ -86,7 +86,7 @@ func RenderMatrixText(uiOutput ui.Output, result *MatrixResult) {
 	routeDiagnostics := collectICMPRouteDiagnostics(result.PingResults)
 	if len(routeDiagnostics) > 0 {
 		uiOutput.Info("")
-		uiOutput.Info("ICMP source-route diagnostics (non-gating):")
+		uiOutput.Info("ICMP routing diagnostics:")
 		for _, diagnostic := range routeDiagnostics {
 			r := diagnostic.Result
 			uiOutput.Info("  %s [%s/%s] → %s [%s/%s]: %s",

--- a/pkg/networkoperatorplugin/connectivity/text_report_test.go
+++ b/pkg/networkoperatorplugin/connectivity/text_report_test.go
@@ -201,15 +201,16 @@ func TestRenderMatrixText_EmptyResultsIsNoOp(t *testing.T) {
 	assert.Empty(t, out.lines)
 }
 
-func TestRenderMatrixText_SurfacesNonGatingICMPRouteDiagnostic(t *testing.T) {
+func TestRenderMatrixText_SurfacesUnexpectedICMPRouteDiagnostic(t *testing.T) {
 	result := &MatrixResult{PingResults: []PingResult{{
 		Test: PingTest{
 			Kind: ICMPCrossRail, SrcPod: "pod-a", DstPod: "pod-b",
 			SrcNode: "worker-a", DstNode: "worker-b",
 			SrcRail: "rail-0", DstRail: "rail-1", SrcIface: "net1", DstIface: "net2",
-			Expectation: ExpectObserve,
+			Expectation:        ExpectObserve,
+			expectedRouteIface: "net1",
 		},
-		OK: true, ObservedOK: true, Expectation: ExpectObserve,
+		OK: true, ObservedOK: false, Expectation: ExpectObserve,
 		Route: RouteCheck{
 			Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
 		},
@@ -219,10 +220,32 @@ func TestRenderMatrixText_SurfacesNonGatingICMPRouteDiagnostic(t *testing.T) {
 	RenderMatrixText(out, result)
 
 	joined := strings.Join(out.lines, "\n")
-	assert.Contains(t, joined, "connected")
-	assert.Contains(t, joined, "ICMP source-route diagnostics (non-gating):")
+	assert.Contains(t, joined, "not connected")
+	assert.Contains(t, joined, "ICMP routing diagnostics:")
 	assert.Contains(t, joined, "worker-a [rail-0/net1] → worker-b [rail-1/net2]")
 	assert.Contains(t, joined, `source route selected dev "net2", expected "net1"`)
+}
+
+func TestRenderMatrixText_DoesNotFlagExpectedDestinationBasedRoute(t *testing.T) {
+	result := &MatrixResult{PingResults: []PingResult{{
+		Test: PingTest{
+			Kind: ICMPCrossRail, SrcPod: "pod-a", DstPod: "pod-b",
+			SrcNode: "worker-a", DstNode: "worker-b",
+			SrcRail: "rail-0", DstRail: "rail-1", SrcIface: "net1", DstIface: "net2",
+			Expectation: ExpectObserve, expectedRouteIface: "net2",
+		},
+		OK: true, ObservedOK: false, Expectation: ExpectObserve,
+		Route: RouteCheck{
+			Command: "ip route get", Output: "198.51.100.20 dev net2 src 192.0.2.10", Dev: "net2", OK: true,
+		},
+	}}}
+	out := &captureOutput{}
+
+	RenderMatrixText(out, result)
+
+	joined := strings.Join(out.lines, "\n")
+	assert.Contains(t, joined, "not connected")
+	assert.NotContains(t, joined, "ICMP routing diagnostics:")
 }
 
 func TestRenderMatrixText_GPUDirectFamilyIncludesEndpointDetails(t *testing.T) {

--- a/skills/k8s-launch-kit-validate/SKILL.md
+++ b/skills/k8s-launch-kit-validate/SKILL.md
@@ -96,12 +96,13 @@ l8k validate [--user-config <PATH>] [--deployment-files <DIR>] [--kubeconfig <PA
 - `strict`: full matrix. Cross-rail gates by `profile.routing`: `source-based`
   must succeed, `destination-based` must stay isolated.
 
-All checks are source-bound. ICMP uses
-`ping -I <src-iface> -I <src-ip>` so the probe stays on the selected rail while
-its source address activates source-based policy rules. The preceding
-`ip route get <dst> from <src>` output is diagnostic only and never replaces
-the observed ping result. Route differences are visible in the terminal and
-HTML reports as non-gating diagnostics. `rping` uses
+All checks are source-bound. Before every ICMP probe, validate confirms that
+`ip route get <dst> from <src>` selects the requested source interface. A route
+using another interface is reported as not connected for that rail pair rather
+than forcing traffic onto it. When the source rail is selected, ICMP uses
+`ping -I <src-ip>` so source-based policy rules participate naturally. Routing
+diagnostics expect the source interface for source-based routing and the
+destination interface for destination-based routing. `rping` uses
 `-I <src-ip>`, and `ib_write_bw` uses
 `--bind_source_ip <src-ip>`. GPUDirect
 adds `--use_cuda=<endpoint-index> --use_cuda_dmabuf` independently on the


### PR DESCRIPTION
## Summary

- remove the dual interface+IP ping binding that forces traffic onto the requested rail
- use `ip route get <dst> from <src>` to establish whether the flow would actually leave through the requested source rail
- run `ping -I <src-ip>` only when that route selects the source rail
- make routing diagnostics profile-aware: source-based expects the source interface; destination-based expects the destination interface

## Why

Live validation showed `observedConnected: true` while the unforced route selected the destination interface. The dual `-I` command applied `SO_BINDTODEVICE`, manufacturing cross-rail reachability under destination-based routing and masking the routing mode.

A cross-rail result is connected only when the kernel route selects the requested source rail and the source-bound ping succeeds. A destination-based route selecting the destination rail is therefore reported as not connected without emitting a misleading diagnostic. A source-based profile selecting the destination rail is reported as an unexpected routing decision.

## Testing

- `go test ./... -count=1`
- `go test -race -count=1 ./pkg/networkoperatorplugin/connectivity`
- `go vet ./...`
- `make build`
- `golangci-lint v2.13.2 run ./...`
- `mkdocs build --strict --clean`
- `git diff --check`