### PR TITLE
feat: download sosreport script on demand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GOMOD=$(GOCMD) mod
 
 # Sosreport script
 SOSREPORT_SCRIPT=scripts/kubectl-netop_sosreport
-SOSREPORT_URL=https://raw.githubusercontent.com/Mellanox/network-operator/master/scripts/sosreport/kubectl-netop_sosreport
+SOSREPORT_URL=https://raw.githubusercontent.com/Mellanox/network-operator/refs/heads/master/scripts/sosreport/kubectl-netop_sosreport
 
 PCI_IDS_URL=https://raw.githubusercontent.com/pciutils/pciids/master/pci.ids
 PCI_IDS_NVIDIA=pkg/networkoperatorplugin/internal/pciids/nvidia.ids

--- a/README.md
+++ b/README.md
@@ -735,7 +735,14 @@ Collect a diagnostic dump from the cluster:
 l8k sosreport --kubeconfig ~/.kube/config --output-dir ./sosreport
 ```
 
-The sosreport contains NicClusterPolicy, pod logs, node info, CRDs, and other diagnostic data. For interactive AI-assisted analysis, use the bundled Claude Code skills under `skills/k8s-launch-kit-troubleshoot/` — they wrap the deterministic commands (`l8k sosreport`, `kubectl`) and let the agent driving the skill do the reasoning.
+The sosreport contains NicClusterPolicy, pod logs, node info, CRDs, and other
+diagnostic data. On first use, `l8k` downloads the Network Operator collection
+script when it is not already available and caches it at
+`<installation-prefix>/share/l8k/scripts/kubectl-netop_sosreport`. For
+interactive AI-assisted analysis, use the bundled Claude Code skills under
+`skills/k8s-launch-kit-troubleshoot/` — they wrap the deterministic commands
+(`l8k sosreport`, `kubectl`) and let the agent driving the skill do the
+reasoning.
 
 ### AI Agent / Automation Usage
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -199,3 +199,8 @@ Set `GITHUB_TOKEN` for authenticated GitHub API requests when updating presets.
 | --- | --- |
 | `--kubeconfig` | Cluster kubeconfig, with the same environment and home-directory fallback as other cluster commands. |
 | `--output-dir` | Diagnostic output directory. Defaults to `./sosreport`. |
+
+The command lazily downloads the Network Operator sosreport script when no
+existing copy is found. It caches the executable script under
+`<installation-prefix>/share/l8k/scripts/`. A failed download reports the raw
+GitHub URL and the exact cache path for manual installation.

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -109,6 +109,12 @@ l8k preset list --config-dir /etc/l8k
 
 Script, Homebrew, and source installs also place the profile templates under `<prefix>/share/l8k/profiles/`. Existing `l8k-config.yaml` and `presets/` overrides under the share directory are preserved during upgrades and are selected only when passed through `--config-dir`.
 
+The Network Operator sosreport script is downloaded lazily on the first
+`l8k sosreport` run that cannot find an existing copy. It is cached at
+`<prefix>/share/l8k/scripts/kubectl-netop_sosreport`. If that directory is not
+writable or the download is unavailable, the command reports the raw source
+URL and exact destination so the executable script can be installed manually.
+
 ## Verify
 
 ```bash

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -147,11 +147,14 @@ l8k sosreport \
   --output-dir ./sosreport
 ```
 
-The kubeconfig can also come from `$KUBECONFIG` or `~/.kube/config`. If the collection script is missing from the source tree or installed share directory, install it with:
-
-```bash
-make download-sosreport
-```
+The kubeconfig can also come from `$KUBECONFIG` or `~/.kube/config`. `l8k`
+reuses an existing Network Operator collection script when available. If the
+script is missing, the command downloads it on first use from
+`https://raw.githubusercontent.com/Mellanox/network-operator/refs/heads/master/scripts/sosreport/kubectl-netop_sosreport`
+and stores it at `<installation-prefix>/share/l8k/scripts/kubectl-netop_sosreport`.
+If the download cannot be completed, the error reports both this source URL
+and the exact installation-adjacent path where an executable copy can be
+placed manually.
 
 Start with the diagnostic summary and collection errors, then correlate:
 

--- a/pkg/cmd/sosreport.go
+++ b/pkg/cmd/sosreport.go
@@ -17,14 +17,24 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
+)
+
+const (
+	sosreportScriptName  = "kubectl-netop_sosreport"
+	sosreportScriptURL   = "https://raw.githubusercontent.com/Mellanox/network-operator/refs/heads/master/scripts/sosreport/kubectl-netop_sosreport"
+	sosreportHTTPTimeout = 30 * time.Second
 )
 
 var sosreportOutputDir string
@@ -52,13 +62,13 @@ and other diagnostic data useful for troubleshooting.`,
 			), outputFormat)
 		}
 
-		// Find the sosreport script
-		scriptPath, err := findSosreportScript()
+		// Reuse an existing sosreport script or download it next to the l8k installation.
+		scriptPath, installPath, err := resolveSosreportScript(cmd.Context())
 		if err != nil {
 			exitWithError(apperrors.NewValidationError(
-				"sosreport script not found",
+				"sosreport script unavailable",
 				err,
-				"Run 'make download-sosreport' to download the script",
+				manualSosreportInstallSuggestion(installPath),
 			), outputFormat)
 		}
 
@@ -89,21 +99,108 @@ and other diagnostic data useful for troubleshooting.`,
 	},
 }
 
-// findSosreportScript looks for the sosreport script in known locations.
-func findSosreportScript() (string, error) {
+func resolveSosreportScript(ctx context.Context) (string, string, error) {
+	executablePath, _ := os.Executable()
+	candidates, installPath := sosreportScriptLocations(executablePath)
+	scriptPath, err := findOrDownloadSosreportScript(
+		ctx,
+		&http.Client{Timeout: sosreportHTTPTimeout},
+		sosreportScriptURL,
+		candidates,
+		installPath,
+	)
+	return scriptPath, installPath, err
+}
+
+// sosreportScriptLocations returns the lookup order and the installation-adjacent
+// path used to cache a lazily downloaded script.
+func sosreportScriptLocations(executablePath string) ([]string, string) {
 	candidates := []string{
-		"scripts/kubectl-netop_sosreport",
-		"/usr/local/share/l8k/scripts/kubectl-netop_sosreport",
+		filepath.Join("scripts", sosreportScriptName),
+		filepath.Join("/usr/local/share/l8k/scripts", sosreportScriptName),
 	}
-	if exe, err := os.Executable(); err == nil {
-		candidates = append(candidates, filepath.Join(filepath.Dir(exe), "..", "share", "l8k", "scripts", "kubectl-netop_sosreport"))
+	installPath := candidates[len(candidates)-1]
+	if executablePath != "" {
+		installPath = filepath.Join(filepath.Dir(executablePath), "..", "share", "l8k", "scripts", sosreportScriptName)
+		candidates = append(candidates, installPath)
 	}
+	return candidates, installPath
+}
+
+func findOrDownloadSosreportScript(
+	ctx context.Context,
+	client *http.Client,
+	sourceURL string,
+	candidates []string,
+	installPath string,
+) (string, error) {
 	for _, p := range candidates {
 		if _, err := os.Stat(p); err == nil {
 			return p, nil
 		}
 	}
-	return "", fmt.Errorf("checked: %v", candidates)
+
+	if err := downloadSosreportScript(ctx, client, sourceURL, installPath); err != nil {
+		return "", fmt.Errorf("failed to download sosreport script from %s to %s: %w", sourceURL, installPath, err)
+	}
+	return installPath, nil
+}
+
+func downloadSosreportScript(ctx context.Context, client *http.Client, sourceURL, installPath string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request script: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("request script: HTTP %s", resp.Status)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(installPath), 0o755); err != nil {
+		return fmt.Errorf("create destination directory: %w", err)
+	}
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(installPath), ".sosreport-*")
+	if err != nil {
+		return fmt.Errorf("create temporary file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpPath)
+	}()
+
+	written, err := io.Copy(tmpFile, resp.Body)
+	if err != nil {
+		return fmt.Errorf("write temporary file: %w", err)
+	}
+	if written == 0 {
+		return fmt.Errorf("downloaded script is empty")
+	}
+	if err := tmpFile.Chmod(0o755); err != nil {
+		return fmt.Errorf("make temporary file executable: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("close temporary file: %w", err)
+	}
+	if err := os.Rename(tmpPath, installPath); err != nil {
+		return fmt.Errorf("install script: %w", err)
+	}
+	return nil
+}
+
+func manualSosreportInstallSuggestion(installPath string) string {
+	return fmt.Sprintf(
+		"Download %s and place it at %s (the share directory next to the l8k installation) with executable permissions",
+		sosreportScriptURL,
+		installPath,
+	)
 }
 
 func init() {

--- a/pkg/cmd/sosreport_test.go
+++ b/pkg/cmd/sosreport_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindOrDownloadSosreportScriptUsesExistingScript(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	existingPath := filepath.Join(dir, sosreportScriptName)
+	require.NoError(t, os.WriteFile(existingPath, []byte("existing"), 0o755))
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte("downloaded"))
+	}))
+	t.Cleanup(server.Close)
+
+	installPath := filepath.Join(dir, "install", sosreportScriptName)
+	path, err := findOrDownloadSosreportScript(
+		context.Background(),
+		server.Client(),
+		server.URL,
+		[]string{existingPath},
+		installPath,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, existingPath, path)
+	assert.Equal(t, int32(0), requests.Load())
+	_, err = os.Stat(installPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestFindOrDownloadSosreportScriptDownloadsMissingScript(t *testing.T) {
+	t.Parallel()
+
+	const script = "#!/bin/bash\necho sosreport\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/kubectl-netop_sosreport", r.URL.Path)
+		_, _ = w.Write([]byte(script))
+	}))
+	t.Cleanup(server.Close)
+
+	installPath := filepath.Join(t.TempDir(), "share", "l8k", "scripts", sosreportScriptName)
+	path, err := findOrDownloadSosreportScript(
+		context.Background(),
+		server.Client(),
+		server.URL+"/kubectl-netop_sosreport",
+		[]string{filepath.Join(t.TempDir(), "missing")},
+		installPath,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, installPath, path)
+	contents, err := os.ReadFile(installPath)
+	require.NoError(t, err)
+	assert.Equal(t, script, string(contents))
+	info, err := os.Stat(installPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}
+
+func TestFindOrDownloadSosreportScriptReportsDownloadLocation(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	installPath := filepath.Join(t.TempDir(), "share", "l8k", "scripts", sosreportScriptName)
+	_, err := findOrDownloadSosreportScript(
+		context.Background(),
+		server.Client(),
+		server.URL,
+		[]string{filepath.Join(t.TempDir(), "missing")},
+		installPath,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), server.URL)
+	assert.Contains(t, err.Error(), installPath)
+	assert.Contains(t, err.Error(), "503 Service Unavailable")
+	_, statErr := os.Stat(installPath)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestDownloadSosreportScriptRejectsEmptyResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	t.Cleanup(server.Close)
+
+	installPath := filepath.Join(t.TempDir(), sosreportScriptName)
+	err := downloadSosreportScript(context.Background(), server.Client(), server.URL, installPath)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "downloaded script is empty")
+	_, statErr := os.Stat(installPath)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestManualSosreportInstallSuggestion(t *testing.T) {
+	t.Parallel()
+
+	installPath := filepath.Join("opt", "l8k", "share", "l8k", "scripts", sosreportScriptName)
+	suggestion := manualSosreportInstallSuggestion(installPath)
+
+	assert.Contains(t, suggestion, sosreportScriptURL)
+	assert.Contains(t, suggestion, installPath)
+	assert.Contains(t, suggestion, "next to the l8k installation")
+	assert.NotContains(t, suggestion, "make download-sosreport")
+}
+
+func TestSosreportScriptLocationsUseInstallationPrefix(t *testing.T) {
+	t.Parallel()
+
+	candidates, installPath := sosreportScriptLocations(filepath.Join("opt", "l8k", "bin", "l8k"))
+
+	expected := filepath.Join("opt", "l8k", "share", "l8k", "scripts", sosreportScriptName)
+	assert.Equal(t, expected, installPath)
+	assert.Equal(t, expected, candidates[len(candidates)-1])
+}

--- a/skills/k8s-launch-kit-troubleshoot/SKILL.md
+++ b/skills/k8s-launch-kit-troubleshoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-troubleshoot
-version: 1.1.3
+version: 1.1.4
 description: "Use this skill when the user has problems with NVIDIA Network Operator on Kubernetes, or wants to analyze a sosreport diagnostic dump. Activate for: OFED driver crashes, SR-IOV pods failing, NicClusterPolicy errors, network operator pod issues, RDMA not working, NIC configuration failures, pods stuck in CrashLoopBackOff or ContainerCreating with network annotations, VF allocation issues, or when the user mentions 'troubleshoot', 'debug', 'sosreport', 'diagnose', or describes any NVIDIA networking failure -- even if they don't explicitly ask for troubleshooting."
 metadata:
   requires:
@@ -32,7 +32,7 @@ ib_write_bw failure needs command output. Trace fields are bounded; failed RDMA
 server logs are collected before cleanup. Add `--keep` only when the workload
 must remain available for follow-up `kubectl exec` inspection.
 
-`l8k sosreport` gathers cluster state, CRDs, operator logs, and per-node NIC info into a structured directory for offline analysis. Use the diagnostic commands and triage workflow below to interpret the dump.
+`l8k sosreport` gathers cluster state, CRDs, operator logs, and per-node NIC info into a structured directory for offline analysis. If the Network Operator collection script is not already present, `l8k` downloads it on first use and caches it under the installation-adjacent `share/l8k/scripts/` directory. A download failure reports the source URL and exact path for manual installation. Use the diagnostic commands and triage workflow below to interpret the dump.
 
 ## Diagnostic Commands
 


### PR DESCRIPTION
## Summary

- reuse an existing Network Operator sosreport script when available
- lazily download and atomically cache a missing script beside the l8k installation
- report the raw source URL and exact manual placement path when download fails
- document the first-use behavior for users and troubleshooting agents

## Validation

- `go build ./...`
- `go test -race -count=1 ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 run ./...`
- verified the configured raw GitHub URL returns HTTP 200