### PR TITLE
feat: configure NV-IPAM per-node block size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,6 +1053,7 @@ The `nvIpam` section supports two modes for subnet configuration:
 ```yaml
 nvIpam:
   poolName: nv-ipam-pool
+  perNodeBlockSize: 10
   subnets:
   - subnet: 192.168.2.0/24
     gateway: 192.168.2.1
@@ -1064,6 +1065,7 @@ nvIpam:
 ```yaml
 nvIpam:
   poolName: nv-ipam-pool
+  perNodeBlockSize: 10
   startingSubnet: "192.168.2.0"
   mask: 24
   offset: 1
@@ -1074,6 +1076,11 @@ With the auto-generation example above, a cluster with 2 groups (4 east-west PFs
 - Group 1: 192.168.6.0/24, 192.168.7.0/24, 192.168.8.0/24, 192.168.9.0/24
 
 The `offset` parameter controls how many subnet blocks to skip between consecutive subnets (offset=1 is contiguous, offset=2 skips every other).
+
+`perNodeBlockSize` controls how many addresses NV-IPAM reserves for each node
+from every generated IPPool. It defaults to `10`. If it is lower than
+`sriov.numVfs`, `l8k generate` warns that the block may not contain enough
+addresses for all VFs on a node.
 
 **IP exclusions** — l8k can populate the IPPool `spec.exclusions` so addresses
 reserved for infrastructure (gateways, EVPN endpoints) are never handed to pods.
@@ -1092,6 +1099,7 @@ gateway is not excluded automatically — it is covered by the low reserve block
 ```yaml
 nvIpam:
   poolName: nv-ipam-pool
+  perNodeBlockSize: 10
   startingSubnet: "192.168.0.0"
   mask: 24
   offset: 1
@@ -1146,6 +1154,7 @@ maintenance:
   maxParallelUpgrades: 4
 nvIpam:
   poolName: nv-ipam-pool
+  perNodeBlockSize: 10
   subnets:
   - subnet: 192.168.2.0/24
     gateway: 192.168.2.1

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -35,7 +35,7 @@ validation settings in the supplied config.
 | `validation` | Connectivity mode, enabled checks, and RDMA parameters. |
 | `docaDriver` | DOCA driver version and module unload behavior. |
 | `maintenance` | Maintenance Operator and upgrade concurrency limits. |
-| `nvIpam` | IPPool subnet generation, manual subnets, and exclusions. |
+| `nvIpam` | IPPool per-node block allocation, subnet generation, manual subnets, and exclusions. |
 | `sriov`, `hostdev`, `rdmaShared`, `ipoib`, `macvlan` | Profile-specific resource and network naming. |
 | `nicConfigurationOperator` | Interface and RDMA device naming templates. |
 | `spectrumX` | Spectrum-X naming defaults. |
@@ -205,6 +205,7 @@ Auto-generate per-group subnets:
 ```yaml
 nvIpam:
   poolName: nv-ipam-pool
+  perNodeBlockSize: 10
   startingSubnet: "192.168.0.0"
   mask: 22
   offset: 1
@@ -216,6 +217,7 @@ Or list subnets manually:
 
 ```yaml
 nvIpam:
+  perNodeBlockSize: 10
   subnets:
     - subnet: 192.168.2.0/24
       gateway: 192.168.2.1
@@ -228,6 +230,7 @@ Reserved first/last IPs are merged with explicit exclusions for every subnet.
 | Field | Meaning |
 | --- | --- |
 | `poolName` | Base name for generated `IPPool` resources. |
+| `perNodeBlockSize` | Non-negative number of addresses reserved per node in each generated `IPPool`; `0` or omission defaults to `10`. SR-IOV generation warns when the effective value is smaller than `sriov.numVfs`. |
 | `startingSubnet` | Aligned IPv4 network address for automatic allocation. |
 | `mask` | Automatic subnet prefix length, from `/1` through `/30`. |
 | `offset` | Number of subnet-sized blocks between allocations; minimum `1`. |

--- a/pkg/app/generate.go
+++ b/pkg/app/generate.go
@@ -197,6 +197,7 @@ func (l *Launcher) executeGeneration(configPath string) error {
 	// Store found profiles for deploy phase
 	l.foundProfiles = foundProfiles
 
+	warnNvIpamBlockSize(fullConfig, l.ui)
 	warnThirdPartyRDMAModules(fullConfig, "generate", l.ui)
 	warnStorageModules(fullConfig, "generate", l.ui)
 

--- a/pkg/app/warnings.go
+++ b/pkg/app/warnings.go
@@ -23,6 +23,21 @@ import (
 	"github.com/nvidia/k8s-launch-kit/pkg/ui"
 )
 
+// warnNvIpamBlockSize warns when NV-IPAM may reserve fewer addresses per node
+// than an SR-IOV policy can expose as VFs.
+func warnNvIpamBlockSize(cfg *config.LaunchKitConfig, output ui.Output) {
+	if cfg == nil || cfg.Profile == nil || cfg.Profile.Deployment != "sriov" ||
+		cfg.NvIpam == nil || cfg.Sriov == nil ||
+		cfg.NvIpam.PerNodeBlockSize >= cfg.Sriov.NumVfs {
+		return
+	}
+
+	output.Warning(
+		"nvIpam.perNodeBlockSize (%d) is less than sriov.numVfs (%d). "+
+			"The NV-IPAM block size may be insufficient for all VFs on each node.",
+		cfg.NvIpam.PerNodeBlockSize, cfg.Sriov.NumVfs)
+}
+
 // warnThirdPartyRDMAModules warns about third-party RDMA modules that will be
 // unloaded. Discovery auto-enables the flag when modules are found, so this only
 // emits the "verify safety" warning when the flag is true and modules are present.

--- a/pkg/app/warnings_test.go
+++ b/pkg/app/warnings_test.go
@@ -35,18 +35,88 @@ func (t *testOutput) Success(format string, args ...interface{}) {}
 func (t *testOutput) Warning(format string, args ...interface{}) {
 	t.warnings = append(t.warnings, fmt.Sprintf(format, args...))
 }
-func (t *testOutput) Error(format string, args ...interface{})       {}
-func (t *testOutput) StartProgress(message string) ui.Progress      { return &noopProgress{} }
-func (t *testOutput) Header(text string)                             {}
-func (t *testOutput) Section(text string)                            {}
-func (t *testOutput) Confirm(prompt string) (bool, error)            { return false, nil }
-func (t *testOutput) IsTTY() bool                                    { return false }
+func (t *testOutput) Error(format string, args ...interface{}) {}
+func (t *testOutput) StartProgress(message string) ui.Progress { return &noopProgress{} }
+func (t *testOutput) Header(text string)                       {}
+func (t *testOutput) Section(text string)                      {}
+func (t *testOutput) Confirm(prompt string) (bool, error)      { return false, nil }
+func (t *testOutput) IsTTY() bool                              { return false }
 
 type noopProgress struct{}
 
 func (p *noopProgress) Update(message string)  {}
 func (p *noopProgress) Success(message string) {}
 func (p *noopProgress) Fail(message string)    {}
+
+func TestWarnNvIpamBlockSize(t *testing.T) {
+	t.Run("warns when block size is smaller than VF count", func(t *testing.T) {
+		out := &testOutput{}
+		cfg := &config.LaunchKitConfig{
+			NvIpam:  &config.NvIpamConfig{PerNodeBlockSize: 7},
+			Sriov:   &config.SriovConfig{NumVfs: 8},
+			Profile: &config.Profile{Deployment: "sriov"},
+		}
+
+		warnNvIpamBlockSize(cfg, out)
+
+		assert.Len(t, out.warnings, 1)
+		assert.Contains(t, out.warnings[0], "nvIpam.perNodeBlockSize (7)")
+		assert.Contains(t, out.warnings[0], "sriov.numVfs (8)")
+		assert.Contains(t, out.warnings[0], "may be insufficient")
+	})
+
+	t.Run("does not warn when block size matches VF count", func(t *testing.T) {
+		out := &testOutput{}
+		cfg := &config.LaunchKitConfig{
+			NvIpam:  &config.NvIpamConfig{PerNodeBlockSize: 8},
+			Sriov:   &config.SriovConfig{NumVfs: 8},
+			Profile: &config.Profile{Deployment: "sriov"},
+		}
+
+		warnNvIpamBlockSize(cfg, out)
+
+		assert.Empty(t, out.warnings)
+	})
+
+	t.Run("does not warn without comparable settings", func(t *testing.T) {
+		for _, cfg := range []*config.LaunchKitConfig{
+			nil,
+			{},
+			{NvIpam: &config.NvIpamConfig{PerNodeBlockSize: 7}},
+			{
+				NvIpam: &config.NvIpamConfig{PerNodeBlockSize: 7},
+				Sriov:  &config.SriovConfig{NumVfs: 8},
+			},
+			{
+				NvIpam:  &config.NvIpamConfig{PerNodeBlockSize: 7},
+				Profile: &config.Profile{Deployment: "sriov"},
+			},
+			{
+				Sriov:   &config.SriovConfig{NumVfs: 8},
+				Profile: &config.Profile{Deployment: "sriov"},
+			},
+		} {
+			out := &testOutput{}
+			warnNvIpamBlockSize(cfg, out)
+			assert.Empty(t, out.warnings)
+		}
+	})
+
+	for _, deployment := range []string{"host_device", "rdma_shared"} {
+		t.Run("does not warn for "+deployment+" deployment", func(t *testing.T) {
+			out := &testOutput{}
+			cfg := &config.LaunchKitConfig{
+				NvIpam:  &config.NvIpamConfig{PerNodeBlockSize: 7},
+				Sriov:   &config.SriovConfig{NumVfs: 8},
+				Profile: &config.Profile{Deployment: deployment},
+			}
+
+			warnNvIpamBlockSize(cfg, out)
+
+			assert.Empty(t, out.warnings)
+		})
+	}
+}
 
 func TestWarnThirdPartyRDMAModules_DriverDisabled(t *testing.T) {
 	out := &testOutput{}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,6 +74,7 @@ func DefaultLaunchKitConfig() (*LaunchKitConfig, error) {
 	if err := NormalizeMaintenance(&cfg); err != nil {
 		return nil, fmt.Errorf("invalid embedded maintenance config: %w", err)
 	}
+	ApplyNvIpamDefaults(&cfg)
 	if err := validateDOCADriverConfig(cfg.DOCADriver); err != nil {
 		return nil, fmt.Errorf("invalid embedded docaDriver config: %w", err)
 	}
@@ -331,12 +332,19 @@ type DOCADriverEnvVar struct {
 	Value string `yaml:"value"`
 }
 
+// DefaultNvIpamPerNodeBlockSize is the address block reserved per node when
+// nvIpam.perNodeBlockSize is omitted.
+const DefaultNvIpamPerNodeBlockSize = 10
+
 type NvIpamConfig struct {
-	PoolName       string               `yaml:"poolName"`
-	Subnets        []NvIpamSubnetConfig `yaml:"subnets,omitempty"`
-	StartingSubnet string               `yaml:"startingSubnet,omitempty"`
-	Mask           int                  `yaml:"mask,omitempty"`
-	Offset         int                  `yaml:"offset,omitempty"`
+	PoolName string `yaml:"poolName"`
+	// PerNodeBlockSize is the number of addresses NV-IPAM reserves for each
+	// node from an IPPool. Zero is treated as unspecified and defaults to 10.
+	PerNodeBlockSize int                  `yaml:"perNodeBlockSize,omitempty"`
+	Subnets          []NvIpamSubnetConfig `yaml:"subnets,omitempty"`
+	StartingSubnet   string               `yaml:"startingSubnet,omitempty"`
+	Mask             int                  `yaml:"mask,omitempty"`
+	Offset           int                  `yaml:"offset,omitempty"`
 	// ReserveFirstIPs excludes the first N host addresses of EVERY subnet
 	// (network address upward, e.g. 10 → .0–.9 on a /24). Applied to both
 	// auto-generated and manually-listed subnets. Mask-agnostic.
@@ -906,6 +914,7 @@ func LoadFullConfigWithSource(configPath string, logger logr.Logger) (*LaunchKit
 		logger.Info("Cluster configuration loaded successfully")
 	}
 
+	ApplyNvIpamDefaults(&config)
 	if err := validateNvIpam(config.NvIpam); err != nil {
 		return nil, nil, fmt.Errorf("invalid nvIpam config in %s: %w", configPath, err)
 	}
@@ -1274,11 +1283,25 @@ func ApplyReservedExclusions(subnets []NvIpamSubnetConfig, reserveFirst, reserve
 	return nil
 }
 
-// validateNvIpam checks the nvIpam exclusion settings before any rendering.
-// It validates the reserve counts and any explicit per-subnet exclusion ranges.
+// ApplyNvIpamDefaults applies defaults to the nvIpam configuration. Public
+// callers may construct a config directly, so rendering calls this too.
+func ApplyNvIpamDefaults(cfg *LaunchKitConfig) {
+	if cfg == nil || cfg.NvIpam == nil {
+		return
+	}
+	if cfg.NvIpam.PerNodeBlockSize == 0 {
+		cfg.NvIpam.PerNodeBlockSize = DefaultNvIpamPerNodeBlockSize
+	}
+}
+
+// validateNvIpam checks the nvIpam settings before any rendering. It validates
+// the block size, reserve counts, and any explicit per-subnet exclusion ranges.
 func validateNvIpam(nv *NvIpamConfig) error {
 	if nv == nil {
 		return nil
+	}
+	if nv.PerNodeBlockSize < 0 {
+		return fmt.Errorf("nvIpam.perNodeBlockSize must be >= 0, got %d", nv.PerNodeBlockSize)
 	}
 	if nv.ReserveFirstIPs < 0 {
 		return fmt.Errorf("nvIpam.reserveFirstIPs must be >= 0, got %d", nv.ReserveFirstIPs)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -112,6 +112,30 @@ func TestSanitizeIdentifierBoundsLongValues(t *testing.T) {
 func TestLoadFullConfig(t *testing.T) {
 	logger := logr.Discard()
 
+	t.Run("load NV-IPAM per-node block size", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "cluster-config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(`nvIpam:
+  poolName: custom-pool
+  perNodeBlockSize: 16
+`), 0o600))
+
+		cfg, err := LoadFullConfig(configPath, logger)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.NvIpam)
+		assert.Equal(t, 16, cfg.NvIpam.PerNodeBlockSize)
+	})
+
+	t.Run("reject negative NV-IPAM per-node block size", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "cluster-config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(`nvIpam:
+  perNodeBlockSize: -1
+`), 0o600))
+
+		_, err := LoadFullConfig(configPath, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nvIpam.perNodeBlockSize must be >= 0")
+	})
+
 	t.Run("load valid config with separate MTU values", func(t *testing.T) {
 		// Create a temporary config file
 		tempDir := t.TempDir()
@@ -258,6 +282,7 @@ func TestDefaultLaunchKitConfig(t *testing.T) {
 	assert.Equal(t, "doca3.5.0-26.07-0.7.7.0-0", cfg.DOCADriver.Version)
 	assert.Empty(t, cfg.DOCADriver.Env, "advanced driver env must be opt-in")
 	require.NotNil(t, cfg.NvIpam, "DefaultLaunchKitConfig must populate NvIpam")
+	assert.Equal(t, DefaultNvIpamPerNodeBlockSize, cfg.NvIpam.PerNodeBlockSize)
 	require.NotNil(t, cfg.Validation, "DefaultLaunchKitConfig must populate Validation")
 	assert.Equal(t, ValidationModeStrict, cfg.Validation.Mode)
 	assert.Equal(t, []string{ValidationCheckICMP, ValidationCheckRPing, ValidationCheckIBWriteBW}, cfg.Validation.Checks)
@@ -1515,6 +1540,12 @@ func TestValidateNvIpam(t *testing.T) {
 		assert.NoError(t, validateNvIpam(nil))
 	})
 
+	t.Run("negative perNodeBlockSize", func(t *testing.T) {
+		err := validateNvIpam(&NvIpamConfig{PerNodeBlockSize: -1})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "perNodeBlockSize must be >= 0")
+	})
+
 	t.Run("negative reserveFirstIPs", func(t *testing.T) {
 		err := validateNvIpam(&NvIpamConfig{ReserveFirstIPs: -1})
 		require.Error(t, err)
@@ -1598,5 +1629,21 @@ func TestValidateNvIpam(t *testing.T) {
 			}},
 		})
 		assert.NoError(t, err)
+	})
+}
+
+func TestApplyNvIpamDefaults(t *testing.T) {
+	t.Run("defaults an omitted block size", func(t *testing.T) {
+		cfg := &LaunchKitConfig{NvIpam: &NvIpamConfig{}}
+
+		ApplyNvIpamDefaults(cfg)
+		assert.Equal(t, DefaultNvIpamPerNodeBlockSize, cfg.NvIpam.PerNodeBlockSize)
+	})
+
+	t.Run("preserves a configured block size", func(t *testing.T) {
+		cfg := &LaunchKitConfig{NvIpam: &NvIpamConfig{PerNodeBlockSize: 32}}
+
+		ApplyNvIpamDefaults(cfg)
+		assert.Equal(t, 32, cfg.NvIpam.PerNodeBlockSize)
 	})
 }

--- a/pkg/config/default-config.yaml
+++ b/pkg/config/default-config.yaml
@@ -96,6 +96,9 @@ maintenance:
 
 nvIpam:
   poolName: nv-ipam-pool
+  # Number of IP addresses reserved per node in every generated IPPool.
+  # Keep this at least as large as sriov.numVfs for SR-IOV deployments.
+  perNodeBlockSize: 10
   # --- Option 1: Auto-generate subnets (used when subnets list is empty) --- 
   # Each group gets its own unique subnet slice; gateway = network address + 1.
   startingSubnet: "192.168.0.0"

--- a/pkg/networkoperatorplugin/discovery/library.go
+++ b/pkg/networkoperatorplugin/discovery/library.go
@@ -269,6 +269,7 @@ func ParseClusterConfig(r io.Reader) (*config.LaunchKitConfig, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("ParseClusterConfig: yaml unmarshal failed: %w", err)
 	}
+	config.ApplyNvIpamDefaults(&cfg)
 	if cfg.NvIpam != nil && len(cfg.NvIpam.Subnets) > 0 {
 		if err := config.ApplyReservedExclusions(
 			cfg.NvIpam.Subnets, cfg.NvIpam.ReserveFirstIPs, cfg.NvIpam.ReserveLastIPs); err != nil {

--- a/pkg/networkoperatorplugin/discovery/library_test.go
+++ b/pkg/networkoperatorplugin/discovery/library_test.go
@@ -44,6 +44,8 @@ networkOperator:
 docaDriver:
   enable: true
   version: doca3.3.0-26.01-1.0.0.0-0
+nvIpam:
+  poolName: nv-ipam-pool
 clusterConfig:
 - identifier: group-0
   machineType: GB300-NVL
@@ -62,6 +64,8 @@ clusterConfig:
 	assert.Equal(t, "v26.4.0-beta.3", cfg.NetworkOperator.Version)
 	require.NotNil(t, cfg.DOCADriver)
 	assert.True(t, cfg.DOCADriver.Enable)
+	require.NotNil(t, cfg.NvIpam)
+	assert.Equal(t, config.DefaultNvIpamPerNodeBlockSize, cfg.NvIpam.PerNodeBlockSize)
 
 	require.Len(t, cfg.ClusterConfig, 1)
 	g := cfg.ClusterConfig[0]

--- a/pkg/networkoperatorplugin/ippool_exclusions_test.go
+++ b/pkg/networkoperatorplugin/ippool_exclusions_test.go
@@ -97,3 +97,25 @@ func TestIPPoolNoExclusionsWhenReserveUnset(t *testing.T) {
 			"IPPool should have no exclusions block when reserve is unset")
 	}
 }
+
+func TestIPPoolPerNodeBlockSizeFromConfig(t *testing.T) {
+	ctrllog.SetLogger(zap.New(zap.UseDevMode(true)))
+	cfg, err := config.LoadFullConfig(
+		filepath.Join("testdata", "grouping", "mixed-same-type.yaml"), ctrllog.Log)
+	require.NoError(t, err)
+	cfg.Profile = &config.Profile{Fabric: "ethernet", Deployment: "sriov", Multirail: true}
+	require.NotNil(t, cfg.NvIpam)
+	cfg.NvIpam.PerNodeBlockSize = 17
+
+	rendered, err := (&NetworkOperatorPlugin{}).GenerateProfileDeploymentFiles(
+		loadProfileFromDir(t, "sriov-ethernet-rdma"), cfg)
+	require.NoError(t, err)
+
+	for _, name := range fileNamesMatching(rendered, "ippool") {
+		for _, doc := range parseDocs(t, name, rendered[name]) {
+			spec, ok := doc["spec"].(map[string]any)
+			require.True(t, ok)
+			assert.EqualValues(t, 17, spec["perNodeBlockSize"])
+		}
+	}
+}

--- a/pkg/networkoperatorplugin/sriov_render_test.go
+++ b/pkg/networkoperatorplugin/sriov_render_test.go
@@ -238,6 +238,11 @@ func TestProfileManifestsAreValidMultiDocYAML(t *testing.T) {
 				if strings.Contains(name, "20-ippool") {
 					sawIPPool = true
 					require.Equal(t, 8, gotDocs, "multirail IPPool must emit one valid doc per rail")
+					for _, doc := range parseDocs(t, name, content) {
+						spec, ok := doc["spec"].(map[string]any)
+						require.True(t, ok)
+						require.EqualValues(t, config.DefaultNvIpamPerNodeBlockSize, spec["perNodeBlockSize"])
+					}
 				}
 			}
 			require.True(t, sawIPPool, "expected an IPPool manifest in profile %s", p.dir)

--- a/pkg/networkoperatorplugin/templates.go
+++ b/pkg/networkoperatorplugin/templates.go
@@ -946,6 +946,7 @@ func (p *NetworkOperatorPlugin) GenerateProfileDeploymentFiles(profile *profiles
 	if err := config.NormalizeMaintenance(cfg); err != nil {
 		return nil, fmt.Errorf("normalize maintenance configuration: %w", err)
 	}
+	config.ApplyNvIpamDefaults(cfg)
 	if len(cfg.NetworkNamespaces) == 0 {
 		cfg.NetworkNamespaces = []string{"default"}
 	}

--- a/profiles/host-device-rdma/20-ippool.yaml
+++ b/profiles/host-device-rdma/20-ippool.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
-  perNodeBlockSize: 50
+  perNodeBlockSize: {{$.NvIpam.PerNodeBlockSize}}
   gateway: {{(index $.NvIpam.Subnets $i).Gateway}}
   {{- with (index $.NvIpam.Subnets $i).Exclusions }}
   exclusions:
@@ -54,7 +54,7 @@ metadata:
   namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
-  perNodeBlockSize: 50
+  perNodeBlockSize: {{.NvIpam.PerNodeBlockSize}}
   gateway: {{(index .NvIpam.Subnets 0).Gateway}}
   {{- with (index .NvIpam.Subnets 0).Exclusions }}
   exclusions:

--- a/profiles/ipoib-rdma-shared/20-ippool.yaml
+++ b/profiles/ipoib-rdma-shared/20-ippool.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
-  perNodeBlockSize: 50
+  perNodeBlockSize: {{$.NvIpam.PerNodeBlockSize}}
   gateway: {{(index $.NvIpam.Subnets $i).Gateway}}
   {{- with (index $.NvIpam.Subnets $i).Exclusions }}
   exclusions:
@@ -55,7 +55,7 @@ metadata:
   namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
-  perNodeBlockSize: 50
+  perNodeBlockSize: {{.NvIpam.PerNodeBlockSize}}
   gateway: {{(index .NvIpam.Subnets 0).Gateway}}
   {{- with (index .NvIpam.Subnets 0).Exclusions }}
   exclusions:

--- a/profiles/macvlan-rdma-shared/20-ippool.yaml
+++ b/profiles/macvlan-rdma-shared/20-ippool.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
-  perNodeBlockSize: 50
+  perNodeBlockSize: {{$.NvIpam.PerNodeBlockSize}}
   gateway: {{(index $.NvIpam.Subnets $i).Gateway}}
   {{- with (index $.NvIpam.Subnets $i).Exclusions }}
   exclusions:
@@ -55,7 +55,7 @@ metadata:
   namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
-  perNodeBlockSize: 50
+  perNodeBlockSize: {{.NvIpam.PerNodeBlockSize}}
   gateway: {{(index .NvIpam.Subnets 0).Gateway}}
   {{- with (index .NvIpam.Subnets 0).Exclusions }}
   exclusions:

--- a/profiles/sriov-ethernet-rdma/20-ippool.yaml
+++ b/profiles/sriov-ethernet-rdma/20-ippool.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
-  perNodeBlockSize: 50
+  perNodeBlockSize: {{$.NvIpam.PerNodeBlockSize}}
   gateway: {{(index $.NvIpam.Subnets $i).Gateway}}
   {{- with (index $.NvIpam.Subnets $i).Exclusions }}
   exclusions:
@@ -54,7 +54,7 @@ metadata:
   namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
-  perNodeBlockSize: 50
+  perNodeBlockSize: {{.NvIpam.PerNodeBlockSize}}
   gateway: {{(index .NvIpam.Subnets 0).Gateway}}
   {{- with (index .NvIpam.Subnets 0).Exclusions }}
   exclusions:

--- a/profiles/sriov-ib-rdma/20-ippool.yaml
+++ b/profiles/sriov-ib-rdma/20-ippool.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: "{{$.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index $.NvIpam.Subnets $i).Subnet}}
-  perNodeBlockSize: 50
+  perNodeBlockSize: {{$.NvIpam.PerNodeBlockSize}}
   gateway: {{(index $.NvIpam.Subnets $i).Gateway}}
   {{- with (index $.NvIpam.Subnets $i).Exclusions }}
   exclusions:
@@ -54,7 +54,7 @@ metadata:
   namespace: "{{.NetworkOperator.Namespace}}"
 spec:
   subnet: {{(index .NvIpam.Subnets 0).Subnet}}
-  perNodeBlockSize: 50
+  perNodeBlockSize: {{.NvIpam.PerNodeBlockSize}}
   gateway: {{(index .NvIpam.Subnets 0).Gateway}}
   {{- with (index .NvIpam.Subnets 0).Exclusions }}
   exclusions:

--- a/skills/k8s-launch-kit-config/SKILL.md
+++ b/skills/k8s-launch-kit-config/SKILL.md
@@ -54,7 +54,7 @@ missing profile fields when it consumes that config.
 | `networkOperator` | Operator namespace, version, image repository, Helm repository, and `skipHelmChart` ownership switch |
 | `docaDriver` | OFED/DOCA driver image, version, blacklist settings |
 | `maintenance` | Maintenance Operator, SR-IOV drain, and legacy OFED upgrade concurrency |
-| `nvIpam` | NV-IPAM IP pool ranges and subnet generation |
+| `nvIpam` | NV-IPAM per-node block size, IP pool ranges, and subnet generation |
 | `sriov` | VF count, resource prefix, MTU, link type |
 | `hostdev` | Host device resource name |
 | `rdmaShared` | RDMA shared device resource name |
@@ -163,6 +163,7 @@ networkOperator:
 
 # Configure NV-IPAM subnets manually
 nvIpam:
+  perNodeBlockSize: 10
   subnets:
     - name: "rail-0-subnet"
       cidr: "10.10.0.0/16"
@@ -186,6 +187,7 @@ networkNamespaces: ["my-namespace"]
   public Network Operator artifact set. Update the entry again when the patch
   is GA.
 - `nvIpam` subnets are auto-generated if not specified — one per rail using non-routable ranges.
+- `nvIpam.perNodeBlockSize` defaults to `10`; generation warns when it is lower than `sriov.numVfs` because the per-node allocation may be too small for all VFs.
 - `docaDriver.unloadThirdPartyRDMAModules: true` auto-populates `UNLOAD_THIRD_PARTY_RDMA_MODULES` from discovered OFED-dependent modules.
 - `docaDriver.env` is an advanced escape hatch. Values override generated MOFED environment entries by name, duplicate custom names use the last value, and bad driver options can disrupt node networking.
 - For release 26.1+, SR-IOV requestor mode requires both the Network Operator drain requestor and the SR-IOV external drainer. l8k renders both; applying only CRs cannot enable their Deployment environment variables.

--- a/skills/k8s-launch-kit-config/references/config-reference.md
+++ b/skills/k8s-launch-kit-config/references/config-reference.md
@@ -133,6 +133,11 @@ nvIpam:
   # Name of the IPPool custom resource created in the operator namespace.
   poolName: nv-ipam-pool
 
+  # int | default: 10
+  # Number of addresses NV-IPAM reserves per node from every generated IPPool.
+  # Generation warns when this is smaller than sriov.numVfs.
+  perNodeBlockSize: 10
+
   # --- Auto-generation mode (used when subnets list is empty) ---
 
   # string | default: "192.168.0.0"

--- a/skills/k8s-launch-kit-generate/SKILL.md
+++ b/skills/k8s-launch-kit-generate/SKILL.md
@@ -231,6 +231,7 @@ win when a one-off override is needed.
   `cluster-config.yaml` with `--groups`; do not reconstruct it from long
   `machineType` and `gpuType` strings.
 - Use `--groups <a,b,...>` (case-sensitive identifier list) or `--gpu-type <X>` (case-insensitive) to scope a generate to a subset of source groups in heterogeneous clusters. Mutually exclusive. Empty match is a validation error. Strict-subset filters split per-source rendering: NodePolicies emit one CR per source (each with its own machine-label nodeSelector but a shared bucket-level resourceName); IPPool/example DaemonSet emit one CR per bucket with an `In` list of source machine labels.
+- Generated IPPools use `nvIpam.perNodeBlockSize` (default `10`). Generation warns when it is lower than `sriov.numVfs`, since the per-node block may not have an address for every VF.
 
 > [!CAUTION]
 > Generation does not apply anything to the cluster. Use `--deploy` or `k8s-launch-kit-deploy` to apply.

--- a/skills/k8s-network-engineer/references/config-schema.md
+++ b/skills/k8s-network-engineer/references/config-schema.md
@@ -78,6 +78,7 @@ Controls NV-IPAM (NVIDIA IP Address Management) pool generation.
 | Field            | Type     | Default          | Description                                          |
 |------------------|----------|------------------|------------------------------------------------------|
 | `poolName`       | string   | `nv-ipam-pool`   | Name of the IPPool CR                                |
+| `perNodeBlockSize` | int    | `10`             | Addresses reserved per node; generation warns when lower than `sriov.numVfs` |
 | `startingSubnet` | string   | `192.168.0.0`    | Base subnet for auto-generation                      |
 | `mask`           | int      | `22`             | Subnet mask length for auto-generated subnets        |
 | `offset`         | int      | `1`              | Offset from network address for gateway (gateway = network + offset) |
@@ -123,6 +124,7 @@ relative to its own network address.
 ```yaml
 nvIpam:
   poolName: nv-ipam-pool
+  perNodeBlockSize: 10
   startingSubnet: "192.168.0.0"
   mask: 24
   offset: 1


### PR DESCRIPTION
## Summary

- add `nvIpam.perNodeBlockSize` to cluster configuration with a default of `10`
- render the configured value into every non-Spectrum-X NV-IPAM `IPPool`
- warn during generation when the block size is lower than `sriov.numVfs`
- document the field and cover default, override, rendering, and warning behavior

## Testing

- `make build`
- `go test ./...`
- smoke-rendered all three grouping fixtures; omitted values rendered as `10`, an explicit `7` rendered as `7`, and the expected warning was emitted against `numVfs: 8`
- `make lint` not run: `golangci-lint` is not installed in the local environment
