### PR TITLE
feat: package sosreport helper in release artifacts

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -19,7 +19,11 @@ name: Packaging
 on:
   pull_request:
     paths:
+      - ".github/workflows/packaging.yml"
       - ".goreleaser.yml"
+      - "Makefile"
+      - "scripts/install.sh"
+      - "scripts/install-local.sh"
 
 permissions:
   contents: read
@@ -47,3 +51,12 @@ jobs:
           distribution: goreleaser
           version: "~> v2"
           args: release --snapshot --clean --skip=publish,sbom
+
+      - name: Verify sosreport helper in Linux archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="$(find dist -maxdepth 1 -type f -name 'l8k_*_linux_amd64.tar.gz' -print -quit)"
+          test -n "$archive"
+          tar -tzf "$archive" | grep -Fx 'scripts/kubectl-netop_sosreport' >/dev/null
+          tar -tvzf "$archive" | grep -E '^-rwx.* scripts/kubectl-netop_sosreport$' >/dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ Thumbs.db
 build/
 dist/
 site/
+scripts/kubectl-netop_sosreport
 
 # GoReleaser
 .goreleaser-artifacts/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,10 @@ version: 2
 
 project_name: l8k
 
+before:
+  hooks:
+    - make download-sosreport
+
 builds:
   - main: .
     binary: l8k
@@ -55,10 +59,11 @@ archives:
         formats:
           - zip
     # Presets and the default l8k-config are embedded in the binary. Profiles
-    # remain external because manifest generation reads their templates from
-    # the filesystem.
+    # and the sosreport helper remain external because commands read or execute
+    # them from the filesystem.
     files:
       - profiles/**/*
+      - scripts/kubectl-netop_sosreport
       - LICENSE
     name_template: "l8k_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
@@ -119,5 +124,7 @@ brews:
     install: |
       bin.install "l8k"
       (share/"l8k").install "profiles"
+      (share/"l8k"/"scripts").install "scripts/kubectl-netop_sosreport"
     test: |
       assert_match version.to_s, shell_output("#{bin}/l8k version")
+      assert_predicate share/"l8k"/"scripts"/"kubectl-netop_sosreport", :executable?

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GOMOD=$(GOCMD) mod
 
 # Sosreport script
 SOSREPORT_SCRIPT=scripts/kubectl-netop_sosreport
-SOSREPORT_URL=https://raw.githubusercontent.com/Mellanox/network-operator/master/scripts/sosreport/kubectl-netop_sosreport
+SOSREPORT_URL=https://raw.githubusercontent.com/Mellanox/network-operator/refs/heads/master/scripts/sosreport/kubectl-netop_sosreport
 
 PCI_IDS_URL=https://raw.githubusercontent.com/pciutils/pciids/master/pci.ids
 PCI_IDS_NVIDIA=pkg/networkoperatorplugin/internal/pciids/nvidia.ids
@@ -125,12 +125,12 @@ version:
 run: build
 	$(BINARY_PATH)
 
-## Install l8k to system paths (copies binary, profiles, config)
-install: build
+## Install l8k to system paths (copies binary, profiles, and sosreport script)
+install: build download-sosreport
 	scripts/install-local.sh
 
 ## Install l8k with dev symlinks (for development)
-dev-install: build
+dev-install: build download-sosreport
 	scripts/install-local.sh --dev-env
 
 ## Development setup
@@ -184,7 +184,7 @@ sync-nic-config-crds:
 sync-network-operator-releases:
 	$(GOCMD) run ./hack/sync-network-operator-releases
 
-## Download sosreport script
+## Download sosreport script for release packaging and source installs
 download-sosreport:
 	@mkdir -p scripts
 	curl -fsSL -o $(SOSREPORT_SCRIPT) $(SOSREPORT_URL)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ make dev-install    # Symlinks instead of copies (for development)
 This runs `scripts/install-local.sh`, which places:
 - `<prefix>/bin/l8k`
 - `<prefix>/share/l8k/profiles/`
+- `<prefix>/share/l8k/scripts/kubectl-netop_sosreport`
+
+The source installer downloads the sosreport helper when it is absent. The
+installed `l8k sosreport` command never downloads executable code at runtime.
 
 Default prefix is `/usr/local`. Override with `PREFIX=/opt/l8k make install`.
 
@@ -735,7 +739,16 @@ Collect a diagnostic dump from the cluster:
 l8k sosreport --kubeconfig ~/.kube/config --output-dir ./sosreport
 ```
 
-The sosreport contains NicClusterPolicy, pod logs, node info, CRDs, and other diagnostic data. For interactive AI-assisted analysis, use the bundled Claude Code skills under `skills/k8s-launch-kit-troubleshoot/` — they wrap the deterministic commands (`l8k sosreport`, `kubectl`) and let the agent driving the skill do the reasoning.
+The sosreport contains NicClusterPolicy, pod logs, node info, CRDs, and other
+diagnostic data. Release archives include the Network Operator collection
+script, and the supported installers place it at
+`<installation-prefix>/share/l8k/scripts/kubectl-netop_sosreport`. `l8k` never
+downloads executable code at runtime. If the script is missing, the error
+reports its upstream URL and exact manual installation path. For interactive
+AI-assisted analysis, use the bundled Claude Code skills under
+`skills/k8s-launch-kit-troubleshoot/` — they wrap the deterministic commands
+(`l8k sosreport`, `kubectl`) and let the agent driving the skill do the
+reasoning.
 
 ### AI Agent / Automation Usage
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -199,3 +199,10 @@ Set `GITHUB_TOKEN` for authenticated GitHub API requests when updating presets.
 | --- | --- |
 | `--kubeconfig` | Cluster kubeconfig, with the same environment and home-directory fallback as other cluster commands. |
 | `--output-dir` | Diagnostic output directory. Defaults to `./sosreport`. |
+
+Release archives include the Network Operator sosreport helper. Supported
+installers place it at
+`<installation-prefix>/share/l8k/scripts/kubectl-netop_sosreport`; the command
+does not download executable code at runtime. If the helper is missing, the
+error reports its raw GitHub URL and exact expected path for manual
+installation.

--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -109,6 +109,13 @@ l8k preset list --config-dir /etc/l8k
 
 Script, Homebrew, and source installs also place the profile templates under `<prefix>/share/l8k/profiles/`. Existing `l8k-config.yaml` and `presets/` overrides under the share directory are preserved during upgrades and are selected only when passed through `--config-dir`.
 
+Release artifacts also contain the Network Operator sosreport helper. The
+installers place it at
+`<prefix>/share/l8k/scripts/kubectl-netop_sosreport`. Source-tree
+`make install`, `make dev-install`, and direct `scripts/install-local.sh`
+invocations download the helper when it is absent; `l8k sosreport` itself never
+downloads executable code at runtime.
+
 ## Verify
 
 ```bash

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -147,11 +147,13 @@ l8k sosreport \
   --output-dir ./sosreport
 ```
 
-The kubeconfig can also come from `$KUBECONFIG` or `~/.kube/config`. If the collection script is missing from the source tree or installed share directory, install it with:
-
-```bash
-make download-sosreport
-```
+The kubeconfig can also come from `$KUBECONFIG` or `~/.kube/config`. Release
+archives contain the collection script, and supported installers place it at
+`<installation-prefix>/share/l8k/scripts/kubectl-netop_sosreport`. The command
+does not download executable code at runtime. If the script is missing, its
+error reports the raw source URL and exact expected path so an executable copy
+can be installed manually. Source-tree developers can populate their checkout
+with `make download-sosreport`.
 
 Start with the diagnostic summary and collection errors, then correlate:
 

--- a/pkg/cmd/sosreport.go
+++ b/pkg/cmd/sosreport.go
@@ -27,6 +27,11 @@ import (
 	apperrors "github.com/nvidia/k8s-launch-kit/pkg/errors"
 )
 
+const (
+	sosreportScriptName = "kubectl-netop_sosreport"
+	sosreportScriptURL  = "https://raw.githubusercontent.com/Mellanox/network-operator/refs/heads/master/scripts/sosreport/kubectl-netop_sosreport"
+)
+
 var sosreportOutputDir string
 
 var sosreportCmd = &cobra.Command{
@@ -53,12 +58,12 @@ and other diagnostic data useful for troubleshooting.`,
 		}
 
 		// Find the sosreport script
-		scriptPath, err := findSosreportScript()
+		scriptPath, installPath, err := findSosreportScript()
 		if err != nil {
 			exitWithError(apperrors.NewValidationError(
 				"sosreport script not found",
 				err,
-				"Run 'make download-sosreport' to download the script",
+				manualSosreportInstallSuggestion(installPath),
 			), outputFormat)
 		}
 
@@ -90,20 +95,69 @@ and other diagnostic data useful for troubleshooting.`,
 }
 
 // findSosreportScript looks for the sosreport script in known locations.
-func findSosreportScript() (string, error) {
-	candidates := []string{
-		"scripts/kubectl-netop_sosreport",
-		"/usr/local/share/l8k/scripts/kubectl-netop_sosreport",
-	}
-	if exe, err := os.Executable(); err == nil {
-		candidates = append(candidates, filepath.Join(filepath.Dir(exe), "..", "share", "l8k", "scripts", "kubectl-netop_sosreport"))
-	}
+func findSosreportScript() (string, string, error) {
+	invokedExecutablePath := executableInvocationPath()
+	resolvedExecutablePath, _ := os.Executable()
+	candidates, installPath := sosreportScriptLocations(invokedExecutablePath, resolvedExecutablePath)
 	for _, p := range candidates {
 		if _, err := os.Stat(p); err == nil {
-			return p, nil
+			return p, installPath, nil
 		}
 	}
-	return "", fmt.Errorf("checked: %v", candidates)
+	return "", installPath, fmt.Errorf("checked: %v", candidates)
+}
+
+func executableInvocationPath() string {
+	path, err := exec.LookPath(os.Args[0])
+	if err != nil {
+		return ""
+	}
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	return absolutePath
+}
+
+func sosreportScriptLocations(invokedExecutablePath, resolvedExecutablePath string) ([]string, string) {
+	candidates := []string{
+		filepath.Join("scripts", sosreportScriptName),
+		filepath.Join("/usr/local/share/l8k/scripts", sosreportScriptName),
+	}
+	installPath := candidates[len(candidates)-1]
+	if invokedExecutablePath != "" {
+		installPath = sosreportScriptPathForExecutable(invokedExecutablePath)
+		candidates = appendUniquePath(candidates, installPath)
+	}
+	if resolvedExecutablePath != "" {
+		resolvedInstallPath := sosreportScriptPathForExecutable(resolvedExecutablePath)
+		if invokedExecutablePath == "" {
+			installPath = resolvedInstallPath
+		}
+		candidates = appendUniquePath(candidates, resolvedInstallPath)
+	}
+	return candidates, installPath
+}
+
+func sosreportScriptPathForExecutable(executablePath string) string {
+	return filepath.Join(filepath.Dir(executablePath), "..", "share", "l8k", "scripts", sosreportScriptName)
+}
+
+func appendUniquePath(paths []string, path string) []string {
+	for _, existingPath := range paths {
+		if existingPath == path {
+			return paths
+		}
+	}
+	return append(paths, path)
+}
+
+func manualSosreportInstallSuggestion(installPath string) string {
+	return fmt.Sprintf(
+		"Download %s and place it at %s next to the l8k installation with executable permissions",
+		sosreportScriptURL,
+		installPath,
+	)
 }
 
 func init() {

--- a/pkg/cmd/sosreport_test.go
+++ b/pkg/cmd/sosreport_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSosreportScriptLocationsUseInvokedInstallationPrefix(t *testing.T) {
+	t.Parallel()
+
+	invokedExecutablePath := filepath.Join("/opt", "l8k", "bin", "l8k")
+	resolvedExecutablePath := filepath.Join("/source", "k8s-launch-kit", "build", "l8k")
+	candidates, installPath := sosreportScriptLocations(invokedExecutablePath, resolvedExecutablePath)
+
+	expected := filepath.Join("/opt", "l8k", "share", "l8k", "scripts", sosreportScriptName)
+	assert.Equal(t, expected, installPath)
+	assert.Contains(t, candidates, expected)
+	assert.Contains(t, candidates, filepath.Join("/source", "k8s-launch-kit", "share", "l8k", "scripts", sosreportScriptName))
+}
+
+func TestSosreportScriptLocationsFallBackToResolvedExecutable(t *testing.T) {
+	t.Parallel()
+
+	resolvedExecutablePath := filepath.Join("/opt", "l8k", "bin", "l8k")
+	candidates, installPath := sosreportScriptLocations("", resolvedExecutablePath)
+
+	expected := filepath.Join("/opt", "l8k", "share", "l8k", "scripts", sosreportScriptName)
+	assert.Equal(t, expected, installPath)
+	assert.Contains(t, candidates, expected)
+}
+
+func TestManualSosreportInstallSuggestion(t *testing.T) {
+	t.Parallel()
+
+	installPath := filepath.Join("/opt", "l8k", "share", "l8k", "scripts", sosreportScriptName)
+	suggestion := manualSosreportInstallSuggestion(installPath)
+
+	assert.Contains(t, suggestion, sosreportScriptURL)
+	assert.Contains(t, suggestion, installPath)
+	assert.Contains(t, suggestion, "next to the l8k installation")
+	assert.NotContains(t, suggestion, "make download-sosreport")
+}

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -15,7 +15,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Install the l8k binary and external profile templates to system paths.
+# Install the l8k binary, external profile templates, and sosreport helper to
+# system paths.
 #
 # Usage:
 #   scripts/install-local.sh                     # Install to /usr/local (copies files)
@@ -25,6 +26,7 @@
 # Install layout:
 #   <prefix>/bin/l8k                       # Binary
 #   <prefix>/share/l8k/profiles/           # Profile templates
+#   <prefix>/share/l8k/scripts/kubectl-netop_sosreport
 #
 # The default config and topology presets are embedded in the binary. Existing
 # filesystem overrides are preserved and can be selected with --config-dir.
@@ -63,11 +65,24 @@ done
 
 SHARE_DIR="${PREFIX}/share/l8k"
 BIN_DIR="${PREFIX}/bin"
+SOSREPORT_SCRIPT="${REPO_ROOT}/scripts/kubectl-netop_sosreport"
 
 # Verify binary exists
 if [ ! -f "${REPO_ROOT}/build/l8k" ]; then
     echo "Error: binary not found at ${REPO_ROOT}/build/l8k"
     echo "Run 'make build' first."
+    exit 1
+fi
+
+# The helper is generated release input and is not committed to the repository.
+# Download it for direct script invocations as well as the Make install targets.
+if [ ! -x "${SOSREPORT_SCRIPT}" ]; then
+    echo "Downloading sosreport helper..."
+    make -C "${REPO_ROOT}" download-sosreport
+fi
+
+if [ ! -x "${SOSREPORT_SCRIPT}" ]; then
+    echo "Error: sosreport helper not found or not executable at ${SOSREPORT_SCRIPT}"
     exit 1
 fi
 
@@ -77,6 +92,9 @@ if [ "$DEV_ENV" = true ]; then
     ln -sfn "${REPO_ROOT}/build/l8k" "${BIN_DIR}/l8k"
     mkdir -p "${SHARE_DIR}"
     ln -sfn "${REPO_ROOT}/profiles" "${SHARE_DIR}/profiles"
+    mkdir -p "${SHARE_DIR}/scripts"
+    ln -sfn "${SOSREPORT_SCRIPT}" \
+        "${SHARE_DIR}/scripts/kubectl-netop_sosreport"
 else
     echo "Installing l8k..."
     mkdir -p "${BIN_DIR}"
@@ -84,12 +102,16 @@ else
     mkdir -p "${SHARE_DIR}"
     rm -rf "${SHARE_DIR}/profiles"
     cp -r "${REPO_ROOT}/profiles" "${SHARE_DIR}/profiles"
+    mkdir -p "${SHARE_DIR}/scripts"
+    install -m 755 "${SOSREPORT_SCRIPT}" \
+        "${SHARE_DIR}/scripts/kubectl-netop_sosreport"
 fi
 
 echo ""
 echo "Installed successfully:"
 echo "  Binary:   ${BIN_DIR}/l8k"
 echo "  Profiles: ${SHARE_DIR}/profiles"
+echo "  Sosreport: ${SHARE_DIR}/scripts/kubectl-netop_sosreport"
 if [ -e "${SHARE_DIR}/presets" ] || [ -e "${SHARE_DIR}/l8k-config.yaml" ]; then
     echo ""
     echo "Existing config overrides were preserved under ${SHARE_DIR}."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -203,6 +203,8 @@ INSTALL_CMDS="
     mkdir -p '${INSTALL_DIR}/share/l8k'
     rm -rf '${INSTALL_DIR}/share/l8k/profiles'
     cp -r '${WORK_DIR}/extracted/profiles' '${INSTALL_DIR}/share/l8k/'
+    mkdir -p '${INSTALL_DIR}/share/l8k/scripts'
+    install -m 755 '${WORK_DIR}/extracted/scripts/kubectl-netop_sosreport' '${INSTALL_DIR}/share/l8k/scripts/kubectl-netop_sosreport'
 "
 
 if [ "$NEED_SUDO" = true ]; then
@@ -220,6 +222,7 @@ echo ""
 echo "Installed successfully:"
 echo "  Binary:   ${INSTALL_DIR}/bin/l8k"
 echo "  Profiles: ${INSTALL_DIR}/share/l8k/profiles"
+echo "  Sosreport: ${INSTALL_DIR}/share/l8k/scripts/kubectl-netop_sosreport"
 if [ -e "${INSTALL_DIR}/share/l8k/presets" ] || [ -e "${INSTALL_DIR}/share/l8k/l8k-config.yaml" ]; then
     echo ""
     echo "Existing config overrides were preserved under ${INSTALL_DIR}/share/l8k."

--- a/skills/k8s-launch-kit-troubleshoot/SKILL.md
+++ b/skills/k8s-launch-kit-troubleshoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: k8s-launch-kit-troubleshoot
-version: 1.1.3
+version: 1.1.4
 description: "Use this skill when the user has problems with NVIDIA Network Operator on Kubernetes, or wants to analyze a sosreport diagnostic dump. Activate for: OFED driver crashes, SR-IOV pods failing, NicClusterPolicy errors, network operator pod issues, RDMA not working, NIC configuration failures, pods stuck in CrashLoopBackOff or ContainerCreating with network annotations, VF allocation issues, or when the user mentions 'troubleshoot', 'debug', 'sosreport', 'diagnose', or describes any NVIDIA networking failure -- even if they don't explicitly ask for troubleshooting."
 metadata:
   requires:
@@ -32,7 +32,7 @@ ib_write_bw failure needs command output. Trace fields are bounded; failed RDMA
 server logs are collected before cleanup. Add `--keep` only when the workload
 must remain available for follow-up `kubectl exec` inspection.
 
-`l8k sosreport` gathers cluster state, CRDs, operator logs, and per-node NIC info into a structured directory for offline analysis. Use the diagnostic commands and triage workflow below to interpret the dump.
+`l8k sosreport` gathers cluster state, CRDs, operator logs, and per-node NIC info into a structured directory for offline analysis. Release installations include the Network Operator collection script under `share/l8k/scripts/`; the command never downloads executable code at runtime. If the script is missing, report the upstream URL and exact expected path emitted by `l8k` so the user can install it manually. Use the diagnostic commands and triage workflow below to interpret the dump.
 
 ## Diagnostic Commands
 


### PR DESCRIPTION
## Summary

- download `kubectl-netop_sosreport` as a GoReleaser `before` hook and include it in every release archive
- install the helper beside `l8k` through the release, source, and Homebrew installation paths
- keep runtime execution offline and report the upstream URL plus expected destination when the helper is missing
- verify release archive contents and executable permissions in the packaging workflow

This supersedes #257, which downloaded the helper lazily at runtime.

## Validation

- `go test -race -count=1 ./...`
- `go build ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 run ./...`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/packaging.yml`
- `bash -n scripts/install-local.sh`
- `sh -n scripts/install.sh`
- GoReleaser v2.18.1 snapshot build; verified the Linux archive contains executable `scripts/kubectl-netop_sosreport`
- verified generated Homebrew formula installs and tests the helper
