### PR TITLE
fix: prefer host CUDA driver for GPUDirect validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,8 +463,12 @@ supplied value is preserved. When enabled, generated validation DaemonSets use
 the release-specific full-runtime DOCA image, propagate
 `networkOperator.imagePullSecrets`, and request the GPU prefix required by the
 largest discovered `GPU<N>` index in the primary DOCA container. The netshoot
-container never requests GPUs. The named pull Secret must exist in every
-validation workload namespace.
+container never requests GPUs. The primary container also sets
+`LD_LIBRARY_PATH` to prefer the NVIDIA driver libraries injected from the host
+and exclude the CUDA compatibility-library directory, which can otherwise load
+a `libcuda` version that does not match the host driver. This override is
+omitted when GPUDirect validation is disabled. The named pull Secret must exist
+in every validation workload namespace.
 
 Validation modes control cross-rail coverage and gating:
 

--- a/docs/user/validation.md
+++ b/docs/user/validation.md
@@ -99,7 +99,11 @@ The generated validation DaemonSet selects its full-runtime DOCA image from
 the Network Operator release catalog and copies
 `networkOperator.imagePullSecrets` into the Pod spec. Create those Secrets in
 every network namespace used by validation. Only the DOCA container requests
-the configured GPU resource.
+the configured GPU resource. When GPUDirect is enabled, that container also
+sets `LD_LIBRARY_PATH` to prefer the host-injected NVIDIA driver libraries and
+exclude the CUDA compatibility-library directory. The override prevents a
+bundled `libcuda` from taking precedence over the host driver and is omitted
+when GPUDirect is disabled.
 
 For each test, Launch Kit maps the source rail and destination rail to their
 own `connectedGPU` value from discovery or the selected topology preset. It

--- a/pkg/networkoperatorplugin/example_daemonset_test.go
+++ b/pkg/networkoperatorplugin/example_daemonset_test.go
@@ -29,6 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
+const gpudirectLDLibraryPath = "/usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64"
+
 func TestExampleDaemonSetTemplatesDeclareICMPHelper(t *testing.T) {
 	templates, err := filepath.Glob(filepath.Join("..", "..", "profiles", "*", "*-example-daemonset.yaml"))
 	require.NoError(t, err)
@@ -68,6 +70,13 @@ func TestExampleDaemonSetTemplatesDeclareReleaseImagePullSecretsAndGPURequests(t
 			branches := strings.Count(body, "kind: DaemonSet")
 			require.Equal(t, branches, strings.Count(body, "image: {{validationImage $.NetworkOperator}}"))
 			require.Equal(t, branches, strings.Count(body, "imagePullSecrets:"))
+			gpudirectEnvBlock := fmt.Sprintf(`{{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: %s
+        {{- end }}`, gpudirectLDLibraryPath)
+			require.Equal(t, branches, strings.Count(body, gpudirectEnvBlock),
+				"every primary container branch must prefer the host-injected CUDA driver during GPUDirect validation")
 			require.GreaterOrEqual(t, strings.Count(body, "{{$.Validation.GPUDirect.GPUResourceType}}"), branches*2,
 				"every primary container branch must request and limit the configured GPU resource")
 		})
@@ -110,9 +119,12 @@ func TestRenderedExampleDaemonSetGPUDirectResources(t *testing.T) {
 	limits := requireMap(t, resources, "limits")
 	require.Equal(t, "8", requests["example.com/gpu"], "merged DaemonSet must cover the highest source-group GPU index")
 	require.Equal(t, "8", limits["example.com/gpu"])
+	require.Equal(t, []any{map[string]any{"name": "LD_LIBRARY_PATH", "value": gpudirectLDLibraryPath}}, primary["env"])
 	helper := containers[1].(map[string]any)
 	_, hasHelperResources := helper["resources"]
 	require.False(t, hasHelperResources)
+	_, hasHelperEnv := helper["env"]
+	require.False(t, hasHelperEnv)
 
 	cfg.Validation.GPUDirect.Enabled = false
 	rendered, err = (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(loadProfileFromDir(t, "sriov-ethernet-rdma"), cfg)
@@ -125,6 +137,8 @@ func TestRenderedExampleDaemonSetGPUDirectResources(t *testing.T) {
 	requests = requireMap(t, requireMap(t, primary, "resources"), "requests")
 	_, hasGPURequest := requests["example.com/gpu"]
 	require.False(t, hasGPURequest, "disabled GPUDirect must not request a GPU")
+	_, hasGPUDirectEnv := primary["env"]
+	require.False(t, hasGPUDirectEnv, "disabled GPUDirect must preserve the validation image environment")
 }
 
 func TestRenderedSpectrumXDRAExampleDaemonSetGPUDirectResources(t *testing.T) {
@@ -159,6 +173,7 @@ func TestRenderedSpectrumXDRAExampleDaemonSetGPUDirectResources(t *testing.T) {
 	require.NotEmpty(t, resources["claims"])
 	require.Equal(t, "8", requireMap(t, resources, "requests")["nvidia.com/gpu"])
 	require.Equal(t, "8", requireMap(t, resources, "limits")["nvidia.com/gpu"])
+	require.Equal(t, []any{map[string]any{"name": "LD_LIBRARY_PATH", "value": gpudirectLDLibraryPath}}, primary["env"])
 }
 
 func TestRenderedExampleDaemonSetsDeclareICMPHelper(t *testing.T) {
@@ -360,8 +375,11 @@ func assertRenderedGPUDirectExample(t *testing.T, profileDir string, cfg *config
 	resources := requireMap(t, primary, "resources")
 	require.Equal(t, count, requireMap(t, resources, "requests")["example.com/gpu"])
 	require.Equal(t, count, requireMap(t, resources, "limits")["example.com/gpu"])
+	require.Equal(t, []any{map[string]any{"name": "LD_LIBRARY_PATH", "value": gpudirectLDLibraryPath}}, primary["env"])
 	_, helperHasResources := containers[1].(map[string]any)["resources"]
 	require.False(t, helperHasResources)
+	_, helperHasEnv := containers[1].(map[string]any)["env"]
+	require.False(t, helperHasEnv)
 }
 
 func requireMap(t *testing.T, parent map[string]any, key string) map[string]any {

--- a/profiles/host-device-rdma/40-example-daemonset.yaml
+++ b/profiles/host-device-rdma/40-example-daemonset.yaml
@@ -51,6 +51,11 @@ spec:
       containers:
       - name: test-container
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
@@ -132,6 +137,11 @@ spec:
       containers:
       - name: test-container
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:

--- a/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/ipoib-rdma-shared/40-example-daemonset.yaml
@@ -51,6 +51,11 @@ spec:
       containers:
       - name: test-container
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
@@ -133,6 +138,11 @@ spec:
       containers:
       - name: test-container
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:

--- a/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
+++ b/profiles/macvlan-rdma-shared/40-example-daemonset.yaml
@@ -51,6 +51,11 @@ spec:
       containers:
       - name: test-container
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
@@ -133,6 +138,11 @@ spec:
       containers:
       - name: test-container
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:

--- a/profiles/spectrum-x-ra2.1/90-example-daemonset.yaml
+++ b/profiles/spectrum-x-ra2.1/90-example-daemonset.yaml
@@ -53,6 +53,11 @@ spec:
       containers:
       - name: spectrum-x-test
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         securityContext:
           capabilities:
             add: ["IPC_LOCK", "NET_RAW"]

--- a/profiles/spectrum-x-ra2.2/90-example-daemonset.yaml
+++ b/profiles/spectrum-x-ra2.2/90-example-daemonset.yaml
@@ -53,6 +53,11 @@ spec:
       containers:
       - name: spectrum-x-test
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         securityContext:
           capabilities:
             add: ["IPC_LOCK", "NET_RAW"]

--- a/profiles/spectrum-x/90-example-daemonset.yaml
+++ b/profiles/spectrum-x/90-example-daemonset.yaml
@@ -53,6 +53,11 @@ spec:
       containers:
       - name: spectrum-x-test
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         securityContext:
           capabilities:
             add: ["IPC_LOCK", "NET_RAW"]

--- a/profiles/sriov-ethernet-rdma/60-example-daemonset.yaml
+++ b/profiles/sriov-ethernet-rdma/60-example-daemonset.yaml
@@ -51,6 +51,11 @@ spec:
       containers:
       - name: test-container
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
@@ -132,6 +137,11 @@ spec:
       containers:
       - name: test-container
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:

--- a/profiles/sriov-ib-rdma/60-example-daemonset.yaml
+++ b/profiles/sriov-ib-rdma/60-example-daemonset.yaml
@@ -51,6 +51,11 @@ spec:
       containers:
       - name: test-container
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:
@@ -132,6 +137,11 @@ spec:
       containers:
       - name: test-container
         image: {{validationImage $.NetworkOperator}}
+        {{- if $.Validation.GPUDirect.Enabled }}
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64:/usr/local/nvidia/lib:/usr/mpi/gcc/openmpi-current/lib:/usr/local/cuda/lib64
+        {{- end }}
         command: ["/bin/bash", "-c", "sleep infinity"]
         securityContext:
           capabilities:

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -135,7 +135,10 @@ When `validation.gpuDirect.enabled` is true, every generated example
 DaemonSet requests `validation.gpuDirect.gpuResourceType` only on its primary
 DOCA container. The request exposes the highest `GPU<N>` referenced by PF
 topology, the image comes from the selected release's `validation.image`, and
-`networkOperator.imagePullSecrets` is copied to the Pod spec. Do not inject
+`networkOperator.imagePullSecrets` is copied to the Pod spec. The primary
+container also sets `LD_LIBRARY_PATH` to prefer the host-injected NVIDIA driver
+libraries and exclude the CUDA compatibility-library directory. The
+environment override is omitted when GPUDirect is disabled. Do not inject
 these fields later at validation runtime.
 
 ```

--- a/skills/k8s-launch-kit-validate/SKILL.md
+++ b/skills/k8s-launch-kit-validate/SKILL.md
@@ -47,8 +47,10 @@ Operator release.
    true and `ib_write_bw` is selected, a distinct DMA-BUF bandwidth family
    uses the connected GPU index for each source and destination rail. Profile templates declare both validation
    containers: the release-specific full-runtime DOCA image for the RDMA checks and `netshoot` for ICMP and route
-   checks. Validate applies the generated DaemonSet without runtime container
-   injection. The default mode is `strict`.
+   checks. GPUDirect-enabled templates set `LD_LIBRARY_PATH` on the DOCA
+   container to prefer host-injected NVIDIA driver libraries over bundled CUDA
+   compatibility libraries. Validate applies the generated DaemonSet without
+   runtime container injection. The default mode is `strict`.
 
 Validation also reports deploy-preflight drift without remediating it.
 `SriovNetworkPoolConfig`, `SriovNetworkNodePolicy`, and `OVSNetwork` objects


### PR DESCRIPTION
## What

- Set `LD_LIBRARY_PATH` on the primary DOCA container when `validation.gpuDirect.enabled` is true.
- Prefer runtime-injected NVIDIA driver libraries and omit the CUDA compatibility directory that can supply a mismatched `libcuda`.
- Apply the conditional override to all 13 validation DaemonSet branches and leave the netshoot helper and non-GPUDirect manifests unchanged.
- Add raw-template and rendered-manifest coverage plus user and skill documentation.

## Why

A CUDA-enabled DOCA image can place its forward-compatibility `libcuda` ahead of the host-injected driver libraries. When that userspace library does not match the loaded host driver, `ib_write_bw --use_cuda_dmabuf` fails at `cuInit(0)` with CUDA error 803 before RDMA setup.

## Validation

- `make build`
- `make test`
- `go vet ./...`
- `golangci-lint` v2.11: 0 issues
- Smoke-rendered `same-ew-different-ns`, `mixed-same-type`, and `true-heterogeneous` fixtures
- Requester-verified on cluster: the GPUDirect DMA-BUF tests pass with this environment override